### PR TITLE
feat(T10): authentication and account integration design

### DIFF
--- a/config/auth/keycloak-realm-export.json
+++ b/config/auth/keycloak-realm-export.json
@@ -1,0 +1,349 @@
+{
+  "_comment": "Keycloak Realm 設定範本 — TITAN 平台 Phase 2 SSO 整合",
+  "_version": "1.0",
+  "_updated": "2026-03-23",
+  "_note": "請在匯入前替換所有 <PLACEHOLDER> 值，勿將此檔案含敏感資料提交至 Git",
+
+  "realm": "titan",
+  "displayName": "TITAN 銀行 IT 平台",
+  "displayNameHtml": "<strong>TITAN</strong> 銀行 IT 平台",
+  "enabled": true,
+  "sslRequired": "all",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": true,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 5,
+
+  "passwordPolicy": "length(12) and upperCase(1) and lowerCase(1) and digits(1) and specialChars(1) and notUsername and passwordHistory(5) and forceExpiredPasswordChange(90)",
+
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 28800,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "offlineSessionIdleTimeout": 2592000,
+
+  "roles": {
+    "realm": [
+      {
+        "name": "titan-admin",
+        "description": "TITAN 平台管理員 — 全部服務完整權限",
+        "composite": false
+      },
+      {
+        "name": "titan-manager",
+        "description": "TITAN 專案/文件管理者 — 可建立管理 Collection 與 Project",
+        "composite": false
+      },
+      {
+        "name": "titan-engineer",
+        "description": "TITAN 工程師 — 一般讀寫作業",
+        "composite": false
+      },
+      {
+        "name": "titan-readonly",
+        "description": "TITAN 唯讀觀察者 — 僅可瀏覽",
+        "composite": false
+      }
+    ]
+  },
+
+  "groups": [
+    {
+      "name": "IT-TITAN-Admin",
+      "realmRoles": ["titan-admin"]
+    },
+    {
+      "name": "IT-TITAN-Manager",
+      "realmRoles": ["titan-manager"]
+    },
+    {
+      "name": "IT-Developers",
+      "realmRoles": ["titan-engineer"]
+    },
+    {
+      "name": "IT-All",
+      "realmRoles": ["titan-readonly"]
+    }
+  ],
+
+  "clients": [
+    {
+      "clientId": "outline",
+      "name": "Outline 知識庫",
+      "description": "TITAN 知識庫服務（Outline）",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "<OUTLINE_OIDC_CLIENT_SECRET>",
+      "redirectUris": [
+        "https://<OUTLINE_DOMAIN>/auth/oidc.callback"
+      ],
+      "webOrigins": [
+        "https://<OUTLINE_DOMAIN>"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "https://<OUTLINE_DOMAIN>"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "clientId": "plane",
+      "name": "Plane 專案管理",
+      "description": "TITAN 專案管理服務（Plane）",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "<PLANE_OIDC_CLIENT_SECRET>",
+      "redirectUris": [
+        "https://<PLANE_DOMAIN>/auth/oidc/callback/"
+      ],
+      "webOrigins": [
+        "https://<PLANE_DOMAIN>"
+      ],
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "https://<PLANE_DOMAIN>"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "bank-ad",
+        "providerId": "ldap",
+        "config": {
+          "enabled": ["true"],
+          "priority": ["0"],
+          "editMode": ["READ_ONLY"],
+          "syncRegistrations": ["false"],
+          "vendor": ["ad"],
+          "usernameLDAPAttribute": ["sAMAccountName"],
+          "rdnLDAPAttribute": ["cn"],
+          "uuidLDAPAttribute": ["objectGUID"],
+          "userObjectClasses": ["person", "organizationalPerson", "user"],
+          "connectionUrl": ["ldaps://<AD_HOST>:636"],
+          "usersDn": ["OU=Users,DC=bank,DC=com"],
+          "authType": ["simple"],
+          "bindDn": ["CN=keycloak-svc,OU=ServiceAccounts,DC=bank,DC=com"],
+          "bindCredential": ["<AD_SERVICE_ACCOUNT_PASSWORD>"],
+          "searchScope": ["2"],
+          "useTruststoreSpi": ["ldapsOnly"],
+          "connectionPooling": ["true"],
+          "pagination": ["true"],
+          "fullSyncPeriod": ["86400"],
+          "changedSyncPeriod": ["3600"],
+          "importEnabled": ["true"],
+          "batchSizeForSync": ["1000"]
+        },
+        "mappers": [
+          {
+            "name": "username",
+            "providerId": "user-attribute-ldap-mapper",
+            "config": {
+              "ldap.attribute": ["sAMAccountName"],
+              "user.model.attribute": ["username"],
+              "always.read.value.from.ldap": ["false"],
+              "is.mandatory.in.ldap": ["true"]
+            }
+          },
+          {
+            "name": "email",
+            "providerId": "user-attribute-ldap-mapper",
+            "config": {
+              "ldap.attribute": ["mail"],
+              "user.model.attribute": ["email"],
+              "always.read.value.from.ldap": ["false"],
+              "is.mandatory.in.ldap": ["false"]
+            }
+          },
+          {
+            "name": "first name",
+            "providerId": "user-attribute-ldap-mapper",
+            "config": {
+              "ldap.attribute": ["givenName"],
+              "user.model.attribute": ["firstName"],
+              "always.read.value.from.ldap": ["true"],
+              "is.mandatory.in.ldap": ["false"]
+            }
+          },
+          {
+            "name": "last name",
+            "providerId": "user-attribute-ldap-mapper",
+            "config": {
+              "ldap.attribute": ["sn"],
+              "user.model.attribute": ["lastName"],
+              "always.read.value.from.ldap": ["true"],
+              "is.mandatory.in.ldap": ["false"]
+            }
+          },
+          {
+            "name": "groups",
+            "providerId": "group-ldap-mapper",
+            "config": {
+              "mode": ["READ_ONLY"],
+              "membership.attribute.type": ["DN"],
+              "user.roles.retrieve.strategy": ["LOAD_GROUPS_BY_MEMBER_ATTRIBUTE"],
+              "group.name.ldap.attribute": ["cn"],
+              "membership.ldap.attribute": ["member"],
+              "preserve.group.inheritance": ["true"],
+              "groups.dn": ["OU=Groups,DC=bank,DC=com"],
+              "mapped.group.attributes": [""],
+              "drop.non.existing.groups.during.sync": ["false"],
+              "group.object.classes": ["group"],
+              "groups.path": ["/"]
+            }
+          }
+        ]
+      }
+    ]
+  },
+
+  "eventsEnabled": true,
+  "eventsExpiration": 7776000,
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR",
+    "REGISTER",
+    "REGISTER_ERROR",
+    "UPDATE_PASSWORD",
+    "UPDATE_PASSWORD_ERROR",
+    "RESET_PASSWORD",
+    "RESET_PASSWORD_ERROR",
+    "CLIENT_LOGIN",
+    "CLIENT_LOGIN_ERROR",
+    "CODE_TO_TOKEN",
+    "CODE_TO_TOKEN_ERROR",
+    "REFRESH_TOKEN",
+    "REFRESH_TOKEN_ERROR",
+    "TOKEN_EXCHANGE",
+    "INTROSPECT_TOKEN",
+    "FEDERATED_IDENTITY_LINK",
+    "REMOVE_FEDERATED_IDENTITY"
+  ],
+
+  "smtpServer": {
+    "_comment": "Phase 1 需要 SMTP 以發送邀請信，請填入銀行內部 SMTP relay 資訊",
+    "host": "<SMTP_HOST>",
+    "port": "587",
+    "from": "titan-noreply@bank.com",
+    "fromDisplayName": "TITAN 平台",
+    "starttls": "true",
+    "auth": "true",
+    "user": "<SMTP_USER>",
+    "password": "<SMTP_PASSWORD>"
+  },
+
+  "loginTheme": "keycloak",
+  "accountTheme": "keycloak",
+  "adminTheme": "keycloak",
+  "emailTheme": "keycloak",
+
+  "internationalizationEnabled": true,
+  "supportedLocales": ["zh-TW", "en"],
+  "defaultLocale": "zh-TW"
+}

