### PR TITLE
feat(T08): Nginx reverse proxy with TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@
 # Homepage 自動產生的快取檔案
 config/homepage/logs/
 config/homepage/cache/
+
+# T08：Nginx TLS 憑證（含私鑰，絕對不可提交）
+# MVP 自簽憑證請執行 scripts/generate-ssl-cert.sh 在本機產生
+config/nginx/certs/*.crt
+config/nginx/certs/*.key
+config/nginx/certs/*.pem
+config/nginx/certs/*.csr
+# 保留 .gitkeep 讓目錄被 git 追蹤
+!config/nginx/certs/.gitkeep

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,0 +1,390 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# TITAN 平台 — Nginx 反向代理設定
+# 任務：T08 — Nginx Reverse Proxy and TLS
+# ─────────────────────────────────────────────────────────────────────────
+# 架構說明：
+#   對外入口：80 (HTTP) → 301 重導向 → 443 (HTTPS)
+#   路由對應：
+#     /          → Homepage 統一儀表板 (titan-homepage:3000)
+#     /outline/  → Outline 知識庫     (titan-outline:3000)
+#     /plane/    → Plane 專案管理     (plane-proxy:80，占位)
+#     /minio/    → MinIO Console      (titan-minio:9001)
+#     /uptime/   → Uptime Kuma        (titan-uptime-kuma:3001)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ── 主進程設定 ─────────────────────────────────────────────────────────────
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+    use                 epoll;
+    multi_accept        on;
+}
+
+http {
+    # ── 基礎 MIME 類型 ─────────────────────────────────────────────────────
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # ── 日誌格式定義 ───────────────────────────────────────────────────────
+    # 標準格式：含真實 IP、請求方法、狀態碼、回應時間
+    log_format  titan_access  '$remote_addr - $remote_user [$time_local] '
+                               '"$request" $status $body_bytes_sent '
+                               '"$http_referer" "$http_user_agent" '
+                               'rt=$request_time uct=$upstream_connect_time '
+                               'uht=$upstream_header_time urt=$upstream_response_time';
+
+    access_log  /var/log/nginx/access.log  titan_access;
+
+    # ── 效能調優 ───────────────────────────────────────────────────────────
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    # 隱藏 Nginx 版本號（安全強化）
+    server_tokens       off;
+
+    # ── Gzip 壓縮 ──────────────────────────────────────────────────────────
+    gzip                on;
+    gzip_vary           on;
+    gzip_proxied        any;
+    gzip_comp_level     6;
+    gzip_min_length     1000;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml
+        image/svg+xml
+        font/truetype
+        font/opentype
+        application/vnd.ms-fontobject;
+
+    # ── 速率限制區域定義 ───────────────────────────────────────────────────
+    # 一般存取：每個 IP 每秒最多 20 個請求，允許突發至 50
+    limit_req_zone  $binary_remote_addr  zone=general:10m   rate=20r/s;
+    # 靜態資源：每個 IP 每秒最多 50 個請求（CSS/JS/圖片）
+    limit_req_zone  $binary_remote_addr  zone=static:10m    rate=50r/s;
+    # API 端點：嚴格限制每個 IP 每秒最多 10 個請求
+    limit_req_zone  $binary_remote_addr  zone=api:10m       rate=10r/s;
+
+    # ── 上游服務定義（Docker 容器名稱解析）────────────────────────────────
+    upstream homepage_backend {
+        server homepage:3000;
+        keepalive 32;
+    }
+
+    upstream outline_backend {
+        server outline:3000;
+        keepalive 32;
+    }
+
+    upstream minio_console_backend {
+        server minio:9001;
+        keepalive 16;
+    }
+
+    upstream minio_api_backend {
+        server minio:9000;
+        keepalive 16;
+    }
+
+    upstream uptime_kuma_backend {
+        server uptime-kuma:3001;
+        keepalive 16;
+    }
+
+    # Plane（占位，待 Plane 啟動後啟用）
+    upstream plane_backend {
+        server plane-proxy:80;
+        keepalive 16;
+    }
+
+    # ══════════════════════════════════════════════════════════════════════
+    # HTTP 伺服器：強制重導向至 HTTPS
+    # ══════════════════════════════════════════════════════════════════════
+    server {
+        listen       80;
+        listen       [::]:80;
+        server_name  titan.bank.local titan.local _;
+
+        # 速率限制
+        limit_req  zone=general  burst=20  nodelay;
+
+        # 健康檢查端點（監控系統使用，不重導向）
+        location = /health {
+            access_log  off;
+            return 200  "OK\n";
+            add_header  Content-Type  text/plain;
+        }
+
+        # 所有其他請求一律 301 轉至 HTTPS
+        location / {
+            return 301  https://$host$request_uri;
+        }
+    }
+
+    # ══════════════════════════════════════════════════════════════════════
+    # HTTPS 伺服器：主要路由入口
+    # ══════════════════════════════════════════════════════════════════════
+    server {
+        listen       443  ssl;
+        listen       [::]:443  ssl;
+        http2        on;
+        server_name  titan.bank.local titan.local;
+
+        # ── SSL/TLS 憑證 ───────────────────────────────────────────────
+        # MVP 使用自簽憑證；正式上線替換為銀行內部 CA 核發憑證
+        ssl_certificate      /etc/nginx/certs/server.crt;
+        ssl_certificate_key  /etc/nginx/certs/server.key;
+
+        # ── SSL/TLS 協議與加密套件 ─────────────────────────────────────
+        # 僅允許 TLS 1.2 / 1.3（銀行業安全要求，禁用 SSL/TLS 1.0/1.1）
+        ssl_protocols             TLSv1.2  TLSv1.3;
+        ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        # ── SSL Session 快取（效能優化）────────────────────────────────
+        ssl_session_cache    shared:SSL:10m;
+        ssl_session_timeout  1d;
+        ssl_session_tickets  off;
+
+        # ── OCSP Stapling（憑證撤銷快速檢查）──────────────────────────
+        ssl_stapling        on;
+        ssl_stapling_verify on;
+        resolver            127.0.0.1  valid=300s;
+        resolver_timeout    5s;
+
+        # ── 全域安全標頭 ───────────────────────────────────────────────
+        # HSTS：強制瀏覽器未來 1 年使用 HTTPS，includeSubDomains
+        add_header  Strict-Transport-Security    "max-age=31536000; includeSubDomains" always;
+        # 禁止 iframe 嵌入（防範點擊劫持）
+        add_header  X-Frame-Options              "SAMEORIGIN" always;
+        # 禁止 MIME 類型嗅探
+        add_header  X-Content-Type-Options       "nosniff" always;
+        # XSS 過濾器（舊版瀏覽器相容）
+        add_header  X-XSS-Protection             "1; mode=block" always;
+        # Referrer 策略：跨域請求只傳送 Origin
+        add_header  Referrer-Policy              "strict-origin-when-cross-origin" always;
+        # 權限策略：禁止相機、麥克風、地理位置
+        add_header  Permissions-Policy           "camera=(), microphone=(), geolocation=()" always;
+        # 內容安全策略：僅允許同源資源（各 location 可覆寫）
+        add_header  Content-Security-Policy      "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' wss: ws:; frame-ancestors 'self';" always;
+
+        # ── 速率限制（全域） ────────────────────────────────────────────
+        limit_req  zone=general  burst=50  nodelay;
+
+        # ── 統一錯誤頁面 ────────────────────────────────────────────────
+        error_page  502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+            internal;
+        }
+
+        # ── Nginx 狀態端點（監控系統使用）──────────────────────────────
+        location = /nginx-status {
+            stub_status  on;
+            access_log   off;
+            # 僅允許內部網路查詢（Docker 內網段）
+            allow  127.0.0.1;
+            allow  172.16.0.0/12;
+            allow  10.0.0.0/8;
+            deny   all;
+        }
+
+        # ── 健康檢查端點 ────────────────────────────────────────────────
+        location = /health {
+            access_log  off;
+            return 200  "OK\n";
+            add_header  Content-Type  text/plain;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 1：Homepage 統一儀表板 → /
+        #   對外 URL：https://titan.bank.local/
+        #   後端容器：titan-homepage:3000
+        # ════════════════════════════════════════════════════════════════
+        location / {
+            limit_req  zone=general  burst=50  nodelay;
+
+            proxy_pass         http://homepage_backend;
+            proxy_http_version 1.1;
+
+            # 標準代理標頭
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+
+            # WebSocket 支援
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # Timeout 設定
+            proxy_connect_timeout   60s;
+            proxy_send_timeout      60s;
+            proxy_read_timeout      60s;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 2：Outline 知識庫 → /outline/
+        #   對外 URL：https://titan.bank.local/outline/
+        #   後端容器：titan-outline:3000
+        # ════════════════════════════════════════════════════════════════
+        location /outline/ {
+            limit_req  zone=general  burst=50  nodelay;
+
+            # 說明：Outline 服務從根路徑開始，代理時去除 /outline 前綴
+            proxy_pass         http://outline_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+            # 告知 Outline 其路徑前綴（需搭配 URL 環境變數設定）
+            proxy_set_header   X-Forwarded-Prefix /outline;
+
+            # WebSocket 支援（協作編輯需要）
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # Timeout（文件操作時間較長）
+            proxy_connect_timeout   120s;
+            proxy_send_timeout      120s;
+            proxy_read_timeout      120s;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 3：Plane 專案管理 → /plane/（占位）
+        #   對外 URL：https://titan.bank.local/plane/
+        #   後端容器：plane-proxy:80（獨立 docker-compose 部署）
+        #   注意：Plane 啟動後需確認 plane-proxy 容器加入 titan-external 網路
+        # ════════════════════════════════════════════════════════════════
+        location /plane/ {
+            limit_req  zone=general  burst=50  nodelay;
+
+            # ⚠️  Plane 尚未啟動時，此路由返回 503
+            proxy_pass         http://plane_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+            proxy_set_header   X-Forwarded-Prefix /plane;
+
+            # WebSocket 支援
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # Timeout
+            proxy_connect_timeout   120s;
+            proxy_send_timeout      120s;
+            proxy_read_timeout      120s;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 4：MinIO Console → /minio/
+        #   對外 URL：https://titan.bank.local/minio/
+        #   後端容器：titan-minio:9001
+        # ════════════════════════════════════════════════════════════════
+        location /minio/ {
+            limit_req  zone=api  burst=20  nodelay;
+
+            proxy_pass         http://minio_console_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+
+            # WebSocket 支援（MinIO Console 需要）
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # MinIO 上傳可能較慢
+            proxy_connect_timeout   60s;
+            proxy_send_timeout      300s;
+            proxy_read_timeout      300s;
+
+            # 不緩衝（大檔案上傳）
+            proxy_buffering     off;
+            proxy_request_buffering off;
+
+            # 上傳大小限制（100MB）
+            client_max_body_size  100m;
+        }
+
+        # ── MinIO S3 API（內部使用）────────────────────────────────────
+        # 注意：此端點為服務間內部通訊使用，不對外開放一般使用者
+        location /minio-api/ {
+            limit_req  zone=api  burst=10  nodelay;
+
+            proxy_pass         http://minio_api_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            # 保留 S3 簽名標頭
+            proxy_set_header   Authorization      $http_authorization;
+            proxy_pass_header  Set-Cookie;
+
+            # 不緩衝（S3 上傳）
+            proxy_buffering     off;
+            proxy_request_buffering off;
+
+            # S3 操作 Timeout
+            proxy_connect_timeout   300s;
+            proxy_send_timeout      300s;
+            proxy_read_timeout      300s;
+
+            # 上傳大小限制（500MB）
+            client_max_body_size  500m;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 5：Uptime Kuma 監控 → /uptime/
+        #   對外 URL：https://titan.bank.local/uptime/
+        #   後端容器：titan-uptime-kuma:3001
+        # ════════════════════════════════════════════════════════════════
+        location /uptime/ {
+            limit_req  zone=general  burst=30  nodelay;
+
+            proxy_pass         http://uptime_kuma_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+
+            # WebSocket 支援（Uptime Kuma 實時推送需要）
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # Timeout
+            proxy_connect_timeout   60s;
+            proxy_send_timeout      60s;
+            proxy_read_timeout      60s;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 # TITAN 容器平台 — 生產就緒版本
 # 任務: T06 — OS 基線與 Harden 設定
 # 任務: T07 — Container Platform Setup / T09 — 資料庫與儲存規劃
+# 任務: T08 — Nginx Reverse Proxy and TLS
 # 所有映像版本均固定，適用於隔離網路（air-gapped）部署
 # 若需更新版本，請同步更新 .env.example 中的備註
 
@@ -202,6 +203,7 @@ services:
 
   # ── 統一儀表板：Homepage ─────────────────────────────────
   # 集中呈現所有 TITAN 服務連結與狀態
+  # T08：移除直接對外端口，改由 Nginx 反向代理提供存取（https://titan.bank.local/）
   homepage:
     image: gethomepage/homepage:v0.9.13
     container_name: titan-homepage
@@ -209,16 +211,15 @@ services:
     environment:
       PUID: ${HOMEPAGE_PUID:-1000}
       PGID: ${HOMEPAGE_PGID:-1000}
-      HOMEPAGE_ALLOWED_HOSTS: ${HOMEPAGE_ALLOWED_HOSTS:-localhost}
+      HOMEPAGE_ALLOWED_HOSTS: ${HOMEPAGE_ALLOWED_HOSTS:-titan.bank.local,titan.local,localhost}
     volumes:
       - ./config/homepage:/app/config      # 服務設定檔
       - /var/run/docker.sock:/var/run/docker.sock:ro  # Docker 狀態讀取（唯讀）
-    # 安全強化：保留外部端口供外部存取
-    ports:
-      - "${HOMEPAGE_PORT:-3000}:3000"
+    # 安全強化：移除直接對外端口，僅允許 Nginx 透過內部網路存取
+    # ports:
+    #   - "${HOMEPAGE_PORT:-3000}:3000"
     networks:
       - titan-internal
-      - titan-external
     depends_on:
       - outline
       - minio
@@ -241,6 +242,7 @@ services:
   # ── 監控儀表板：Uptime Kuma ──────────────────────────────
   # 服務可用性監控與狀態頁面
   # 版本固定：louislam/uptime-kuma:1.23.13
+  # T08：移除直接對外端口，改由 Nginx 反向代理提供存取（https://titan.bank.local/uptime/）
   uptime-kuma:
     image: louislam/uptime-kuma:1.23.13
     container_name: titan-uptime-kuma
@@ -248,10 +250,11 @@ services:
     volumes:
       - uptime-kuma-data:/app/data
       - /var/run/docker.sock:/var/run/docker.sock:ro  # 監控 Docker 容器狀態（唯讀）
-    ports:
-      - "${UPTIME_KUMA_PORT:-3002}:3001"
+    # 安全強化：移除直接對外端口，僅允許 Nginx 透過內部網路存取
+    # ports:
+    #   - "${UPTIME_KUMA_PORT:-3002}:3001"
     networks:
-      - titan-network
+      - titan-internal
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:3001/api/entry-page || exit 1"]
       interval: 30s
@@ -285,6 +288,57 @@ services:
   #
   # 存取入口：http://<SERVER_IP>:${PLANE_PORT:-8082}
 
+  # ── 反向代理：Nginx ───────────────────────────────────────
+  # 統一對外入口：HTTP(80) 重導向至 HTTPS(443)，TLS 終止於此
+  # 版本固定：nginx:1.25-alpine（隔離網路相容）
+  # 路由對應：
+  #   /          → Homepage     (titan-homepage:3000)
+  #   /outline/  → Outline      (titan-outline:3000)
+  #   /plane/    → Plane        (plane-proxy:80，待部署)
+  #   /minio/    → MinIO 控制台  (titan-minio:9001)
+  #   /uptime/   → Uptime Kuma  (titan-uptime-kuma:3001)
+  nginx:
+    image: nginx:1.25-alpine
+    container_name: titan-nginx
+    restart: unless-stopped
+    ports:
+      - "${NGINX_HTTP_PORT:-80}:80"
+      - "${NGINX_HTTPS_PORT:-443}:443"
+    volumes:
+      # Nginx 主設定檔（唯讀掛載）
+      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # TLS 憑證目錄（唯讀掛載，MVP 自簽 / 正式環境替換為 CA 憑證）
+      - ./config/nginx/certs:/etc/nginx/certs:ro
+      # 存取日誌持久化
+      - nginx-logs:/var/log/nginx
+    networks:
+      - titan-internal
+      - titan-external
+    depends_on:
+      homepage:
+        condition: service_healthy
+      outline:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      uptime-kuma:
+        condition: service_healthy
+    # 安全強化：Resource limits
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+        reservations:
+          cpus: '0.1'
+          memory: 32M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
 # ═══════════════════════════════════════════════════════════
 # 具名 Volume（持久化資料）
 # ═══════════════════════════════════════════════════════════
@@ -299,17 +353,20 @@ volumes:
     name: titan-outline-data
   uptime-kuma-data:
     name: titan-uptime-kuma-data
+  # T08 新增：Nginx 存取日誌持久化
+  nginx-logs:
+    name: titan-nginx-logs
 
 # ═══════════════════════════════════════════════════════════
 # 網路設定：強化隔離
 # ═══════════════════════════════════════════════════════════
 networks:
-  # 內部網路：僅允許服務間通訊，不對外開放
+  # 內部網路：服務間通訊（所有後端服務加入此網路）
   titan-internal:
     name: titan-internal
     driver: bridge
-    internal: false  #允許 DNS 解析
-  # 外部網路：允許對外服務（Homepage）
+    internal: false  # 允許 DNS 解析（需對外下載套件時使用）
+  # 外部網路：Nginx 透過此網路對外開放（T08：Nginx 取代 Homepage 直接對外）
   titan-external:
     name: titan-external
     driver: bridge

--- a/docs/nginx-setup.md
+++ b/docs/nginx-setup.md
@@ -1,0 +1,338 @@
+# TITAN 平台 — Nginx 反向代理設定說明
+
+> 任務：T08 — Nginx Reverse Proxy and TLS
+> 對應 Issue：[#10](https://github.com/cct08311github/titan/issues/10)
+
+---
+
+## 目錄
+
+1. [架構概覽](#架構概覽)
+2. [URL 路由對應表](#url-路由對應表)
+3. [SSL/TLS 設定](#ssltls-設定)
+4. [安全標頭說明](#安全標頭說明)
+5. [速率限制設定](#速率限制設定)
+6. [如何替換為銀行內部 CA 憑證](#如何替換為銀行內部-ca-憑證)
+7. [常見問題排查](#常見問題排查)
+
+---
+
+## 架構概覽
+
+```
+外部用戶端
+    │
+    ▼
+Nginx (titan-nginx)
+    ├── :80  → 301 重導向至 HTTPS
+    └── :443 → 反向代理路由
+              │
+              ├── /          → Homepage     (titan-homepage:3000)
+              ├── /outline/  → Outline      (titan-outline:3000)
+              ├── /plane/    → Plane        (plane-proxy:80)
+              ├── /minio/    → MinIO 控制台  (titan-minio:9001)
+              └── /uptime/   → Uptime Kuma  (titan-uptime-kuma:3001)
+```
+
+所有應用服務僅透過 `titan-internal` Docker 網路互通，不直接對外開放端口。Nginx 作為唯一對外入口，所有 HTTPS 流量集中在此終止並轉發。
+
+---
+
+## URL 路由對應表
+
+| 對外 URL 路徑 | 後端容器 | 內部端口 | 用途說明 |
+|---|---|---|---|
+| `https://titan.bank.local/` | `titan-homepage` | 3000 | 統一儀表板，集中呈現所有服務入口 |
+| `https://titan.bank.local/outline/` | `titan-outline` | 3000 | Outline 知識庫，團隊文件協作平台 |
+| `https://titan.bank.local/plane/` | `plane-proxy` | 80 | Plane 專案管理（占位，待部署啟用） |
+| `https://titan.bank.local/minio/` | `titan-minio` | 9001 | MinIO 管理控制台，物件儲存管理介面 |
+| `https://titan.bank.local/uptime/` | `titan-uptime-kuma` | 3001 | Uptime Kuma，服務可用性監控儀表板 |
+| `https://titan.bank.local/minio-api/` | `titan-minio` | 9000 | MinIO S3 API（服務間內部使用） |
+| `https://titan.bank.local/nginx-status` | 本機 | — | Nginx 狀態資訊（僅限內網 IP 存取） |
+| `https://titan.bank.local/health` | 本機 | — | 健康檢查端點（監控系統使用） |
+
+### 備注
+
+- **Outline 路由**：Outline 內部服務從根路徑運行（`/`），Nginx 透過 `proxy_pass http://outline_backend/` 去除 `/outline` 前綴後轉發。需確保 Outline 的 `URL` 環境變數設定為 `https://titan.bank.local/outline`。
+- **Plane 占位路由**：Plane 採用獨立 docker-compose 部署，請參閱 `docs/plane-setup.md`。部署完成後需將 `plane-proxy` 容器加入 `titan-external` 網路。
+- **MinIO S3 API**：`/minio-api/` 為後端服務互通使用，前端使用者無需直接訪問。
+
+---
+
+## SSL/TLS 設定
+
+### MVP 自簽憑證（初始佈署）
+
+執行以下指令產生自簽憑證：
+
+```bash
+bash scripts/generate-ssl-cert.sh
+```
+
+憑證輸出路徑：
+
+```
+config/nginx/certs/
+├── server.crt   ← 憑證（PEM 格式）
+└── server.key   ← 私鑰（PEM 格式，限制 600 權限）
+```
+
+**憑證規格：**
+
+| 項目 | 規格 |
+|---|---|
+| 金鑰算法 | RSA 2048 bit |
+| 簽章算法 | SHA-256 |
+| 有效期限 | 10 年（MVP 測試用） |
+| 主網域 | `titan.bank.local` |
+| SAN | `titan.bank.local`、`titan.local`、`localhost`、`127.0.0.1` |
+
+### 測試環境信任自簽憑證
+
+**macOS：**
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+    -k /Library/Keychains/System.keychain \
+    config/nginx/certs/server.crt
+```
+
+**Ubuntu / Debian：**
+
+```bash
+sudo cp config/nginx/certs/server.crt /usr/local/share/ca-certificates/titan.crt
+sudo update-ca-certificates
+```
+
+**Windows（PowerShell，以管理員身份執行）：**
+
+```powershell
+Import-Certificate -FilePath ".\config\nginx\certs\server.crt" `
+    -CertStoreLocation Cert:\LocalMachine\Root
+```
+
+---
+
+## 如何替換為銀行內部 CA 憑證
+
+正式上線前，需以銀行資安部門核發的憑證取代自簽憑證。
+
+### 步驟一：取得銀行內部 CA 憑證
+
+向銀行資安部門申請，說明用途為：
+
+- **服務名稱**：TITAN 平台
+- **網域名稱**：`titan.bank.local`（主網域），加上所需 SAN
+- **憑證格式**：PEM（.crt）
+- **金鑰長度**：最低 2048 bit RSA 或 256 bit ECDSA
+
+### 步驟二：產生 CSR（Certificate Signing Request）
+
+```bash
+# 產生私鑰
+openssl genrsa -out config/nginx/certs/server.key 2048
+
+# 產生 CSR（送交 CA 簽發）
+openssl req -new \
+    -key  config/nginx/certs/server.key \
+    -out  config/nginx/certs/server.csr \
+    -subj "/C=TW/ST=Taipei/L=Taipei/O=TITAN Bank Internal/CN=titan.bank.local"
+
+# 顯示 CSR 內容（送交資安部門）
+openssl req -text -noout -in config/nginx/certs/server.csr
+```
+
+### 步驟三：部署 CA 核發的憑證
+
+收到 CA 核發的憑證後（格式：`.crt` PEM）：
+
+```bash
+# 備份自簽憑證
+cp config/nginx/certs/server.crt config/nginx/certs/server.crt.selfsigned.bak
+
+# 放置新憑證
+cp /path/to/issued.crt config/nginx/certs/server.crt
+
+# 若有中介 CA 憑證，合併成憑證鏈
+cat /path/to/issued.crt /path/to/intermediate.crt > config/nginx/certs/server.crt
+
+# 設定正確權限
+chmod 644 config/nginx/certs/server.crt
+chmod 600 config/nginx/certs/server.key
+
+# 重新啟動 Nginx
+docker compose restart nginx
+```
+
+### 步驟四：驗證憑證置換結果
+
+```bash
+# 確認憑證簽發者
+openssl x509 -noout -issuer -subject -dates -in config/nginx/certs/server.crt
+
+# 測試 HTTPS 連線
+curl -v --cacert /path/to/bank-ca.crt https://titan.bank.local/health
+```
+
+---
+
+## 安全標頭說明
+
+以下為 Nginx 設定的 HTTP 安全回應標頭及其目的說明：
+
+### Strict-Transport-Security (HSTS)
+
+```nginx
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+```
+
+**作用**：告知瀏覽器在未來 365 天內，對此網域（含子網域）的所有請求均使用 HTTPS，即使用戶手動輸入 `http://`。
+
+**風險**：啟用後若 HTTPS 無法訪問，使用者將完全無法進入網站。確認 HTTPS 穩定後再啟用。
+
+---
+
+### X-Frame-Options
+
+```nginx
+add_header X-Frame-Options "SAMEORIGIN" always;
+```
+
+**作用**：防範點擊劫持（Clickjacking）攻擊。`SAMEORIGIN` 允許同源 iframe，禁止外部網站嵌入。
+
+---
+
+### X-Content-Type-Options
+
+```nginx
+add_header X-Content-Type-Options "nosniff" always;
+```
+
+**作用**：禁止瀏覽器猜測（MIME sniffing）回應的內容類型，防止將腳本偽裝成其他格式上傳後執行。
+
+---
+
+### X-XSS-Protection
+
+```nginx
+add_header X-XSS-Protection "1; mode=block" always;
+```
+
+**作用**：啟用瀏覽器內建 XSS 過濾器（主要針對 IE/舊版 Chrome）。現代瀏覽器已透過 CSP 處理，此標頭作為舊版相容保護。
+
+---
+
+### Referrer-Policy
+
+```nginx
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+```
+
+**作用**：跨域請求時只傳送 Origin（不含路徑及查詢字串），防止內部 URL 結構洩漏給外部服務。
+
+---
+
+### Permissions-Policy
+
+```nginx
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+```
+
+**作用**：禁止網頁使用相機、麥克風、地理位置等敏感 API，減少意外授權風險。
+
+---
+
+### Content-Security-Policy (CSP)
+
+```nginx
+add_header Content-Security-Policy "default-src 'self'; ..." always;
+```
+
+**作用**：定義資源載入白名單，防止 XSS 攻擊載入外部惡意腳本。
+
+**注意**：TITAN 各服務可能需要不同的 CSP 設定。若某服務出現資源載入錯誤，需於對應 `location` 區塊覆寫 CSP。
+
+---
+
+## 速率限制設定
+
+| 限制區域 | 適用端點 | 速率限制 | 允許突發 | 說明 |
+|---|---|---|---|---|
+| `general` | 一般頁面 | 20 req/s/IP | 50 | 適用大多數頁面請求 |
+| `api` | MinIO API / Console | 10 req/s/IP | 20 | API 端點較嚴格 |
+| `static` | 靜態資源 | 50 req/s/IP | 100 | CSS/JS/圖片（目前未單獨套用） |
+
+超過速率限制時，Nginx 回傳 `429 Too Many Requests`。
+
+---
+
+## 常見問題排查
+
+### 問題：瀏覽器顯示憑證不受信任
+
+**原因**：使用自簽憑證，瀏覽器無法驗證信任鏈。
+
+**解決**：
+1. 將 `config/nginx/certs/server.crt` 加入作業系統受信任根憑證（參閱上方說明）
+2. 或換用銀行內部 CA 核發的憑證
+
+---
+
+### 問題：/outline/ 路由 404 或樣式錯誤
+
+**原因**：Outline 的 `URL` 環境變數未設定為含路徑前綴的完整 URL。
+
+**解決**：在 `.env` 中設定：
+
+```bash
+OUTLINE_URL=https://titan.bank.local/outline
+```
+
+---
+
+### 問題：/plane/ 返回 502 Bad Gateway
+
+**原因**：Plane 尚未啟動，或 `plane-proxy` 容器未加入 `titan-external` 網路。
+
+**解決**：
+
+```bash
+# 確認 Plane 已啟動
+docker compose -f /opt/titan/plane-docker-compose.yml ps
+
+# 將 plane-proxy 加入 titan-external 網路
+docker network connect titan-external plane-proxy
+```
+
+---
+
+### 問題：MinIO Console /minio/ 登入後頁面空白
+
+**原因**：MinIO Console 的 WebSocket 連線路徑需匹配前綴。
+
+**解決**：確認 MinIO 環境變數：
+
+```bash
+MINIO_BROWSER_REDIRECT_URL=https://titan.bank.local/minio
+```
+
+---
+
+### 問題：Nginx 無法啟動，憑證路徑錯誤
+
+**解決**：
+
+```bash
+# 確認憑證存在
+ls -la config/nginx/certs/
+
+# 若不存在，重新產生
+bash scripts/generate-ssl-cert.sh
+
+# 重新啟動
+docker compose up -d nginx
+```
+
+---
+
+*最後更新：2026-03-23 | 任務 T08 | 負責人：IT Operations Team*

--- a/scripts/generate-ssl-cert.sh
+++ b/scripts/generate-ssl-cert.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+# TITAN 平台 — 自簽 SSL 憑證產生腳本
+# 任務：T08 — Nginx Reverse Proxy and TLS
+# ─────────────────────────────────────────────────────────────────────────
+# 用途：為 MVP 環境產生自簽 TLS 憑證，供 Nginx 使用
+#       正式上線時，以銀行內部 CA 核發憑證取代（請參閱 docs/nginx-setup.md）
+#
+# 使用方式：
+#   bash scripts/generate-ssl-cert.sh
+#
+# 輸出：
+#   config/nginx/certs/server.crt  — 自簽憑證（PEM 格式）
+#   config/nginx/certs/server.key  — 私鑰（PEM 格式，2048 bit RSA）
+# ═══════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+# ── 設定區 ─────────────────────────────────────────────────────────────────
+DOMAIN="${TITAN_DOMAIN:-titan.bank.local}"
+CERT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/config/nginx/certs"
+CERT_FILE="${CERT_DIR}/server.crt"
+KEY_FILE="${CERT_DIR}/server.key"
+DAYS=3650          # 憑證有效期 10 年（MVP 內部使用）
+KEY_BITS=2048      # RSA 金鑰長度
+COUNTRY="TW"
+STATE="Taipei"
+CITY="Taipei"
+ORG="TITAN Bank Internal"
+OU="IT Operations"
+
+# ── 顏色輸出 ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()    { echo -e "${BLUE}[INFO]${NC}  $*"; }
+log_success() { echo -e "${GREEN}[OK]${NC}    $*"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ── 前置檢查 ────────────────────────────────────────────────────────────────
+check_prerequisites() {
+    log_info "檢查必要工具..."
+    if ! command -v openssl &>/dev/null; then
+        log_error "未找到 openssl，請先安裝："
+        log_error "  Debian/Ubuntu: sudo apt-get install -y openssl"
+        log_error "  RHEL/CentOS:   sudo yum install -y openssl"
+        exit 1
+    fi
+    log_success "openssl $(openssl version | awk '{print $2}') 已就緒"
+}
+
+# ── 建立輸出目錄 ────────────────────────────────────────────────────────────
+prepare_directory() {
+    log_info "建立憑證目錄：${CERT_DIR}"
+    mkdir -p "${CERT_DIR}"
+    chmod 700 "${CERT_DIR}"
+    log_success "目錄已就緒"
+}
+
+# ── 確認是否覆寫既有憑證 ────────────────────────────────────────────────────
+check_existing_cert() {
+    if [[ -f "${CERT_FILE}" || -f "${KEY_FILE}" ]]; then
+        log_warn "偵測到既有憑證："
+        [[ -f "${CERT_FILE}" ]] && log_warn "  ${CERT_FILE}"
+        [[ -f "${KEY_FILE}"  ]] && log_warn "  ${KEY_FILE}"
+
+        if [[ "${FORCE:-}" != "1" ]]; then
+            read -r -p "是否覆寫既有憑證？[y/N] " confirm
+            if [[ "${confirm,,}" != "y" ]]; then
+                log_info "操作取消，未覆寫憑證"
+                exit 0
+            fi
+        else
+            log_warn "FORCE=1，強制覆寫既有憑證"
+        fi
+    fi
+}
+
+# ── 產生自簽憑證 ────────────────────────────────────────────────────────────
+generate_certificate() {
+    log_info "產生自簽 TLS 憑證..."
+    log_info "  網域名稱：${DOMAIN}"
+    log_info "  有效期限：${DAYS} 天（約 $(( DAYS / 365 )) 年）"
+    log_info "  RSA 金鑰：${KEY_BITS} bit"
+
+    # 建立 SAN (Subject Alternative Names) 設定檔
+    local san_conf
+    san_conf="$(mktemp)"
+    cat > "${san_conf}" <<EOF
+[req]
+default_bits       = ${KEY_BITS}
+prompt             = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions     = req_ext
+x509_extensions    = v3_ca
+
+[dn]
+C  = ${COUNTRY}
+ST = ${STATE}
+L  = ${CITY}
+O  = ${ORG}
+OU = ${OU}
+CN = ${DOMAIN}
+
+[req_ext]
+subjectAltName = @alt_names
+
+[v3_ca]
+subjectKeyIdentifier   = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints       = critical, CA:false
+keyUsage               = critical, digitalSignature, keyEncipherment
+extendedKeyUsage       = serverAuth
+subjectAltName         = @alt_names
+
+[alt_names]
+DNS.1 = ${DOMAIN}
+DNS.2 = titan.local
+DNS.3 = localhost
+IP.1  = 127.0.0.1
+EOF
+
+    # 一次性產生私鑰與自簽憑證
+    openssl req \
+        -x509 \
+        -nodes \
+        -newkey "rsa:${KEY_BITS}" \
+        -keyout "${KEY_FILE}" \
+        -out    "${CERT_FILE}" \
+        -days   "${DAYS}" \
+        -config "${san_conf}" \
+        2>/dev/null
+
+    rm -f "${san_conf}"
+
+    # 設定安全權限
+    chmod 600 "${KEY_FILE}"    # 私鑰：僅擁有者可讀
+    chmod 644 "${CERT_FILE}"   # 憑證：其他人可讀
+
+    log_success "憑證已產生"
+}
+
+# ── 驗證憑證內容 ────────────────────────────────────────────────────────────
+verify_certificate() {
+    log_info "驗證憑證..."
+
+    local subject validity san
+    subject=$(openssl x509 -noout -subject -in "${CERT_FILE}" 2>/dev/null)
+    validity=$(openssl x509 -noout -dates  -in "${CERT_FILE}" 2>/dev/null)
+    san=$(openssl x509 -noout -ext subjectAltName -in "${CERT_FILE}" 2>/dev/null | tail -1)
+
+    log_success "憑證主旨：${subject#*=}"
+    log_info "  有效期間：$(echo "${validity}" | grep notAfter | cut -d= -f2)"
+    log_info "  SAN：${san}"
+    log_info "  憑證路徑：${CERT_FILE}"
+    log_info "  私鑰路徑：${KEY_FILE}"
+}
+
+# ── 顯示後續操作說明 ────────────────────────────────────────────────────────
+print_next_steps() {
+    echo ""
+    echo -e "${GREEN}╔══════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${GREEN}║  憑證產生完成！後續步驟：                                    ║${NC}"
+    echo -e "${GREEN}╚══════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo "  1. 重新啟動 Nginx 服務："
+    echo "     docker compose restart nginx"
+    echo ""
+    echo "  2. 在測試機器加入 /etc/hosts："
+    echo "     <SERVER_IP>  titan.bank.local"
+    echo ""
+    echo "  3. 瀏覽器信任自簽憑證（開發測試用）："
+    echo "     macOS:   sudo security add-trusted-cert -d -r trustRoot \\"
+    echo "              -k /Library/Keychains/System.keychain ${CERT_FILE}"
+    echo "     Ubuntu:  sudo cp ${CERT_FILE} /usr/local/share/ca-certificates/"
+    echo "              sudo update-ca-certificates"
+    echo ""
+    echo -e "${YELLOW}  ⚠  正式上線請以銀行內部 CA 憑證取代，詳見 docs/nginx-setup.md${NC}"
+    echo ""
+}
+
+# ── 主流程 ──────────────────────────────────────────────────────────────────
+main() {
+    echo ""
+    echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  TITAN 平台 — 自簽 SSL 憑證產生腳本                   ${NC}"
+    echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    check_prerequisites
+    prepare_directory
+    check_existing_cert
+    generate_certificate
+    verify_certificate
+    print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- `docker-compose.yml` 新增 `nginx:1.25-alpine` 服務，版本固定，對外開放 80/443 端口
- `config/nginx/nginx.conf` 完整反向代理設定：路由五大服務（Homepage、Outline、Plane、MinIO、Uptime Kuma）、SSL/TLS（TLS 1.2/1.3）、安全標頭（HSTS、CSP、X-Frame-Options 等）、速率限制、Gzip 壓縮、存取日誌
- `scripts/generate-ssl-cert.sh` MVP 自簽憑證產生腳本（含 SAN、互動式覆寫確認）
- `docs/nginx-setup.md` 完整設定文件：URL 路由表、自簽憑證替換為銀行內部 CA 憑證步驟、安全標頭說明

## Test plan

- [ ] `POSTGRES_PASSWORD=x REDIS_PASSWORD=x MINIO_ROOT_PASSWORD=x OUTLINE_SECRET_KEY=x OUTLINE_UTILS_SECRET=x docker compose config` 通過語法驗證
- [ ] 執行 `bash scripts/generate-ssl-cert.sh`，確認 `config/nginx/certs/` 產生 `server.crt` / `server.key`
- [ ] `docker compose up -d nginx` 啟動後，`curl http://localhost/health` 回傳 301 重導向
- [ ] `curl -k https://localhost/health` 回傳 `OK`
- [ ] 驗證安全標頭：`curl -kI https://localhost/ | grep -E "Strict-Transport|X-Frame|X-Content"`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)