### PR TITLE
feat(T06): OS baseline and hardening

### DIFF
--- a/docs/os-hardening.md
+++ b/docs/os-hardening.md
@@ -1,0 +1,438 @@
+# OS 基礎強化指南（Linux Baseline Hardening）
+
+> 適用系統：Ubuntu 22.04 LTS / Debian 12+
+> 時區設定：Asia/Taipei
+> 最後更新：2026-03-23
+
+---
+
+## 目錄
+
+1. [時區與時間同步（NTP）](#1-時區與時間同步ntp)
+2. [最小化套件安裝原則](#2-最小化套件安裝原則)
+3. [防火牆規則（UFW）](#3-防火牆規則ufw)
+4. [SSH 強化設定](#4-ssh-強化設定)
+5. [帳號與密碼政策](#5-帳號與密碼政策)
+6. [核心參數調整（Docker 相容）](#6-核心參數調整docker-相容)
+7. [稽核與日誌設定](#7-稽核與日誌設定)
+8. [驗證清單](#8-驗證清單)
+
+---
+
+## 1. 時區與時間同步（NTP）
+
+### 1.1 設定時區為 Asia/Taipei
+
+```bash
+timedatectl set-timezone Asia/Taipei
+timedatectl status
+```
+
+預期輸出包含：`Time zone: Asia/Taipei (CST, +0800)`
+
+### 1.2 安裝並啟用 chrony（NTP 時間同步）
+
+```bash
+apt-get install -y chrony
+systemctl enable --now chrony
+chronyc tracking
+```
+
+建議 `/etc/chrony.conf` 設定使用台灣 NTP 池：
+
+```
+pool tw.pool.ntp.org iburst maxsources 4
+```
+
+套用後重啟：
+
+```bash
+systemctl restart chrony
+chronyc sources -v
+```
+
+---
+
+## 2. 最小化套件安裝原則
+
+### 2.1 移除不必要套件
+
+```bash
+apt-get purge -y telnet rsh-client rsh-redone-client nis yp-tools \
+  talk talkd xinetd inetutils-telnetd
+apt-get autoremove -y
+apt-get autoclean
+```
+
+### 2.2 停用不必要服務
+
+```bash
+systemctl disable --now avahi-daemon cups bluetooth 2>/dev/null || true
+```
+
+### 2.3 定期安全更新
+
+設定無人值守安全更新（`unattended-upgrades`）：
+
+```bash
+apt-get install -y unattended-upgrades apt-listchanges
+dpkg-reconfigure --priority=low unattended-upgrades
+```
+
+設定檔 `/etc/apt/apt.conf.d/50unattended-upgrades`，確認以下項目啟用：
+
+```
+Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+```
+
+---
+
+## 3. 防火牆規則（UFW）
+
+### 3.1 安裝並啟用 UFW
+
+```bash
+apt-get install -y ufw
+ufw --force reset
+```
+
+### 3.2 預設政策（白名單原則）
+
+```bash
+ufw default deny incoming
+ufw default allow outgoing
+```
+
+### 3.3 允許必要連接埠
+
+| 服務 | 連接埠 | 通訊協定 | 說明 |
+|------|--------|----------|------|
+| SSH | 22 | TCP | 遠端管理（建議改為非預設 port） |
+| HTTP | 80 | TCP | Web 服務（若有 Nginx） |
+| HTTPS | 443 | TCP | Web 服務（TLS） |
+
+```bash
+ufw allow 22/tcp    # SSH
+ufw allow 80/tcp    # HTTP
+ufw allow 443/tcp   # HTTPS
+```
+
+> 若 SSH 已改為自訂 port（例如 2222），請相應調整，並確認先允許新 port 再停用 22。
+
+### 3.4 Docker 橋接網路放行
+
+Docker 使用 `172.17.0.0/16` 等內部網路。UFW 不干預 Docker iptables 規則，但需確認 `/etc/default/ufw` 中：
+
+```
+DEFAULT_FORWARD_POLICY="ACCEPT"
+```
+
+### 3.5 啟用防火牆
+
+```bash
+ufw --force enable
+ufw status verbose
+```
+
+---
+
+## 4. SSH 強化設定
+
+編輯 `/etc/ssh/sshd_config`，套用以下設定：
+
+### 4.1 核心安全設定
+
+```sshd_config
+# 禁止 root 直接登入
+PermitRootLogin no
+
+# 禁止密碼認證，僅允許金鑰
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# 限制 SSH 協定版本
+Protocol 2
+
+# 限制允許登入的使用者（替換為實際使用者）
+AllowUsers deploy admin
+
+# 連線逾時設定
+ClientAliveInterval 300
+ClientAliveCountMax 2
+LoginGraceTime 60
+
+# 限制最大認證嘗試次數
+MaxAuthTries 3
+MaxSessions 4
+
+# 停用不必要功能
+X11Forwarding no
+AllowAgentForwarding no
+AllowTcpForwarding no
+PrintMotd no
+
+# 限制 SSH 監聽介面（視情況調整）
+# ListenAddress 0.0.0.0
+
+# 記錄級別
+LogLevel VERBOSE
+```
+
+### 4.2 套用設定
+
+```bash
+sshd -t                          # 語法檢查
+systemctl reload sshd
+```
+
+> **重要**：套用前確認已有可用的 SSH 金鑰及 sudo 存取，避免鎖死。
+
+### 4.3 SSH 金鑰設定建議
+
+```bash
+# 產生 ED25519 金鑰（更安全，更小）
+ssh-keygen -t ed25519 -C "deploy@titan"
+
+# 授權金鑰存放位置
+~/.ssh/authorized_keys  # 權限必須為 600
+```
+
+---
+
+## 5. 帳號與密碼政策
+
+### 5.1 密碼複雜度（PAM）
+
+安裝 `libpam-pwquality`：
+
+```bash
+apt-get install -y libpam-pwquality
+```
+
+編輯 `/etc/security/pwquality.conf`：
+
+```ini
+# 最小長度 12 字元
+minlen = 12
+
+# 至少包含 1 個大寫、1 個小寫、1 個數字、1 個特殊字元
+minclass = 4
+ucredit = -1
+lcredit = -1
+dcredit = -1
+ocredit = -1
+
+# 禁止與使用者名稱相同
+usercheck = 1
+
+# 禁止重複使用最近 5 個密碼（在 /etc/pam.d/common-password 中設定 remember=5）
+```
+
+### 5.2 帳號有效期限（/etc/login.defs）
+
+```bash
+# 編輯 /etc/login.defs
+PASS_MAX_DAYS   90     # 密碼最長有效 90 天
+PASS_MIN_DAYS   1      # 密碼修改最短間隔 1 天
+PASS_WARN_AGE   7      # 到期前 7 天警告
+```
+
+套用至現有使用者（以 `deploy` 為例）：
+
+```bash
+chage -M 90 -m 1 -W 7 deploy
+chage -l deploy    # 確認設定
+```
+
+### 5.3 停用不必要系統帳號
+
+```bash
+# 鎖定不使用的帳號
+passwd -l games
+passwd -l news
+passwd -l mail
+
+# 確認沒有空白密碼帳號
+awk -F: '($2 == "" ) { print $1 }' /etc/shadow
+```
+
+### 5.4 sudo 設定
+
+```bash
+# 建議使用 sudoers.d 目錄管理
+visudo -f /etc/sudoers.d/titan-admins
+```
+
+範例內容（限制指令）：
+
+```sudoers
+# 允許 deploy 使用者執行特定指令而不需密碼
+deploy ALL=(ALL) NOPASSWD: /usr/bin/docker, /usr/bin/docker-compose, /bin/systemctl
+```
+
+---
+
+## 6. 核心參數調整（Docker 相容）
+
+建立 `/etc/sysctl.d/99-titan-hardening.conf`：
+
+```ini
+# ============================================================
+# 網路安全強化
+# ============================================================
+
+# 停用 IP 轉發（Docker 需要時設為 1）
+net.ipv4.ip_forward = 1
+
+# 停用 IPv6（若不使用）
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+
+# 防止 SYN Flood 攻擊
+net.ipv4.tcp_syncookies = 1
+net.ipv4.tcp_max_syn_backlog = 4096
+net.ipv4.tcp_synack_retries = 2
+
+# 禁止回應 ICMP 廣播（Smurf 攻擊防護）
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+
+# 啟用反向路徑過濾（防 IP 偽造）
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+
+# 禁止接受 ICMP 重定向（防止路由攻擊）
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+
+# 禁止接受 Source Route 封包
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+
+# 記錄偽造、不完整的封包
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+
+# ============================================================
+# 記憶體與核心安全
+# ============================================================
+
+# 停用 Magic SysRq 鍵（防止意外操作）
+kernel.sysrq = 0
+
+# 限制核心訊息讀取（非 root 使用者）
+kernel.dmesg_restrict = 1
+
+# 防止 core dump 洩漏敏感資訊
+fs.suid_dumpable = 0
+kernel.core_uses_pid = 1
+
+# 位址空間隨機化（ASLR）—— 設為最高
+kernel.randomize_va_space = 2
+
+# 禁止掛載 user namespace（視 Docker 需求調整）
+# kernel.unprivileged_userns_clone = 0
+
+# ============================================================
+# Docker / 容器相關
+# ============================================================
+
+# 允許 Docker 橋接網路
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+
+# 增加最大連線追蹤數
+net.netfilter.nf_conntrack_max = 1048576
+
+# ============================================================
+# 效能調整
+# ============================================================
+
+# 增加檔案描述符上限（Docker 容器需要）
+fs.file-max = 2097152
+
+# TCP 連線最佳化
+net.core.somaxconn = 65535
+net.ipv4.tcp_tw_reuse = 1
+```
+
+套用設定：
+
+```bash
+sysctl --system
+# 或僅套用特定檔案
+sysctl -p /etc/sysctl.d/99-titan-hardening.conf
+```
+
+---
+
+## 7. 稽核與日誌設定
+
+### 7.1 安裝 auditd
+
+```bash
+apt-get install -y auditd audispd-plugins
+systemctl enable --now auditd
+```
+
+### 7.2 基本稽核規則 `/etc/audit/rules.d/titan.rules`
+
+```
+# 監控 /etc/passwd 和 /etc/shadow 變更
+-w /etc/passwd -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/group -p wa -k identity
+
+# 監控 SSH 設定變更
+-w /etc/ssh/sshd_config -p wa -k sshd
+
+# 監控 sudo 使用
+-w /var/log/sudo.log -p wa -k sudo_log
+-w /etc/sudoers -p wa -k sudoers
+
+# 監控特權指令
+-a always,exit -F arch=b64 -S execve -F euid=0 -k root_cmd
+
+# 監控網路設定變更
+-w /etc/network/ -p wa -k network_cfg
+```
+
+套用規則：
+
+```bash
+auditctl -R /etc/audit/rules.d/titan.rules
+systemctl restart auditd
+```
+
+### 7.3 日誌集中保留
+
+```bash
+# 設定 journald 永久保留
+sed -i 's/#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf
+systemctl restart systemd-journald
+```
+
+---
+
+## 8. 驗證清單
+
+完成設定後，執行 `scripts/os-verify.sh` 進行自動驗證。
+
+手動檢查項目：
+
+- [ ] `timedatectl` 顯示 `Asia/Taipei` 時區且 NTP 已同步
+- [ ] `ufw status` 顯示 active，且只開放必要 port
+- [ ] `sshd -T | grep permitrootlogin` 顯示 `no`
+- [ ] `sshd -T | grep passwordauthentication` 顯示 `no`
+- [ ] `sysctl net.ipv4.tcp_syncookies` 顯示 `1`
+- [ ] `sysctl kernel.randomize_va_space` 顯示 `2`
+- [ ] `systemctl is-active auditd` 顯示 `active`
+- [ ] `chronyc tracking` 顯示時間已同步
+
+---
+
+> 本文件由 TITAN 專案 T06 任務產生。如有異動請同步更新 `scripts/os-harden.sh`。

--- a/scripts/os-harden.sh
+++ b/scripts/os-harden.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN 專案 — OS 基礎強化腳本
+# 任務：T06 — OS Baseline and Hardening
+# 適用：Ubuntu 22.04 LTS / Debian 12+
+# 作者：TITAN Team
+# 版本：1.0.0
+#
+# 使用方式：
+#   sudo ./os-harden.sh           # 實際執行
+#   sudo ./os-harden.sh --dry-run # 模擬執行（不變更系統）
+# =============================================================================
+
+set -euo pipefail
+
+# ── 顏色定義 ─────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'  # No Color
+
+# ── 全域變數 ─────────────────────────────────────────────────────────────────
+DRY_RUN=false
+LOG_FILE="/var/log/titan-os-harden.log"
+SSHD_CONFIG="/etc/ssh/sshd_config"
+SYSCTL_FILE="/etc/sysctl.d/99-titan-hardening.conf"
+CHRONY_CONF="/etc/chrony.conf"
+PWQUALITY_CONF="/etc/security/pwquality.conf"
+AUDIT_RULES="/etc/audit/rules.d/titan.rules"
+
+# ── 解析參數 ─────────────────────────────────────────────────────────────────
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    --help|-h)
+      echo "用法: sudo $0 [--dry-run] [--help]"
+      echo "  --dry-run   模擬執行，不實際變更系統"
+      echo "  --help      顯示此說明"
+      exit 0
+      ;;
+    *)
+      echo "未知參數: $arg"
+      echo "使用 --help 查看說明"
+      exit 1
+      ;;
+  esac
+done
+
+# ── 工具函數 ─────────────────────────────────────────────────────────────────
+log() {
+  local level="$1"
+  shift
+  local msg="$*"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  case "$level" in
+    INFO)  echo -e "${GREEN}[INFO]${NC}  ${timestamp} ${msg}" ;;
+    WARN)  echo -e "${YELLOW}[WARN]${NC}  ${timestamp} ${msg}" ;;
+    ERROR) echo -e "${RED}[ERROR]${NC} ${timestamp} ${msg}" >&2 ;;
+    STEP)  echo -e "${BLUE}[STEP]${NC}  ${timestamp} ${msg}" ;;
+  esac
+  if [[ "$DRY_RUN" == false ]] && [[ -w "$(dirname "$LOG_FILE")" ]]; then
+    echo "[${level}] ${timestamp} ${msg}" >> "$LOG_FILE"
+  fi
+}
+
+run_cmd() {
+  # 執行指令，若為 dry-run 模式則僅印出
+  local cmd=("$@")
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將執行: ${cmd[*]}"
+  else
+    "${cmd[@]}"
+  fi
+}
+
+write_file() {
+  # 寫入檔案，dry-run 模式下僅顯示內容
+  local filepath="$1"
+  local content="$2"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將寫入 ${filepath}:"
+    echo "---"
+    echo "$content"
+    echo "---"
+  else
+    echo "$content" > "$filepath"
+    log INFO "已寫入 ${filepath}"
+  fi
+}
+
+set_config_value() {
+  # 設定設定檔中的特定 key，若不存在則追加
+  local filepath="$1"
+  local key="$2"
+  local value="$3"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將設定 ${filepath}: ${key} = ${value}"
+    return
+  fi
+  if grep -qE "^#?[[:space:]]*${key}[[:space:]]" "$filepath"; then
+    sed -i "s|^#\?[[:space:]]*${key}[[:space:]].*|${key} ${value}|g" "$filepath"
+  else
+    echo "${key} ${value}" >> "$filepath"
+  fi
+  log INFO "已設定 ${filepath}: ${key} ${value}"
+}
+
+# ── 前置檢查 ─────────────────────────────────────────────────────────────────
+check_prerequisites() {
+  log STEP "=== 前置條件檢查 ==="
+
+  # 必須以 root 執行
+  if [[ $EUID -ne 0 ]]; then
+    log ERROR "此腳本必須以 root 身份執行（sudo ./os-harden.sh）"
+    exit 1
+  fi
+
+  # 確認作業系統
+  if [[ ! -f /etc/os-release ]]; then
+    log ERROR "無法識別作業系統（找不到 /etc/os-release）"
+    exit 1
+  fi
+  # shellcheck source=/dev/null
+  source /etc/os-release
+  if [[ "$ID" != "ubuntu" && "$ID" != "debian" ]]; then
+    log WARN "偵測到非 Ubuntu/Debian 系統（$ID），部分設定可能不適用"
+  fi
+  log INFO "作業系統：${PRETTY_NAME:-$ID}"
+
+  if [[ "$DRY_RUN" == true ]]; then
+    log INFO "========================================"
+    log INFO "  模擬執行模式（DRY-RUN）已啟用"
+    log INFO "  所有變更僅顯示，不實際套用"
+    log INFO "========================================"
+  fi
+}
+
+# ── 1. 時區與 NTP 設定 ────────────────────────────────────────────────────────
+setup_timezone_ntp() {
+  log STEP "=== [1/7] 時區與 NTP 設定 ==="
+
+  # 設定時區
+  local current_tz
+  current_tz="$(timedatectl show --property=Timezone --value 2>/dev/null || echo 'unknown')"
+  if [[ "$current_tz" == "Asia/Taipei" ]]; then
+    log INFO "時區已設定為 Asia/Taipei，跳過"
+  else
+    log INFO "目前時區：${current_tz}，設定為 Asia/Taipei"
+    run_cmd timedatectl set-timezone Asia/Taipei
+  fi
+
+  # 安裝 chrony
+  if dpkg -l chrony &>/dev/null; then
+    log INFO "chrony 已安裝，跳過安裝"
+  else
+    log INFO "安裝 chrony..."
+    run_cmd apt-get install -y chrony
+  fi
+
+  # 設定 chrony 使用台灣 NTP 池
+  if [[ "$DRY_RUN" == false ]] && ! grep -q "tw.pool.ntp.org" "$CHRONY_CONF" 2>/dev/null; then
+    log INFO "在 ${CHRONY_CONF} 加入台灣 NTP 池設定"
+    run_cmd bash -c "echo 'pool tw.pool.ntp.org iburst maxsources 4' >> ${CHRONY_CONF}"
+  elif [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將加入台灣 NTP 池設定至 ${CHRONY_CONF}"
+  else
+    log INFO "台灣 NTP 池設定已存在，跳過"
+  fi
+
+  run_cmd systemctl enable --now chrony
+  run_cmd systemctl restart chrony
+  log INFO "時區與 NTP 設定完成"
+}
+
+# ── 2. 最小化套件 ─────────────────────────────────────────────────────────────
+minimize_packages() {
+  log STEP "=== [2/7] 移除不必要套件 ==="
+
+  local remove_pkgs=(
+    telnet rsh-client rsh-redone-client nis yp-tools
+    talk talkd xinetd inetutils-telnetd
+  )
+
+  local to_remove=()
+  for pkg in "${remove_pkgs[@]}"; do
+    if dpkg -l "$pkg" &>/dev/null; then
+      to_remove+=("$pkg")
+    fi
+  done
+
+  if [[ ${#to_remove[@]} -eq 0 ]]; then
+    log INFO "無需移除的套件，跳過"
+  else
+    log INFO "將移除：${to_remove[*]}"
+    run_cmd apt-get purge -y "${to_remove[@]}"
+    run_cmd apt-get autoremove -y
+  fi
+
+  # 停用不必要服務
+  local disable_services=(avahi-daemon cups bluetooth)
+  for svc in "${disable_services[@]}"; do
+    if systemctl list-unit-files "${svc}.service" &>/dev/null; then
+      log INFO "停用服務：${svc}"
+      run_cmd systemctl disable --now "$svc" 2>/dev/null || true
+    fi
+  done
+
+  # 安裝 unattended-upgrades
+  if ! dpkg -l unattended-upgrades &>/dev/null; then
+    log INFO "安裝 unattended-upgrades..."
+    run_cmd apt-get install -y unattended-upgrades apt-listchanges
+  else
+    log INFO "unattended-upgrades 已安裝，跳過"
+  fi
+
+  log INFO "套件最小化完成"
+}
+
+# ── 3. 防火牆設定（UFW）───────────────────────────────────────────────────────
+setup_firewall() {
+  log STEP "=== [3/7] 防火牆設定（UFW） ==="
+
+  if ! dpkg -l ufw &>/dev/null; then
+    log INFO "安裝 UFW..."
+    run_cmd apt-get install -y ufw
+  fi
+
+  # 重置並設定預設政策
+  run_cmd ufw --force reset
+  run_cmd ufw default deny incoming
+  run_cmd ufw default allow outgoing
+
+  # 設定 Docker 橋接轉發
+  if [[ "$DRY_RUN" == false ]]; then
+    if grep -q "DEFAULT_FORWARD_POLICY" /etc/default/ufw; then
+      sed -i 's/DEFAULT_FORWARD_POLICY="DROP"/DEFAULT_FORWARD_POLICY="ACCEPT"/' /etc/default/ufw
+    fi
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將設定 /etc/default/ufw: DEFAULT_FORWARD_POLICY=ACCEPT"
+  fi
+
+  # 允許必要連接埠
+  run_cmd ufw allow 22/tcp    # SSH
+  run_cmd ufw allow 80/tcp    # HTTP
+  run_cmd ufw allow 443/tcp   # HTTPS
+
+  # 啟用防火牆
+  run_cmd ufw --force enable
+  log INFO "防火牆設定完成"
+}
+
+# ── 4. SSH 強化 ────────────────────────────────────────────────────────────────
+harden_ssh() {
+  log STEP "=== [4/7] SSH 強化設定 ==="
+
+  if [[ ! -f "$SSHD_CONFIG" ]]; then
+    log ERROR "找不到 ${SSHD_CONFIG}，跳過 SSH 設定"
+    return
+  fi
+
+  # 備份原始設定
+  if [[ "$DRY_RUN" == false ]] && [[ ! -f "${SSHD_CONFIG}.bak" ]]; then
+    run_cmd cp "$SSHD_CONFIG" "${SSHD_CONFIG}.bak"
+    log INFO "已備份 ${SSHD_CONFIG} 至 ${SSHD_CONFIG}.bak"
+  fi
+
+  local ssh_settings=(
+    "PermitRootLogin no"
+    "PasswordAuthentication no"
+    "ChallengeResponseAuthentication no"
+    "X11Forwarding no"
+    "AllowAgentForwarding no"
+    "AllowTcpForwarding no"
+    "MaxAuthTries 3"
+    "MaxSessions 4"
+    "LoginGraceTime 60"
+    "ClientAliveInterval 300"
+    "ClientAliveCountMax 2"
+    "PrintMotd no"
+    "LogLevel VERBOSE"
+    "Protocol 2"
+  )
+
+  for setting in "${ssh_settings[@]}"; do
+    local key value
+    key="$(echo "$setting" | awk '{print $1}')"
+    value="$(echo "$setting" | awk '{$1=""; print $0}' | sed 's/^ //')"
+    set_config_value "$SSHD_CONFIG" "$key" "$value"
+  done
+
+  # 語法檢查
+  if [[ "$DRY_RUN" == false ]]; then
+    if sshd -t; then
+      run_cmd systemctl reload sshd
+      log INFO "SSH 設定已套用"
+    else
+      log ERROR "SSH 設定語法錯誤！正在還原備份..."
+      cp "${SSHD_CONFIG}.bak" "$SSHD_CONFIG"
+      exit 1
+    fi
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將執行 sshd -t 語法檢查並重新載入 sshd"
+  fi
+
+  log INFO "SSH 強化完成"
+}
+
+# ── 5. 帳號與密碼政策 ─────────────────────────────────────────────────────────
+setup_account_policies() {
+  log STEP "=== [5/7] 帳號與密碼政策 ==="
+
+  # 安裝 libpam-pwquality
+  if ! dpkg -l libpam-pwquality &>/dev/null; then
+    log INFO "安裝 libpam-pwquality..."
+    run_cmd apt-get install -y libpam-pwquality
+  fi
+
+  # 設定密碼複雜度
+  if [[ "$DRY_RUN" == false ]]; then
+    cat > "$PWQUALITY_CONF" <<'PWEOF'
+# TITAN OS Hardening — 密碼複雜度政策
+minlen = 12
+minclass = 4
+ucredit = -1
+lcredit = -1
+dcredit = -1
+ocredit = -1
+usercheck = 1
+enforcing = 1
+PWEOF
+    log INFO "已寫入密碼複雜度設定至 ${PWQUALITY_CONF}"
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將寫入密碼複雜度設定至 ${PWQUALITY_CONF}"
+  fi
+
+  # 設定 login.defs 密碼有效期
+  local login_defs="/etc/login.defs"
+  set_config_value "$login_defs" "PASS_MAX_DAYS" "90"
+  set_config_value "$login_defs" "PASS_MIN_DAYS" "1"
+  set_config_value "$login_defs" "PASS_WARN_AGE" "7"
+
+  # 確認沒有空白密碼帳號
+  if [[ "$DRY_RUN" == false ]]; then
+    local empty_pw
+    empty_pw="$(awk -F: '($2 == "" ) { print $1 }' /etc/shadow 2>/dev/null || true)"
+    if [[ -n "$empty_pw" ]]; then
+      log WARN "偵測到空白密碼帳號：${empty_pw}，請手動處理"
+    else
+      log INFO "無空白密碼帳號"
+    fi
+  fi
+
+  log INFO "帳號政策設定完成"
+}
+
+# ── 6. 核心參數（sysctl）─────────────────────────────────────────────────────
+setup_kernel_params() {
+  log STEP "=== [6/7] 核心參數調整（Docker 相容） ==="
+
+  local sysctl_content='# TITAN OS Hardening — 核心參數設定
+# 由 os-harden.sh 自動產生，請勿手動編輯
+
+# ── 網路安全 ────────────────────────────────────────────────
+net.ipv4.ip_forward = 1
+net.ipv4.tcp_syncookies = 1
+net.ipv4.tcp_max_syn_backlog = 4096
+net.ipv4.tcp_synack_retries = 2
+net.ipv4.icmp_echo_ignore_broadcasts = 1
+net.ipv4.icmp_ignore_bogus_error_responses = 1
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.all.send_redirects = 0
+net.ipv6.conf.all.accept_redirects = 0
+net.ipv4.conf.all.accept_source_route = 0
+net.ipv4.conf.default.accept_source_route = 0
+net.ipv4.conf.all.log_martians = 1
+net.ipv4.conf.default.log_martians = 1
+
+# ── 核心安全 ────────────────────────────────────────────────
+kernel.sysrq = 0
+kernel.dmesg_restrict = 1
+fs.suid_dumpable = 0
+kernel.core_uses_pid = 1
+kernel.randomize_va_space = 2
+
+# ── Docker / 容器相容 ────────────────────────────────────────
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.netfilter.nf_conntrack_max = 1048576
+
+# ── 效能調整 ────────────────────────────────────────────────
+fs.file-max = 2097152
+net.core.somaxconn = 65535
+net.ipv4.tcp_tw_reuse = 1'
+
+  write_file "$SYSCTL_FILE" "$sysctl_content"
+
+  if [[ "$DRY_RUN" == false ]]; then
+    # 載入 br_netfilter 模組（Docker bridge 需要）
+    modprobe br_netfilter 2>/dev/null || true
+    if ! grep -q "br_netfilter" /etc/modules-load.d/*.conf 2>/dev/null; then
+      echo "br_netfilter" > /etc/modules-load.d/titan-br_netfilter.conf
+    fi
+    sysctl --system
+    log INFO "核心參數已套用"
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將執行 sysctl --system 套用核心參數"
+  fi
+
+  log INFO "核心參數設定完成"
+}
+
+# ── 7. 稽核設定（auditd）──────────────────────────────────────────────────────
+setup_auditd() {
+  log STEP "=== [7/7] 稽核與日誌設定（auditd） ==="
+
+  if ! dpkg -l auditd &>/dev/null; then
+    log INFO "安裝 auditd..."
+    run_cmd apt-get install -y auditd audispd-plugins
+  fi
+
+  run_cmd systemctl enable --now auditd
+
+  local audit_rules_content='-w /etc/passwd -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/group -p wa -k identity
+-w /etc/ssh/sshd_config -p wa -k sshd
+-w /var/log/sudo.log -p wa -k sudo_log
+-w /etc/sudoers -p wa -k sudoers
+-a always,exit -F arch=b64 -S execve -F euid=0 -k root_cmd
+-w /etc/network/ -p wa -k network_cfg'
+
+  if [[ "$DRY_RUN" == false ]]; then
+    mkdir -p "$(dirname "$AUDIT_RULES")"
+  fi
+  write_file "$AUDIT_RULES" "$audit_rules_content"
+
+  if [[ "$DRY_RUN" == false ]]; then
+    run_cmd systemctl restart auditd
+    log INFO "auditd 稽核規則已套用"
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將重啟 auditd 並套用規則"
+  fi
+
+  # 設定 journald 永久保留日誌
+  if [[ "$DRY_RUN" == false ]]; then
+    sed -i 's/^#Storage=auto/Storage=persistent/' /etc/systemd/journald.conf 2>/dev/null || true
+    systemctl restart systemd-journald
+    log INFO "journald 已設定為永久保留日誌"
+  else
+    echo -e "${YELLOW}[DRY-RUN]${NC} 將設定 journald Storage=persistent"
+  fi
+
+  log INFO "稽核設定完成"
+}
+
+# ── 完成摘要 ─────────────────────────────────────────────────────────────────
+print_summary() {
+  echo ""
+  echo -e "${GREEN}================================================================${NC}"
+  if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${GREEN}  TITAN OS 強化腳本 — 模擬執行完成（未實際變更系統）${NC}"
+  else
+    echo -e "${GREEN}  TITAN OS 強化腳本 — 執行完成${NC}"
+  fi
+  echo -e "${GREEN}================================================================${NC}"
+  echo ""
+  echo "已完成步驟："
+  echo "  [1] 時區設定（Asia/Taipei）+ chrony NTP"
+  echo "  [2] 移除不必要套件 + unattended-upgrades"
+  echo "  [3] UFW 防火牆（預設拒絕入站，開放 22/80/443）"
+  echo "  [4] SSH 強化（禁止 root 登入、禁止密碼認證）"
+  echo "  [5] 密碼複雜度政策（12 字元、4 類別）"
+  echo "  [6] 核心參數（SYN cookie、ASLR、Docker 橋接）"
+  echo "  [7] auditd 稽核規則 + journald 永久日誌"
+  echo ""
+  if [[ "$DRY_RUN" == false ]]; then
+    echo -e "${YELLOW}建議後續步驟：${NC}"
+    echo "  1. 執行 scripts/os-verify.sh 驗證設定"
+    echo "  2. 確認可以使用 SSH 金鑰登入後，再完全停用密碼認證"
+    echo "  3. 依專案需求調整 UFW 規則（如需開放其他 port）"
+    echo "  4. 完整日誌請查看 ${LOG_FILE}"
+  fi
+  echo ""
+}
+
+# ── 主程式 ────────────────────────────────────────────────────────────────────
+main() {
+  check_prerequisites
+  setup_timezone_ntp
+  minimize_packages
+  setup_firewall
+  harden_ssh
+  setup_account_policies
+  setup_kernel_params
+  setup_auditd
+  print_summary
+}
+
+main "$@"

--- a/scripts/os-verify.sh
+++ b/scripts/os-verify.sh
@@ -1,0 +1,485 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN 專案 — OS 強化驗證腳本
+# 任務：T06 — OS Baseline and Hardening
+# 適用：Ubuntu 22.04 LTS / Debian 12+
+#
+# 使用方式：
+#   sudo ./os-verify.sh           # 完整驗證
+#   sudo ./os-verify.sh --quiet   # 僅顯示失敗項目
+# =============================================================================
+
+set -euo pipefail
+
+# ── 顏色定義 ─────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ── 全域統計 ─────────────────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+WARN=0
+QUIET=false
+
+# ── 解析參數 ─────────────────────────────────────────────────────────────────
+for arg in "$@"; do
+  case "$arg" in
+    --quiet|-q) QUIET=true ;;
+    --help|-h)
+      echo "用法: sudo $0 [--quiet] [--help]"
+      echo "  --quiet   僅顯示失敗與警告項目"
+      echo "  --help    顯示此說明"
+      exit 0
+      ;;
+    *)
+      echo "未知參數: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+# ── 工具函數 ─────────────────────────────────────────────────────────────────
+pass() {
+  PASS=$((PASS + 1))
+  if [[ "$QUIET" == false ]]; then
+    echo -e "  ${GREEN}[PASS]${NC} $*"
+  fi
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo -e "  ${RED}[FAIL]${NC} $*"
+}
+
+warn() {
+  WARN=$((WARN + 1))
+  echo -e "  ${YELLOW}[WARN]${NC} $*"
+}
+
+section() {
+  echo ""
+  echo -e "${BLUE}── $* ──────────────────────────────────────────────────────────${NC}"
+}
+
+check_cmd_exists() {
+  local cmd="$1"
+  if command -v "$cmd" &>/dev/null; then
+    pass "指令存在：${cmd}"
+    return 0
+  else
+    fail "指令不存在：${cmd}"
+    return 1
+  fi
+}
+
+check_service_active() {
+  local svc="$1"
+  if systemctl is-active --quiet "$svc" 2>/dev/null; then
+    pass "服務運行中：${svc}"
+    return 0
+  else
+    fail "服務未運行：${svc}"
+    return 1
+  fi
+}
+
+check_service_enabled() {
+  local svc="$1"
+  if systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+    pass "服務已啟用（開機自啟）：${svc}"
+    return 0
+  else
+    fail "服務未設為開機自啟：${svc}"
+    return 1
+  fi
+}
+
+# ── 前置檢查 ─────────────────────────────────────────────────────────────────
+check_prerequisites() {
+  if [[ $EUID -ne 0 ]]; then
+    echo -e "${RED}錯誤：此腳本必須以 root 身份執行（sudo ./os-verify.sh）${NC}"
+    exit 1
+  fi
+}
+
+# ── 1. 時區與 NTP 驗證 ────────────────────────────────────────────────────────
+verify_timezone_ntp() {
+  section "1. 時區與 NTP"
+
+  # 時區
+  local tz
+  tz="$(timedatectl show --property=Timezone --value 2>/dev/null || timedatectl | awk '/Time zone/{print $3}')"
+  if [[ "$tz" == "Asia/Taipei" ]]; then
+    pass "時區：${tz}"
+  else
+    fail "時區不正確：${tz}（期望：Asia/Taipei）"
+  fi
+
+  # NTP 同步狀態
+  local ntp_sync
+  ntp_sync="$(timedatectl show --property=NTPSynchronized --value 2>/dev/null || echo 'unknown')"
+  if [[ "$ntp_sync" == "yes" ]]; then
+    pass "NTP 時間已同步"
+  else
+    warn "NTP 尚未同步（${ntp_sync}），請確認網路連線與 chrony 服務"
+  fi
+
+  # chrony 服務
+  check_service_active chrony
+  check_service_enabled chrony
+
+  # chrony 追蹤狀態
+  if command -v chronyc &>/dev/null; then
+    local stratum
+    stratum="$(chronyc tracking 2>/dev/null | awk '/Stratum/{print $3}' || echo '0')"
+    if [[ -n "$stratum" ]] && [[ "$stratum" -gt 0 ]] 2>/dev/null; then
+      pass "chrony 已同步，Stratum：${stratum}"
+    else
+      warn "chrony 同步狀態不確定（Stratum: ${stratum}）"
+    fi
+  fi
+}
+
+# ── 2. 套件驗證 ───────────────────────────────────────────────────────────────
+verify_packages() {
+  section "2. 套件與服務"
+
+  # 確認危險套件已移除
+  local danger_pkgs=(telnet rsh-client xinetd)
+  for pkg in "${danger_pkgs[@]}"; do
+    if ! dpkg -l "$pkg" &>/dev/null; then
+      pass "套件已移除：${pkg}"
+    else
+      fail "危險套件仍存在：${pkg}（應移除）"
+    fi
+  done
+
+  # unattended-upgrades
+  if dpkg -l unattended-upgrades &>/dev/null; then
+    pass "unattended-upgrades 已安裝"
+  else
+    warn "unattended-upgrades 未安裝，建議安裝以啟用自動安全更新"
+  fi
+}
+
+# ── 3. 防火牆驗證 ─────────────────────────────────────────────────────────────
+verify_firewall() {
+  section "3. 防火牆（UFW）"
+
+  if ! command -v ufw &>/dev/null; then
+    fail "UFW 未安裝"
+    return
+  fi
+
+  local ufw_status
+  ufw_status="$(ufw status | head -1)"
+  if echo "$ufw_status" | grep -qi "active"; then
+    pass "UFW 防火牆：已啟用"
+  else
+    fail "UFW 防火牆：未啟用（${ufw_status}）"
+  fi
+
+  # 檢查預設政策
+  local default_in
+  default_in="$(ufw status verbose 2>/dev/null | awk '/Default.*incoming/{print $2}' || echo 'unknown')"
+  if [[ "$default_in" == "deny" ]]; then
+    pass "UFW 預設入站政策：deny（正確）"
+  else
+    fail "UFW 預設入站政策：${default_in}（期望：deny）"
+  fi
+
+  # 檢查必要 port
+  local ufw_rules
+  ufw_rules="$(ufw status numbered 2>/dev/null || echo '')"
+  for port in 22 80 443; do
+    if echo "$ufw_rules" | grep -q "${port}/tcp\|${port} "; then
+      pass "UFW 允許 port ${port}/tcp"
+    else
+      warn "UFW 未明確允許 port ${port}/tcp，請確認是否需要"
+    fi
+  done
+
+  # Docker 轉發設定
+  local forward_policy
+  forward_policy="$(grep '^DEFAULT_FORWARD_POLICY' /etc/default/ufw 2>/dev/null | cut -d'"' -f2 || echo 'unknown')"
+  if [[ "$forward_policy" == "ACCEPT" ]]; then
+    pass "UFW Docker 橋接轉發：ACCEPT（正確）"
+  else
+    warn "UFW DEFAULT_FORWARD_POLICY=${forward_policy}（Docker 可能需要 ACCEPT）"
+  fi
+}
+
+# ── 4. SSH 驗證 ───────────────────────────────────────────────────────────────
+verify_ssh() {
+  section "4. SSH 強化設定"
+
+  if ! command -v sshd &>/dev/null; then
+    warn "sshd 未安裝，跳過 SSH 驗證"
+    return
+  fi
+
+  # 讀取 sshd 有效設定（包含 Include 檔案）
+  local sshd_runtime
+  sshd_runtime="$(sshd -T 2>/dev/null || echo '')"
+
+  check_sshd_setting() {
+    local key="$1"
+    local expected="$2"
+    local actual
+    actual="$(echo "$sshd_runtime" | awk -v k="${key,,}" 'tolower($1)==k{print tolower($2); exit}')"
+    if [[ "$actual" == "${expected,,}" ]]; then
+      pass "sshd ${key}：${actual}（正確）"
+    else
+      fail "sshd ${key}：${actual}（期望：${expected}）"
+    fi
+  }
+
+  check_sshd_setting "PermitRootLogin"          "no"
+  check_sshd_setting "PasswordAuthentication"   "no"
+  check_sshd_setting "X11Forwarding"            "no"
+  check_sshd_setting "AllowAgentForwarding"     "no"
+  check_sshd_setting "AllowTcpForwarding"       "no"
+  check_sshd_setting "LogLevel"                 "verbose"
+
+  # MaxAuthTries 不應超過 5
+  local max_auth_tries
+  max_auth_tries="$(echo "$sshd_runtime" | awk 'tolower($1)=="maxauthtries"{print $2}')"
+  if [[ -n "$max_auth_tries" ]] && [[ "$max_auth_tries" -le 5 ]] 2>/dev/null; then
+    pass "sshd MaxAuthTries：${max_auth_tries}（≤5，正確）"
+  else
+    fail "sshd MaxAuthTries：${max_auth_tries:-未設定}（期望：≤5）"
+  fi
+
+  # sshd 服務運行狀態
+  check_service_active sshd || check_service_active ssh
+}
+
+# ── 5. 帳號政策驗證 ───────────────────────────────────────────────────────────
+verify_account_policies() {
+  section "5. 帳號與密碼政策"
+
+  # login.defs
+  local login_defs="/etc/login.defs"
+  check_login_defs() {
+    local key="$1"
+    local expected="$2"
+    local actual
+    actual="$(awk -v k="$key" '$1==k{print $2}' "$login_defs" 2>/dev/null || echo '')"
+    if [[ "$actual" == "$expected" ]]; then
+      pass "${login_defs} ${key}：${actual}（正確）"
+    else
+      fail "${login_defs} ${key}：${actual}（期望：${expected}）"
+    fi
+  }
+
+  check_login_defs "PASS_MAX_DAYS" "90"
+  check_login_defs "PASS_MIN_DAYS" "1"
+  check_login_defs "PASS_WARN_AGE" "7"
+
+  # libpam-pwquality
+  if dpkg -l libpam-pwquality &>/dev/null; then
+    pass "libpam-pwquality 已安裝"
+    local minlen
+    minlen="$(awk -F'=' '/^minlen/{gsub(/ /,"",$2); print $2}' /etc/security/pwquality.conf 2>/dev/null || echo '')"
+    if [[ -n "$minlen" ]] && [[ "$minlen" -ge 12 ]] 2>/dev/null; then
+      pass "密碼最小長度：${minlen}（≥12，正確）"
+    else
+      fail "密碼最小長度：${minlen:-未設定}（期望：≥12）"
+    fi
+  else
+    fail "libpam-pwquality 未安裝"
+  fi
+
+  # 空白密碼帳號
+  local empty_pw
+  empty_pw="$(awk -F: '($2 == "" ) { print $1 }' /etc/shadow 2>/dev/null || echo '')"
+  if [[ -z "$empty_pw" ]]; then
+    pass "無空白密碼帳號"
+  else
+    fail "偵測到空白密碼帳號：${empty_pw}"
+  fi
+}
+
+# ── 6. 核心參數驗證 ───────────────────────────────────────────────────────────
+verify_kernel_params() {
+  section "6. 核心參數（sysctl）"
+
+  check_sysctl() {
+    local key="$1"
+    local expected="$2"
+    local actual
+    actual="$(sysctl -n "$key" 2>/dev/null || echo 'N/A')"
+    if [[ "$actual" == "$expected" ]]; then
+      pass "${key}：${actual}（正確）"
+    else
+      fail "${key}：${actual}（期望：${expected}）"
+    fi
+  }
+
+  # 網路安全
+  check_sysctl "net.ipv4.tcp_syncookies"                   "1"
+  check_sysctl "net.ipv4.icmp_echo_ignore_broadcasts"      "1"
+  check_sysctl "net.ipv4.conf.all.accept_redirects"        "0"
+  check_sysctl "net.ipv4.conf.all.send_redirects"          "0"
+  check_sysctl "net.ipv4.conf.all.accept_source_route"     "0"
+  check_sysctl "net.ipv4.conf.all.log_martians"            "1"
+  check_sysctl "net.ipv4.conf.all.rp_filter"               "1"
+
+  # 核心安全
+  check_sysctl "kernel.sysrq"                              "0"
+  check_sysctl "kernel.dmesg_restrict"                     "1"
+  check_sysctl "kernel.randomize_va_space"                 "2"
+  check_sysctl "fs.suid_dumpable"                          "0"
+
+  # Docker 相關
+  check_sysctl "net.ipv4.ip_forward"                       "1"
+
+  # 設定檔存在
+  if [[ -f "/etc/sysctl.d/99-titan-hardening.conf" ]]; then
+    pass "sysctl 設定檔存在：/etc/sysctl.d/99-titan-hardening.conf"
+  else
+    warn "未找到 TITAN sysctl 設定檔（/etc/sysctl.d/99-titan-hardening.conf）"
+  fi
+}
+
+# ── 7. 稽核驗證 ───────────────────────────────────────────────────────────────
+verify_auditd() {
+  section "7. 稽核（auditd）"
+
+  check_service_active auditd
+  check_service_enabled auditd
+
+  # 稽核規則
+  local audit_rules
+  audit_rules="$(auditctl -l 2>/dev/null || echo '')"
+
+  check_audit_rule() {
+    local desc="$1"
+    local pattern="$2"
+    if echo "$audit_rules" | grep -q "$pattern"; then
+      pass "稽核規則存在：${desc}"
+    else
+      fail "稽核規則缺失：${desc}"
+    fi
+  }
+
+  check_audit_rule "/etc/passwd 監控"      "/etc/passwd"
+  check_audit_rule "/etc/shadow 監控"      "/etc/shadow"
+  check_audit_rule "sshd_config 監控"      "sshd_config"
+  check_audit_rule "sudoers 監控"          "sudoers"
+
+  # journald 持久化
+  local journald_storage
+  journald_storage="$(awk -F'=' '/^Storage/{gsub(/ /,"",$2); print $2}' /etc/systemd/journald.conf 2>/dev/null || echo 'auto')"
+  if [[ "$journald_storage" == "persistent" ]]; then
+    pass "journald Storage：persistent（日誌永久保留）"
+  else
+    warn "journald Storage：${journald_storage}（建議設為 persistent）"
+  fi
+}
+
+# ── 8. 額外安全檢查 ───────────────────────────────────────────────────────────
+verify_extra() {
+  section "8. 額外安全檢查"
+
+  # 監聽埠檢查（非預期的開放 port）
+  if command -v ss &>/dev/null; then
+    local listening_ports
+    listening_ports="$(ss -tlnp 2>/dev/null | awk 'NR>1{print $4}' | sort -u || echo '')"
+    local unexpected_ports=()
+    while IFS= read -r addr; do
+      local port
+      port="$(echo "$addr" | rev | cut -d: -f1 | rev)"
+      case "$port" in
+        22|80|443|25|587|3306|5432|6379|8080|8443) ;;  # 已知服務
+        *)
+          if [[ -n "$port" ]] && [[ "$port" =~ ^[0-9]+$ ]]; then
+            unexpected_ports+=("$port")
+          fi
+          ;;
+      esac
+    done <<< "$listening_ports"
+
+    if [[ ${#unexpected_ports[@]} -eq 0 ]]; then
+      pass "無意外開放的監聽埠"
+    else
+      warn "偵測到非預期監聽埠：${unexpected_ports[*]}，請確認是否必要"
+    fi
+  fi
+
+  # SUID/SGID 檔案數量（警戒值）
+  local suid_count
+  suid_count="$(find / -xdev \( -perm -4000 -o -perm -2000 \) -type f 2>/dev/null | wc -l || echo '0')"
+  if [[ "$suid_count" -le 50 ]]; then
+    pass "SUID/SGID 檔案數量：${suid_count}（≤50，正常）"
+  else
+    warn "SUID/SGID 檔案數量：${suid_count}（建議手動審查）"
+  fi
+
+  # 確認 /tmp 掛載選項（若為獨立分割區）
+  if mount | grep -q " on /tmp "; then
+    local tmp_opts
+    tmp_opts="$(mount | awk '$3=="/tmp"{print $6}')"
+    if echo "$tmp_opts" | grep -q "noexec"; then
+      pass "/tmp 掛載含 noexec 選項"
+    else
+      warn "/tmp 未設定 noexec 掛載選項，建議評估是否需要"
+    fi
+  fi
+}
+
+# ── 彙整報告 ─────────────────────────────────────────────────────────────────
+print_report() {
+  local total=$((PASS + FAIL + WARN))
+  echo ""
+  echo -e "${BLUE}================================================================${NC}"
+  echo -e "${BLUE}  TITAN OS 強化驗證報告${NC}"
+  echo -e "${BLUE}================================================================${NC}"
+  printf "  %-12s %s\n" "主機名稱：" "$(hostname)"
+  printf "  %-12s %s\n" "驗證時間：" "$(date '+%Y-%m-%d %H:%M:%S %Z')"
+  printf "  %-12s %s\n" "執行身份：" "$(id)"
+  echo ""
+  printf "  ${GREEN}%-10s %d${NC}\n" "通過：" "$PASS"
+  printf "  ${RED}%-10s %d${NC}\n" "失敗：" "$FAIL"
+  printf "  ${YELLOW}%-10s %d${NC}\n" "警告：" "$WARN"
+  printf "  %-10s %d\n" "總計：" "$total"
+  echo ""
+
+  if [[ "$FAIL" -eq 0 ]]; then
+    echo -e "${GREEN}  [結論] 所有強制項目均通過，系統符合 TITAN OS 強化基準${NC}"
+    if [[ "$WARN" -gt 0 ]]; then
+      echo -e "${YELLOW}  [提醒] 有 ${WARN} 個警告項目，建議評估處理${NC}"
+    fi
+  else
+    echo -e "${RED}  [結論] 有 ${FAIL} 個項目不符合強化基準，請執行 scripts/os-harden.sh 修復${NC}"
+  fi
+  echo -e "${BLUE}================================================================${NC}"
+  echo ""
+
+  # 以結果決定退出碼
+  [[ "$FAIL" -eq 0 ]]
+}
+
+# ── 主程式 ────────────────────────────────────────────────────────────────────
+main() {
+  check_prerequisites
+
+  echo ""
+  echo -e "${BLUE}TITAN OS 強化驗證腳本 — 開始執行${NC}"
+  echo -e "${BLUE}時間：$(date '+%Y-%m-%d %H:%M:%S %Z')${NC}"
+
+  verify_timezone_ntp
+  verify_packages
+  verify_firewall
+  verify_ssh
+  verify_account_policies
+  verify_kernel_params
+  verify_auditd
+  verify_extra
+  print_report
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- 新增 `docs/os-hardening.md`：Linux 系統基礎強化指南（繁體中文），涵蓋時區/NTP、最小化套件、UFW 防火牆、SSH 強化、帳號政策、Docker 相容核心參數、auditd 稽核
- 新增 `scripts/os-harden.sh`：自動化強化腳本，具冪等性、支援 `--dry-run` 模式、7 大強化步驟、彩色輸出與執行日誌
- 新增 `scripts/os-verify.sh`：強化驗證腳本，8 大類別檢查、PASS/FAIL/WARN 統計報告、非零退出碼（有 FAIL 時）供 CI 使用

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)