--- a/config/auth/roles.yaml
+++ b/config/auth/roles.yaml
@@ -1,0 +1,233 @@
+# TITAN 平台 RBAC 角色定義
+# 文件版本：v1.0
+# 更新日期：2026-03-23
+# 說明：定義 TITAN 平台（Outline + Plane）的角色與權限矩陣
+#       Phase 1 由管理員手動指派；Phase 2 由 Keycloak 群組對映自動指派
+
+---
+roles:
+
+  # ─────────────────────────────────────────────────────
+  # admin：平台管理員（全部權限）
+  # 適用：TITAN 維運人員，建議不超過 2 人
+  # ─────────────────────────────────────────────────────
+  - name: admin
+    display_name: 平台管理員
+    description: 擁有 TITAN 所有服務的完整管理權限，包括系統設定、帳號管理及稽核日誌查閱。
+    ad_group: IT-TITAN-Admin         # Phase 2：對應 AD 群組
+    keycloak_role: titan-admin        # Phase 2：Keycloak Realm Role
+
+    permissions:
+      outline:
+        collections:
+          - create
+          - read
+          - update
+          - delete
+          - manage_permissions
+        documents:
+          - create
+          - read
+          - update
+          - delete
+          - publish
+          - archive
+          - export
+        members:
+          - invite
+          - remove
+          - change_role
+        settings:
+          - manage_workspace
+          - manage_integrations
+          - view_audit_log
+
+      plane:
+        projects:
+          - create
+          - read
+          - update
+          - delete
+          - archive
+        issues:
+          - create
+          - read
+          - update
+          - delete
+          - assign
+          - change_status
+        cycles:
+          - create
+          - read
+          - update
+          - delete
+        modules:
+          - create
+          - read
+          - update
+          - delete
+        members:
+          - invite
+          - remove
+          - change_role
+        settings:
+          - manage_workspace
+          - manage_integrations
+          - view_activity_log
+
+  # ─────────────────────────────────────────────────────
+  # manager：專案/文件管理者
+  # 適用：部門主管、Tech Lead、Scrum Master
+  # ─────────────────────────────────────────────────────
+  - name: manager
+    display_name: 專案管理者
+    description: 可建立與管理 Collection / Project，負責任務指派與進度追蹤。無法變更系統層級設定。
+    ad_group: IT-TITAN-Manager
+    keycloak_role: titan-manager
+
+    permissions:
+      outline:
+        collections:
+          - create
+          - read
+          - update
+          - delete               # 僅自己建立的 Collection
+        documents:
+          - create
+          - read
+          - update
+          - delete               # 僅自己建立的文件
+          - publish
+          - export
+        members:
+          # manager 無法管理 workspace 層級成員，僅能邀請至自己的 Collection
+        settings: []             # 無系統設定權限
+
+      plane:
+        projects:
+          - create
+          - read
+          - update
+          - archive
+        issues:
+          - create
+          - read
+          - update
+          - delete               # 僅自己建立的 Issue
+          - assign
+          - change_status
+        cycles:
+          - create
+          - read
+          - update
+          - delete
+        modules:
+          - create
+          - read
+          - update
+          - delete
+        members:
+          - invite               # 僅 Project 層級
+          - remove               # 僅 Project 層級
+        settings: []             # 無 workspace 設定權限
+
+  # ─────────────────────────────────────────────────────
+  # engineer：工程師（一般成員）
+  # 適用：開發工程師、SA、DBA、測試人員
+  # ─────────────────────────────────────────────────────
+  - name: engineer
+    display_name: 工程師
+    description: 可在既有 Collection/Project 中建立與編輯文件/Issue，為日常作業主要角色。
+    ad_group: IT-Developers
+    keycloak_role: titan-engineer
+
+    permissions:
+      outline:
+        collections:
+          - read
+        documents:
+          - create
+          - read
+          - update
+          - delete               # 僅自己建立的文件
+          - export
+        members: []
+        settings: []
+
+      plane:
+        projects:
+          - read
+        issues:
+          - create
+          - read
+          - update
+          - delete               # 僅自己建立的 Issue
+          - change_status        # 僅自己負責的 Issue
+        cycles:
+          - read
+        modules:
+          - read
+        members: []
+        settings: []
+
+  # ─────────────────────────────────────────────────────
+  # readonly：唯讀觀察者
+  # 適用：稽核人員、資安稽核、其他部門觀察者
+  # ─────────────────────────────────────────────────────
+  - name: readonly
+    display_name: 唯讀觀察者
+    description: 僅可瀏覽 TITAN 各服務內容，不可建立、修改或刪除任何資料。
+    ad_group: IT-All
+    keycloak_role: titan-readonly
+
+    permissions:
+      outline:
+        collections:
+          - read
+        documents:
+          - read
+          - export
+        members: []
+        settings: []
+
+      plane:
+        projects:
+          - read
+        issues:
+          - read
+        cycles:
+          - read
+        modules:
+          - read
+        members: []
+        settings: []
+
+# ─────────────────────────────────────────────────────
+# 角色對映摘要（供快速參考）
+# ─────────────────────────────────────────────────────
+role_mapping:
+  # Phase 1：本地帳號指派（手動）
+  phase1:
+    outline_roles:
+      admin:    admin
+      manager:  member        # Outline 沒有 manager 角色，用 member + Collection owner 實現
+      engineer: member
+      readonly: viewer
+    plane_roles:
+      admin:    owner
+      manager:  admin         # Plane Project-level admin
+      engineer: member
+      readonly: viewer
+
+  # Phase 2：Keycloak 群組對映（自動）
+  phase2:
+    keycloak_to_outline:
+      titan-admin:    admin
+      titan-manager:  member
+      titan-engineer: member
+      titan-readonly: viewer
+    keycloak_to_plane:
+      titan-admin:    owner
+      titan-manager:  admin
+      titan-engineer: member
+      titan-readonly: viewer

