### PR TITLE
feat: Kimai time tracking deep integration

### DIFF
--- a/config/homepage/services.yaml
+++ b/config/homepage/services.yaml
@@ -58,3 +58,22 @@
         description: 快取與任務佇列（Redis 7）
         server: titan-docker
         container: titan-redis
+
+# ── 工時管理 ───────────────────────────────────────────────
+- 工時管理:
+    - Kimai:
+        icon: kimai.png
+        href: "{{HOMEPAGE_VAR_KIMAI_URL}}"
+        description: 工時追蹤與工時報表系統
+        server: titan-docker
+        container: titan-kimai
+        widget:
+          type: customapi
+          url: "{{HOMEPAGE_VAR_KIMAI_URL}}/api/version"
+          method: GET
+          headers:
+            Authorization: "Bearer {{HOMEPAGE_VAR_KIMAI_API_TOKEN}}"
+          mappings:
+            - field: version
+              label: 版本
+              format: text

--- a/config/kimai/.env.example
+++ b/config/kimai/.env.example
@@ -1,0 +1,92 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# TITAN 平台 — Kimai 工時追蹤環境變數範本
+# Issue: #64 — Kimai Time Tracking Deep Integration
+# ─────────────────────────────────────────────────────────────────────────
+# 使用方式：
+#   cp config/kimai/.env.example .env
+#   編輯 .env，填入實際值（切勿提交 .env 至版本控制）
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ── MySQL 資料庫設定 ────────────────────────────────────────────────────────
+# Kimai 專用 MySQL 8.0（與 TITAN 的 PostgreSQL 16 獨立）
+
+# MySQL root 密碼（僅初始化使用，請使用強密碼）
+KIMAI_MYSQL_ROOT_PASSWORD=change_me_root_password
+
+# Kimai 應用程式資料庫帳號
+KIMAI_DB_NAME=kimai
+KIMAI_DB_USER=kimai
+KIMAI_DB_PASSWORD=change_me_kimai_db_password
+
+# ── Kimai 應用程式設定 ──────────────────────────────────────────────────────
+
+# APP_SECRET：隨機 32 位元十六進位字串（可用 openssl rand -hex 32 生成）
+KIMAI_APP_SECRET=change_me_32_char_random_secret_here
+
+# 時區（銀行 IT 環境：台北時間 UTC+8）
+KIMAI_TIMEZONE=Asia/Taipei
+
+# ── 超級管理員帳號（初次部署時自動建立）──────────────────────────────────────
+# ⚠️  部署完成後請立即從管理介面修改密碼
+KIMAI_ADMIN_EMAIL=admin@titan.bank.local
+KIMAI_ADMIN_PASSWORD=change_me_admin_password
+
+# ── 信任主機設定（配合 Nginx 反向代理）───────────────────────────────────────
+# 多個主機名稱用逗號分隔
+KIMAI_TRUSTED_HOSTS=titan.bank.local,titan.local,localhost
+
+# ── Homepage Widget 整合 ───────────────────────────────────────────────────
+# Kimai 對外 URL（透過 Nginx 反向代理）
+HOMEPAGE_VAR_KIMAI_URL=https://titan.bank.local/kimai
+
+# Homepage 使用的 Kimai API Token（從 Kimai 管理介面 → API Access Tokens 建立）
+HOMEPAGE_VAR_KIMAI_API_TOKEN=change_me_kimai_api_token
+
+# ── LDAP / AD 整合設定（選用）────────────────────────────────────────────────
+# 啟用後使用者可透過 AD/LDAP 帳號登入 Kimai（單一登入）
+# 設定完成後需重啟 Kimai 容器
+
+# 是否啟用 LDAP 整合（true / false）
+KIMAI_LDAP_ACTIVE=false
+
+# LDAP 伺服器地址（Active Directory 網域控制器）
+KIMAI_LDAP_HOST=ldap://dc01.bank.local
+
+# LDAP 連線埠（標準 389，TLS 加密 636）
+KIMAI_LDAP_PORT=389
+
+# 搜尋用帳號（建議使用唯讀服務帳號）
+KIMAI_LDAP_BIND_DN=CN=kimai-svc,OU=ServiceAccounts,DC=bank,DC=local
+KIMAI_LDAP_BIND_PASSWORD=change_me_ldap_service_account_password
+
+# 使用者搜尋基底（User Search Base DN）
+KIMAI_LDAP_USER_BASE_DN=OU=Users,DC=bank,DC=local
+
+# 使用者篩選條件（僅允許特定 OU 或群組成員登入）
+KIMAI_LDAP_USER_FILTER=(objectClass=person)
+
+# 使用者屬性映射
+KIMAI_LDAP_ATTR_USERNAME=sAMAccountName
+KIMAI_LDAP_ATTR_EMAIL=mail
+KIMAI_LDAP_ATTR_DISPLAYNAME=displayName
+
+# ── Plane 整合設定（專案同步腳本使用）────────────────────────────────────────
+# 用於 scripts/kimai-sync-projects.sh
+
+# Plane API 基底 URL
+PLANE_API_BASE_URL=https://titan.bank.local/plane/api/v1
+
+# Plane API Token（從 Plane 設定 → API Tokens 取得）
+PLANE_API_TOKEN=change_me_plane_api_token
+
+# Plane Workspace Slug（URL 中的工作區識別碼）
+PLANE_WORKSPACE_SLUG=titan-bank
+
+# Kimai API 基底 URL（供腳本呼叫）
+KIMAI_API_BASE_URL=https://titan.bank.local/kimai/api
+
+# Kimai API Token（腳本使用的 API 存取金鑰，從 Kimai 管理介面建立）
+KIMAI_API_TOKEN=change_me_kimai_api_token_for_scripts
+
+# ── 郵件通知設定（選用，工時報表寄送使用）────────────────────────────────────
+# KIMAI_MAILER_URL=smtp://smtp.bank.local:587?encryption=tls&auth_mode=login&username=kimai-noreply@bank.local&password=change_me

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -10,6 +10,7 @@
 #     /plane/    → Plane 專案管理     (plane-proxy:80，占位)
 #     /minio/    → MinIO Console      (titan-minio:9001)
 #     /uptime/   → Uptime Kuma        (titan-uptime-kuma:3001)
+#     /kimai/    → Kimai 工時追蹤     (titan-kimai:8001，Issue #64)
 # ═══════════════════════════════════════════════════════════════════════════
 
 # ── 主進程設定 ─────────────────────────────────────────────────────────────
