### PR TITLE
feat(T11): Homepage unified portal configuration

### DIFF
--- a/config/homepage/bookmarks.yaml
+++ b/config/homepage/bookmarks.yaml
@@ -1,0 +1,44 @@
+# TITAN Homepage — 書籤設定
+# 任務: T11 — Homepage Basic Deployment
+# 文件: https://gethomepage.dev/latest/configs/bookmarks/
+# 收錄常用內部連結與外部參考資源，方便團隊快速存取
+
+---
+# ── 內部資源 ───────────────────────────────────────────────
+# TITAN 平台各服務的直接連結
+- 內部資源:
+    - Outline 知識庫:
+        - abbr: OL
+          href: "{{HOMEPAGE_VAR_OUTLINE_URL}}"
+    - MinIO 物件儲存:
+        - abbr: MN
+          href: "{{HOMEPAGE_VAR_MINIO_CONSOLE_URL}}"
+    - Portainer（容器管理）:
+        - abbr: PT
+          href: "http://localhost:9000"
+
+# ── 開發參考 ───────────────────────────────────────────────
+# 常用技術文件與工具，支援日常開發工作
+- 開發參考:
+    - Homepage 官方文件:
+        - abbr: HP
+          href: https://gethomepage.dev/latest/
+    - Docker Hub:
+        - abbr: DH
+          href: https://hub.docker.com
+    - PostgreSQL 文件:
+        - abbr: PG
+          href: https://www.postgresql.org/docs/15/
+    - Redis 文件:
+        - abbr: RD
+          href: https://redis.io/docs/
+
+# ── TITAN 專案 ─────────────────────────────────────────────
+# 專案追蹤與協作相關連結
+- TITAN 專案:
+    - GitHub Repository:
+        - abbr: GH
+          href: https://github.com/cct08311github/titan
+    - GitHub Issues:
+        - abbr: IS
+          href: https://github.com/cct08311github/titan/issues

--- a/config/homepage/services.yaml
+++ b/config/homepage/services.yaml
@@ -1,9 +1,17 @@
 # TITAN Homepage — 服務清單設定
-# 任務: T07 — Container Platform Setup
+# 任務: T11 — Homepage Basic Deployment
 # 文件: https://gethomepage.dev/latest/configs/services/
 # 修改後需重啟 Homepage 容器才能生效
 
 ---
+# ── 專案管理 ───────────────────────────────────────────────
+# ⚠️  Plane 將於 T12 任務完成後啟用，目前為佔位設定
+- 專案管理:
+    - Plane:
+        icon: plane.png
+        href: "#"
+        description: 敏捷專案管理平台（T12 實作中，敬請期待）
+
 # ── 知識管理 ───────────────────────────────────────────────
 - 知識管理:
     - Outline:
@@ -50,13 +58,3 @@
         description: 快取與任務佇列（Redis 7）
         server: titan-docker
         container: titan-redis
-
-# ── 專案管理（待啟用）──────────────────────────────────────
-# ⚠️  Plane 將於 T12 任務完成後啟用
-# - 專案管理:
-#     - Plane:
-#         icon: plane.png
-#         href: "{{HOMEPAGE_VAR_PLANE_URL}}"
-#         description: 敏捷專案管理平台（T12 實作）
-#         server: titan-docker
-#         container: titan-plane-frontend

--- a/config/homepage/settings.yaml
+++ b/config/homepage/settings.yaml
@@ -1,0 +1,29 @@
+# TITAN Homepage — 全域設定
+# 任務: T11 — Homepage Basic Deployment
+# 文件: https://gethomepage.dev/latest/configs/settings/
+# 修改後需重啟 Homepage 容器才能生效
+
+---
+# 入口網站標題
+title: "TITAN — 團隊整合作業平台"
+
+# 深色主題，配合銀行 IT 團隊正式環境風格
+theme: dark
+
+# Slate 色系：低飽和度藍灰，適合長時間使用
+color: slate
+
+# 介面語言：繁體中文
+language: zh-TW
+
+# 頁面 Header 設定
+headerStyle: clean
+
+# 服務狀態顯示方式（dot = 小圓點）
+statusStyle: dot
+
+# 啟用記憶體與 CPU 使用率顯示
+useEqualHeights: true
+
+# 日誌層級（info / debug / warn / error）
+logLevel: info

--- a/config/homepage/widgets.yaml
+++ b/config/homepage/widgets.yaml
@@ -1,0 +1,36 @@
+# TITAN Homepage — 頁面 Widget 設定
+# 任務: T11 — Homepage Basic Deployment
+# 文件: https://gethomepage.dev/latest/configs/widgets/
+# Widget 顯示於頁面頂部，提供快速資訊與搜尋功能
+
+---
+# ── 搜尋 Widget ────────────────────────────────────────────
+# 提供全域搜尋功能，預設使用 DuckDuckGo（隱私優先）
+- search:
+    provider: duckduckgo
+    target: _blank
+    focus: false
+    showSearchSuggestions: true
+
+# ── 日期時間 Widget ────────────────────────────────────────
+# 顯示台北時區的即時日期與時間
+- datetime:
+    text_size: xl
+    format:
+      # 顯示格式：西元年 / 月 / 日（星期幾）HH:MM
+      dateStyle: short
+      timeStyle: short
+      hourCycle: h23
+    locale: zh-TW
+    timezone: Asia/Taipei
+
+# ── 系統資源 Widget ────────────────────────────────────────
+# 顯示主機 CPU / 記憶體使用率（需 Homepage 有權限讀取 /proc）
+- resources:
+    cpu: true
+    memory: true
+    disk:
+      - /
+    cacheInterval: 10
+    expanded: false
+    label: 主機資源


### PR DESCRIPTION
## Summary

- 新增 `config/homepage/settings.yaml`：深色主題、繁體中文、slate 色系
- 新增 `config/homepage/widgets.yaml`：搜尋、台北時區日期時間、系統資源 Widget
- 新增 `config/homepage/bookmarks.yaml`：內部資源、開發參考、TITAN 專案書籤
- 更新 `config/homepage/services.yaml`：依任務要求調整分類順序（專案管理排第一，含 Plane 佔位設定）

## 服務分類

| 分類 | 服務 |
|------|------|
| 專案管理 | Plane（佔位，T12 實作） |
| 知識管理 | Outline |
| 開發工具 | MinIO Console |
| 基礎設施 | PostgreSQL、Redis |

## Test plan

- [ ] 確認 Homepage 容器啟動後可正常讀取四個設定檔
- [ ] 驗證頁面顯示繁體中文介面與深色主題
- [ ] 確認台北時區時間顯示正確
- [ ] 確認搜尋 Widget 可正常使用
- [ ] 確認各服務連結正確指向對應容器

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)