--- a/docs/auth-design.md
+++ b/docs/auth-design.md
@@ -1,0 +1,317 @@
+# TITAN 認證與帳號整合設計
+
+**文件版本：** v1.0
+**建立日期：** 2026-03-23
+**適用對象：** 銀行 IT 團隊（TITAN 平台管理員、資安人員）
+**相關 Issue：** #12
+
+---
+
+## 目錄
+
+1. [整體策略](#整體策略)
+2. [Phase 1：本地認證（MVP）](#phase-1本地認證mvp)
+3. [Phase 2：OIDC/SSO 整合（後 MVP）](#phase-2oidcsso-整合後-mvp)
+4. [RBAC 角色模型](#rbac-角色模型)
+5. [銀行環境安全考量](#銀行環境安全考量)
+6. [實作時程建議](#實作時程建議)
+
+---
+
+## 整體策略
+
+TITAN 平台採用**兩階段認證演進策略**：
+
+- **Phase 1（MVP）**：各服務使用內建本地帳號體系，快速上線，無 AD 依賴。
+- **Phase 2（後 MVP）**：引入 Keycloak 作為身份代理（Identity Broker），銜接銀行現有 AD/LDAP，統一 OIDC/SSO 登入。
+
+此設計原則：**先讓服務跑起來，再做身份整合；不因 SSO 延誤 MVP 上線。**
+
+---
+
+## Phase 1：本地認證（MVP）
+
+### 1.1 設計決策：共用帳號資料庫 vs 各服務獨立帳號
+
+| 面向 | 共用帳號資料庫 | 各服務獨立帳號（建議採用） |
+|------|--------------|--------------------------|
+| 複雜度 | 需額外中介層或自建 IdP | 直接使用各服務內建機制，複雜度低 |
+| MVP 速度 | 較慢，需額外開發 | **快速上線** |
+| 帳號同步 | 自動同步 | 需手動或腳本管理多份帳號 |
+| Phase 2 相容性 | 需整合遷移 | 直接切換至 Keycloak OIDC，舊帳號停用 |
+| 風險 | 單點故障風險較高 | 各服務獨立，故障隔離較佳 |
+
+**MVP 建議：各服務使用內建帳號體系，Phase 2 統一切換至 OIDC，Phase 1 帳號屆時停用。**
+
+### 1.2 各服務本地認證方式
+
+#### Outline（知識庫）
+
+- 內建支援 Email + 密碼登入
+- 初始化時建立管理員帳號（見 `scripts/auth-init.sh`）
+- 設定檔關鍵環境變數：
+
+```env
+# .env
+SECRET_KEY=<隨機產生，至少 32 字元>
+UTILS_SECRET=<隨機產生，至少 32 字元>
+# 允許本地 email 認證（Phase 1）
+ALLOWED_DOMAINS=
+# 停用 Google/Slack 等 OAuth（Phase 1 不需要）
+GOOGLE_CLIENT_ID=
+SLACK_KEY=
+```
+
+- 預設啟用電子郵件邀請：管理員在後台建立使用者 → 系統發送邀請信 → 使用者設定密碼
+
+#### Plane（專案管理）
+
+- 內建帳號系統，支援 Email + 密碼
+- 管理員透過後台 `/settings/members/` 邀請成員
+- 初始 superuser 由環境變數或 `manage.py createsuperuser` 建立
+
+```env
+# plane/.env
+SECRET_KEY=<隨機產生>
+WEB_URL=https://plane.internal.bank.com
+# Phase 1：停用外部 OAuth
+ENABLE_SIGNUP=0    # 停用公開自行註冊，改由管理員邀請
+```
+
+### 1.3 初始管理員建立流程
+
+詳見 `scripts/auth-init.sh`，流程摘要如下：
+
+1. **部署服務**：執行 `docker compose up -d`，等待健康檢查通過
+2. **Outline 管理員**：
+   - 呼叫 Outline API 建立第一位管理員
+   - 管理員收到邀請信，完成首次登入並設定密碼
+3. **Plane 管理員**：
+   - 進入 Plane 容器執行 `python manage.py createsuperuser`
+   - 或透過 Plane 設定頁面完成初始設定
+4. **記錄帳號**：將管理員清單記錄於內部 ITSM 系統（非 Git）
+
+---
+
+## Phase 2：OIDC/SSO 整合（後 MVP）
+
+### 2.1 架構概覽
+
+```
+使用者瀏覽器
+     │
+     ▼
+┌─────────────────────────────────────────┐
+│  Outline / Plane（OIDC Client）          │
+│  發起 Authorization Code Flow            │
+└────────────────┬────────────────────────┘
+                 │ OIDC redirect
+                 ▼
+┌─────────────────────────────────────────┐
+│  Keycloak（Identity Broker，自架）       │
+│  Realm: titan                            │
+│  - 管理 TITAN 應用程式客戶端設定         │
+│  - 連接銀行 AD/LDAP                     │
+│  - 群組對映（AD Group → App Role）       │
+└────────────────┬────────────────────────┘
+                 │ LDAP/Kerberos
+                 ▼
+┌─────────────────────────────────────────┐
+│  銀行 Active Directory / LDAP           │
+│  - 員工帳號主目錄                        │
+│  - 部門群組（IT、IM、Security…）         │
+└─────────────────────────────────────────┘
+```
+
+### 2.2 Keycloak 作為 Identity Broker
+
+**部署建議：**
+- 自架於銀行內網，不對外開放
+- 建議與 TITAN 服務同網段，透過 Docker Compose 或獨立 VM 部署
+- 版本：Keycloak 24.x（LTS）
+
+**Realm 設定：**
+- Realm 名稱：`titan`
+- 設定請參考 `config/auth/keycloak-realm-export.json`
+
+**LDAP User Federation 設定：**
+
+```
+Provider：Active Directory
+Connection URL：ldaps://ad.internal.bank.com:636
+Users DN：OU=Users,DC=bank,DC=com
+Bind DN：CN=keycloak-svc,OU=ServiceAccounts,DC=bank,DC=com
+Bind Credential：<服務帳號密碼，存放於 Vault>
+User Object Classes：person, organizationalPerson, user
+```
+
+### 2.3 Outline OIDC 設定
+
+```env
+# Outline OIDC（Phase 2）
+OIDC_CLIENT_ID=outline
+OIDC_CLIENT_SECRET=<Keycloak 產生>
+OIDC_AUTH_URI=https://keycloak.internal.bank.com/realms/titan/protocol/openid-connect/auth
+OIDC_TOKEN_URI=https://keycloak.internal.bank.com/realms/titan/protocol/openid-connect/token
+OIDC_USERINFO_URI=https://keycloak.internal.bank.com/realms/titan/protocol/openid-connect/userinfo
+OIDC_USERNAME_CLAIM=preferred_username
+OIDC_DISPLAY_NAME=銀行 SSO 登入
+OIDC_SCOPES=openid profile email
+```
+
+### 2.4 Plane OIDC 設定
+
+Plane 透過 `OIDC_PROVIDERS` 設定或 Django Allauth OIDC 後端對接 Keycloak：
+
+```env
+# Plane OIDC（Phase 2）
+OIDC_PROVIDER_NAME=銀行SSO
+OIDC_CLIENT_ID=plane
+OIDC_CLIENT_SECRET=<Keycloak 產生>
+OIDC_ISSUER=https://keycloak.internal.bank.com/realms/titan
+OIDC_CALLBACK_URL=https://plane.internal.bank.com/auth/oidc/callback/
+```
+
+### 2.5 群組對映（AD Groups → App Roles）
+
+| AD 群組 | Keycloak 角色 | Outline 角色 | Plane 角色 |
+|---------|--------------|-------------|-----------|
+| `IT-TITAN-Admin` | `titan-admin` | admin | owner |
+| `IT-TITAN-Manager` | `titan-manager` | member（可建立 Collection） | admin（Project 管理） |
+| `IT-Developers` | `titan-engineer` | member | member |
+| `IT-All` | `titan-readonly` | viewer | viewer |
+
+**Keycloak Mapper 設定方式：**
+
+1. 進入 Realm → `titan` → Clients → `outline`（或 `plane`）
+2. 新增 Mapper：Type = `Group Membership`
+3. Token Claim Name = `groups`
+4. 各應用程式讀取 `groups` claim，依群組名稱設定角色
+
+---
+
+## RBAC 角色模型
+
+### 4.1 角色定義
+
+詳見 `config/auth/roles.yaml`。
+
+| 角色 | 說明 | 適用人員 |
+|------|------|---------|
+| `admin` | 平台管理員，全部權限 | TITAN 維運人員（1-2 人） |
+| `manager` | 專案/文件管理者，可建立/刪除資源 | 部門主管、Tech Lead |
+| `engineer` | 工程師，可讀寫自身工作範圍 | 開發人員、SA、DBA |
+| `readonly` | 唯讀，僅瀏覽 | 審計人員、其他部門觀察者 |
+
+### 4.2 各服務權限矩陣
+
+#### Outline（知識庫）
+
+| 操作 | admin | manager | engineer | readonly |
+|------|:-----:|:-------:|:--------:|:--------:|
+| 建立 Collection | ✅ | ✅ | ❌ | ❌ |
+| 建立/編輯 Document | ✅ | ✅ | ✅ | ❌ |
+| 刪除 Document | ✅ | ✅ | ❌（僅自己） | ❌ |
+| 管理成員權限 | ✅ | ❌ | ❌ | ❌ |
+| 瀏覽文件 | ✅ | ✅ | ✅ | ✅ |
+| 匯出文件 | ✅ | ✅ | ✅ | ✅ |
+| 系統設定 | ✅ | ❌ | ❌ | ❌ |
+
+#### Plane（專案管理）
+
+| 操作 | admin | manager | engineer | readonly |
+|------|:-----:|:-------:|:--------:|:--------:|
+| 建立 Project | ✅ | ✅ | ❌ | ❌ |
+| 建立/編輯 Issue | ✅ | ✅ | ✅ | ❌ |
+| 關閉/刪除 Issue | ✅ | ✅ | ❌（僅自己） | ❌ |
+| 管理 Sprint/Cycle | ✅ | ✅ | ❌ | ❌ |
+| 管理成員 | ✅ | ✅（Project 內） | ❌ | ❌ |
+| 瀏覽 Issue | ✅ | ✅ | ✅ | ✅ |
+| 系統設定 | ✅ | ❌ | ❌ | ❌ |
+
+---
+
+## 銀行環境安全考量
+
+### 5.1 密碼政策
+
+- Phase 1 本地帳號：
+  - 最小長度：12 字元
+  - 須包含大小寫英文、數字、特殊符號
+  - 密碼有效期：90 天（參照銀行資安規範）
+  - 連續失敗 5 次鎖定帳號
+
+- Phase 2 SSO：
+  - 密碼政策由 AD 統一管理，Keycloak 繼承
+  - 建議啟用 MFA（銀行 OTP Token 或 TOTP App）
+
+### 5.2 Session 管理
+
+- Outline/Plane Session 逾時：**8 小時**（符合銀行上班時段）
+- 閒置逾時：**30 分鐘**
+- 強制登出：管理員可在後台 revoke session
+- Phase 2：Keycloak 統一管理 SSO session，支援單一登出（Single Logout）
+
+### 5.3 傳輸安全
+
+- 所有服務必須透過 **HTTPS**（TLS 1.2+）存取
+- Keycloak ↔ AD/LDAP：使用 **LDAPS**（port 636）或 STARTTLS
+- 內部服務間通訊（Docker 網路）可使用 HTTP，但邊界必須有反向代理（nginx/traefik）做 TLS 終止
+
+### 5.4 服務帳號管理
+
+- Keycloak 連接 AD 使用的服務帳號（bind account）：
+  - 最小化權限：僅 Read 目錄，禁止寫入
+  - 放置於 `OU=ServiceAccounts`，獨立管理
+  - 密碼存放於 HashiCorp Vault 或銀行 PAM 系統，**禁止明文寫入設定檔**
+- OIDC Client Secret 同樣存放於 Vault，透過 Docker Secret 或 Env 注入
+
+### 5.5 稽核日誌
+
+| 事件類型 | 記錄位置 | 保存期限 |
+|---------|---------|---------|
+| 登入成功/失敗 | Keycloak Events + SIEM | 1 年 |
+| 帳號建立/停用 | Keycloak Admin Events | 2 年 |
+| 角色/權限變更 | Keycloak Admin Events | 2 年 |
+| 文件存取 | Outline Audit Log | 6 個月 |
+| Issue 操作 | Plane Activity Log | 6 個月 |
+
+- 稽核日誌**不可刪除、不可被應用程式管理員修改**
+- 建議串接至銀行既有 SIEM（如 Splunk/QRadar）
+
+### 5.6 網路隔離
+
+```
+[使用者端點]
+     │ HTTPS:443
+     ▼
+[DMZ 反向代理：nginx]
+     │ HTTP（內網）
+     ▼
+[TITAN 應用服務群（內網 VLAN）]
+     │ LDAPS:636
+     ▼
+[AD/LDAP 伺服器（AD VLAN）]
+```
+
+- TITAN 服務不直接對外；反向代理為唯一入口
+- Keycloak 僅對內網 TITAN VLAN 開放
+
+---
+
+## 實作時程建議
+
+| 階段 | 項目 | 預計工時 | 前置條件 |
+|------|------|---------|---------|
+| Phase 1 | 本地帳號初始化腳本 | 0.5 天 | 服務部署完成 |
+| Phase 1 | 建立初始帳號、驗證 RBAC | 0.5 天 | 腳本完成 |
+| Phase 2 | Keycloak 部署與 Realm 設定 | 1 天 | 銀行 AD 服務帳號申請核准 |
+| Phase 2 | LDAP Federation 設定與測試 | 1 天 | Keycloak 部署完成、AD 連線允許 |
+| Phase 2 | Outline/Plane OIDC 對接 | 1 天 | Keycloak Realm 設定完成 |
+| Phase 2 | 群組對映測試與上線 | 0.5 天 | 各服務 OIDC 設定完成 |
+
+**總估計：Phase 1 約 1 天；Phase 2 約 4 天**（不含 AD 服務帳號申請等行政流程）
+
+---
+
+*本文件由 TITAN 平台設計團隊維護，修改請開 GitHub Issue。*

--- a/scripts/auth-init.sh
+++ b/scripts/auth-init.sh
@@ -1,0 +1,353 @@
+#!/usr/bin/env bash
+# =============================================================================
+# auth-init.sh — TITAN 平台認證初始化腳本
+# 用途：建立 Outline 初始管理員帳號，並輸出首次登入說明
+# 版本：v1.0
+# 更新：2026-03-23
+# 相關文件：docs/auth-design.md
+# =============================================================================
+set -euo pipefail
+
+# ─────────────────────────────────────────────────────
+# 顏色輸出
+# ─────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+log_info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ─────────────────────────────────────────────────────
+# 設定區（可由環境變數覆蓋）
+# ─────────────────────────────────────────────────────
+OUTLINE_URL="${OUTLINE_URL:-https://outline.internal.bank.com}"
+OUTLINE_API_TOKEN="${OUTLINE_API_TOKEN:-}"          # 需預先產生 API Token
+
+# 初始管理員帳號（可傳入環境變數）
+ADMIN_EMAIL="${ADMIN_EMAIL:-titan-admin@bank.com}"
+ADMIN_NAME="${ADMIN_NAME:-TITAN 管理員}"
+
+# 腳本行為
+DRY_RUN="${DRY_RUN:-false}"
+SKIP_HEALTH_CHECK="${SKIP_HEALTH_CHECK:-false}"
+
+# ─────────────────────────────────────────────────────
+# 前置檢查
+# ─────────────────────────────────────────────────────
+check_dependencies() {
+    log_info "檢查必要工具..."
+    local missing=0
+
+    for cmd in curl jq docker; do
+        if ! command -v "$cmd" &>/dev/null; then
+            log_error "缺少必要工具：$cmd"
+            missing=$((missing + 1))
+        fi
+    done
+
+    if [[ $missing -gt 0 ]]; then
+        log_error "請先安裝缺少的工具後再執行此腳本。"
+        exit 1
+    fi
+    log_success "工具檢查通過（curl, jq, docker）"
+}
+
+check_env_vars() {
+    log_info "檢查必要環境變數..."
+    local missing=0
+
+    if [[ -z "${OUTLINE_API_TOKEN}" ]]; then
+        log_error "OUTLINE_API_TOKEN 未設定。"
+        log_warn "  請至 Outline 後台 → 設定 → API 取得管理員 API Token"
+        log_warn "  設定方式：export OUTLINE_API_TOKEN='your-token-here'"
+        missing=$((missing + 1))
+    fi
+
+    if [[ $missing -gt 0 ]]; then
+        exit 1
+    fi
+    log_success "環境變數檢查通過"
+}
+
+# ─────────────────────────────────────────────────────
+# 健康檢查：等待 Outline 服務就緒
+# ─────────────────────────────────────────────────────
+wait_for_outline() {
+    if [[ "${SKIP_HEALTH_CHECK}" == "true" ]]; then
+        log_warn "跳過健康檢查（SKIP_HEALTH_CHECK=true）"
+        return
+    fi
+
+    log_info "等待 Outline 服務就緒：${OUTLINE_URL}"
+    local max_attempts=30
+    local attempt=0
+
+    while [[ $attempt -lt $max_attempts ]]; do
+        attempt=$((attempt + 1))
+        if curl -sf "${OUTLINE_URL}/api/auth.info" \
+            -H "Authorization: Bearer ${OUTLINE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --connect-timeout 5 \
+            -o /dev/null 2>/dev/null; then
+            log_success "Outline 服務就緒！"
+            return
+        fi
+        log_info "  等待中... (${attempt}/${max_attempts})"
+        sleep 10
+    done
+
+    log_error "Outline 服務在 ${max_attempts} 次嘗試後仍未就緒，請確認容器狀態。"
+    log_info "  檢查指令：docker compose ps outline"
+    log_info "  日誌查看：docker compose logs outline"
+    exit 1
+}
+
+# ─────────────────────────────────────────────────────
+# Outline API 輔助函數
+# ─────────────────────────────────────────────────────
+outline_api() {
+    local endpoint="$1"
+    local data="${2:-{}}"
+
+    curl -sf \
+        -X POST \
+        "${OUTLINE_URL}/api/${endpoint}" \
+        -H "Authorization: Bearer ${OUTLINE_API_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "${data}"
+}
+
+# ─────────────────────────────────────────────────────
+# 建立 Outline 管理員帳號（發送邀請）
+# ─────────────────────────────────────────────────────
+create_outline_admin() {
+    log_info "建立 Outline 管理員帳號..."
+    log_info "  Email：${ADMIN_EMAIL}"
+    log_info "  姓名：${ADMIN_NAME}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_warn "[DRY RUN] 模擬呼叫 Outline API users.invite"
+        return
+    fi
+
+    local response
+    response=$(outline_api "users.invite" "{
+        \"invites\": [
+            {
+                \"email\": \"${ADMIN_EMAIL}\",
+                \"name\": \"${ADMIN_NAME}\",
+                \"role\": \"admin\"
+            }
+        ]
+    }" 2>&1) || {
+        log_error "呼叫 Outline API 失敗：${response}"
+        log_warn "  可能原因：帳號已存在、或 API Token 權限不足"
+        return 1
+    }
+
+    local status
+    status=$(echo "${response}" | jq -r '.ok // false')
+
+    if [[ "${status}" == "true" ]]; then
+        log_success "管理員邀請成功！邀請信已發送至：${ADMIN_EMAIL}"
+    else
+        local error
+        error=$(echo "${response}" | jq -r '.error // "未知錯誤"')
+        if [[ "${error}" == "user_already_exists" ]]; then
+            log_warn "帳號已存在，跳過建立：${ADMIN_EMAIL}"
+        else
+            log_error "建立帳號失敗：${error}"
+            return 1
+        fi
+    fi
+}
+
+# ─────────────────────────────────────────────────────
+# 建立 Outline 預設 Collection
+# ─────────────────────────────────────────────────────
+create_outline_collections() {
+    log_info "建立 Outline 預設 Collection..."
+
+    local collections=(
+        "IT 技術文件|存放系統架構、API 文件、技術規範|#2563EB"
+        "專案管理|存放專案計畫、會議記錄、決策日誌|#059669"
+        "操作手冊|存放 SOP、維運指南、故障排除手冊|#D97706"
+        "資安政策|存放資安規範、存取控制政策、稽核要求|#DC2626"
+    )
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_warn "[DRY RUN] 模擬建立以下 Collection："
+        for coll in "${collections[@]}"; do
+            IFS='|' read -r name _ _ <<< "$coll"
+            echo "  - ${name}"
+        done
+        return
+    fi
+
+    for coll in "${collections[@]}"; do
+        IFS='|' read -r name description color <<< "$coll"
+
+        local response
+        response=$(outline_api "collections.create" "{
+            \"name\": \"${name}\",
+            \"description\": \"${description}\",
+            \"color\": \"${color}\",
+            \"permission\": \"read\"
+        }" 2>&1) || true
+
+        local status
+        status=$(echo "${response}" | jq -r '.ok // false' 2>/dev/null || echo "false")
+
+        if [[ "${status}" == "true" ]]; then
+            log_success "  建立 Collection：${name}"
+        else
+            log_warn "  Collection 建立失敗或已存在：${name}"
+        fi
+    done
+}
+
+# ─────────────────────────────────────────────────────
+# Plane 管理員建立說明
+# ─────────────────────────────────────────────────────
+setup_plane_admin() {
+    echo ""
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${CYAN}  Plane 管理員初始設定（需手動執行）${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "  Plane 需要進入容器建立 superuser，請依序執行："
+    echo ""
+    echo -e "  ${YELLOW}步驟 1：進入 Plane API 容器${NC}"
+    echo -e "  $ docker compose exec plane-api python manage.py createsuperuser"
+    echo ""
+    echo -e "  ${YELLOW}步驟 2：依提示輸入以下資訊${NC}"
+    echo -e "    Email    : ${ADMIN_EMAIL}"
+    echo -e "    Password : （請使用符合密碼政策的強密碼，長度 ≥ 12 字元）"
+    echo ""
+    echo -e "  ${YELLOW}步驟 3：首次登入 Plane 後台${NC}"
+    echo -e "    URL：https://plane.internal.bank.com/"
+    echo -e "    以上方建立的帳號登入後完成 workspace 初始設定"
+    echo ""
+    echo -e "  ${YELLOW}步驟 4：邀請成員${NC}"
+    echo -e "    進入 Settings → Members → Invite Members"
+    echo -e "    依 roles.yaml 定義指派適當角色"
+    echo ""
+}
+
+# ─────────────────────────────────────────────────────
+# 輸出首次登入說明
+# ─────────────────────────────────────────────────────
+print_first_login_instructions() {
+    echo ""
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${GREEN}  TITAN 平台首次登入說明${NC}"
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "  ${CYAN}【Outline 知識庫】${NC}"
+    echo -e "  網址：${OUTLINE_URL}"
+    echo ""
+    echo -e "  1. 管理員（${ADMIN_EMAIL}）應已收到邀請信"
+    echo -e "     → 點擊信中連結，設定密碼後登入"
+    echo -e "  2. 若未收到邀請信，請至 Outline 後台手動重發："
+    echo -e "     Settings → Members → 找到帳號 → Resend invite"
+    echo -e "  3. 登入後請先設定："
+    echo -e "     - 工作區名稱：TITAN 銀行 IT 平台"
+    echo -e "     - 上傳工作區 Logo"
+    echo -e "     - 確認各 Collection 權限設定正確"
+    echo ""
+    echo -e "  ${CYAN}【邀請其他成員（Outline）】${NC}"
+    echo -e "  Settings → Members → Invite people"
+    echo -e "  依 config/auth/roles.yaml 對應角色指派"
+    echo ""
+    echo -e "  ${CYAN}【Phase 2 — SSO 整合提醒】${NC}"
+    echo -e "  當 Keycloak + AD 整合完成後："
+    echo -e "  1. 更新 .env 填入 OIDC 設定（見 docs/auth-design.md）"
+    echo -e "  2. 重啟 Outline/Plane 服務"
+    echo -e "  3. 通知所有成員改用 SSO 登入"
+    echo -e "  4. 舊的本地帳號將於 SSO 上線後停用"
+    echo ""
+    echo -e "  ${YELLOW}重要安全提醒：${NC}"
+    echo -e "  - 請勿在 Git 或文件中儲存帳號密碼"
+    echo -e "  - 管理員帳號資訊請記錄至 ITSM 或 PAM 系統"
+    echo -e "  - 初始密碼須於首次登入後立即變更"
+    echo ""
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+# ─────────────────────────────────────────────────────
+# 主流程
+# ─────────────────────────────────────────────────────
+main() {
+    echo ""
+    echo -e "${CYAN}============================================================${NC}"
+    echo -e "${CYAN}  TITAN 平台認證初始化腳本 v1.0${NC}"
+    echo -e "${CYAN}============================================================${NC}"
+    echo ""
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_warn "DRY RUN 模式：不會實際呼叫 API 或修改任何資料"
+        echo ""
+    fi
+
+    # 前置檢查
+    check_dependencies
+    check_env_vars
+
+    # 等待服務就緒
+    wait_for_outline
+
+    # 建立 Outline 管理員
+    create_outline_admin
+
+    # 建立預設 Collection
+    create_outline_collections
+
+    # 輸出 Plane 手動設定說明
+    setup_plane_admin
+
+    # 輸出首次登入說明
+    print_first_login_instructions
+
+    log_success "認證初始化完成！"
+}
+
+# ─────────────────────────────────────────────────────
+# 使用說明
+# ─────────────────────────────────────────────────────
+usage() {
+    echo "用法："
+    echo "  $0 [選項]"
+    echo ""
+    echo "環境變數："
+    echo "  OUTLINE_URL          Outline 服務 URL（預設：https://outline.internal.bank.com）"
+    echo "  OUTLINE_API_TOKEN    Outline API Token（必填）"
+    echo "  ADMIN_EMAIL          管理員 Email（預設：titan-admin@bank.com）"
+    echo "  ADMIN_NAME           管理員姓名（預設：TITAN 管理員）"
+    echo "  DRY_RUN              設為 true 啟用模擬模式（預設：false）"
+    echo "  SKIP_HEALTH_CHECK    設為 true 跳過服務健康檢查（預設：false）"
+    echo ""
+    echo "範例："
+    echo "  # 基本執行"
+    echo "  OUTLINE_API_TOKEN='your-token' ./scripts/auth-init.sh"
+    echo ""
+    echo "  # 自訂管理員帳號"
+    echo "  OUTLINE_API_TOKEN='your-token' \\"
+    echo "    ADMIN_EMAIL='john.doe@bank.com' \\"
+    echo "    ADMIN_NAME='John Doe' \\"
+    echo "    ./scripts/auth-init.sh"
+    echo ""
+    echo "  # 模擬模式（不實際執行）"
+    echo "  OUTLINE_API_TOKEN='dummy' DRY_RUN=true ./scripts/auth-init.sh"
+}
+
+# 處理命令列參數
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    *) main "$@" ;;
+esac


### PR DESCRIPTION
## Summary

- 新增 `docs/auth-design.md`：兩階段認證設計（Phase 1 本地帳號 MVP + Phase 2 Keycloak OIDC/SSO）
- 新增 `config/auth/roles.yaml`：RBAC 角色定義，涵蓋 admin / manager / engineer / readonly 及 Outline/Plane 權限矩陣
- 新增 `config/auth/keycloak-realm-export.json`：Keycloak Realm 設定範本，含 AD LDAP Federation、OIDC Client、群組對映
- 新增 `scripts/auth-init.sh`：Outline 管理員帳號初始化腳本，支援 DRY_RUN 模式及首次登入說明輸出

## Test plan

- [ ] `DRY_RUN=true OUTLINE_API_TOKEN=dummy ./scripts/auth-init.sh` 應正常執行並輸出模擬訊息（不呼叫 API）
- [ ] `./scripts/auth-init.sh --help` 輸出使用說明
- [ ] 確認 `config/auth/keycloak-realm-export.json` 為合法 JSON（`jq . config/auth/keycloak-realm-export.json`）
- [ ] 確認 `config/auth/roles.yaml` YAML 格式正確（`python3 -c "import yaml; yaml.safe_load(open('config/auth/roles.yaml'))"`)
- [ ] Review `docs/auth-design.md` 確認銀行環境安全考量完整性

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)