### PR TITLE
feat(T09): database and storage planning

### DIFF
--- a/docs/database-plan.md
+++ b/docs/database-plan.md
@@ -1,0 +1,347 @@
+# TITAN 資料庫與儲存規劃
+
+> 任務：T09 — 資料庫與儲存規劃
+> 對應 Issue：[#11](https://github.com/cct08311github/titan/issues/11)
+> 適用環境：銀行 IT 部門封閉網路（Air-Gapped）5 人團隊
+> 最後更新：2026-03
+
+---
+
+## 目錄
+
+1. [PostgreSQL 架構策略](#1-postgresql-架構策略)
+2. [資料庫命名規範](#2-資料庫命名規範)
+3. [使用者與角色設定](#3-使用者與角色設定)
+4. [連線池考量](#4-連線池考量)
+5. [儲存容量估算](#5-儲存容量估算)
+6. [Redis Keyspace 分區](#6-redis-keyspace-分區)
+7. [MinIO Bucket 組織](#7-minio-bucket-組織)
+8. [資料保留政策](#8-資料保留政策)
+
+---
+
+## 1. PostgreSQL 架構策略
+
+### 決策：共用 PostgreSQL 實例，獨立資料庫
+
+TITAN 採用**單一 PostgreSQL 容器 + 多個獨立資料庫**的架構，而非每個服務各自部署獨立 PostgreSQL 實例。
+
+```
+titan-postgres (PostgreSQL 16)
+├── outline_db      ← Outline 知識庫
+├── plane_db        ← Plane 專案管理
+└── titan_admin_db  ← 未來管理功能預留
+```
+
+### 選擇理由
+
+| 考量 | 共用實例 + 獨立 DB | 獨立實例（每服務） |
+|------|-------------------|------------------|
+| 資源消耗 | 低（共用記憶體/程序） | 高（各自佔用資源） |
+| 維護複雜度 | 低（單一備份點） | 高（多份備份流程） |
+| 服務隔離 | 資料庫層隔離（足夠） | 完全隔離 |
+| 5 人團隊適用 | ✅ 適合 | ❌ 過度設計 |
+| 硬體需求 | 低 | 高 |
+
+### 各服務資料庫對應
+
+| 服務 | 資料庫名稱 | 說明 |
+|------|-----------|------|
+| Outline | `outline_db` | 知識庫文件、使用者、權限 |
+| Plane | `plane_db` | 專案、Issue、Sprint、成員 |
+| 未來擴充 | `titan_admin_db` | 管理儀表板、審計日誌（預留） |
+
+---
+
+## 2. 資料庫命名規範
+
+### 資料庫命名
+
+格式：`{服務名稱}_db`（全小寫，底線分隔）
+
+| 類型 | 範例 | 說明 |
+|------|------|------|
+| 服務資料庫 | `outline_db`、`plane_db` | 各服務主資料庫 |
+| 管理資料庫 | `titan_admin_db` | 平台管理用途 |
+
+### 使用者命名
+
+格式：`{服務名稱}_user`（全小寫，底線分隔）
+
+| 類型 | 範例 | 說明 |
+|------|------|------|
+| 服務帳號 | `outline_user`、`plane_user` | 各服務專用帳號 |
+| 唯讀帳號 | `outline_readonly`、`plane_readonly` | 報表/稽核查詢用 |
+| 管理帳號 | `titan_admin` | 超級管理員（限 DBA 使用） |
+
+### Schema 命名
+
+格式：`{模組名稱}` 或直接使用 `public`（視服務而定）
+
+- Outline：使用 `public` schema（Outline 預設）
+- Plane：使用 `public` schema（Plane 預設）
+- 未來自開發：建議建立獨立 schema，例如 `analytics`、`audit`
+
+---
+
+## 3. 使用者與角色設定
+
+### 最小權限原則
+
+每個服務帳號僅擁有其對應資料庫的必要權限，**不跨資料庫授權**。
+
+### 權限矩陣
+
+| 使用者 | 資料庫 | SELECT | INSERT | UPDATE | DELETE | CREATE | SUPERUSER |
+|--------|--------|--------|--------|--------|--------|--------|-----------|
+| `outline_user` | `outline_db` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `outline_readonly` | `outline_db` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `plane_user` | `plane_db` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `plane_readonly` | `plane_db` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `titan` (root) | ALL | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+> ⚠️ **安全注意事項**：`titan` 超級管理員帳號僅供初始化及緊急維護使用。日常應用應使用各服務專用帳號。
+
+### 帳號設定範本
+
+```sql
+-- Outline 服務帳號
+CREATE USER outline_user WITH
+    LOGIN
+    NOSUPERUSER
+    NOCREATEDB
+    NOCREATEROLE
+    NOREPLICATION
+    CONNECTION LIMIT 10
+    PASSWORD '<強密碼>';
+
+-- Plane 服務帳號
+CREATE USER plane_user WITH
+    LOGIN
+    NOSUPERUSER
+    NOCREATEDB
+    NOCREATEROLE
+    NOREPLICATION
+    CONNECTION LIMIT 10
+    PASSWORD '<強密碼>';
+```
+
+---
+
+## 4. 連線池考量
+
+### 現況配置（5 人團隊）
+
+```
+PostgreSQL max_connections = 100（預設）
+├── Outline: min=1, max=5（docker-compose.yml 已設定）
+├── Plane API: min=2, max=10（建議值）
+├── 管理工具連線: 5（DBA 手動連線）
+└── 預留緩衝: 80（充足空間）
+```
+
+### 各服務連線設定建議
+
+| 服務 | 最小連線 | 最大連線 | 說明 |
+|------|---------|---------|------|
+| Outline | 1 | 5 | 5 人團隊，低並發 |
+| Plane API | 2 | 10 | API 服務，中度並發 |
+| Plane Worker | 1 | 3 | 背景任務 |
+
+### PgBouncer 評估
+
+**目前規模（5 人）不需要 PgBouncer**。當符合以下任一條件時再考慮引入：
+
+- 同時在線人數超過 20 人
+- 連線數超過 PostgreSQL `max_connections` 的 60%
+- 出現連線等待 timeout 錯誤
+
+---
+
+## 5. 儲存容量估算
+
+### 假設條件
+
+- 團隊規模：5 人
+- 使用週期：1 年（約 250 個工作天）
+- 使用強度：中等（每人每天活躍操作）
+
+### PostgreSQL 資料量估算
+
+| 資料庫 | 估算基礎 | 1 年估算容量 |
+|--------|---------|------------|
+| `outline_db` | 每人每週新增 5 頁文件，每頁約 10KB | ~13MB |
+| `plane_db` | 每週建立 20 個 Issue，每筆 2KB | ~5MB |
+| 索引與 WAL overhead | 資料量 × 3 | ~54MB |
+| **小計** | | **~75MB** |
+
+> 實際容量含備份 WAL 日誌，建議預留 **5GB** 給 PostgreSQL Volume。
+
+### MinIO 物件儲存估算
+
+| Bucket | 內容類型 | 估算基礎 | 1 年估算容量 |
+|--------|---------|---------|------------|
+| `outline-attachments` | 圖片、PDF、Office 文件 | 每人每週上傳 5 個附件，平均 500KB | ~3.25GB |
+| `titan-backups` | PostgreSQL dump | 每日備份，約 100MB/份，保留 30 天 | ~3GB |
+| `titan-exports` | 資料匯出檔 | 每週 1 份，約 50MB | ~2.5GB |
+| **小計** | | | **~9GB** |
+
+> 建議預留 **20GB** 給 MinIO Volume（含安全餘裕 2×）。
+
+### Redis 記憶體估算
+
+| 用途 | 估算 |
+|------|------|
+| Outline Session + Cache | ~50MB |
+| Plane 任務佇列 + Cache | ~30MB |
+| 系統 overhead | ~20MB |
+| **建議 maxmemory** | **256MB** |
+
+### 整體 Volume 建議配置
+
+| Volume | 建議大小 | 說明 |
+|--------|---------|------|
+| `titan-postgres-data` | 5GB | 含 WAL 與備份空間 |
+| `titan-redis-data` | 1GB | 含 AOF 持久化 |
+| `titan-minio-data` | 20GB | 附件 + 備份 + 匯出 |
+| `titan-outline-data` | 2GB | 本地快取與臨時檔 |
+| **總計** | **28GB** | 建議主機留出 40GB 空間 |
+
+---
+
+## 6. Redis Keyspace 分區
+
+### 資料庫編號分配
+
+Redis 支援 16 個獨立邏輯資料庫（DB 0–15），TITAN 分配如下：
+
+| DB 編號 | 用途 | 服務 | Keyspace 前綴 |
+|---------|------|------|--------------|
+| DB 0 | Session + Cache | Outline | `outline:session:*`、`outline:cache:*` |
+| DB 1 | 任務佇列 + Cache | Plane | `plane:queue:*`、`plane:cache:*` |
+| DB 2 | 健康監控 | 系統 | `titan:health:*` |
+| DB 3–14 | 預留 | 未來服務 | — |
+| DB 15 | 測試/暫存 | 開發用 | `test:*` |
+
+### Keyspace 命名規範
+
+格式：`{服務}:{功能}:{識別子}`
+
+```
+outline:session:user_abc123      ← 使用者 Session
+outline:cache:doc_456            ← 文件快取
+plane:queue:email_789            ← Email 通知任務
+plane:cache:project_001          ← 專案資料快取
+titan:health:initialized         ← 系統健康狀態
+```
+
+### 連線設定範本
+
+```bash
+# Outline（連線至 DB 0）
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+
+# Plane（連線至 DB 1）
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/1
+```
+
+---
+
+## 7. MinIO Bucket 組織
+
+### Bucket 清單
+
+| Bucket 名稱 | 存取策略 | 用途 | 保留期限 |
+|------------|---------|------|---------|
+| `outline-attachments` | Private | Outline 文件附件（圖片、PDF 等） | 永久（依文件生命週期） |
+| `titan-backups` | Private | PostgreSQL 每日備份 dump | 30 天滾動保留 |
+| `titan-exports` | Private | 資料匯出（CSV、ZIP） | 90 天 |
+| `plane-uploads` | Private | Plane Issue 附件 | 永久（依 Issue 生命週期） |
+
+### 目錄結構慣例
+
+```
+outline-attachments/
+├── uploads/
+│   ├── avatars/          ← 使用者頭像
+│   └── documents/        ← 文件附件
+└── .healthcheck          ← 健康檢查用（自動建立/刪除）
+
+titan-backups/
+├── postgres/
+│   ├── YYYY-MM-DD/
+│   │   ├── outline_db.dump
+│   │   └── plane_db.dump
+└── minio/
+    └── YYYY-MM-DD/       ← MinIO metadata 備份
+
+titan-exports/
+└── YYYY-MM-DD/
+    └── {export_name}.zip
+
+plane-uploads/
+└── attachments/
+    └── {issue_id}/       ← 依 Issue 分資料夾
+```
+
+### Bucket 存取控制
+
+所有 Bucket 均設定為 **Private（拒絕匿名存取）**，應用程式透過 MinIO IAM Policy 存取：
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"AWS": ["arn:aws:iam:::user/outline-svc"]},
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": ["arn:aws:s3:::outline-attachments/*"]
+    }
+  ]
+}
+```
+
+---
+
+## 8. 資料保留政策
+
+### 各類資料保留期限
+
+| 資料類型 | 存放位置 | 保留期限 | 刪除方式 |
+|---------|---------|---------|---------|
+| PostgreSQL WAL | postgres-data | 7 天（`wal_keep_size`） | 自動清理 |
+| PostgreSQL 每日備份 | `titan-backups` | 30 天 | MinIO 生命週期規則 |
+| Redis Session | DB 0 | TTL 24 小時（Outline 預設） | 自動過期 |
+| Redis 任務佇列 | DB 1 | 完成後 7 天 | Celery 自動清理 |
+| MinIO 附件 | `outline-attachments`、`plane-uploads` | 永久（跟隨文件/Issue） | 手動或軟刪除 |
+| MinIO 匯出 | `titan-exports` | 90 天 | MinIO 生命週期規則 |
+| 應用程式日誌 | Docker stdout | 7 天（Docker log rotation） | Docker daemon 自動輪轉 |
+
+### Docker Log Rotation 建議設定
+
+在 `docker-compose.yml` 各服務加入：
+
+```yaml
+logging:
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "7"
+```
+
+### 備份排程建議
+
+```cron
+# 每日凌晨 2:00 備份 PostgreSQL
+0 2 * * * /opt/titan/scripts/backup-postgres.sh
+
+# 每週日凌晨 3:00 清理過期備份
+0 3 * * 0 /opt/titan/scripts/cleanup-backups.sh
+```
+
+> 詳細備份腳本規劃見後續 T10（維運與備份）任務。
+
+---
+
+*文件版本：v1.0 | 維護者：DevOps + Backend 團隊*

--- a/scripts/db-health-check.sh
+++ b/scripts/db-health-check.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN 資料服務健康檢查腳本
+# 任務：T09 — 資料庫與儲存規劃
+# 用途：檢查 PostgreSQL、Redis、MinIO 連線狀態與基本統計
+# 適用環境：銀行 IT 部門封閉網路（Air-Gapped）
+#
+# 使用方式：
+#   chmod +x scripts/db-health-check.sh
+#   ./scripts/db-health-check.sh           # 互動式彩色輸出
+#   ./scripts/db-health-check.sh --json    # JSON 格式輸出（適合監控整合）
+#   ./scripts/db-health-check.sh --quiet   # 僅顯示失敗項目
+#
+# 回傳碼：
+#   0 — 所有服務健康
+#   1 — 部分服務異常（詳見輸出）
+# =============================================================================
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 設定區
+# ---------------------------------------------------------------------------
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_ADMIN_USER="${POSTGRES_USER:-titan}"
+POSTGRES_ADMIN_PASSWORD="${POSTGRES_PASSWORD:-}"
+
+REDIS_HOST="${REDIS_HOST:-localhost}"
+REDIS_PORT="${REDIS_PORT:-6379}"
+REDIS_PASSWORD="${REDIS_PASSWORD:-}"
+
+MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://localhost:9000}"
+MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-}"
+MINIO_ALIAS="${MINIO_ALIAS:-titan}"
+
+# 檢查對象資料庫
+OUTLINE_DB="${OUTLINE_DB:-outline_db}"
+PLANE_DB="${PLANE_DB:-plane_db}"
+
+# 輸出模式
+OUTPUT_MODE="${1:-normal}"   # normal | --json | --quiet
+
+# ---------------------------------------------------------------------------
+# 顏色輸出
+# ---------------------------------------------------------------------------
+if [ "${OUTPUT_MODE}" = "--json" ]; then
+    # JSON 模式不使用顏色
+    RED='' GREEN='' YELLOW='' BLUE='' CYAN='' BOLD='' NC=''
+else
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+fi
+
+# ---------------------------------------------------------------------------
+# 全域狀態追蹤
+# ---------------------------------------------------------------------------
+declare -A CHECK_RESULTS   # check_name -> "PASS|FAIL|WARN|SKIP"
+declare -A CHECK_DETAILS   # check_name -> 詳細訊息
+OVERALL_STATUS="PASS"
+TIMESTAMP=$(date -Iseconds 2>/dev/null || date +"%Y-%m-%dT%H:%M:%S%z")
+
+# ---------------------------------------------------------------------------
+# 輸出工具
+# ---------------------------------------------------------------------------
+log_check_pass() {
+    local name="$1"
+    local detail="${2:-}"
+    CHECK_RESULTS["${name}"]="PASS"
+    CHECK_DETAILS["${name}"]="${detail}"
+    if [ "${OUTPUT_MODE}" != "--quiet" ] && [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo -e "  ${GREEN}[PASS]${NC} ${name}${detail:+: ${detail}}"
+    fi
+}
+
+log_check_fail() {
+    local name="$1"
+    local detail="${2:-}"
+    CHECK_RESULTS["${name}"]="FAIL"
+    CHECK_DETAILS["${name}"]="${detail}"
+    OVERALL_STATUS="FAIL"
+    if [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo -e "  ${RED}[FAIL]${NC} ${name}${detail:+: ${detail}}"
+    fi
+}
+
+log_check_warn() {
+    local name="$1"
+    local detail="${2:-}"
+    CHECK_RESULTS["${name}"]="WARN"
+    CHECK_DETAILS["${name}"]="${detail}"
+    if [ "${OVERALL_STATUS}" = "PASS" ]; then
+        OVERALL_STATUS="WARN"
+    fi
+    if [ "${OUTPUT_MODE}" != "--quiet" ] && [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo -e "  ${YELLOW}[WARN]${NC} ${name}${detail:+: ${detail}}"
+    fi
+}
+
+log_check_skip() {
+    local name="$1"
+    local detail="${2:-}"
+    CHECK_RESULTS["${name}"]="SKIP"
+    CHECK_DETAILS["${name}"]="${detail}"
+    if [ "${OUTPUT_MODE}" != "--quiet" ] && [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo -e "  ${BLUE}[SKIP]${NC} ${name}${detail:+: ${detail}}"
+    fi
+}
+
+log_section() {
+    if [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo -e "\n${CYAN}${BOLD}▶ $*${NC}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# PostgreSQL 健康檢查
+# ---------------------------------------------------------------------------
+check_postgres() {
+    log_section "PostgreSQL 健康檢查"
+
+    # 工具可用性
+    if ! command -v psql &>/dev/null || ! command -v pg_isready &>/dev/null; then
+        log_check_skip "postgres_tools" "psql/pg_isready 不在 PATH，略過 PostgreSQL 檢查"
+        return 0
+    fi
+
+    # 1. 連線測試
+    if PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" pg_isready \
+        -h "${POSTGRES_HOST}" \
+        -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -q 2>/dev/null; then
+        log_check_pass "postgres_connectivity" "${POSTGRES_HOST}:${POSTGRES_PORT}"
+    else
+        log_check_fail "postgres_connectivity" "無法連線至 ${POSTGRES_HOST}:${POSTGRES_PORT}"
+        return 1
+    fi
+
+    # 執行 psql 查詢的包裝函數
+    local psql_base="PGPASSWORD=${POSTGRES_ADMIN_PASSWORD} psql -h ${POSTGRES_HOST} -p ${POSTGRES_PORT} -U ${POSTGRES_ADMIN_USER} -tAq"
+
+    # 2. PostgreSQL 版本
+    local pg_version
+    pg_version=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -tAc "SELECT version();" 2>/dev/null | head -1 | cut -d' ' -f1-3) || true
+    if [ -n "${pg_version}" ]; then
+        log_check_pass "postgres_version" "${pg_version}"
+    else
+        log_check_warn "postgres_version" "無法取得版本資訊"
+    fi
+
+    # 3. 資料庫存在性
+    for db in "${OUTLINE_DB}" "${PLANE_DB}"; do
+        local db_exists
+        db_exists=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+            -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+            -U "${POSTGRES_ADMIN_USER}" \
+            -tAc "SELECT 1 FROM pg_database WHERE datname='${db}';" 2>/dev/null) || true
+        if [ "${db_exists}" = "1" ]; then
+            log_check_pass "postgres_db_${db}" "資料庫存在"
+        else
+            log_check_fail "postgres_db_${db}" "資料庫不存在（請執行 db-init.sh）"
+        fi
+    done
+
+    # 4. 連線統計
+    local active_conn
+    active_conn=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -tAc "SELECT count(*) FROM pg_stat_activity WHERE state='active';" 2>/dev/null) || active_conn="N/A"
+    local max_conn
+    max_conn=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -tAc "SHOW max_connections;" 2>/dev/null) || max_conn="N/A"
+    log_check_pass "postgres_connections" "活躍連線 ${active_conn} / 最大 ${max_conn}"
+
+    # 5. 資料庫大小
+    for db in "${OUTLINE_DB}" "${PLANE_DB}"; do
+        local db_size
+        db_size=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+            -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+            -U "${POSTGRES_ADMIN_USER}" \
+            -tAc "SELECT pg_size_pretty(pg_database_size('${db}'));" 2>/dev/null) || db_size="N/A"
+        log_check_pass "postgres_size_${db}" "${db_size}"
+    done
+
+    # 6. 長時間運行查詢偵測（超過 5 分鐘）
+    local long_queries
+    long_queries=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -tAc "SELECT count(*) FROM pg_stat_activity WHERE state='active' AND now() - query_start > interval '5 minutes';" 2>/dev/null) || long_queries="0"
+    if [ "${long_queries}" = "0" ] || [ "${long_queries}" = "" ]; then
+        log_check_pass "postgres_long_queries" "無長時間查詢"
+    else
+        log_check_warn "postgres_long_queries" "${long_queries} 個查詢超過 5 分鐘，請確認是否正常"
+    fi
+
+    # 7. 複製槽（replication slot）積壓偵測
+    local replication_lag
+    replication_lag=$(PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -tAc "SELECT count(*) FROM pg_replication_slots WHERE active = false;" 2>/dev/null) || replication_lag="0"
+    if [ "${replication_lag}" = "0" ] || [ "${replication_lag}" = "" ]; then
+        log_check_pass "postgres_replication" "無非活躍複製槽"
+    else
+        log_check_warn "postgres_replication" "${replication_lag} 個非活躍複製槽，可能導致 WAL 積壓"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Redis 健康檢查
+# ---------------------------------------------------------------------------
+check_redis() {
+    log_section "Redis 健康檢查"
+
+    # 工具可用性
+    if ! command -v redis-cli &>/dev/null; then
+        log_check_skip "redis_tools" "redis-cli 不在 PATH，略過 Redis 檢查"
+        return 0
+    fi
+
+    # Redis CLI 包裝函數
+    redis_cmd() {
+        if [ -n "${REDIS_PASSWORD}" ]; then
+            redis-cli -h "${REDIS_HOST}" -p "${REDIS_PORT}" -a "${REDIS_PASSWORD}" --no-auth-warning "$@" 2>/dev/null
+        else
+            redis-cli -h "${REDIS_HOST}" -p "${REDIS_PORT}" "$@" 2>/dev/null
+        fi
+    }
+
+    # 1. 連線測試（PING）
+    local ping_result
+    ping_result=$(redis_cmd PING 2>/dev/null) || ping_result=""
+    if [ "${ping_result}" = "PONG" ]; then
+        log_check_pass "redis_connectivity" "${REDIS_HOST}:${REDIS_PORT}"
+    else
+        log_check_fail "redis_connectivity" "PING 失敗（回應：${ping_result:-無回應}）"
+        return 1
+    fi
+
+    # 2. Redis 版本
+    local redis_version
+    redis_version=$(redis_cmd INFO server 2>/dev/null | grep "redis_version" | cut -d: -f2 | tr -d '[:space:]') || redis_version="N/A"
+    log_check_pass "redis_version" "Redis ${redis_version}"
+
+    # 3. 記憶體使用量
+    local used_memory
+    used_memory=$(redis_cmd INFO memory 2>/dev/null | grep "used_memory_human" | cut -d: -f2 | tr -d '[:space:]') || used_memory="N/A"
+    local max_memory
+    max_memory=$(redis_cmd INFO memory 2>/dev/null | grep "^maxmemory_human" | cut -d: -f2 | tr -d '[:space:]') || max_memory="N/A"
+    log_check_pass "redis_memory" "使用 ${used_memory}，上限 ${max_memory:-未設定}"
+
+    # 4. 連線數
+    local connected_clients
+    connected_clients=$(redis_cmd INFO clients 2>/dev/null | grep "connected_clients" | cut -d: -f2 | tr -d '[:space:]') || connected_clients="N/A"
+    log_check_pass "redis_clients" "目前連線數：${connected_clients}"
+
+    # 5. 各 DB Keyspace 狀態
+    local outline_keys plane_keys
+    outline_keys=$(redis_cmd -n 0 DBSIZE 2>/dev/null) || outline_keys="N/A"
+    plane_keys=$(redis_cmd -n 1 DBSIZE 2>/dev/null) || plane_keys="N/A"
+    log_check_pass "redis_keyspace_db0" "Outline (DB 0)：${outline_keys} 個 key"
+    log_check_pass "redis_keyspace_db1" "Plane (DB 1)：${plane_keys} 個 key"
+
+    # 6. 持久化狀態（RDB）
+    local rdb_last_save
+    rdb_last_save=$(redis_cmd LASTSAVE 2>/dev/null) || rdb_last_save="0"
+    if [ "${rdb_last_save}" != "0" ] && [ -n "${rdb_last_save}" ]; then
+        local save_age=$(( $(date +%s) - rdb_last_save ))
+        local save_hours=$(( save_age / 3600 ))
+        if [ "${save_hours}" -lt 24 ]; then
+            log_check_pass "redis_persistence" "上次 RDB 儲存：${save_hours} 小時前"
+        else
+            log_check_warn "redis_persistence" "上次 RDB 儲存距今 ${save_hours} 小時，請確認持久化設定"
+        fi
+    else
+        log_check_warn "redis_persistence" "無法取得 RDB 儲存時間"
+    fi
+
+    # 7. Slow Log 積壓
+    local slowlog_count
+    slowlog_count=$(redis_cmd SLOWLOG LEN 2>/dev/null) || slowlog_count="0"
+    if [ "${slowlog_count:-0}" -lt 10 ]; then
+        log_check_pass "redis_slowlog" "Slow Log 項目數：${slowlog_count}"
+    else
+        log_check_warn "redis_slowlog" "Slow Log 積壓 ${slowlog_count} 條，可能有效能問題"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# MinIO 健康檢查
+# ---------------------------------------------------------------------------
+check_minio() {
+    log_section "MinIO 健康檢查"
+
+    local minio_available=false
+
+    # 優先使用 mc（MinIO Client）
+    if command -v mc &>/dev/null; then
+        # 設定 mc 別名（若未設定）
+        mc alias set "${MINIO_ALIAS}" \
+            "${MINIO_ENDPOINT}" \
+            "${MINIO_ROOT_USER}" \
+            "${MINIO_ROOT_PASSWORD}" \
+            --api S3v4 >/dev/null 2>&1 || true
+
+        # 1. 連線測試
+        if mc admin info "${MINIO_ALIAS}" &>/dev/null 2>&1; then
+            log_check_pass "minio_connectivity" "${MINIO_ENDPOINT}"
+            minio_available=true
+        else
+            log_check_fail "minio_connectivity" "無法連線至 ${MINIO_ENDPOINT}（mc admin info 失敗）"
+        fi
+
+        if [ "${minio_available}" = "true" ]; then
+            # 2. 檢查各 Bucket 存在性
+            local buckets=("outline-attachments" "plane-uploads" "titan-backups" "titan-exports")
+            for bucket in "${buckets[@]}"; do
+                if mc ls "${MINIO_ALIAS}/${bucket}" &>/dev/null 2>&1; then
+                    local bucket_size
+                    bucket_size=$(mc du "${MINIO_ALIAS}/${bucket}" 2>/dev/null | awk '{print $1}') || bucket_size="N/A"
+                    log_check_pass "minio_bucket_${bucket}" "大小：${bucket_size}"
+                else
+                    log_check_fail "minio_bucket_${bucket}" "Bucket 不存在（請執行 db-init.sh）"
+                fi
+            done
+
+            # 3. 磁碟使用量
+            local disk_info
+            disk_info=$(mc admin info "${MINIO_ALIAS}" 2>/dev/null | grep -E "Used|Total" | head -2 | tr '\n' ' ') || disk_info="N/A"
+            log_check_pass "minio_disk" "${disk_info:-請至 MinIO Console 查看}"
+
+            # 4. 寫入測試
+            local write_test
+            write_test=$(echo "healthcheck-$(date +%s)" | mc pipe "${MINIO_ALIAS}/outline-attachments/.healthcheck" 2>/dev/null && \
+                mc rm "${MINIO_ALIAS}/outline-attachments/.healthcheck" 2>/dev/null && echo "ok") || write_test=""
+            if [ "${write_test}" = "ok" ]; then
+                log_check_pass "minio_write_test" "讀寫測試通過"
+            else
+                log_check_warn "minio_write_test" "讀寫測試失敗，請手動確認"
+            fi
+        fi
+
+    elif command -v curl &>/dev/null; then
+        # 降級：使用 curl 測試 MinIO Health Endpoint
+        local health_endpoint="${MINIO_ENDPOINT}/minio/health/live"
+        local http_code
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "${health_endpoint}" 2>/dev/null) || http_code="000"
+        if [ "${http_code}" = "200" ]; then
+            log_check_pass "minio_connectivity" "${MINIO_ENDPOINT} (HTTP ${http_code})"
+        else
+            log_check_fail "minio_connectivity" "Health endpoint 回傳 HTTP ${http_code}（端點：${health_endpoint}）"
+        fi
+        log_check_skip "minio_buckets" "mc 不可用，略過 Bucket 詳細檢查"
+    else
+        log_check_skip "minio_all" "mc 與 curl 均不在 PATH，略過 MinIO 檢查"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 輸出健康報告
+# ---------------------------------------------------------------------------
+print_report_text() {
+    local pass_count=0
+    local fail_count=0
+    local warn_count=0
+    local skip_count=0
+
+    for key in "${!CHECK_RESULTS[@]}"; do
+        case "${CHECK_RESULTS[$key]}" in
+            PASS) pass_count=$((pass_count + 1)) ;;
+            FAIL) fail_count=$((fail_count + 1)) ;;
+            WARN) warn_count=$((warn_count + 1)) ;;
+            SKIP) skip_count=$((skip_count + 1)) ;;
+        esac
+    done
+
+    echo ""
+    echo -e "${BOLD}══════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}  TITAN 資料服務健康報告${NC}"
+    echo -e "${BOLD}══════════════════════════════════════════════════════${NC}"
+    echo "  檢查時間：${TIMESTAMP}"
+    echo ""
+
+    case "${OVERALL_STATUS}" in
+        PASS) echo -e "  整體狀態：${GREEN}${BOLD}HEALTHY${NC}" ;;
+        WARN) echo -e "  整體狀態：${YELLOW}${BOLD}DEGRADED${NC}（有警告項目）" ;;
+        FAIL) echo -e "  整體狀態：${RED}${BOLD}UNHEALTHY${NC}（有異常項目）" ;;
+    esac
+
+    echo ""
+    echo -e "  ${GREEN}通過：${pass_count}${NC}  ${RED}失敗：${fail_count}${NC}  ${YELLOW}警告：${warn_count}${NC}  ${BLUE}略過：${skip_count}${NC}"
+    echo ""
+
+    if [ "${fail_count}" -gt 0 ]; then
+        echo -e "${RED}失敗項目：${NC}"
+        for key in "${!CHECK_RESULTS[@]}"; do
+            if [ "${CHECK_RESULTS[$key]}" = "FAIL" ]; then
+                echo -e "  ${RED}✗${NC} ${key}: ${CHECK_DETAILS[$key]}"
+            fi
+        done
+        echo ""
+    fi
+
+    if [ "${warn_count}" -gt 0 ]; then
+        echo -e "${YELLOW}警告項目：${NC}"
+        for key in "${!CHECK_RESULTS[@]}"; do
+            if [ "${CHECK_RESULTS[$key]}" = "WARN" ]; then
+                echo -e "  ${YELLOW}!${NC} ${key}: ${CHECK_DETAILS[$key]}"
+            fi
+        done
+        echo ""
+    fi
+
+    echo -e "${BOLD}══════════════════════════════════════════════════════${NC}"
+}
+
+print_report_json() {
+    local checks_json=""
+    local first=true
+
+    for key in "${!CHECK_RESULTS[@]}"; do
+        if [ "${first}" = "true" ]; then
+            first=false
+        else
+            checks_json="${checks_json},"
+        fi
+        # 簡單 JSON 轉義
+        local detail="${CHECK_DETAILS[$key]//\"/\\\"}"
+        checks_json="${checks_json}\"${key}\":{\"status\":\"${CHECK_RESULTS[$key]}\",\"detail\":\"${detail}\"}"
+    done
+
+    echo "{"
+    echo "  \"timestamp\": \"${TIMESTAMP}\","
+    echo "  \"overall_status\": \"${OVERALL_STATUS}\","
+    echo "  \"checks\": {${checks_json}}"
+    echo "}"
+}
+
+# ---------------------------------------------------------------------------
+# 主流程
+# ---------------------------------------------------------------------------
+main() {
+    if [ "${OUTPUT_MODE}" != "--json" ]; then
+        echo ""
+        echo "══════════════════════════════════════════════════════"
+        echo "  TITAN — 資料服務健康檢查 (T09)"
+        echo "══════════════════════════════════════════════════════"
+        echo ""
+    fi
+
+    check_postgres
+    check_redis
+    check_minio
+
+    if [ "${OUTPUT_MODE}" = "--json" ]; then
+        print_report_json
+    else
+        print_report_text
+    fi
+
+    # 回傳碼
+    case "${OVERALL_STATUS}" in
+        PASS) exit 0 ;;
+        WARN) exit 0 ;;  # 警告不阻斷，僅記錄
+        FAIL) exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/scripts/db-init.sh
+++ b/scripts/db-init.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN 資料庫初始化腳本
+# 任務：T09 — 資料庫與儲存規劃
+# 用途：建立各服務資料庫、專用使用者（最小權限），以及 MinIO Bucket
+# 適用環境：銀行 IT 部門封閉網路（Air-Gapped）
+#
+# 使用方式：
+#   chmod +x scripts/db-init.sh
+#   ./scripts/db-init.sh
+#
+# 前置條件：
+#   - docker compose up -d postgres minio 已執行且服務健康
+#   - 環境變數已設定（參考 .env.example）
+#   - mc（MinIO Client）已安裝於 PATH
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 顏色輸出工具
+# ---------------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_ok()      { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_section() { echo -e "\n${CYAN}══════════════════════════════════════${NC}"; echo -e "${CYAN}  $*${NC}"; echo -e "${CYAN}══════════════════════════════════════${NC}"; }
+
+# ---------------------------------------------------------------------------
+# 設定區（從環境變數讀取，提供合理預設值）
+# ---------------------------------------------------------------------------
+
+# PostgreSQL 超級管理員
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_ADMIN_USER="${POSTGRES_USER:-titan}"
+POSTGRES_ADMIN_PASSWORD="${POSTGRES_PASSWORD:?錯誤：POSTGRES_PASSWORD 環境變數未設定}"
+
+# Outline 資料庫設定
+OUTLINE_DB="${OUTLINE_DB:-outline_db}"
+OUTLINE_DB_USER="${OUTLINE_DB_USER:-outline_user}"
+OUTLINE_DB_PASSWORD="${OUTLINE_DB_PASSWORD:?錯誤：OUTLINE_DB_PASSWORD 環境變數未設定}"
+OUTLINE_DB_READONLY_USER="${OUTLINE_DB_READONLY_USER:-outline_readonly}"
+OUTLINE_DB_READONLY_PASSWORD="${OUTLINE_DB_READONLY_PASSWORD:-}"
+
+# Plane 資料庫設定
+PLANE_DB="${PLANE_DB:-plane_db}"
+PLANE_DB_USER="${PLANE_DB_USER:-plane_user}"
+PLANE_DB_PASSWORD="${PLANE_DB_PASSWORD:?錯誤：PLANE_DB_PASSWORD 環境變數未設定}"
+PLANE_DB_READONLY_USER="${PLANE_DB_READONLY_USER:-plane_readonly}"
+PLANE_DB_READONLY_PASSWORD="${PLANE_DB_READONLY_PASSWORD:-}"
+
+# MinIO 設定
+MINIO_ALIAS="${MINIO_ALIAS:-titan}"
+MINIO_ENDPOINT="${MINIO_ENDPOINT:-http://localhost:9000}"
+MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:?錯誤：MINIO_ROOT_PASSWORD 環境變數未設定}"
+
+# Bucket 名稱
+BUCKET_OUTLINE="${BUCKET_OUTLINE:-outline-attachments}"
+BUCKET_PLANE="${BUCKET_PLANE:-plane-uploads}"
+BUCKET_BACKUPS="${BUCKET_BACKUPS:-titan-backups}"
+BUCKET_EXPORTS="${BUCKET_EXPORTS:-titan-exports}"
+
+# ---------------------------------------------------------------------------
+# 工具函數
+# ---------------------------------------------------------------------------
+
+# 執行 psql 指令（以管理員身份）
+psql_admin() {
+    PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" \
+        -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -v ON_ERROR_STOP=1 \
+        "$@"
+}
+
+# 執行 psql 指令至特定資料庫
+psql_db() {
+    local db="$1"
+    shift
+    PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" psql \
+        -h "${POSTGRES_HOST}" \
+        -p "${POSTGRES_PORT}" \
+        -U "${POSTGRES_ADMIN_USER}" \
+        -d "${db}" \
+        -v ON_ERROR_STOP=1 \
+        "$@"
+}
+
+# 執行 mc 指令
+mc_cmd() {
+    mc "$@"
+}
+
+# 等待 PostgreSQL 就緒
+wait_for_postgres() {
+    local retries=30
+    local wait_sec=2
+    log_info "等待 PostgreSQL 就緒（最多 $((retries * wait_sec)) 秒）..."
+    for i in $(seq 1 "${retries}"); do
+        if PGPASSWORD="${POSTGRES_ADMIN_PASSWORD}" pg_isready \
+            -h "${POSTGRES_HOST}" \
+            -p "${POSTGRES_PORT}" \
+            -U "${POSTGRES_ADMIN_USER}" \
+            -q 2>/dev/null; then
+            log_ok "PostgreSQL 已就緒"
+            return 0
+        fi
+        log_info "  等待中... (${i}/${retries})"
+        sleep "${wait_sec}"
+    done
+    log_error "PostgreSQL 在等待時間內未就緒，請檢查容器狀態"
+    return 1
+}
+
+# 等待 MinIO 就緒
+wait_for_minio() {
+    local retries=30
+    local wait_sec=2
+    log_info "等待 MinIO 就緒（最多 $((retries * wait_sec)) 秒）..."
+    for i in $(seq 1 "${retries}"); do
+        if mc_cmd alias list "${MINIO_ALIAS}" &>/dev/null 2>&1; then
+            log_ok "MinIO 已就緒"
+            return 0
+        fi
+        log_info "  等待中... (${i}/${retries})"
+        sleep "${wait_sec}"
+    done
+    log_error "MinIO 在等待時間內未就緒，請檢查容器狀態"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# 前置檢查
+# ---------------------------------------------------------------------------
+check_prerequisites() {
+    log_section "前置條件檢查"
+
+    local missing=0
+
+    # 檢查 psql
+    if ! command -v psql &>/dev/null; then
+        log_error "找不到 'psql' 指令，請安裝 postgresql-client"
+        missing=$((missing + 1))
+    else
+        log_ok "psql: $(psql --version)"
+    fi
+
+    # 檢查 pg_isready
+    if ! command -v pg_isready &>/dev/null; then
+        log_error "找不到 'pg_isready' 指令，請安裝 postgresql-client"
+        missing=$((missing + 1))
+    else
+        log_ok "pg_isready: 已找到"
+    fi
+
+    # 檢查 mc（MinIO Client）
+    if ! command -v mc &>/dev/null; then
+        log_warn "找不到 'mc'（MinIO Client），將略過 MinIO 初始化步驟"
+        SKIP_MINIO=true
+    else
+        log_ok "mc: $(mc --version 2>&1 | head -1)"
+        SKIP_MINIO=false
+    fi
+
+    if [ "${missing}" -gt 0 ]; then
+        log_error "缺少必要工具，請先安裝後再執行本腳本"
+        exit 1
+    fi
+
+    log_ok "前置條件檢查完成"
+}
+
+# ---------------------------------------------------------------------------
+# PostgreSQL：建立資料庫
+# ---------------------------------------------------------------------------
+create_databases() {
+    log_section "建立 PostgreSQL 資料庫"
+
+    # 建立 Outline 資料庫
+    if psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname='${OUTLINE_DB}'" | grep -q 1; then
+        log_warn "資料庫 '${OUTLINE_DB}' 已存在，略過建立"
+    else
+        psql_admin -c "CREATE DATABASE ${OUTLINE_DB}
+            WITH
+            OWNER = ${POSTGRES_ADMIN_USER}
+            ENCODING = 'UTF8'
+            LC_COLLATE = 'en_US.utf8'
+            LC_CTYPE = 'en_US.utf8'
+            TEMPLATE = template0
+            CONNECTION LIMIT = 50;"
+        log_ok "資料庫 '${OUTLINE_DB}' 建立成功"
+    fi
+
+    # 建立 Plane 資料庫
+    if psql_admin -tAc "SELECT 1 FROM pg_database WHERE datname='${PLANE_DB}'" | grep -q 1; then
+        log_warn "資料庫 '${PLANE_DB}' 已存在，略過建立"
+    else
+        psql_admin -c "CREATE DATABASE ${PLANE_DB}
+            WITH
+            OWNER = ${POSTGRES_ADMIN_USER}
+            ENCODING = 'UTF8'
+            LC_COLLATE = 'en_US.utf8'
+            LC_CTYPE = 'en_US.utf8'
+            TEMPLATE = template0
+            CONNECTION LIMIT = 50;"
+        log_ok "資料庫 '${PLANE_DB}' 建立成功"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# PostgreSQL：建立服務使用者（最小權限）
+# ---------------------------------------------------------------------------
+create_db_users() {
+    log_section "建立 PostgreSQL 服務使用者"
+
+    # ── Outline 服務帳號 ────────────────────────────────────────────────────
+    if psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname='${OUTLINE_DB_USER}'" | grep -q 1; then
+        log_warn "使用者 '${OUTLINE_DB_USER}' 已存在，更新密碼"
+        psql_admin -c "ALTER USER ${OUTLINE_DB_USER} WITH PASSWORD '${OUTLINE_DB_PASSWORD}';"
+    else
+        psql_admin -c "CREATE USER ${OUTLINE_DB_USER} WITH
+            LOGIN
+            NOSUPERUSER
+            NOCREATEDB
+            NOCREATEROLE
+            NOREPLICATION
+            CONNECTION LIMIT 10
+            PASSWORD '${OUTLINE_DB_PASSWORD}';"
+        log_ok "使用者 '${OUTLINE_DB_USER}' 建立成功"
+    fi
+
+    # 授予 Outline 服務帳號權限
+    psql_admin -c "GRANT CONNECT ON DATABASE ${OUTLINE_DB} TO ${OUTLINE_DB_USER};"
+    psql_db "${OUTLINE_DB}" -c "GRANT USAGE ON SCHEMA public TO ${OUTLINE_DB_USER};"
+    psql_db "${OUTLINE_DB}" -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${OUTLINE_DB_USER};"
+    psql_db "${OUTLINE_DB}" -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${OUTLINE_DB_USER};"
+    psql_db "${OUTLINE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${OUTLINE_DB_USER};"
+    psql_db "${OUTLINE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO ${OUTLINE_DB_USER};"
+    log_ok "Outline 服務帳號 '${OUTLINE_DB_USER}' 權限設定完成"
+
+    # ── Outline 唯讀帳號（選用）────────────────────────────────────────────
+    if [ -n "${OUTLINE_DB_READONLY_PASSWORD:-}" ]; then
+        if psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname='${OUTLINE_DB_READONLY_USER}'" | grep -q 1; then
+            log_warn "使用者 '${OUTLINE_DB_READONLY_USER}' 已存在，更新密碼"
+            psql_admin -c "ALTER USER ${OUTLINE_DB_READONLY_USER} WITH PASSWORD '${OUTLINE_DB_READONLY_PASSWORD}';"
+        else
+            psql_admin -c "CREATE USER ${OUTLINE_DB_READONLY_USER} WITH
+                LOGIN
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOREPLICATION
+                CONNECTION LIMIT 5
+                PASSWORD '${OUTLINE_DB_READONLY_PASSWORD}';"
+            log_ok "使用者 '${OUTLINE_DB_READONLY_USER}' 建立成功"
+        fi
+        psql_admin -c "GRANT CONNECT ON DATABASE ${OUTLINE_DB} TO ${OUTLINE_DB_READONLY_USER};"
+        psql_db "${OUTLINE_DB}" -c "GRANT USAGE ON SCHEMA public TO ${OUTLINE_DB_READONLY_USER};"
+        psql_db "${OUTLINE_DB}" -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${OUTLINE_DB_READONLY_USER};"
+        psql_db "${OUTLINE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${OUTLINE_DB_READONLY_USER};"
+        log_ok "Outline 唯讀帳號 '${OUTLINE_DB_READONLY_USER}' 權限設定完成"
+    else
+        log_warn "OUTLINE_DB_READONLY_PASSWORD 未設定，略過建立唯讀帳號"
+    fi
+
+    # ── Plane 服務帳號 ───────────────────────────────────────────────────────
+    if psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname='${PLANE_DB_USER}'" | grep -q 1; then
+        log_warn "使用者 '${PLANE_DB_USER}' 已存在，更新密碼"
+        psql_admin -c "ALTER USER ${PLANE_DB_USER} WITH PASSWORD '${PLANE_DB_PASSWORD}';"
+    else
+        psql_admin -c "CREATE USER ${PLANE_DB_USER} WITH
+            LOGIN
+            NOSUPERUSER
+            NOCREATEDB
+            NOCREATEROLE
+            NOREPLICATION
+            CONNECTION LIMIT 15
+            PASSWORD '${PLANE_DB_PASSWORD}';"
+        log_ok "使用者 '${PLANE_DB_USER}' 建立成功"
+    fi
+
+    # 授予 Plane 服務帳號權限
+    psql_admin -c "GRANT CONNECT ON DATABASE ${PLANE_DB} TO ${PLANE_DB_USER};"
+    psql_db "${PLANE_DB}" -c "GRANT USAGE ON SCHEMA public TO ${PLANE_DB_USER};"
+    psql_db "${PLANE_DB}" -c "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${PLANE_DB_USER};"
+    psql_db "${PLANE_DB}" -c "GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${PLANE_DB_USER};"
+    psql_db "${PLANE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${PLANE_DB_USER};"
+    psql_db "${PLANE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO ${PLANE_DB_USER};"
+    log_ok "Plane 服務帳號 '${PLANE_DB_USER}' 權限設定完成"
+
+    # ── Plane 唯讀帳號（選用）──────────────────────────────────────────────
+    if [ -n "${PLANE_DB_READONLY_PASSWORD:-}" ]; then
+        if psql_admin -tAc "SELECT 1 FROM pg_roles WHERE rolname='${PLANE_DB_READONLY_USER}'" | grep -q 1; then
+            log_warn "使用者 '${PLANE_DB_READONLY_USER}' 已存在，更新密碼"
+            psql_admin -c "ALTER USER ${PLANE_DB_READONLY_USER} WITH PASSWORD '${PLANE_DB_READONLY_PASSWORD}';"
+        else
+            psql_admin -c "CREATE USER ${PLANE_DB_READONLY_USER} WITH
+                LOGIN
+                NOSUPERUSER
+                NOCREATEDB
+                NOCREATEROLE
+                NOREPLICATION
+                CONNECTION LIMIT 5
+                PASSWORD '${PLANE_DB_READONLY_PASSWORD}';"
+            log_ok "使用者 '${PLANE_DB_READONLY_USER}' 建立成功"
+        fi
+        psql_admin -c "GRANT CONNECT ON DATABASE ${PLANE_DB} TO ${PLANE_DB_READONLY_USER};"
+        psql_db "${PLANE_DB}" -c "GRANT USAGE ON SCHEMA public TO ${PLANE_DB_READONLY_USER};"
+        psql_db "${PLANE_DB}" -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO ${PLANE_DB_READONLY_USER};"
+        psql_db "${PLANE_DB}" -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${PLANE_DB_READONLY_USER};"
+        log_ok "Plane 唯讀帳號 '${PLANE_DB_READONLY_USER}' 權限設定完成"
+    else
+        log_warn "PLANE_DB_READONLY_PASSWORD 未設定，略過建立唯讀帳號"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# PostgreSQL：啟用必要擴展
+# ---------------------------------------------------------------------------
+setup_extensions() {
+    log_section "設定 PostgreSQL 擴展"
+
+    for db in "${OUTLINE_DB}" "${PLANE_DB}"; do
+        log_info "在 '${db}' 啟用擴展..."
+        psql_db "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";" && \
+            log_ok "  ${db}: uuid-ossp 已啟用"
+        psql_db "${db}" -c "CREATE EXTENSION IF NOT EXISTS \"pg_trgm\";" && \
+            log_ok "  ${db}: pg_trgm 已啟用"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# MinIO：設定別名並建立 Bucket
+# ---------------------------------------------------------------------------
+setup_minio() {
+    log_section "設定 MinIO 物件儲存"
+
+    if [ "${SKIP_MINIO:-false}" = "true" ]; then
+        log_warn "略過 MinIO 初始化（mc 指令不可用）"
+        return 0
+    fi
+
+    # 設定 mc 別名
+    log_info "設定 MinIO Client 別名 '${MINIO_ALIAS}'..."
+    mc_cmd alias set "${MINIO_ALIAS}" \
+        "${MINIO_ENDPOINT}" \
+        "${MINIO_ROOT_USER}" \
+        "${MINIO_ROOT_PASSWORD}" \
+        --api S3v4 2>&1
+
+    # 等待 MinIO 就緒
+    wait_for_minio
+
+    # 建立各 Bucket
+    local buckets=(
+        "${BUCKET_OUTLINE}"
+        "${BUCKET_PLANE}"
+        "${BUCKET_BACKUPS}"
+        "${BUCKET_EXPORTS}"
+    )
+
+    for bucket in "${buckets[@]}"; do
+        if mc_cmd ls "${MINIO_ALIAS}/${bucket}" &>/dev/null 2>&1; then
+            log_warn "Bucket '${bucket}' 已存在，略過建立"
+        else
+            mc_cmd mb "${MINIO_ALIAS}/${bucket}"
+            log_ok "Bucket '${bucket}' 建立成功"
+        fi
+
+        # 設定所有 Bucket 為私有（拒絕匿名存取）
+        mc_cmd anonymous set none "${MINIO_ALIAS}/${bucket}" 2>/dev/null || \
+        mc_cmd anonymous set private "${MINIO_ALIAS}/${bucket}" 2>/dev/null || \
+        log_warn "  無法設定 '${bucket}' 存取策略（mc 版本差異），請手動確認"
+        log_ok "  '${bucket}' 存取策略：Private"
+    done
+
+    # 設定 titan-backups 生命週期：30 天後刪除
+    log_info "設定 '${BUCKET_BACKUPS}' 生命週期規則（30 天）..."
+    mc_cmd ilm add --expiry-days 30 "${MINIO_ALIAS}/${BUCKET_BACKUPS}" 2>/dev/null && \
+        log_ok "  生命週期規則設定完成（30 天後刪除）" || \
+        log_warn "  生命週期規則設定失敗（可能需手動於 MinIO Console 設定）"
+
+    # 設定 titan-exports 生命週期：90 天後刪除
+    log_info "設定 '${BUCKET_EXPORTS}' 生命週期規則（90 天）..."
+    mc_cmd ilm add --expiry-days 90 "${MINIO_ALIAS}/${BUCKET_EXPORTS}" 2>/dev/null && \
+        log_ok "  生命週期規則設定完成（90 天後刪除）" || \
+        log_warn "  生命週期規則設定失敗（可能需手動於 MinIO Console 設定）"
+
+    # 測試寫入健康檢查檔
+    log_info "測試 MinIO 寫入能力..."
+    echo "healthcheck" | mc_cmd pipe "${MINIO_ALIAS}/${BUCKET_OUTLINE}/.healthcheck" && \
+        mc_cmd rm "${MINIO_ALIAS}/${BUCKET_OUTLINE}/.healthcheck" && \
+        log_ok "MinIO 讀寫測試通過" || \
+        log_warn "MinIO 讀寫測試失敗，請手動檢查"
+}
+
+# ---------------------------------------------------------------------------
+# 驗證：列出資料庫與 Bucket
+# ---------------------------------------------------------------------------
+verify_setup() {
+    log_section "驗證初始化結果"
+
+    log_info "PostgreSQL 資料庫清單："
+    psql_admin -c "\l ${OUTLINE_DB} ${PLANE_DB}" 2>/dev/null || \
+    psql_admin -tAc "SELECT datname FROM pg_database WHERE datname IN ('${OUTLINE_DB}', '${PLANE_DB}') ORDER BY datname;"
+
+    log_info "PostgreSQL 服務帳號清單："
+    psql_admin -tAc "SELECT rolname, rolcanlogin, rolconnlimit FROM pg_roles WHERE rolname IN ('${OUTLINE_DB_USER}', '${PLANE_DB_USER}', '${OUTLINE_DB_READONLY_USER}', '${PLANE_DB_READONLY_USER}') ORDER BY rolname;"
+
+    if [ "${SKIP_MINIO:-false}" = "false" ]; then
+        log_info "MinIO Bucket 清單："
+        mc_cmd ls "${MINIO_ALIAS}/" 2>/dev/null || log_warn "無法列出 MinIO Bucket"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 列印後續步驟
+# ---------------------------------------------------------------------------
+print_next_steps() {
+    log_section "初始化完成"
+
+    echo ""
+    echo "  後續設定步驟："
+    echo ""
+    echo "  1. 設定 Outline 連線字串（config/outline.env）："
+    echo "     DATABASE_URL=postgres://${OUTLINE_DB_USER}:<密碼>@postgres:5432/${OUTLINE_DB}"
+    echo ""
+    echo "  2. 設定 Plane 連線字串（config/plane/.env）："
+    echo "     DATABASE_URL=postgresql://${PLANE_DB_USER}:<密碼>@postgres:5432/${PLANE_DB}"
+    echo "     REDIS_URL=redis://:<密碼>@redis:6379/1"
+    echo ""
+    echo "  3. 啟動應用服務："
+    echo "     docker compose up -d outline"
+    echo "     docker compose -f plane-docker-compose.yml up -d"
+    echo ""
+    echo "  4. 執行 Outline 資料庫 Migration："
+    echo "     docker compose exec outline yarn db:migrate"
+    echo ""
+    echo "  5. 健康檢查："
+    echo "     ./scripts/db-health-check.sh"
+    echo ""
+    echo "  詳細規劃請參考：docs/database-plan.md"
+    echo ""
+}
+
+# ---------------------------------------------------------------------------
+# 主流程
+# ---------------------------------------------------------------------------
+main() {
+    echo ""
+    echo "══════════════════════════════════════════════════════"
+    echo "  TITAN — 資料庫與儲存初始化腳本 (T09)"
+    echo "══════════════════════════════════════════════════════"
+    echo ""
+
+    check_prerequisites
+    wait_for_postgres
+    create_databases
+    create_db_users
+    setup_extensions
+    setup_minio
+    verify_setup
+    print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- `docs/database-plan.md`：PostgreSQL 架構策略（共用實例/獨立 DB）、命名規範、使用者權限矩陣、連線池建議、儲存容量估算（5 人團隊 1 年）、Redis Keyspace 分區、MinIO Bucket 組織、資料保留政策
- `scripts/db-init.sh`：建立 outline_db、plane_db，各服務獨立帳號（最小權限），唯讀帳號，MinIO 4 個 Bucket 含生命週期規則
- `scripts/db-health-check.sh`：PostgreSQL/Redis/MinIO 連線測試與統計，支援 `--json` 輸出與 `--quiet` 模式，回傳碼 0/1 可整合監控系統

## Test plan

- [ ] `bash -n scripts/db-init.sh` 語法驗證通過
- [ ] `bash -n scripts/db-health-check.sh` 語法驗證通過
- [ ] 在含 PostgreSQL/Redis/MinIO 的環境執行 `db-init.sh` 確認建立結果
- [ ] 執行 `db-health-check.sh` 確認健康報告輸出正確
- [ ] 執行 `db-health-check.sh --json` 確認 JSON 格式正確
- [ ] 確認 `docs/database-plan.md` 與 `docker-compose.yml` 現有設定一致

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)