### PR TITLE
feat(T07): production-ready Docker Compose for MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,83 @@
+# ═══════════════════════════════════════════════════════════
+# TITAN 環境變數範本
+# 任務: T07 — Container Platform Setup
+# ═══════════════════════════════════════════════════════════
+# 使用方式：
+#   cp .env.example .env
+#   編輯 .env，填入實際值
+# ⚠️  .env 絕對不可提交至版本控制（已加入 .gitignore）
+# ═══════════════════════════════════════════════════════════
+
+# ── PostgreSQL ───────────────────────────────────────────────
+POSTGRES_USER=titan
+# 必填：請設定強密碼（至少 16 字元，含大小寫英文、數字、符號）
+POSTGRES_PASSWORD=changeme_strong_password_here
+POSTGRES_DB=titan
+# 主機埠（預設 5432，若與本機衝突可修改）
+POSTGRES_PORT=5432
+
+# ── Redis ────────────────────────────────────────────────────
+# 必填：Redis 認證密碼
+REDIS_PASSWORD=changeme_redis_password_here
+# 主機埠（預設 6379）
+REDIS_PORT=6379
+
+# ── MinIO 物件儲存 ───────────────────────────────────────────
+# Root 帳號（等同 AWS Access Key）
+MINIO_ROOT_USER=minioadmin
+# 必填：Root 密碼（至少 8 字元）
+MINIO_ROOT_PASSWORD=changeme_minio_password_here
+# S3 API 埠（預設 9000）
+MINIO_API_PORT=9000
+# Web 管理介面埠（預設 9001）
+MINIO_CONSOLE_PORT=9001
+# 區域設定（MinIO 相容 S3 區域格式）
+MINIO_REGION=us-east-1
+
+# ── Outline 知識庫 ───────────────────────────────────────────
+# 必填：使用 `openssl rand -hex 32` 產生兩組不同的隨機字串
+OUTLINE_SECRET_KEY=generate_with_openssl_rand_hex_32
+OUTLINE_UTILS_SECRET=generate_with_openssl_rand_hex_32_different
+# Outline 對外存取 URL（不含尾部斜線）
+OUTLINE_URL=http://localhost:3001
+# 主機埠（預設 3001）
+OUTLINE_PORT=3001
+# Outline 在 MinIO 中的 bucket 名稱（首次啟動需在 MinIO console 建立）
+OUTLINE_S3_BUCKET=outline
+# 日誌等級：error / warn / info / debug
+OUTLINE_LOG_LEVEL=info
+
+# ── Outline OIDC 單一登入（選用）────────────────────────────
+# 若使用公司 SSO（如 Keycloak、Azure AD），請填入以下設定
+# 若不使用 SSO，留空即可（使用 email + 密碼登入）
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_AUTH_URI=
+OIDC_TOKEN_URI=
+OIDC_USERINFO_URI=
+OIDC_USERNAME_CLAIM=email
+
+# ── SMTP 郵件（選用）────────────────────────────────────────
+# 若不設定，Outline 將無法發送邀請信與通知信
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM_EMAIL=no-reply@titan.local
+# true = TLS（465 埠），false = STARTTLS（587 埠）
+SMTP_SECURE=false
+
+# ── Homepage 統一儀表板 ──────────────────────────────────────
+# 容器執行使用者 UID/GID（與 config/homepage 檔案擁有者一致）
+HOMEPAGE_PUID=1000
+HOMEPAGE_PGID=1000
+# 允許存取 Homepage 的主機名稱（多個用逗號分隔）
+HOMEPAGE_ALLOWED_HOSTS=localhost
+# 主機埠（預設 3000）
+HOMEPAGE_PORT=3000
+
+# ── Plane 專案管理（T12 任務佔位符）────────────────────────
+# ⚠️  以下設定保留給 T12 實作，目前無效
+# PLANE_SECRET_KEY=
+# PLANE_DB_NAME=plane
+# PLANE_REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/1

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# TITAN 環境變數範本
+# 複製並改名為 .env 後填入實際值
+
+# Database
+POSTGRES_PASSWORD=your_secure_password_here
+
+# Redis（可選）
+# REDIS_PASSWORD=your_redis_password
+
+# 私有 Registry（若使用）
+# HARBOR_USER=admin
+# HARBOR_PASSWORD=your_harbor_password

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# 環境變數（含敏感資訊，絕對不可提交）
+.env
+.env.local
+.env.*.local
+
+# macOS 系統檔案
+.DS_Store
+
+# Homepage 自動產生的快取檔案
+config/homepage/logs/
+config/homepage/cache/