@@ -107,6 +108,12 @@ http {
     # Plane（占位，待 Plane 啟動後啟用）
     upstream plane_backend {
         server plane-proxy:80;
+        keepalive 16;
+    }
+
+    # Kimai 工時追蹤（Issue #64）
+    upstream kimai_backend {
+        server kimai:8001;
         keepalive 16;
     }
 
@@ -383,6 +390,64 @@ http {
 
             # Timeout
             proxy_connect_timeout   60s;
+            proxy_send_timeout      60s;
+            proxy_read_timeout      60s;
+        }
+
+        # ════════════════════════════════════════════════════════════════
+        # 路由 6：Kimai 工時追蹤 → /kimai/
+        #   對外 URL：https://titan.bank.local/kimai/
+        #   後端容器：titan-kimai:8001（Apache variant）
+        #   Issue：#64 — Kimai Time Tracking Deep Integration
+        # ════════════════════════════════════════════════════════════════
+        location /kimai/ {
+            limit_req  zone=general  burst=30  nodelay;
+
+            # Kimai Apache variant 監聽 8001，前綴由 Apache rewrite 處理
+            proxy_pass         http://kimai_backend/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+            # 告知 Kimai 其路徑前綴（需搭配 TRUSTED_PROXIES 設定）
+            proxy_set_header   X-Forwarded-Prefix /kimai;
+
+            # WebSocket 不適用於 Kimai，但保留標準標頭
+            proxy_set_header   Upgrade     $http_upgrade;
+            proxy_set_header   Connection  "upgrade";
+
+            # Timeout（工時報表查詢可能較耗時）
+            proxy_connect_timeout   60s;
+            proxy_send_timeout      120s;
+            proxy_read_timeout      120s;
+
+            # Kimai API 回應可緩衝
+            proxy_buffering    on;
+            proxy_buffer_size  8k;
+        }
+
+        # ── Kimai REST API 獨立限速端點 ──────────────────────────────
+        # 供 scripts/kimai-sync-projects.sh 等自動化腳本使用
+        location /kimai/api/ {
+            limit_req  zone=api  burst=20  nodelay;
+
+            proxy_pass         http://kimai_backend/api/;
+            proxy_http_version 1.1;
+
+            proxy_set_header   Host               $host;
+            proxy_set_header   X-Real-IP          $remote_addr;
+            proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto  $scheme;
+            proxy_set_header   X-Forwarded-Host   $host;
+            proxy_set_header   X-Forwarded-Prefix /kimai;
+
+            # API 回應不緩衝（確保即時性）
+            proxy_buffering    off;
+
+            proxy_connect_timeout   30s;
             proxy_send_timeout      60s;
             proxy_read_timeout      60s;
         }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,135 @@
+# TITAN 平台 — Kimai 工時追蹤整合擴充設定
+# Issue: #64 — Kimai Time Tracking Deep Integration
+# 此檔案覆寫 docker-compose.yml 的預設設定，新增 Kimai + MySQL 服務
+# 使用方式：docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+#
+# 架構說明：
+#   Kimai 使用獨立的 MySQL 8.0（與 TITAN 的 PostgreSQL 16 分開）
+#   所有服務加入 titan-internal 網路，透過 Nginx /kimai/ 路徑對外服務
+#
+# 版本固定原則（air-gapped 部署相容）：
+#   kimai: kimai/kimai2:apache-2.21.0（Apache variant，支援 URL rewrite）
+#   mysql: mysql:8.0.36（與 Kimai 2.x 官方相容版本）
+
+version: '3.8'
+
+services:
+
+  # ── Kimai 工時追蹤 MySQL 資料庫 ──────────────────────────
+  # 獨立 MySQL 8.0，供 Kimai 專用（不與 TITAN PostgreSQL 混用）
+  # 資料持久化至 kimai-mysql-data volume
+  kimai-mysql:
+    image: mysql:8.0.36
+    container_name: titan-kimai-mysql
+    restart: unless-stopped
+    # 安全強化：使用 mysql 使用者執行
+    user: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${KIMAI_MYSQL_ROOT_PASSWORD:?KIMAI_MYSQL_ROOT_PASSWORD is required}
+      MYSQL_DATABASE: ${KIMAI_DB_NAME:-kimai}
+      MYSQL_USER: ${KIMAI_DB_USER:-kimai}
+      MYSQL_PASSWORD: ${KIMAI_DB_PASSWORD:?KIMAI_DB_PASSWORD is required}
+      # 時區設定（與 Kimai 一致）
+      TZ: ${KIMAI_TIMEZONE:-Asia/Taipei}
+    volumes:
+      - kimai-mysql-data:/var/lib/mysql
+    # 安全強化：不對外開放端口，僅供 Kimai 容器內部存取
+    # ports:
+    #   - "3306:3306"
+    networks:
+      - titan-internal
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+08:00
+      - --max-allowed-packet=128M
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost",
+             "-u", "${KIMAI_DB_USER:-kimai}", "-p${KIMAI_DB_PASSWORD}"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  # ── Kimai 工時追蹤應用 ────────────────────────────────────
+  # 版本固定：kimai/kimai2:apache-2.21.0
+  # Apache variant：內建 mod_rewrite，支援 URL 前綴（/kimai/）
+  # 文件：https://www.kimai.org/documentation/docker.html
+  kimai:
+    image: kimai/kimai2:apache-2.21.0
+    container_name: titan-kimai
+    restart: unless-stopped
+    environment:
+      # ── 資料庫連線 ────────────────────────────────────────
+      DATABASE_URL: "mysql://${KIMAI_DB_USER:-kimai}:${KIMAI_DB_PASSWORD}@kimai-mysql:3306/${KIMAI_DB_NAME:-kimai}?charset=utf8mb4&serverVersion=8.0.36"
+      # ── 應用程式設定 ──────────────────────────────────────
+      APP_ENV: production
+      APP_SECRET: ${KIMAI_APP_SECRET:?KIMAI_APP_SECRET is required}
+      KIMAI_LANGUAGE: zh_TW
+      # ── 時區（與銀行 IT 環境一致）──────────────────────────
+      KIMAI_TIMEZONE: ${KIMAI_TIMEZONE:-Asia/Taipei}
+      # ── 超級管理員帳號（初次部署時建立）──────────────────
+      ADMINMAIL: ${KIMAI_ADMIN_EMAIL:?KIMAI_ADMIN_EMAIL is required}
+      ADMINPASS: ${KIMAI_ADMIN_PASSWORD:?KIMAI_ADMIN_PASSWORD is required}
+      # ── 信任 Nginx 反向代理 ────────────────────────────────
+      TRUSTED_PROXIES: "nginx,172.16.0.0/12,10.0.0.0/8"
+      TRUSTED_HOSTS: "${KIMAI_TRUSTED_HOSTS:-titan.bank.local,titan.local,localhost}"
+      # ── LDAP 整合（選用，設定見 config/kimai/.env.example）─
+      KIMAI_LDAP_ACTIVE: ${KIMAI_LDAP_ACTIVE:-false}
+      # ── URL 前綴（Nginx 反向代理路徑）─────────────────────
+      # 注意：Kimai Apache variant 需搭配 /kimai/ Nginx location 使用
+    volumes:
+      - kimai-var-data:/opt/kimai/var
+      - kimai-public-data:/opt/kimai/public/uploads
+    # 安全強化：不對外開放端口，僅透過 Nginx 反向代理存取
+    # ports:
+    #   - "8001:8001"
+    networks:
+      - titan-internal
+    depends_on:
+      kimai-mysql:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8001/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
+  # ── Nginx：新增 Kimai upstream（覆寫）────────────────────
+  # 讓 Nginx 容器的依賴包含 Kimai（確保啟動順序正確）
+  nginx:
+    depends_on:
+      kimai:
+        condition: service_healthy
+
+# ── 持久化 Volume ────────────────────────────────────────
+volumes:
+  kimai-mysql-data:
+    name: titan-kimai-mysql-data
+  kimai-var-data:
+    name: titan-kimai-var-data
+  kimai-public-data:
+    name: titan-kimai-public-data
+
+# ── 網路（沿用主 compose 定義，無需重複宣告）────────────────
+networks:
+  titan-internal:
+    external: true
+    name: titan-internal

--- a/docs/kimai-integration.md
+++ b/docs/kimai-integration.md
@@ -1,0 +1,413 @@
+# Kimai 工時追蹤深度整合指南
+
+> **Issue**: #64 — Kimai Time Tracking Deep Integration
+> **文件版本**: 1.0
+> **最後更新**: 2026-03-23
+> **適用版本**: Kimai 2.21.x + TITAN 平台
+
+---
+
+## 目錄
+
+1. [架構概述](#架構概述)
+2. [服務啟動方式](#服務啟動方式)
+3. [現有 MySQL dump 匯入指南](#現有-mysql-dump-匯入指南)
+4. [LDAP / AD 單一登入設定](#ldap--ad-單一登入設定)
+5. [Plane 專案結構對應](#plane-專案結構對應)
+6. [Kimai REST API 整合端點](#kimai-rest-api-整合端點)
+7. [常見問題排查](#常見問題排查)
+
+---
+
+## 架構概述
+
+Kimai 透過 `docker-compose.override.yml` 整合進 TITAN 容器平台，與現有服務共享 `titan-internal` 網路，但使用獨立的 MySQL 8.0 資料庫（與 TITAN 的 PostgreSQL 16 分開管理）。
+
+```
+使用者瀏覽器
+    │
+    ▼
+Nginx 反向代理 (titan-nginx)
+    │  https://titan.bank.local/kimai/
+    ▼
+Kimai Apache 容器 (titan-kimai:8001)
+    │
+    ▼
+MySQL 8.0 (titan-kimai-mysql:3306)
+    │
+    ▼  Volume 持久化
+kimai-mysql-data / kimai-var-data / kimai-public-data
+```
+
+### 網路流量路徑
+
+| 元件 | 容器名稱 | 網路 | 對外路徑 |
+|------|---------|------|---------|
+| Nginx 反向代理 | titan-nginx | titan-internal + titan-external | — |
+| Kimai 應用程式 | titan-kimai | titan-internal | `/kimai/` |
+| Kimai MySQL | titan-kimai-mysql | titan-internal | 不對外 |
+
+### 與其他 TITAN 服務的整合關係
+
+- **Nginx**：提供 `/kimai/` 及 `/kimai/api/` 兩個 location block，分別對應 UI 及 API 呼叫（API 端點套用較嚴格的速率限制）
+- **Homepage**：在「工時管理」類別顯示 Kimai 服務卡片，並透過 Kimai REST API 顯示版本資訊
+- **Plane**：透過 `scripts/kimai-sync-projects.sh` 定期將 Plane 專案同步至 Kimai，維持一致的專案結構
+- **Uptime Kuma**：建議新增 Kimai 健康監控端點（`https://titan.bank.local/kimai/`）
+
+---
+
+## 服務啟動方式
+
+### 首次部署
+
+```bash
+# 1. 複製環境變數範本
+cp config/kimai/.env.example .env
+# 編輯 .env，填入所有必要值（特別是密碼欄位）
+
+# 2. 啟動 Kimai + MySQL（疊加主 compose）
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.override.yml \
+  up -d kimai-mysql kimai
+
+# 3. 等待服務就緒（約 90 秒）
+docker compose logs -f kimai
+
+# 4. 確認服務狀態
+docker compose ps kimai kimai-mysql
+
+# 5. 重新載入 Nginx（新增 /kimai/ 路由）
+docker compose restart nginx
+```
+
+### 驗證部署
+
+```bash
+# 確認 Kimai 可正常回應
+curl -s https://titan.bank.local/kimai/api/version | jq .
+
+# 預期回應：
+# { "version": "2.21.0", ... }
+```
+
+---
+
+## 現有 MySQL dump 匯入指南
+
+團隊於 2025 年 6 月安裝的 Kimai 資料可透過以下步驟匯入。
+
+### 步驟 1：準備舊版資料庫 dump
+
+```bash
+# 從舊伺服器匯出（在舊伺服器執行）
+mysqldump \
+  -u kimai_user \
+  -p \
+  --single-transaction \
+  --routines \
+  --triggers \
+  kimai_db > /tmp/kimai-backup-$(date +%Y%m%d).sql
+
+# 將 dump 檔傳輸至 TITAN 伺服器
+scp /tmp/kimai-backup-*.sql admin@titan.bank.local:/opt/titan/backups/
+```
+
+### 步驟 2：確認新容器 MySQL 已初始化
+
+```bash
+# 確認 titan-kimai-mysql 容器健康
+docker exec titan-kimai-mysql mysqladmin \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" ping
+# 回應：mysqld is alive
+```
+
+### 步驟 3：匯入資料
+
+```bash
+# 清空預設資料庫（首次部署時 Kimai 會自動建立空表）
+docker exec -i titan-kimai-mysql mysql \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" kimai \
+  -e "DROP DATABASE kimai; CREATE DATABASE kimai CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+# 匯入備份資料
+docker exec -i titan-kimai-mysql mysql \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" kimai \
+  < /opt/titan/backups/kimai-backup-YYYYMMDD.sql
+```
+
+### 步驟 4：執行資料庫 Migration
+
+```bash
+# 舊版資料結構需 migration 至 Kimai 2.21.x schema
+docker exec titan-kimai \
+  /opt/kimai/bin/console kimai:update --no-interaction
+```
+
+### 步驟 5：驗證資料完整性
+
+```bash
+# 確認使用者數量
+docker exec titan-kimai-mysql mysql \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" kimai \
+  -e "SELECT COUNT(*) AS users FROM kimai2_users;"
+
+# 確認工時記錄數量
+docker exec titan-kimai-mysql mysql \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" kimai \
+  -e "SELECT COUNT(*) AS timesheets FROM kimai2_timesheet;"
+```
+
+---
+
+## LDAP / AD 單一登入設定
+
+啟用 LDAP 整合後，使用者可直接以 Active Directory 帳號登入 Kimai，無需額外記憶獨立密碼。
+
+### 前置條件
+
+- 已取得唯讀 AD 服務帳號（建議 `kimai-svc@bank.local`）
+- LDAP 伺服器可從 Docker 內網存取（需確認防火牆規則）
+
+### 設定步驟
+
+**步驟 1：在 .env 啟用 LDAP**
+
+```bash
+KIMAI_LDAP_ACTIVE=true
+KIMAI_LDAP_HOST=ldap://dc01.bank.local
+KIMAI_LDAP_PORT=389
+KIMAI_LDAP_BIND_DN=CN=kimai-svc,OU=ServiceAccounts,DC=bank,DC=local
+KIMAI_LDAP_BIND_PASSWORD=服務帳號密碼
+KIMAI_LDAP_USER_BASE_DN=OU=ITDept,DC=bank,DC=local
+KIMAI_LDAP_USER_FILTER=(memberOf=CN=TITAN-Users,OU=Groups,DC=bank,DC=local)
+KIMAI_LDAP_ATTR_USERNAME=sAMAccountName
+KIMAI_LDAP_ATTR_EMAIL=mail
+KIMAI_LDAP_ATTR_DISPLAYNAME=displayName
+```
+
+**步驟 2：新增 Kimai LDAP 設定檔**
+
+在 `kimai-var-data` volume 中建立 `config/packages/local.yaml`：
+
+```yaml
+# /opt/kimai/config/packages/local.yaml
+kimai:
+  ldap:
+    activate: true
+    connection:
+      host: '%env(KIMAI_LDAP_HOST)%'
+      port: '%env(int:KIMAI_LDAP_PORT)%'
+      bindRequiresDn: true
+    user:
+      baseDn: '%env(KIMAI_LDAP_USER_BASE_DN)%'
+      filter: '%env(KIMAI_LDAP_USER_FILTER)%'
+      usernameAttribute: '%env(KIMAI_LDAP_ATTR_USERNAME)%'
+      attributesFilter: '(objectClass=person)'
+      attributes:
+        - { ldap_attr: '%env(KIMAI_LDAP_ATTR_EMAIL)%', user_method: setEmail }
+        - { ldap_attr: '%env(KIMAI_LDAP_ATTR_DISPLAYNAME)%', user_method: setAlias }
+```
+
+**步驟 3：清除快取並重啟**
+
+```bash
+docker exec titan-kimai \
+  /opt/kimai/bin/console cache:clear --env=production
+
+docker compose restart kimai
+```
+
+**步驟 4：測試 LDAP 連線**
+
+```bash
+docker exec titan-kimai \
+  /opt/kimai/bin/console kimai:ldap:sync --dry-run
+```
+
+### 權限對應建議
+
+| AD 群組 | Kimai 角色 | 說明 |
+|---------|-----------|------|
+| `TITAN-Users` | `ROLE_USER` | 一般 IT 人員，可記錄工時 |
+| `TITAN-Leads` | `ROLE_TEAMLEAD` | 主管，可審核下屬工時 |
+| `TITAN-Admin` | `ROLE_ADMIN` | 管理員，可管理專案與使用者 |
+
+---
+
+## Plane 專案結構對應
+
+### 對應設計原則
+
+TITAN 採用以下映射策略確保 Kimai 工時與 Plane 任務可相互關聯：
+
+```
+Plane Workspace
+└── Plane Project（如：CORE-後端重構）
+    └── Plane Issue（如：CORE-42 修復登入 Bug）
+        ↕ 對應
+Kimai 專案（如：[CORE] 後端重構）
+└── Kimai Activity（如：程式開發、測試與驗證）
+    └── Kimai Timesheet Entry
+        └── Description 欄位填入 Plane Issue 編號（如：CORE-42）
+```
+
+### 活動類型標準（銀行 IT 工作分類）
+
+每個 Kimai 專案自動建立以下 10 種活動類型：
+
+| 活動名稱 | 說明 | 典型工作內容 |
+|---------|------|------------|
+| 需求分析與規劃 | 收集使用者需求、評估可行性 | 訪談、文件撰寫、工作量估算 |
+| 系統設計 | 架構設計、技術選型 | UML 繪製、技術 PoC |
+| 程式開發 | 功能實作、Code Review | Coding、PR Review |
+| 測試與驗證 | 功能測試、整合測試 | SIT、UAT、Bug 驗證 |
+| 文件撰寫 | 操作手冊、技術文件 | 系統文件、使用者指南 |
+| 部署與上線 | 生產環境部署 | Release、上線支援 |
+| 問題排查與修復 | 生產問題處理 | 障礙排除、Hotfix |
+| 會議與溝通 | 各類會議 | Standup、評審會議 |
+| 教育訓練 | 技術培訓 | 新人訓練、技術分享 |
+| 專案管理 | 專案推進 | 進度追蹤、風險管理 |
+
+### 同步腳本使用方式
+
+```bash
+# 預覽同步內容（不執行寫入）
+bash scripts/kimai-sync-projects.sh --dry-run
+
+# 正式同步
+bash scripts/kimai-sync-projects.sh
+
+# 詳細模式（顯示 API 回應）
+bash scripts/kimai-sync-projects.sh --verbose
+```
+
+建議透過 cron 定期執行（每日一次），確保 Kimai 專案與 Plane 保持同步：
+
+```bash
+# crontab -e（在 TITAN 主機上）
+0 8 * * * /opt/titan/scripts/kimai-sync-projects.sh >> /var/log/titan/kimai-sync.log 2>&1
+```
+
+---
+
+## Kimai REST API 整合端點
+
+Kimai 提供完整的 REST API，基底 URL：`https://titan.bank.local/kimai/api`
+
+API 文件（Swagger UI）：`https://titan.bank.local/kimai/api/doc`
+
+### 認證方式
+
+```bash
+# 方式 1：API Token（推薦，用於自動化腳本）
+curl -H "Authorization: Bearer YOUR_API_TOKEN" \
+     https://titan.bank.local/kimai/api/version
+
+# 方式 2：HTTP Basic Auth（測試用）
+curl -u "username:password" \
+     https://titan.bank.local/kimai/api/version
+```
+
+### 常用 API 端點
+
+| 方法 | 端點 | 說明 |
+|------|------|------|
+| `GET` | `/api/version` | 取得 Kimai 版本資訊 |
+| `GET` | `/api/projects` | 列出所有專案 |
+| `POST` | `/api/projects` | 建立新專案 |
+| `GET` | `/api/activities` | 列出所有活動 |
+| `POST` | `/api/activities` | 建立新活動 |
+| `GET` | `/api/timesheets` | 查詢工時記錄 |
+| `POST` | `/api/timesheets` | 新增工時記錄 |
+| `PATCH` | `/api/timesheets/{id}/stop` | 停止計時 |
+| `GET` | `/api/users` | 列出使用者 |
+| `GET` | `/api/teams` | 列出團隊 |
+
+### 工時記錄新增範例
+
+```bash
+# 開始計時（不指定結束時間 = 即時計時）
+curl -X POST https://titan.bank.local/kimai/api/timesheets \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project": 1,
+    "activity": 3,
+    "begin": "2026-03-23T09:00:00+08:00",
+    "description": "CORE-42 修復使用者登入問題"
+  }'
+
+# 手動新增固定時段工時
+curl -X POST https://titan.bank.local/kimai/api/timesheets \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project": 1,
+    "activity": 3,
+    "begin": "2026-03-23T09:00:00+08:00",
+    "end": "2026-03-23T11:30:00+08:00",
+    "description": "CORE-42 後端 API 修復"
+  }'
+```
+
+### 工時查詢範例
+
+```bash
+# 查詢本週工時（依使用者）
+curl "https://titan.bank.local/kimai/api/timesheets?\
+begin=2026-03-18T00:00:00%2B08:00&\
+end=2026-03-24T23:59:59%2B08:00&\
+user=1" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" | jq .
+```
+
+---
+
+## 常見問題排查
+
+### Kimai 容器啟動失敗
+
+```bash
+# 查看詳細日誌
+docker logs titan-kimai --tail=100
+
+# 常見原因：MySQL 尚未就緒
+# 解決方案：等待 kimai-mysql healthcheck 通過後再啟動 kimai
+docker compose up -d kimai-mysql
+# 等待 30-60 秒
+docker compose up -d kimai
+```
+
+### 無法透過 /kimai/ 存取
+
+```bash
+# 確認 Nginx 設定已更新並重新載入
+docker exec titan-nginx nginx -t
+docker exec titan-nginx nginx -s reload
+
+# 確認 Kimai 容器在 titan-internal 網路上
+docker network inspect titan-internal | grep kimai
+```
+
+### LDAP 登入失敗
+
+```bash
+# 測試 LDAP 連線
+docker exec titan-kimai \
+  /opt/kimai/bin/console kimai:ldap:sync --dry-run --username 測試帳號
+
+# 查看 Kimai 應用程式日誌
+docker exec titan-kimai \
+  tail -f /opt/kimai/var/log/prod.log
+```
+
+### MySQL 資料庫備份
+
+```bash
+# 定期備份（建議加入 cron）
+docker exec titan-kimai-mysql mysqldump \
+  -u kimai -p"${KIMAI_DB_PASSWORD}" \
+  --single-transaction \
+  kimai > /opt/titan/backups/kimai-$(date +%Y%m%d-%H%M%S).sql
+```

--- a/docs/timesheet-reporting.md
+++ b/docs/timesheet-reporting.md
@@ -1,0 +1,337 @@
+# 工時報表產生指南
+
+> **Issue**: #64 — Kimai Time Tracking Deep Integration
+> **文件版本**: 1.0
+> **最後更新**: 2026-03-23
+> **適用版本**: Kimai 2.21.x + TITAN 平台
+
+---
+
+## 目錄
+
+1. [報表概述](#報表概述)
+2. [週報產生方式（Kimai API）](#週報產生方式kimai-api)
+3. [報表格式範本](#報表格式範本)
+4. [Plane 任務資料結合](#plane-任務資料結合)
+5. [自動化報表腳本](#自動化報表腳本)
+6. [匯出格式說明](#匯出格式說明)
+
+---
+
+## 報表概述
+
+TITAN 工時報表系統整合 Kimai（工時記錄）與 Plane（任務管理），提供 IT 主管所需的多維度工時分析報表。
+
+### 報表用途
+
+| 報表類型 | 頻率 | 主要閱讀對象 | 用途 |
+|---------|------|------------|------|
+| 個人週報 | 每週一 | IT 人員本人 | 確認自身工時是否合理 |
+| 專案工時彙整 | 每週一 | 專案主管 | 掌握各專案耗用資源 |
+| 部門月報 | 每月 1 日 | IT 部門主管 | 月度資源分配檢討 |
+| 個別任務工時 | 按需 | 技術主管 | 特定 Plane Issue 工時分析 |
+
+---
+
+## 週報產生方式（Kimai API）
+
+### 方法 1：Kimai 內建報表（建議一般使用）
+
+1. 登入 `https://titan.bank.local/kimai/`
+2. 左側選單 → **報表** → **週報**
+3. 選擇使用者（或「我的報表」）
+4. 選擇目標週次
+5. 點選「匯出 PDF」或「匯出 Excel」
+
+### 方法 2：REST API 查詢（適合自動化）
+
+```bash
+# 設定報表週期（以本週為例）
+WEEK_START=$(date -d "monday" +%Y-%m-%dT00:00:00+08:00)
+WEEK_END=$(date -d "sunday" +%Y-%m-%dT23:59:59+08:00)
+
+# 查詢全部人員工時（需 ROLE_ADMIN 或 ROLE_TEAMLEAD）
+curl -s "https://titan.bank.local/kimai/api/timesheets?\
+begin=${WEEK_START}&\
+end=${WEEK_END}&\
+full=true&\
+size=500" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" | jq .
+```
+
+### 方法 3：Kimai 內建匯出 API
+
+```bash
+# 匯出本週工時為 CSV（所有使用者）
+curl -s "https://titan.bank.local/kimai/api/timesheets/export?\
+type=csv&\
+begin=${WEEK_START}&\
+end=${WEEK_END}" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" \
+  -o "weekly-timesheet-$(date +%Y-W%V).csv"
+```
+
+---
+
+## 報表格式範本
+
+### 個人週報格式
+
+```
+════════════════════════════════════════════════════════════
+TITAN IT 部門 — 個人工時週報
+姓名：{員工姓名}
+週次：{YYYY} 年第 {WW} 週（{MM/DD} ~ {MM/DD}）
+════════════════════════════════════════════════════════════
+
+一、工時總覽
+─────────────────────────────────────────────────────────
+  本週總工時：{X.XX} 小時
+  標準工時：40.00 小時
+  超時 / 不足：{+/-X.XX} 小時
+
+二、各專案工時分配
+─────────────────────────────────────────────────────────
+  專案名稱                      活動類型        工時
+  [CORE] 後端核心系統             程式開發        12.50 h
+  [CORE] 後端核心系統             測試與驗證       4.00 h
+  [INFRA] 基礎設施現代化          部署與上線       3.00 h
+  [MGMT] 專案管理                 會議與溝通       6.00 h
+  ────────────────────────────────────────────────────
+  合計                                           25.50 h
+
+三、工時明細（依日期排序）
+─────────────────────────────────────────────────────────
+  日期        開始     結束     工時   專案          活動          說明
+  2026-03-18  09:00   12:00   3.00   [CORE]        程式開發      CORE-42 修復登入 Bug
+  2026-03-18  13:00   17:30   4.50   [CORE]        程式開發      CORE-45 API 效能優化
+  2026-03-19  09:00   11:00   2.00   [INFRA]       部署與上線    K8s 版本升級
+  ...
+
+四、備註
+─────────────────────────────────────────────────────────
+  {員工自填備註}
+
+════════════════════════════════════════════════════════════
+產生時間：{YYYY-MM-DD HH:MM:SS} | 資料來源：Kimai 2.21 + Plane
+```
+
+### 專案工時彙整格式
+
+```
+════════════════════════════════════════════════════════════
+TITAN IT 部門 — 專案工時彙整週報
+週次：{YYYY} 年第 {WW} 週（{MM/DD} ~ {MM/DD}）
+════════════════════════════════════════════════════════════
+
+一、各專案工時總覽
+─────────────────────────────────────────────────────────
+  排名  專案識別碼  專案名稱              本週工時  累計工時  人員數
+   1    CORE       後端核心系統           45.50 h  280.00 h    3
+   2    INFRA      基礎設施現代化         22.00 h  156.50 h    2
+   3    SEC        資安強化計畫           15.00 h   98.00 h    2
+   4    MGMT       專案管理              12.00 h   88.50 h    1
+
+二、人員工時分配矩陣
+─────────────────────────────────────────────────────────
+              CORE   INFRA   SEC   MGMT   其他   合計
+  張小明      18.5    6.0    3.0   3.0    0.0   30.5 h
+  李小華      15.0    8.0    4.0   3.0    0.0   30.0 h
+  王小英      12.0    8.0    8.0   6.0    0.0   34.0 h
+  ──────────────────────────────────────────────────
+  小計        45.5   22.0   15.0  12.0    0.0   94.5 h
+
+三、Plane Issue 工時關聯（本週新增 / 完成）
+─────────────────────────────────────────────────────────
+  Issue 編號   標題                        狀態   工時
+  CORE-42      修復使用者登入 Bug           完成   8.5 h
+  CORE-45      API 回應效能優化            進行中  6.0 h
+  INFRA-18     Kubernetes 版本升級         完成   12.0 h
+
+════════════════════════════════════════════════════════════
+產生時間：{YYYY-MM-DD HH:MM:SS} | 資料來源：Kimai 2.21 + Plane API
+```
+
+---
+
+## Plane 任務資料結合
+
+### 整合原理
+
+Kimai 工時記錄的 `description` 欄位填入 Plane Issue 編號（如 `CORE-42`），透過 API 交叉查詢即可取得完整的「工時 × 任務」分析。
+
+### 範例：查詢特定 Issue 的工時
+
+```bash
+# 查詢所有包含 CORE-42 的工時記錄
+ISSUE_REF="CORE-42"
+curl -s "https://titan.bank.local/kimai/api/timesheets?\
+term=${ISSUE_REF}&size=100" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" | \
+  jq '[.[] | {
+    date: .begin[:10],
+    user: .user.alias,
+    project: .project.name,
+    activity: .activity.name,
+    hours: (.duration / 3600),
+    description: .description
+  }]'
+```
+
+### 範例：從 Plane 取得 Issue 詳情並結合工時
+
+```bash
+PLANE_ISSUE_ID="CORE-42"
+KIMAI_API_TOKEN="your_token"
+PLANE_API_TOKEN="your_plane_token"
+
+# 取得 Plane Issue 詳情
+plane_issue=$(curl -s \
+  "https://titan.bank.local/plane/api/v1/workspaces/titan-bank/issues/?search=${PLANE_ISSUE_ID}" \
+  -H "X-Api-Key: ${PLANE_API_TOKEN}" | jq '.results[0]')
+
+# 取得對應工時
+kimai_hours=$(curl -s \
+  "https://titan.bank.local/kimai/api/timesheets?term=${PLANE_ISSUE_ID}&size=100" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" | \
+  jq '[.[].duration] | add // 0 | . / 3600')
+
+echo "Issue: ${PLANE_ISSUE_ID}"
+echo "標題: $(echo $plane_issue | jq -r '.name')"
+echo "狀態: $(echo $plane_issue | jq -r '.state_detail.name')"
+echo "總工時: ${kimai_hours} 小時"
+```
+
+---
+
+## 自動化報表腳本
+
+以下腳本可搭配 cron 自動產生並儲存週報資料。
+
+### 週報自動產生（存為 JSON）
+
+```bash
+#!/usr/bin/env bash
+# generate-weekly-report.sh — 產生本週工時報表 JSON
+
+set -euo pipefail
+
+# 載入環境變數
+source "$(dirname "$0")/../.env"
+
+# 計算本週日期範圍（週一至週日）
+WEEK_START=$(date -d "last monday" +%Y-%m-%dT00:00:00+08:00 2>/dev/null || \
+             date -v-monday +%Y-%m-%dT00:00:00+08:00)
+WEEK_END=$(date -d "next sunday 23:59:59" +%Y-%m-%dT23:59:59+08:00 2>/dev/null || \
+           date -v+sunday +%Y-%m-%dT23:59:59+08:00)
+WEEK_NUM=$(date +%V)
+YEAR=$(date +%Y)
+
+OUTPUT_DIR="/opt/titan/reports/timesheets"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT_FILE="${OUTPUT_DIR}/weekly-${YEAR}-W${WEEK_NUM}.json"
+
+echo "正在產生 ${YEAR} 年第 ${WEEK_NUM} 週工時報表..."
+
+# 查詢 Kimai API
+curl -s \
+  "https://titan.bank.local/kimai/api/timesheets?begin=${WEEK_START}&end=${WEEK_END}&full=true&size=1000" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" | \
+  jq '{
+    report_type: "weekly",
+    year: '"$YEAR"',
+    week: '"$WEEK_NUM"',
+    period: { start: "'"$WEEK_START"'", end: "'"$WEEK_END"'" },
+    generated_at: now | todate,
+    entries: [.[] | {
+      date: .begin[:10],
+      user: .user.alias,
+      project: .project.name,
+      activity: .activity.name,
+      hours: (.duration / 3600 * 100 | round / 100),
+      description: (.description // "")
+    }],
+    summary: {
+      total_hours: ([.[].duration] | add // 0) / 3600,
+      unique_users: ([.[].user.alias] | unique | length),
+      unique_projects: ([.[].project.name] | unique | length)
+    }
+  }' > "$OUTPUT_FILE"
+
+echo "報表已儲存至：$OUTPUT_FILE"
+```
+
+### cron 設定範例
+
+```bash
+# /etc/cron.d/titan-reports
+
+# 每週一早上 08:00 自動產生上週工時報表
+0 8 * * 1 titan /opt/titan/scripts/generate-weekly-report.sh >> /var/log/titan/reports.log 2>&1
+
+# 每月 1 日早上 08:30 產生上月工時月報
+30 8 1 * * titan /opt/titan/scripts/generate-monthly-report.sh >> /var/log/titan/reports.log 2>&1
+```
+
+---
+
+## 匯出格式說明
+
+Kimai 支援多種匯出格式，可從 UI 或 API 取得。
+
+### UI 匯出（Kimai 管理介面）
+
+1. 登入 Kimai → **工時記錄** → 設定日期範圍
+2. 點選右上角 **匯出** 按鈕
+3. 可選格式：
+
+| 格式 | 用途 | 備註 |
+|------|------|------|
+| PDF | 正式報表、送簽 | 包含銀行 LOGO（需設定） |
+| Excel (.xlsx) | 資料分析 | 可直接在 Excel 加工 |
+| CSV | 系統整合 | 純文字，編碼 UTF-8 |
+| DOCX | Word 格式 | 適合插入其他文件 |
+
+### API 匯出參數
+
+```bash
+# 匯出指定月份工時為 Excel
+curl -s "https://titan.bank.local/kimai/api/timesheets/export?\
+type=xlsx&\
+begin=2026-03-01T00:00:00%2B08:00&\
+end=2026-03-31T23:59:59%2B08:00" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" \
+  -o "march-2026-timesheet.xlsx"
+
+# 匯出特定專案工時為 CSV
+PROJECT_ID=1
+curl -s "https://titan.bank.local/kimai/api/timesheets/export?\
+type=csv&\
+project[]=${PROJECT_ID}&\
+begin=2026-03-01T00:00:00%2B08:00&\
+end=2026-03-31T23:59:59%2B08:00" \
+  -H "Authorization: Bearer ${KIMAI_API_TOKEN}" \
+  -o "project-${PROJECT_ID}-march-2026.csv"
+```
+
+### CSV 欄位說明
+
+匯出的 CSV 包含以下標準欄位：
+
+| 欄位名稱 | 說明 | 範例 |
+|---------|------|------|
+| `Date` | 工時日期 | `2026-03-23` |
+| `From` | 開始時間 | `09:00` |
+| `To` | 結束時間 | `11:30` |
+| `Duration` | 工時（時:分） | `2:30` |
+| `Username` | 登入帳號 | `zhangxiaomin` |
+| `Name` | 顯示名稱 | `張小明` |
+| `Project` | 專案名稱 | `[CORE] 後端核心系統` |
+| `Activity` | 活動類型 | `程式開發` |
+| `Description` | 工作說明 | `CORE-42 修復登入 Bug` |
+| `Exported` | 是否已匯出過 | `false` |
+| `Tags` | 標籤 | `hotfix,priority-high` |
+| `Hourly rate` | 時薪（若有設定） | `0` |
+| `Total` | 小計金額（若有設定） | `0` |
+
+> **注意**：銀行內部工時系統通常不計費，`Hourly rate` 與 `Total` 欄位可忽略。

--- a/scripts/kimai-sync-projects.sh
+++ b/scripts/kimai-sync-projects.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+# TITAN 平台 — Plane 專案同步至 Kimai 腳本
+# Issue: #64 — Kimai Time Tracking Deep Integration
+# ─────────────────────────────────────────────────────────────────────────
+# 功能說明：
+#   從 Plane REST API 讀取所有專案，同步建立對應的 Kimai 專案與活動（Activity）
+#   讓 IT 團隊可在 Kimai 中針對 Plane 專案記錄工時
+#
+# 使用方式：
+#   bash scripts/kimai-sync-projects.sh [--dry-run] [--verbose]
+#
+# 前置需求：
+#   - curl（HTTP 請求）
+#   - jq（JSON 解析）
+#   - 已設定 config/kimai/.env.example 中的環境變數
+#
+# 環境變數（從 .env 載入或手動匯出）：
+#   PLANE_API_BASE_URL    — Plane API 基底 URL
+#   PLANE_API_TOKEN       — Plane API 存取金鑰
+#   PLANE_WORKSPACE_SLUG  — Plane 工作區識別碼
+#   KIMAI_API_BASE_URL    — Kimai API 基底 URL
+#   KIMAI_API_TOKEN       — Kimai API 存取金鑰
+# ═══════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+# ── 顏色輸出 ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# ── 旗標解析 ────────────────────────────────────────────────────────────────
+DRY_RUN=false
+VERBOSE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)  DRY_RUN=true ;;
+    --verbose)  VERBOSE=true ;;
+    --help|-h)
+      echo "使用方式: $0 [--dry-run] [--verbose]"
+      echo ""
+      echo "  --dry-run   僅顯示將執行的操作，不實際寫入 Kimai"
+      echo "  --verbose   顯示詳細 API 回應"
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}[錯誤]${NC} 未知參數: $arg"
+      exit 1
+      ;;
+  esac
+done
+
+# ── 載入環境變數 ─────────────────────────────────────────────────────────────
+# 優先從腳本目錄的上層 .env 載入
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/../.env"
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  echo -e "${BLUE}[資訊]${NC} 已載入環境變數：$ENV_FILE"
+else
+  echo -e "${YELLOW}[警告]${NC} 找不到 .env 檔案，使用現有環境變數"
+fi
+
+# ── 必要變數驗證 ─────────────────────────────────────────────────────────────
+REQUIRED_VARS=(
+  PLANE_API_BASE_URL
+  PLANE_API_TOKEN
+  PLANE_WORKSPACE_SLUG
+  KIMAI_API_BASE_URL
+  KIMAI_API_TOKEN
+)
+
+MISSING_VARS=()
+for var in "${REQUIRED_VARS[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    MISSING_VARS+=("$var")
+  fi
+done
+
+if [[ ${#MISSING_VARS[@]} -gt 0 ]]; then
+  echo -e "${RED}[錯誤]${NC} 缺少必要環境變數："
+  for var in "${MISSING_VARS[@]}"; do
+    echo "  - $var"
+  done
+  echo ""
+  echo "請參閱 config/kimai/.env.example 並設定上述變數"
+  exit 1
+fi
+
+# ── 工具函數 ─────────────────────────────────────────────────────────────────
+
+log_info()    { echo -e "${BLUE}[資訊]${NC} $*"; }
+log_success() { echo -e "${GREEN}[成功]${NC} $*"; }
+log_warn()    { echo -e "${YELLOW}[警告]${NC} $*"; }
+log_error()   { echo -e "${RED}[錯誤]${NC} $*" >&2; }
+log_dry()     { echo -e "${YELLOW}[DRY-RUN]${NC} $*"; }
+
+# 呼叫 Plane API
+plane_api() {
+  local method="$1"
+  local endpoint="$2"
+  local data="${3:-}"
+
+  local url="${PLANE_API_BASE_URL}${endpoint}"
+  local response
+
+  if [[ -n "$data" ]]; then
+    response=$(curl -s -X "$method" "$url" \
+      -H "X-Api-Key: ${PLANE_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$data" \
+      -w "\n%{http_code}")
+  else
+    response=$(curl -s -X "$method" "$url" \
+      -H "X-Api-Key: ${PLANE_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -w "\n%{http_code}")
+  fi
+
+  local http_code
+  http_code=$(echo "$response" | tail -n1)
+  local body
+  body=$(echo "$response" | head -n -1)
+
+  if [[ "$VERBOSE" == "true" ]]; then
+    log_info "Plane API ${method} ${endpoint} → HTTP ${http_code}"
+    echo "$body" | jq . 2>/dev/null || echo "$body"
+  fi
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log_error "Plane API 請求失敗（HTTP ${http_code}）：${endpoint}"
+    echo "$body" >&2
+    return 1
+  fi
+
+  echo "$body"
+}
+
+# 呼叫 Kimai API
+kimai_api() {
+  local method="$1"
+  local endpoint="$2"
+  local data="${3:-}"
+
+  local url="${KIMAI_API_BASE_URL}${endpoint}"
+  local response
+
+  if [[ -n "$data" ]]; then
+    response=$(curl -s -X "$method" "$url" \
+      -H "Authorization: Bearer ${KIMAI_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d "$data" \
+      -w "\n%{http_code}")
+  else
+    response=$(curl -s -X "$method" "$url" \
+      -H "Authorization: Bearer ${KIMAI_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -w "\n%{http_code}")
+  fi
+
+  local http_code
+  http_code=$(echo "$response" | tail -n1)
+  local body
+  body=$(echo "$response" | head -n -1)
+
+  if [[ "$VERBOSE" == "true" ]]; then
+    log_info "Kimai API ${method} ${endpoint} → HTTP ${http_code}"
+    echo "$body" | jq . 2>/dev/null || echo "$body"
+  fi
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log_error "Kimai API 請求失敗（HTTP ${http_code}）：${endpoint}"
+    echo "$body" >&2
+    return 1
+  fi
+
+  echo "$body"
+}
+
+# ── 取得 Kimai 現有專案清單（用於去重判斷）────────────────────────────────────
+get_kimai_projects() {
+  kimai_api GET "/projects?visible=1&page=1&size=200" || echo "[]"
+}
+
+# ── 在 Kimai 建立專案 ─────────────────────────────────────────────────────────
+# 參數：plane_project_id plane_name plane_identifier plane_description
+create_kimai_project() {
+  local plane_id="$1"
+  local plane_name="$2"
+  local plane_identifier="$3"
+  local plane_description="${4:-}"
+
+  # Kimai 專案命名規則：[PLANE-識別碼] 專案名稱
+  local kimai_name="[${plane_identifier}] ${plane_name}"
+  # 在備註欄記錄 Plane 專案 ID，便於後續比對
+  local comment="Plane 專案 ID: ${plane_id} | 自動同步於 $(date '+%Y-%m-%d %H:%M:%S')"
+  local meta_note="${plane_description:0:500}"  # 限制說明長度
+
+  local payload
+  payload=$(jq -n \
+    --arg name "$kimai_name" \
+    --arg comment "$comment" \
+    --argjson visible true \
+    --argjson billable false \
+    '{
+      name: $name,
+      comment: $comment,
+      visible: $visible,
+      billable: $billable
+    }')
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_dry "將建立 Kimai 專案：${kimai_name}"
+    return 0
+  fi
+
+  local result
+  result=$(kimai_api POST "/projects" "$payload")
+  local kimai_project_id
+  kimai_project_id=$(echo "$result" | jq -r '.id // empty')
+
+  if [[ -n "$kimai_project_id" ]]; then
+    log_success "已建立 Kimai 專案：${kimai_name}（ID: ${kimai_project_id}）"
+    echo "$kimai_project_id"
+  else
+    log_error "建立 Kimai 專案失敗：${kimai_name}"
+    return 1
+  fi
+}
+
+# ── 在 Kimai 建立活動（Activity）──────────────────────────────────────────────
+# 每個 Kimai 專案建立標準活動類型，對應銀行 IT 工作分類
+create_default_activities() {
+  local kimai_project_id="$1"
+  local project_name="$2"
+
+  # 銀行 IT 標準工時活動類型
+  local -a activities=(
+    "需求分析與規劃"
+    "系統設計"
+    "程式開發"
+    "測試與驗證"
+    "文件撰寫"
+    "部署與上線"
+    "問題排查與修復"
+    "會議與溝通"
+    "教育訓練"
+    "專案管理"
+  )
+
+  for activity_name in "${activities[@]}"; do
+    local payload
+    payload=$(jq -n \
+      --arg name "$activity_name" \
+      --argjson project "$kimai_project_id" \
+      --argjson visible true \
+      --argjson billable false \
+      '{
+        name: $name,
+        project: $project,
+        visible: $visible,
+        billable: $billable
+      }')
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+      log_dry "  將建立活動：${activity_name}（專案 ID: ${kimai_project_id}）"
+      continue
+    fi
+
+    if kimai_api POST "/activities" "$payload" > /dev/null 2>&1; then
+      log_success "  已建立活動：${activity_name}"
+    else
+      log_warn "  活動建立失敗（可能已存在）：${activity_name}"
+    fi
+  done
+}
+
+# ── 主流程 ───────────────────────────────────────────────────────────────────
+
+main() {
+  echo ""
+  echo "════════════════════════════════════════════════════════"
+  echo "  TITAN — Plane → Kimai 專案同步工具"
+  echo "  執行時間：$(date '+%Y-%m-%d %H:%M:%S')"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "  模式：${YELLOW}DRY-RUN（僅預覽，不執行寫入）${NC}"
+  else
+    echo "  模式：正式執行"
+  fi
+  echo "════════════════════════════════════════════════════════"
+  echo ""
+
+  # ── 步驟 1：取得 Plane 所有專案 ────────────────────────────────────────────
+  log_info "正在從 Plane 取得專案清單..."
+  local plane_projects
+  plane_projects=$(plane_api GET "/workspaces/${PLANE_WORKSPACE_SLUG}/projects/?per_page=100")
+
+  local total_plane
+  total_plane=$(echo "$plane_projects" | jq '.count // (.results | length) // 0')
+  log_info "Plane 共有 ${total_plane} 個專案"
+
+  if [[ "$total_plane" -eq 0 ]]; then
+    log_warn "Plane 中沒有專案可同步"
+    exit 0
+  fi
+
+  # ── 步驟 2：取得 Kimai 現有專案（用於避免重複建立）──────────────────────────
+  log_info "正在取得 Kimai 現有專案清單..."
+  local kimai_projects
+  kimai_projects=$(get_kimai_projects)
+  local kimai_project_names
+  kimai_project_names=$(echo "$kimai_projects" | jq -r '.[].name // empty' 2>/dev/null || echo "")
+
+  # ── 步驟 3：逐一同步 Plane 專案至 Kimai ────────────────────────────────────
+  local synced=0
+  local skipped=0
+  local failed=0
+
+  while IFS= read -r project_json; do
+    local plane_id plane_name plane_identifier plane_description
+    plane_id=$(echo "$project_json" | jq -r '.id')
+    plane_name=$(echo "$project_json" | jq -r '.name')
+    plane_identifier=$(echo "$project_json" | jq -r '.identifier')
+    plane_description=$(echo "$project_json" | jq -r '.description // ""')
+
+    local kimai_name="[${plane_identifier}] ${plane_name}"
+
+    # 檢查是否已存在
+    if echo "$kimai_project_names" | grep -qF "$kimai_name"; then
+      log_warn "已存在，略過：${kimai_name}"
+      ((skipped++)) || true
+      continue
+    fi
+
+    log_info "同步專案：${plane_name}（識別碼: ${plane_identifier}）"
+
+    # 建立 Kimai 專案
+    local kimai_project_id
+    if kimai_project_id=$(create_kimai_project \
+        "$plane_id" "$plane_name" "$plane_identifier" "$plane_description"); then
+
+      # 建立預設活動類型
+      if [[ -n "$kimai_project_id" ]]; then
+        create_default_activities "$kimai_project_id" "$plane_name"
+      fi
+      ((synced++)) || true
+    else
+      ((failed++)) || true
+    fi
+
+  done < <(echo "$plane_projects" | jq -c '.results[]? // .[]?')
+
+  # ── 步驟 4：輸出同步摘要 ────────────────────────────────────────────────────
+  echo ""
+  echo "════════════════════════════════════════════════════════"
+  echo "  同步完成摘要"
+  echo "  ─────────────────────────────────────────────────────"
+  echo -e "  新增同步：${GREEN}${synced}${NC} 個專案"
+  echo -e "  已存在略過：${YELLOW}${skipped}${NC} 個專案"
+  if [[ "$failed" -gt 0 ]]; then
+    echo -e "  同步失敗：${RED}${failed}${NC} 個專案"
+  fi
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo -e "  ${YELLOW}（DRY-RUN 模式：以上操作均未實際執行）${NC}"
+  fi
+  echo "════════════════════════════════════════════════════════"
+  echo ""
+
+  if [[ "$failed" -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+# ── 依賴工具檢查 ─────────────────────────────────────────────────────────────
+for tool in curl jq; do
+  if ! command -v "$tool" &>/dev/null; then
+    log_error "缺少必要工具：${tool}，請先安裝後再執行此腳本"
+    exit 1
+  fi
+done
+
+main "$@"


### PR DESCRIPTION
## Summary

- 新增 `docker-compose.override.yml`：Kimai Apache 2.21.0 + MySQL 8.0.36，獨立 volume 持久化，加入 titan-internal 網路
- 更新 `config/nginx/nginx.conf`：新增 `/kimai/` location block 反向代理 Kimai，`/kimai/api/` 獨立限速
- 更新 `config/homepage/services.yaml`：新增「工時管理」類別與 Kimai 服務卡片（API Token widget）
- 新增 `config/kimai/.env.example`：Kimai 所有環境變數範本（DB、LDAP、Plane 整合）
- 新增 `scripts/kimai-sync-projects.sh`：Plane 專案 → Kimai 專案自動同步腳本，支援 `--dry-run`
- 新增 `docs/kimai-integration.md`：架構說明、MySQL dump 匯入、LDAP SSO 設定、API 整合端點
- 新增 `docs/timesheet-reporting.md`：週報/月報產生方式、報表格式範本、Plane 任務工時結合

## Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.override.yml up -d kimai-mysql kimai` 確認容器健康啟動
- [ ] `curl -s https://titan.bank.local/kimai/api/version` 確認 Nginx 反向代理正常
- [ ] `bash scripts/kimai-sync-projects.sh --dry-run` 確認腳本可執行且無語法錯誤
- [ ] 登入 Homepage 確認「工時管理 → Kimai」卡片顯示正常
- [ ] 確認 `.env.example` 未包含任何真實密碼或 API Token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #64