### PR TITLE
feat(T09): 資料庫與儲存規劃

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,15 +8,21 @@
 # ⚠️  .env 絕對不可提交至版本控制（已加入 .gitignore）
 # ═══════════════════════════════════════════════════════════
 
-# ── PostgreSQL ───────────────────────────────────────────────
+# ── PostgreSQL 16 ───────────────────────────────────────────
+# 版本固定：postgres:16-alpine（隔離網路相容）
 POSTGRES_USER=titan
 # 必填：請設定強密碼（至少 16 字元，含大小寫英文、數字、符號）
 POSTGRES_PASSWORD=changeme_strong_password_here
 POSTGRES_DB=titan
 # 主機埠（預設 5432，若與本機衝突可修改）
 POSTGRES_PORT=5432
+# 應用程式專用帳號（用於服務連線，非超級使用者）
+POSTGRES_APP_USER=titan_app
+# 必填：請設定強密碼
+POSTGRES_APP_PASSWORD=changeme_app_password_here
 
-# ── Redis ────────────────────────────────────────────────────
+# ── Redis 7 ─────────────────────────────────────────────────
+# 版本固定：redis:7-alpine
 # 必填：Redis 認證密碼
 REDIS_PASSWORD=changeme_redis_password_here
 # 主機埠（預設 6379）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # TITAN 容器平台 — 生產就緒版本
-# 任務: T07 — Container Platform Setup
+# 任務: T07 — Container Platform Setup / T09 — 資料庫與儲存規劃
 # 所有映像版本均固定，適用於隔離網路（air-gapped）部署
 # 若需更新版本，請同步更新 .env.example 中的備註
 
@@ -10,10 +10,11 @@ version: '3.8'
 # ═══════════════════════════════════════════════════════════
 services:
 
-  # ── 資料層：PostgreSQL 15 ────────────────────────────────
+  # ── 資料層：PostgreSQL 16 ────────────────────────────────
   # 共用資料庫，供 Outline 及未來服務使用
+  # 版本固定：postgres:16-alpine（隔離網路相容）
   postgres:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     container_name: titan-postgres
     restart: unless-stopped
     environment:
@@ -22,6 +23,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-titan}
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./scripts/init:/docker-entrypoint-initdb.d:ro
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     networks:

--- a/scripts/init/01-postgres-init.sql
+++ b/scripts/init/01-postgres-init.sql
@@ -1,0 +1,54 @@
+-- ═══════════════════════════════════════════════════════════
+-- PostgreSQL 初始化腳本
+-- 任務: T09 — 資料庫與儲存規劃
+-- 用途：建立共用資料庫使用者、擴展、功能
+-- ═══════════════════════════════════════════════════════════
+
+-- 建立應用程式專用使用者（非超級使用者）
+-- 注意：實際建立使用者時，請確保使用強密碼
+DO $$
+BEGIN
+    -- 檢查是否已存在應用程式使用者
+    IF NOT EXISTS (
+        SELECT FROM pg_catalog.pg_roles
+        WHERE  rolname = '${POSTGRES_APP_USER:-titan_app}'
+    ) THEN
+        CREATE ROLE ${POSTGRES_APP_USER:-titan_app} WITH LOGIN PASSWORD '${POSTGRES_APP_PASSWORD:-}';
+        GRANT CONNECT ON DATABASE ${POSTGRES_DB:-titan} TO ${POSTGRES_APP_USER:-titan_app};
+        GRANT USAGE ON SCHEMA public TO ${POSTGRES_APP_USER:-titan_app};
+        GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${POSTGRES_APP_USER:-titan_app};
+        ALTER ROLE ${POSTGRES_APP_USER:-titan_app} SET search_path TO public;
+        RAISE NOTICE 'Created user: titan_app';
+    ELSE
+        RAISE NOTICE 'User titan_app already exists';
+    END IF;
+END
+$$;
+
+-- 啟用必要的 PostgreSQL 擴展（視需求啟用）
+-- 範例：啟用 UUID 產生器
+-- CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- 範例：啟用 pg_trgm（全文檢索支援）
+-- CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+-- 預設表格結構（預留給未來服務使用）
+-- CREATE TABLE IF NOT EXISTS public.service_registry (
+--     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+--     service_name VARCHAR(100) NOT NULL UNIQUE,
+--     service_type VARCHAR(50) NOT NULL,
+--     endpoint VARCHAR(255),
+--     status VARCHAR(20) DEFAULT 'active',
+--     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+--     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+-- );
+
+-- 建立通用序列（供未來 ID 使用）
+-- CREATE SEQUENCE IF NOT EXISTS public.global_id_seq;
+
+-- 記錄初始化完成
+DO $$
+BEGIN
+    RAISE NOTICE 'PostgreSQL initialization completed at %', NOW();
+END
+$$;

--- a/scripts/init/02-redis-init.sh
+++ b/scripts/init/02-redis-init.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════
+# Redis 初始化腳本
+# 任務: T09 — 資料庫與儲存規劃
+# 用途：設定 Redis 監控鍵、健康檢查、效能調校
+# ═══════════════════════════════════════════════════════════
+
+set -e
+
+# 等待 Redis 啟動
+echo "Waiting for Redis to be ready..."
+sleep 5
+
+# Redis CLI 命令
+REDIS-cli() {
+    redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning "$@"
+}
+
+echo "Starting Redis initialization..."
+
+# 設定 Redis 監控鍵（可用於 健康檢查）
+REDIS-cli SET "titan:health:initialized" "true" EX 86400
+REDIS-cli SET "titan:health:last_init" "$(date -Iseconds)" EX 86400
+
+# 設定 keyspace 事件通知（用於監控 key 過期、刪除等）
+# 注意：notify-keyspace-events 會消耗效能，生產環境請謹慎使用
+# REDIS-cli CONFIG SET notify-keyspace-events "Ex"
+
+# 設定記憶體策略（LRU - Least Recently Used）
+REDIS-cli CONFIG SET maxmemory-policy allkeys-lru
+
+# 設定 slow log（記錄超過 10ms 的命令）
+REDIS-cli CONFIG SET slowlog-log-slower-than 10000
+REDIS-cli CONFIG SET slowlog-max-len 128
+
+# 設定 clients timeout（防止閒置連線）
+REDIS-cli CONFIG SET timeout 300
+REDIS-cli CONFIG SET tcp-keepalive 60
+
+# 建立應用程式專用 key prefix（用於區分不同服務）
+# Outline 使用: titan:outline:*
+# 預留給 future: titan:app:*
+
+# 驗證設定
+echo "Redis configuration:"
+REDIS-cli INFO server | grep redis_version
+REDIS-cli INFO memory | grep used_memory_human
+
+echo "Redis initialization completed successfully!"
+echo "$(date -Iseconds) - Redis init done" >> /tmp/redis-init.log

--- a/scripts/init/03-minio-init.sh
+++ b/scripts/init/03-minio-init.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════
+# MinIO 初始化腳本
+# 任務: T09 — 資料庫與儲存規劃
+# 用途：建立 S3 bucket、設置生命週期策略、存取權限
+# ═══════════════════════════════════════════════════════════
+
+set -e
+
+# MinIO 配置
+MINIO_ENDPOINT="minio:9000"
+MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD}"
+MC="/usr/bin/mc"
+
+# 等待 MinIO 啟動
+echo "Waiting for MinIO to be ready..."
+until ${MC} alias list minio &>/dev/null; do
+    sleep 2
+done
+
+echo "MinIO is ready!"
+
+# 設定 MinIO CLI alias
+${MC} alias set minio http://${MINIO_ENDPOINT} ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD}
+
+# ═══════════════════════════════════════════════════════════
+# 建立 Bucket（依賴環境變數）
+# ═══════════════════════════════════════════════════════════
+
+# Outline bucket（如果未指定，預設為 outline）
+OUTLINE_BUCKET="${OUTLINE_S3_BUCKET:-outline}"
+if [ ! -z "${OUTLINE_BUCKET}" ]; then
+    echo "Creating bucket: ${OUTLINE_BUCKET}"
+    ${MC} mb minio/${OUTLINE_BUCKET} --ignore-existing
+    
+    # 設定 bucket 為 private（預設）
+    ${MC} anonymous set private minio/${OUTLINE_BUCKET}
+    
+    # 設定生命週期（可選）- 30 天後刪除未使用的物件
+    # ${MC} lifecycle add minio/${OUTLINE_BUCKET} /config/lifecycle.json
+    
+    echo "Bucket ${OUTLINE_BUCKET} ready!"
+fi
+
+# 預留 bucket（未來服務使用）
+# BACKUP_BUCKET="titan-backup"
+# ${MC} mb minio/${BACKUP_BUCKET} --ignore-existing
+
+# ═══════════════════════════════════════════════════════════
+# 設定 CORS（允許瀏覽器存取）
+# ═══════════════════════════════════════════════════════════
+# 注意：生產環境請設定正確的 CORS 規則
+# ${MC} cors apply minio/${OUTLINE_BUCKET} /config/cors.json
+
+# ═══════════════════════════════════════════════════════════
+# 設定存取策略（預設為 restricted）
+# ═══════════════════════════════════════════════════════════
+# 允許特定使用者存取（透過 policy）
+
+# 驗證 bucket 列表
+echo "Current buckets:"
+${MC} ls minio/
+
+# 測試上傳
+echo "Testing write access..."
+echo "test" | ${MC} pipe minio/${OUTLINE_BUCKET}/.healthcheck
+${MC} rm minio/${OUTLINE_BUCKET}/.healthcheck
+
+echo "MinIO initialization completed successfully!"
+echo "$(date -Iseconds) - MinIO init done" >> /tmp/minio-init.log


### PR DESCRIPTION
## 摘要
- 將 PostgreSQL 版本鎖定更新為 `postgres:16-alpine`
- 補齊 PostgreSQL / Redis 資料庫相關環境變數範本
- 新增初始化腳本目錄，提供 PostgreSQL、Redis、MinIO 初始化腳本
- 保留並延續既有 health check 配置

## 變更內容
- `docker-compose.yml`
  - PostgreSQL 升級為 `postgres:16-alpine`
  - 掛載 `./scripts/init` 至 `/docker-entrypoint-initdb.d`
- `.env.example`
  - 新增 `POSTGRES_APP_USER`、`POSTGRES_APP_PASSWORD`
  - 補充 PostgreSQL / Redis 版本鎖定註記
- `scripts/init/01-postgres-init.sql`
  - PostgreSQL 初始化 SQL
- `scripts/init/02-redis-init.sh`
  - Redis 初始化腳本
- `scripts/init/03-minio-init.sh`
  - MinIO bucket 初始化腳本

## 注意事項
- PostgreSQL 官方 entrypoint 只會自動執行 `/docker-entrypoint-initdb.d` 中的 `.sql` / `.sql.gz` / `.sh`；目前已正確掛載給 PostgreSQL。
- Redis / MinIO 初始化腳本已一併納入版本控制，後續若要自動執行，需在對應服務加入 bootstrap/init job。

## 驗收建議
1. `cp .env.example .env` 並填入密碼
2. `docker compose up -d`
3. `docker compose ps` 確認 health check 為 healthy
4. 檢查 PostgreSQL 是否執行初始化 SQL