--- a/DOCKER_COMPOSE_README.md
+++ b/DOCKER_COMPOSE_README.md
@@ -1,0 +1,61 @@
+# T07: 容器平台建置
+
+## 概述
+本任務完成 Titan 專案的 Docker Compose 基礎設施建置。
+
+## 已完成
+- [x] PostgreSQL 15 配置（資料持久化）
+- [x] Redis 7 配置（附 healthcheck）
+- [x] 私有 Registry 匯入策略文件
+- [x] 環境變數範本 (.env.example)
+
+## 使用方式
+
+### 1. 複製環境變數範本
+```bash
+cp .env.example .env
+# 編輯 .env 填入實際值
+```
+
+### 2. 啟動服務
+```bash
+docker-compose up -d
+```
+
+### 3. 驗證服務狀態
+```bash
+docker-compose ps
+docker-compose logs -f
+```
+
+### 4. 停止服務
+```bash
+docker-compose down
+```
+
+## 私有 Registry 策略
+
+### 使用外部私有 Registry（如 Harbor）
+1. 登入 Registry：
+   ```bash
+   echo "$HARBOR_PASSWORD" | docker login harbor.titan.internal --username="$HARBOR_USER" --password-stdin
+   ```
+2. 在 docker-compose.override.yml 中覆寫 image：
+   ```yaml
+   services:
+     app:
+       image: harbor.titan.internal/myapp:latest
+   ```
+
+### 本地 Registry（可選）
+若需建立本地私有 Registry：
+```bash
+docker run -d -p 5000:5000 --name registry -v registry-data:/var/lib/registry registry:2
+```
+
+## 依賴
+- T06: 需先完成基礎設施規劃
+
+## 維運
+- 資料 volume 預設掛載至 Docker 無名 volume
+- 生產環境建議使用具名 volume 或 bind mount

--- a/config/homepage/docker.yaml
+++ b/config/homepage/docker.yaml
@@ -1,0 +1,10 @@
+# TITAN Homepage — Docker 整合設定
+# 任務: T07 — Container Platform Setup
+# 文件: https://gethomepage.dev/latest/widgets/services/docker/
+# 透過 Docker socket 讀取容器狀態（唯讀掛載）
+
+---
+# 本機 Docker 主機設定
+# docker.sock 以唯讀方式掛載至 Homepage 容器
+titan-docker:
+  socket: /var/run/docker.sock

--- a/config/homepage/services.yaml
+++ b/config/homepage/services.yaml
@@ -1,0 +1,62 @@
+# TITAN Homepage — 服務清單設定
+# 任務: T07 — Container Platform Setup
+# 文件: https://gethomepage.dev/latest/configs/services/
+# 修改後需重啟 Homepage 容器才能生效
+
+---
+# ── 知識管理 ───────────────────────────────────────────────
+- 知識管理:
+    - Outline:
+        icon: outline.png
+        href: "{{HOMEPAGE_VAR_OUTLINE_URL}}"
+        description: 團隊知識庫與文件協作
+        server: titan-docker
+        container: titan-outline
+        widget:
+          type: customapi
+          url: "{{HOMEPAGE_VAR_OUTLINE_URL}}/_health"
+          method: GET
+          mappings:
+            - field: status
+              label: 狀態
+              format: text
+
+# ── 開發工具 ───────────────────────────────────────────────
+- 開發工具:
+    - MinIO Console:
+        icon: minio.png
+        href: "{{HOMEPAGE_VAR_MINIO_CONSOLE_URL}}"
+        description: S3 相容物件儲存管理介面
+        server: titan-docker
+        container: titan-minio
+        widget:
+          type: minio
+          url: "{{HOMEPAGE_VAR_MINIO_CONSOLE_URL}}"
+          username: "{{HOMEPAGE_VAR_MINIO_ROOT_USER}}"
+          password: "{{HOMEPAGE_VAR_MINIO_ROOT_PASSWORD}}"
+
+# ── 基礎設施 ───────────────────────────────────────────────
+- 基礎設施:
+    - PostgreSQL:
+        icon: postgresql.png
+        href: "#"
+        description: 共用關聯式資料庫（PostgreSQL 15）
+        server: titan-docker
+        container: titan-postgres
+
+    - Redis:
+        icon: redis.png
+        href: "#"
+        description: 快取與任務佇列（Redis 7）
+        server: titan-docker
+        container: titan-redis
+
+# ── 專案管理（待啟用）──────────────────────────────────────
+# ⚠️  Plane 將於 T12 任務完成後啟用
+# - 專案管理:
+#     - Plane:
+#         icon: plane.png
+#         href: "{{HOMEPAGE_VAR_PLANE_URL}}"
+#         description: 敏捷專案管理平台（T12 實作）
+#         server: titan-docker
+#         container: titan-plane-frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,207 @@
-# TITAN Docker Compose — DRAFT
-# ⚠️ 此配置為初始草稿，需在 T07/T09 任務中驗證和修正
-# Plane 官方部署方式需參考 https://docs.plane.so/self-hosting
-# 正式版將在 Phase C 開發時產出
+# TITAN 容器平台 — 生產就緒版本
+# 任務: T07 — Container Platform Setup
+# 所有映像版本均固定，適用於隔離網路（air-gapped）部署
+# 若需更新版本，請同步更新 .env.example 中的備註
 
 version: '3.8'
 
+# ═══════════════════════════════════════════════════════════
+# 服務定義
+# ═══════════════════════════════════════════════════════════
 services:
-  # ── 資料層 ──
+
+  # ── 資料層：PostgreSQL 15 ────────────────────────────────
+  # 共用資料庫，供 Outline 及未來服務使用
   postgres:
     image: postgres:15-alpine
     container_name: titan-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-titan}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-titan}
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
-      POSTGRES_DB: titan
     ports:
-      - "5432:5432"
-    restart: unless-stopped
+      - "${POSTGRES_PORT:-5432}:5432"
+    networks:
+      - titan-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-titan} -d ${POSTGRES_DB:-titan}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
+  # ── 快取層：Redis 7 ──────────────────────────────────────
+  # 快取與非同步任務佇列（供 Outline 使用）
   redis:
     image: redis:7-alpine
     container_name: titan-redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
     volumes:
       - redis-data:/data
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - titan-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  # ── 物件儲存：MinIO ──────────────────────────────────────
+  # S3 相容物件儲存，供 Outline 附件使用
+  # 版本固定：RELEASE.2024-01-01T00-00-00Z（適合隔離網路）
+  minio:
+    image: minio/minio:RELEASE.2024-01-01T00-00-00Z
+    container_name: titan-minio
     restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"       # S3 API 端點
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"   # Web 管理介面
+    networks:
+      - titan-network
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+      start_period: 30s
 
-  # ── 應用層（Phase C 時啟用）──
-  # homepage:
-  #   image: gethomepage/homepage:v0.9
-  #   container_name: titan-homepage
-  #   ports:
-  #     - "3000:3000"
-  #   volumes:
-  #     - ./config/homepage:/app/config
-  #   restart: unless-stopped
+  # ── 知識庫：Outline ──────────────────────────────────────
+  # 團隊知識庫與文件協作平台
+  outline:
+    image: outlinewiki/outline:0.80.2
+    container_name: titan-outline
+    restart: unless-stopped
+    environment:
+      # 應用程式設定
+      SECRET_KEY: ${OUTLINE_SECRET_KEY:?OUTLINE_SECRET_KEY is required}
+      UTILS_SECRET: ${OUTLINE_UTILS_SECRET:?OUTLINE_UTILS_SECRET is required}
+      URL: ${OUTLINE_URL:-http://localhost:3001}
+      PORT: 3000
+      # 資料庫連線
+      DATABASE_URL: postgres://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}
+      DATABASE_CONNECTION_POOL_MIN: 1
+      DATABASE_CONNECTION_POOL_MAX: 5
+      # Redis 連線
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      # 物件儲存（MinIO S3 相容）
+      AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER:-minioadmin}
+      AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+      AWS_REGION: ${MINIO_REGION:-us-east-1}
+      AWS_S3_UPLOAD_BUCKET_URL: http://minio:9000
+      AWS_S3_UPLOAD_BUCKET_NAME: ${OUTLINE_S3_BUCKET:-outline}
+      AWS_S3_FORCE_PATH_STYLE: "true"
+      AWS_S3_ACL: private
+      # 認證設定（預設使用 email/密碼）
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+      OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+      OIDC_AUTH_URI: ${OIDC_AUTH_URI:-}
+      OIDC_TOKEN_URI: ${OIDC_TOKEN_URI:-}
+      OIDC_USERINFO_URI: ${OIDC_USERINFO_URI:-}
+      OIDC_USERNAME_CLAIM: ${OIDC_USERNAME_CLAIM:-email}
+      # 郵件設定（選用，SMTP）
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL:-no-reply@titan.local}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
+      # 其他設定
+      NODE_ENV: production
+      ENABLE_UPDATES: "false"       # 隔離網路不自動更新
+      WEB_CONCURRENCY: 1
+      MAXIMUM_IMPORT_SIZE: 5120000
+      LOG_LEVEL: ${OUTLINE_LOG_LEVEL:-info}
+      FORCE_HTTPS: "false"
+    volumes:
+      - outline-data:/var/lib/outline/data
+    ports:
+      - "${OUTLINE_PORT:-3001}:3000"
+    networks:
+      - titan-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/_health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
-  # outline:
-  #   image: outlinewiki/outline:0.80
-  #   container_name: titan-outline
-  #   depends_on:
-  #     - postgres
-  #     - redis
-  #   restart: unless-stopped
+  # ── 統一儀表板：Homepage ─────────────────────────────────
+  # 集中呈現所有 TITAN 服務連結與狀態
+  homepage:
+    image: gethomepage/homepage:v0.9.13
+    container_name: titan-homepage
+    restart: unless-stopped
+    environment:
+      PUID: ${HOMEPAGE_PUID:-1000}
+      PGID: ${HOMEPAGE_PGID:-1000}
+      HOMEPAGE_ALLOWED_HOSTS: ${HOMEPAGE_ALLOWED_HOSTS:-localhost}
+    volumes:
+      - ./config/homepage:/app/config      # 服務設定檔
+      - /var/run/docker.sock:/var/run/docker.sock:ro  # Docker 狀態讀取（唯讀）
+    ports:
+      - "${HOMEPAGE_PORT:-3000}:3000"
+    networks:
+      - titan-network
+    depends_on:
+      - outline
+      - minio
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
+  # ── 專案管理：Plane（佔位符）────────────────────────────
+  # ⚠️  Plane 需要多容器架構（前端、後端、Worker、Beat、Proxy）
+  # ⚠️  實際部署設定請參閱任務 T12
+  # ⚠️  以下為佔位符，T12 完成前請勿啟用
+  #
+  # plane-frontend:
+  #   image: makeplane/plane-frontend:stable
+  #   ...（待 T12 實作）
+  #
+  # plane-backend:
+  #   image: makeplane/plane-backend:stable
+  #   ...（待 T12 實作）
+
+# ═══════════════════════════════════════════════════════════
+# 具名 Volume（持久化資料）
+# ═══════════════════════════════════════════════════════════
 volumes:
   postgres-data:
+    name: titan-postgres-data
   redis-data:
+    name: titan-redis-data
+  minio-data:
+    name: titan-minio-data
+  outline-data:
+    name: titan-outline-data
 
+# ═══════════════════════════════════════════════════════════
+# 網路設定
+# ═══════════════════════════════════════════════════════════
 networks:
-  default:
+  titan-network:
     name: titan-network
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-# TITAN Docker Compose — DRAFT
-# ⚠️ 此配置為初始草稿，需在 T07/T09 任務中驗證和修正
-# Plane 官方部署方式需參考 https://docs.plane.so/self-hosting
-# 正式版將在 Phase C 開發時產出
+# TITAN Docker Compose — 生產級配置
+# T07: 容器平台建置
+# 包含 PostgreSQL + Redis + 基礎網路設定
 
 version: '3.8'
 
@@ -18,6 +17,11 @@ services:
     ports:
       - "5432:5432"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
@@ -27,24 +31,19 @@ services:
     ports:
       - "6379:6379"
     restart: unless-stopped
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
-  # ── 應用層（Phase C 時啟用）──
-  # homepage:
-  #   image: gethomepage/homepage:v0.9
-  #   container_name: titan-homepage
-  #   ports:
-  #     - "3000:3000"
-  #   volumes:
-  #     - ./config/homepage:/app/config
-  #   restart: unless-stopped
-
-  # outline:
-  #   image: outlinewiki/outline:0.80
-  #   container_name: titan-outline
-  #   depends_on:
-  #     - postgres
-  #     - redis
-  #   restart: unless-stopped
+  # ── 私有 Registry 匯入策略說明 ──
+  # 若需使用私有 Docker Registry（如 Harbor）：
+  # 1. 設定 DOCKER_CONFIG 環境變數
+  # 2. 在執行 docker-compose 前先登入：
+  #    echo "$HARBOR_PASSWORD" | docker login harbor.titan.internal --username="$HARBOR_USER" --password-stdin
+  # 3. 或使用 docker-compose.override.yml 覆寫 image 路徑
 
 volumes:
   postgres-data:
@@ -53,3 +52,4 @@ volumes:
 networks:
   default:
     name: titan-network
+    driver: bridge


### PR DESCRIPTION
## Summary
- Production-ready docker-compose.yml with version-pinned images
- PostgreSQL 15, Redis 7, MinIO, Outline, Homepage
- Plane placeholder (complex setup deferred to T12)
- .env.example with all required variables
- Homepage config for unified dashboard

Closes #9