### PR TITLE
feat(sprint2): task management + kanban board

### DIFF
--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -1,8 +1,221 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Plus, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TaskCard, type TaskCardData } from "@/app/components/task-card";
+import { TaskFilters, type TaskFilters as FiltersType } from "@/app/components/task-filters";
+import { TaskDetailModal } from "@/app/components/task-detail-modal";
+
+type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
+
+const COLUMNS: { status: TaskStatus; label: string; color: string }[] = [
+  { status: "BACKLOG", label: "待辦清單", color: "text-zinc-400" },
+  { status: "TODO", label: "待處理", color: "text-blue-400" },
+  { status: "IN_PROGRESS", label: "進行中", color: "text-yellow-400" },
+  { status: "REVIEW", label: "審核中", color: "text-purple-400" },
+  { status: "DONE", label: "已完成", color: "text-emerald-400" },
+];
+
+const columnBorder: Record<TaskStatus, string> = {
+  BACKLOG: "border-zinc-700/50",
+  TODO: "border-blue-500/20",
+  IN_PROGRESS: "border-yellow-500/20",
+  REVIEW: "border-purple-500/20",
+  DONE: "border-emerald-500/20",
+};
+
+const columnHeaderBg: Record<TaskStatus, string> = {
+  BACKLOG: "bg-zinc-800/60",
+  TODO: "bg-blue-500/10",
+  IN_PROGRESS: "bg-yellow-500/10",
+  REVIEW: "bg-purple-500/10",
+  DONE: "bg-emerald-500/10",
+};
+
 export default function KanbanPage() {
+  const [tasks, setTasks] = useState<TaskCardData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filters, setFilters] = useState<FiltersType>({ assignee: "", priority: "", category: "" });
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState<TaskStatus | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [movingTask, setMovingTask] = useState<string | null>(null);
+
+  const fetchTasks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (filters.assignee) params.set("assignee", filters.assignee);
+      if (filters.priority) params.set("priority", filters.priority);
+      if (filters.category) params.set("category", filters.category);
+      const res = await fetch(`/api/tasks?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        setTasks(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [filters]);
+
+  useEffect(() => { fetchTasks(); }, [fetchTasks]);
+
+  async function moveTask(taskId: string, newStatus: TaskStatus) {
+    const task = tasks.find((t) => t.id === taskId);
+    if (!task || task.status === newStatus) return;
+
+    setTasks((prev) => prev.map((t) => t.id === taskId ? { ...t, status: newStatus } : t));
+    setMovingTask(taskId);
+
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) {
+        setTasks((prev) => prev.map((t) => t.id === taskId ? { ...t, status: task.status } : t));
+      }
+    } catch {
+      setTasks((prev) => prev.map((t) => t.id === taskId ? { ...t, status: task.status } : t));
+    } finally {
+      setMovingTask(null);
+    }
+  }
+
+  function handleDragStart(e: React.DragEvent, taskId: string) {
+    e.dataTransfer.setData("taskId", taskId);
+    setDraggingId(taskId);
+  }
+
+  function handleDragEnd() {
+    setDraggingId(null);
+    setDragOver(null);
+  }
+
+  function handleDragOver(e: React.DragEvent, status: TaskStatus) {
+    e.preventDefault();
+    setDragOver(status);
+  }
+
+  function handleDrop(e: React.DragEvent, status: TaskStatus) {
+    e.preventDefault();
+    const taskId = e.dataTransfer.getData("taskId");
+    if (taskId) moveTask(taskId, status);
+    setDragOver(null);
+    setDraggingId(null);
+  }
+
+  const tasksByStatus = (status: TaskStatus) => tasks.filter((t) => t.status === status);
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-medium tracking-[-0.04em]">看板</h1>
-      <p className="text-muted-foreground mt-1">開發中...</p>
+    <div className="flex flex-col h-full gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-shrink-0">
+        <div>
+          <h1 className="text-2xl font-medium tracking-[-0.04em]">看板</h1>
+          <p className="text-muted-foreground text-sm mt-0.5">共 {tasks.length} 項任務</p>
+        </div>
+        <button className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700">
+          <Plus className="h-3.5 w-3.5" />
+          新增任務
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex-shrink-0">
+        <TaskFilters filters={filters} onChange={setFilters} />
+      </div>
+
+      {/* Board */}
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+        </div>
+      ) : (
+        <div className="flex-1 flex gap-3 overflow-x-auto pb-4 min-h-0">
+          {COLUMNS.map(({ status, label, color }) => {
+            const colTasks = tasksByStatus(status);
+            const isOver = dragOver === status;
+            return (
+              <div
+                key={status}
+                className={cn(
+                  "flex flex-col w-72 flex-shrink-0 rounded-xl border transition-colors",
+                  columnBorder[status],
+                  isOver && "ring-1 ring-zinc-500"
+                )}
+                onDragOver={(e) => handleDragOver(e, status)}
+                onDragLeave={() => setDragOver(null)}
+                onDrop={(e) => handleDrop(e, status)}
+              >
+                {/* Column header */}
+                <div className={cn("flex items-center justify-between px-3 py-2.5 rounded-t-xl", columnHeaderBg[status])}>
+                  <div className="flex items-center gap-2">
+                    <span className={cn("text-xs font-semibold uppercase tracking-wider", color)}>
+                      {label}
+                    </span>
+                    <span className="text-xs text-zinc-500 tabular-nums bg-zinc-800/60 px-1.5 py-0.5 rounded">
+                      {colTasks.length}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Cards */}
+                <div className="flex-1 overflow-y-auto p-2 space-y-2 min-h-[120px]">
+                  {colTasks.map((task) => (
+                    <div
+                      key={task.id}
+                      draggable
+                      onDragStart={(e) => handleDragStart(e, task.id)}
+                      onDragEnd={handleDragEnd}
+                      className={cn(
+                        "transition-opacity",
+                        draggingId === task.id && "opacity-40"
+                      )}
+                    >
+                      <TaskCard
+                        task={task}
+                        onClick={() => setSelectedTaskId(task.id)}
+                        isDragging={draggingId === task.id}
+                      />
+                      {movingTask === task.id && (
+                        <div className="flex justify-center py-1">
+                          <Loader2 className="h-3 w-3 animate-spin text-zinc-500" />
+                        </div>
+                      )}
+                    </div>
+                  ))}
+
+                  {colTasks.length === 0 && (
+                    <div
+                      className={cn(
+                        "flex items-center justify-center h-20 rounded-lg border border-dashed text-xs text-zinc-600 transition-colors",
+                        isOver ? "border-zinc-500 bg-zinc-800/30 text-zinc-400" : "border-zinc-800"
+                      )}
+                    >
+                      {isOver ? "放置到此欄" : "尚無任務"}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Task detail modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdated={() => {
+            setSelectedTaskId(null);
+            fetchTasks();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Plus, Loader2, ChevronRight, X, Target } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PlanTree } from "@/app/components/plan-tree";
+import { TaskDetailModal } from "@/app/components/task-detail-modal";
+
+type GoalStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
+
+type Task = {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: string;
+  category: string;
+  dueDate?: string | null;
+  primaryAssignee?: { id: string; name: string; avatar?: string | null } | null;
+};
+
+type MonthlyGoal = {
+  id: string;
+  month: number;
+  title: string;
+  status: GoalStatus;
+  progressPct: number;
+  _count?: { tasks: number };
+  tasks?: Task[];
+};
+
+type AnnualPlan = {
+  id: string;
+  year: number;
+  title: string;
+  progressPct: number;
+  monthlyGoals: MonthlyGoal[];
+};
+
+const statusLabels: Record<TaskStatus, string> = {
+  BACKLOG: "待辦清單",
+  TODO: "待處理",
+  IN_PROGRESS: "進行中",
+  REVIEW: "審核中",
+  DONE: "已完成",
+};
+
+const statusColors: Record<TaskStatus, string> = {
+  BACKLOG: "text-zinc-400",
+  TODO: "text-blue-400",
+  IN_PROGRESS: "text-yellow-400",
+  REVIEW: "text-purple-400",
+  DONE: "text-emerald-400",
+};
+
+const monthNames = ["", "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
+
+export default function PlansPage() {
+  const [plans, setPlans] = useState<AnnualPlan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedGoal, setSelectedGoal] = useState<MonthlyGoal | null>(null);
+  const [goalLoading, setGoalLoading] = useState(false);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  // Create plan form
+  const [showPlanForm, setShowPlanForm] = useState(false);
+  const [newPlanYear, setNewPlanYear] = useState(new Date().getFullYear().toString());
+  const [newPlanTitle, setNewPlanTitle] = useState("");
+  const [creatingPlan, setCreatingPlan] = useState(false);
+
+  // Create goal form
+  const [showGoalForm, setShowGoalForm] = useState(false);
+  const [newGoalPlanId, setNewGoalPlanId] = useState("");
+  const [newGoalMonth, setNewGoalMonth] = useState("1");
+  const [newGoalTitle, setNewGoalTitle] = useState("");
+  const [creatingGoal, setCreatingGoal] = useState(false);
+
+  const fetchPlans = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/plans");
+      if (res.ok) {
+        const data = await res.json();
+        setPlans(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchPlans(); }, [fetchPlans]);
+
+  async function loadGoal(goalId: string) {
+    setGoalLoading(true);
+    try {
+      const res = await fetch(`/api/goals/${goalId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setSelectedGoal(data);
+      }
+    } finally {
+      setGoalLoading(false);
+    }
+  }
+
+  async function createPlan() {
+    if (!newPlanTitle.trim() || !newPlanYear) return;
+    setCreatingPlan(true);
+    try {
+      const res = await fetch("/api/plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ year: parseInt(newPlanYear), title: newPlanTitle.trim() }),
+      });
+      if (res.ok) {
+        setNewPlanTitle("");
+        setShowPlanForm(false);
+        fetchPlans();
+      }
+    } finally {
+      setCreatingPlan(false);
+    }
+  }
+
+  async function createGoal() {
+    if (!newGoalTitle.trim() || !newGoalPlanId) return;
+    setCreatingGoal(true);
+    try {
+      const res = await fetch("/api/goals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ annualPlanId: newGoalPlanId, month: parseInt(newGoalMonth), title: newGoalTitle.trim() }),
+      });
+      if (res.ok) {
+        setNewGoalTitle("");
+        setShowGoalForm(false);
+        fetchPlans();
+      }
+    } finally {
+      setCreatingGoal(false);
+    }
+  }
+
+  const inputCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors placeholder:text-zinc-600";
+  const selectCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors cursor-pointer";
+
+  return (
+    <div className="flex flex-col gap-6 max-w-5xl">
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-1.5 text-xs text-zinc-500">
+        <span className="text-zinc-300 font-medium">年度計畫</span>
+        {selectedGoal && (
+          <>
+            <ChevronRight className="h-3 w-3" />
+            <span className="text-zinc-300 font-medium">
+              {monthNames[selectedGoal.month]} — {selectedGoal.title}
+            </span>
+          </>
+        )}
+      </nav>
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-medium tracking-[-0.04em]">年度計畫</h1>
+          <p className="text-muted-foreground text-sm mt-0.5">管理年度計畫與月度目標</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowGoalForm(true)}
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            新增月度目標
+          </button>
+          <button
+            onClick={() => setShowPlanForm(true)}
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 rounded-md transition-colors"
+          >
+            <Target className="h-3.5 w-3.5" />
+            新增年度計畫
+          </button>
+        </div>
+      </div>
+
+      {/* Create plan form */}
+      {showPlanForm && (
+        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-zinc-200">新增年度計畫</h3>
+            <button onClick={() => setShowPlanForm(false)} className="text-zinc-500 hover:text-zinc-200">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex gap-3">
+            <input
+              type="number"
+              value={newPlanYear}
+              onChange={(e) => setNewPlanYear(e.target.value)}
+              placeholder="年份"
+              className={cn(inputCls, "w-24")}
+            />
+            <input
+              type="text"
+              value={newPlanTitle}
+              onChange={(e) => setNewPlanTitle(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && createPlan()}
+              placeholder="計畫標題"
+              className={cn(inputCls, "flex-1")}
+              autoFocus
+            />
+            <button
+              onClick={createPlan}
+              disabled={creatingPlan || !newPlanTitle.trim()}
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+            >
+              {creatingPlan ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create goal form */}
+      {showGoalForm && (
+        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-zinc-200">新增月度目標</h3>
+            <button onClick={() => setShowGoalForm(false)} className="text-zinc-500 hover:text-zinc-200">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex gap-3 flex-wrap">
+            <select
+              value={newGoalPlanId}
+              onChange={(e) => setNewGoalPlanId(e.target.value)}
+              className={cn(selectCls, "flex-1 min-w-40")}
+            >
+              <option value="">選擇年度計畫</option>
+              {plans.map((p) => (
+                <option key={p.id} value={p.id}>{p.year} — {p.title}</option>
+              ))}
+            </select>
+            <select
+              value={newGoalMonth}
+              onChange={(e) => setNewGoalMonth(e.target.value)}
+              className={cn(selectCls, "w-24")}
+            >
+              {monthNames.slice(1).map((m, i) => (
+                <option key={i + 1} value={i + 1}>{m}</option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={newGoalTitle}
+              onChange={(e) => setNewGoalTitle(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && createGoal()}
+              placeholder="目標標題"
+              className={cn(inputCls, "flex-1 min-w-48")}
+              autoFocus
+            />
+            <button
+              onClick={createGoal}
+              disabled={creatingGoal || !newGoalTitle.trim() || !newGoalPlanId}
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+            >
+              {creatingGoal ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Plan tree */}
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+        </div>
+      ) : (
+        <PlanTree
+          plans={plans}
+          onSelectGoal={(goalId) => loadGoal(goalId)}
+          onSelectPlan={() => {}}
+        />
+      )}
+
+      {/* Goal detail panel */}
+      {selectedGoal && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-xl">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+            <div>
+              <div className="text-xs text-zinc-500 mb-0.5">月度目標詳情</div>
+              <h2 className="text-sm font-medium text-zinc-200">
+                {monthNames[selectedGoal.month]} — {selectedGoal.title}
+              </h2>
+            </div>
+            <div className="flex items-center gap-3">
+              {goalLoading && <Loader2 className="h-4 w-4 animate-spin text-zinc-500" />}
+              <button
+                onClick={() => setSelectedGoal(null)}
+                className="text-zinc-500 hover:text-zinc-200 transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Tasks in this goal */}
+          <div className="p-4">
+            {selectedGoal.tasks && selectedGoal.tasks.length > 0 ? (
+              <div className="space-y-2">
+                <h3 className="text-xs font-medium text-zinc-400 mb-3">個人任務</h3>
+                {selectedGoal.tasks.map((task) => (
+                  <div
+                    key={task.id}
+                    onClick={() => setSelectedTaskId(task.id)}
+                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-zinc-800/50 cursor-pointer transition-colors group"
+                  >
+                    <span className={cn("text-xs font-medium w-16 flex-shrink-0", statusColors[task.status])}>
+                      {statusLabels[task.status]}
+                    </span>
+                    <span className="flex-1 text-sm text-zinc-200 group-hover:text-white truncate transition-colors">
+                      {task.title}
+                    </span>
+                    {task.primaryAssignee && (
+                      <div className="flex-shrink-0 h-5 w-5 rounded-full bg-zinc-700 flex items-center justify-center text-[10px] text-zinc-300">
+                        {task.primaryAssignee.name.charAt(0)}
+                      </div>
+                    )}
+                    {task.dueDate && (
+                      <span className="text-[10px] text-zinc-500 flex-shrink-0">
+                        {new Date(task.dueDate).getMonth() + 1}/{new Date(task.dueDate).getDate()}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-zinc-600 text-center py-6">此月度目標尚無任務</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Task detail modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdated={() => {
+            setSelectedTaskId(null);
+            if (selectedGoal) loadGoal(selectedGoal.id);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const body = await req.json();
+
+    const deliverable = await prisma.deliverable.update({
+      where: { id },
+      data: {
+        ...(body.status !== undefined && { status: body.status }),
+        ...(body.title !== undefined && { title: body.title }),
+        ...(body.attachmentUrl !== undefined && { attachmentUrl: body.attachmentUrl }),
+        ...(body.acceptedBy !== undefined && { acceptedBy: body.acceptedBy }),
+        ...(body.acceptedAt !== undefined && { acceptedAt: body.acceptedAt ? new Date(body.acceptedAt) : null }),
+      },
+    });
+
+    return NextResponse.json(deliverable);
+  } catch (error) {
+    console.error("PATCH /api/deliverables/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    await prisma.deliverable.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/deliverables/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const body = await req.json();
+    const { title, type, taskId, kpiId, annualPlanId, monthlyGoalId, attachmentUrl } = body;
+
+    if (!title || !type) {
+      return NextResponse.json({ error: "標題和類型為必填" }, { status: 400 });
+    }
+
+    const deliverable = await prisma.deliverable.create({
+      data: {
+        title,
+        type,
+        taskId: taskId || null,
+        kpiId: kpiId || null,
+        annualPlanId: annualPlanId || null,
+        monthlyGoalId: monthlyGoalId || null,
+        attachmentUrl: attachmentUrl || null,
+      },
+    });
+
+    return NextResponse.json(deliverable, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/deliverables error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const goal = await prisma.monthlyGoal.findUnique({
+      where: { id },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+        tasks: {
+          include: {
+            primaryAssignee: { select: { id: true, name: true, avatar: true } },
+            backupAssignee: { select: { id: true, name: true, avatar: true } },
+            subTasks: true,
+            deliverables: true,
+          },
+          orderBy: [{ priority: "asc" }, { dueDate: "asc" }],
+        },
+        deliverables: true,
+      },
+    });
+
+    if (!goal) return NextResponse.json({ error: "目標不存在" }, { status: 404 });
+    return NextResponse.json(goal);
+  } catch (error) {
+    console.error("GET /api/goals/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const body = await req.json();
+    const { title, description, status, progressPct } = body;
+
+    const goal = await prisma.monthlyGoal.update({
+      where: { id },
+      data: {
+        ...(title !== undefined && { title }),
+        ...(description !== undefined && { description }),
+        ...(status !== undefined && { status }),
+        ...(progressPct !== undefined && { progressPct }),
+      },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+        tasks: true,
+      },
+    });
+
+    return NextResponse.json(goal);
+  } catch (error) {
+    console.error("PUT /api/goals/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { searchParams } = new URL(req.url);
+    const planId = searchParams.get("planId");
+    const month = searchParams.get("month");
+
+    const goals = await prisma.monthlyGoal.findMany({
+      where: {
+        ...(planId && { annualPlanId: planId }),
+        ...(month && { month: parseInt(month) }),
+      },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+        _count: { select: { tasks: true } },
+        deliverables: true,
+      },
+      orderBy: [{ annualPlanId: "asc" }, { month: "asc" }],
+    });
+
+    return NextResponse.json(goals);
+  } catch (error) {
+    console.error("GET /api/goals error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const body = await req.json();
+    const { annualPlanId, month, title, description } = body;
+
+    if (!annualPlanId || !month || !title) {
+      return NextResponse.json({ error: "計畫ID、月份和標題為必填" }, { status: 400 });
+    }
+
+    const goal = await prisma.monthlyGoal.create({
+      data: {
+        annualPlanId,
+        month: parseInt(month),
+        title,
+        description: description || null,
+      },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+        tasks: true,
+      },
+    });
+
+    return NextResponse.json(goal, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/goals error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const plan = await prisma.annualPlan.findUnique({
+      where: { id },
+      include: {
+        creator: { select: { id: true, name: true } },
+        milestones: { orderBy: { order: "asc" } },
+        deliverables: true,
+        monthlyGoals: {
+          orderBy: { month: "asc" },
+          include: {
+            tasks: {
+              include: {
+                primaryAssignee: { select: { id: true, name: true, avatar: true } },
+                backupAssignee: { select: { id: true, name: true, avatar: true } },
+                _count: { select: { subTasks: true } },
+              },
+            },
+            deliverables: true,
+          },
+        },
+      },
+    });
+
+    if (!plan) return NextResponse.json({ error: "計畫不存在" }, { status: 404 });
+    return NextResponse.json(plan);
+  } catch (error) {
+    console.error("GET /api/plans/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const body = await req.json();
+    const { title, description, implementationPlan, progressPct } = body;
+
+    const plan = await prisma.annualPlan.update({
+      where: { id },
+      data: {
+        ...(title !== undefined && { title }),
+        ...(description !== undefined && { description }),
+        ...(implementationPlan !== undefined && { implementationPlan }),
+        ...(progressPct !== undefined && { progressPct }),
+      },
+      include: { milestones: true, monthlyGoals: true },
+    });
+
+    return NextResponse.json(plan);
+  } catch (error) {
+    console.error("PUT /api/plans/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { searchParams } = new URL(req.url);
+    const year = searchParams.get("year");
+
+    const plans = await prisma.annualPlan.findMany({
+      where: year ? { year: parseInt(year) } : undefined,
+      include: {
+        creator: { select: { id: true, name: true } },
+        milestones: { orderBy: { order: "asc" } },
+        monthlyGoals: {
+          orderBy: { month: "asc" },
+          include: {
+            _count: { select: { tasks: true } },
+          },
+        },
+        _count: { select: { monthlyGoals: true } },
+      },
+      orderBy: { year: "desc" },
+    });
+
+    return NextResponse.json(plans);
+  } catch (error) {
+    console.error("GET /api/plans error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const body = await req.json();
+    const { year, title, description, implementationPlan, milestones } = body;
+
+    if (!year || !title) {
+      return NextResponse.json({ error: "年份和標題為必填" }, { status: 400 });
+    }
+
+    const plan = await prisma.annualPlan.create({
+      data: {
+        year: parseInt(year),
+        title,
+        description: description || null,
+        implementationPlan: implementationPlan || null,
+        createdBy: session.user.id,
+        milestones: milestones?.length
+          ? {
+              create: milestones.map(
+                (m: { title: string; plannedEnd: string; plannedStart?: string; description?: string; order?: number }, i: number) => ({
+                  title: m.title,
+                  plannedEnd: new Date(m.plannedEnd),
+                  plannedStart: m.plannedStart ? new Date(m.plannedStart) : null,
+                  description: m.description || null,
+                  order: m.order ?? i,
+                })
+              ),
+            }
+          : undefined,
+      },
+      include: {
+        milestones: true,
+        monthlyGoals: true,
+      },
+    });
+
+    return NextResponse.json(plan, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/plans error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/subtasks/[id]/route.ts
+++ b/app/api/subtasks/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    const body = await req.json();
+
+    const subtask = await prisma.subTask.update({
+      where: { id },
+      data: {
+        ...(body.done !== undefined && { done: body.done }),
+        ...(body.title !== undefined && { title: body.title }),
+        ...(body.assigneeId !== undefined && { assigneeId: body.assigneeId || null }),
+        ...(body.dueDate !== undefined && { dueDate: body.dueDate ? new Date(body.dueDate) : null }),
+      },
+    });
+
+    return NextResponse.json(subtask);
+  } catch (error) {
+    console.error("PATCH /api/subtasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const { id } = await params;
+    await prisma.subTask.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/subtasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/subtasks/route.ts
+++ b/app/api/subtasks/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const body = await req.json();
+    const { taskId, title, assigneeId, dueDate, order } = body;
+
+    if (!taskId || !title) {
+      return NextResponse.json({ error: "taskId 和標題為必填" }, { status: 400 });
+    }
+
+    const subtask = await prisma.subTask.create({
+      data: {
+        taskId,
+        title,
+        assigneeId: assigneeId || null,
+        dueDate: dueDate ? new Date(dueDate) : null,
+        order: order ?? 0,
+      },
+    });
+
+    return NextResponse.json(subtask, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/subtasks error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    const { id } = await params;
+    const task = await prisma.task.findUnique({
+      where: { id },
+      include: {
+        primaryAssignee: { select: { id: true, name: true, avatar: true, email: true } },
+        backupAssignee: { select: { id: true, name: true, avatar: true, email: true } },
+        creator: { select: { id: true, name: true } },
+        monthlyGoal: {
+          select: {
+            id: true,
+            title: true,
+            month: true,
+            annualPlan: { select: { id: true, title: true, year: true } },
+          },
+        },
+        subTasks: { orderBy: { order: "asc" } },
+        comments: {
+          include: { user: { select: { id: true, name: true, avatar: true } } },
+          orderBy: { createdAt: "asc" },
+        },
+        deliverables: true,
+        taskChanges: {
+          include: { changedByUser: { select: { id: true, name: true } } },
+          orderBy: { changedAt: "desc" },
+        },
+        kpiLinks: {
+          include: { kpi: { select: { id: true, code: true, title: true } } },
+        },
+      },
+    });
+
+    if (!task) {
+      return NextResponse.json({ error: "任務不存在" }, { status: 404 });
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error("GET /api/tasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    const { id } = await params;
+    const body = await req.json();
+    const {
+      title,
+      description,
+      status,
+      priority,
+      category,
+      primaryAssigneeId,
+      backupAssigneeId,
+      monthlyGoalId,
+      dueDate,
+      startDate,
+      estimatedHours,
+      tags,
+      addedReason,
+      addedSource,
+      progressPct,
+    } = body;
+
+    // Check if due date changed for TaskChange tracking
+    const existing = await prisma.task.findUnique({ where: { id } });
+    if (!existing) {
+      return NextResponse.json({ error: "任務不存在" }, { status: 404 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (title !== undefined) updates.title = title;
+    if (description !== undefined) updates.description = description;
+    if (status !== undefined) updates.status = status;
+    if (priority !== undefined) updates.priority = priority;
+    if (category !== undefined) updates.category = category;
+    if (primaryAssigneeId !== undefined) updates.primaryAssigneeId = primaryAssigneeId || null;
+    if (backupAssigneeId !== undefined) updates.backupAssigneeId = backupAssigneeId || null;
+    if (monthlyGoalId !== undefined) updates.monthlyGoalId = monthlyGoalId || null;
+    if (dueDate !== undefined) updates.dueDate = dueDate ? new Date(dueDate) : null;
+    if (startDate !== undefined) updates.startDate = startDate ? new Date(startDate) : null;
+    if (estimatedHours !== undefined) updates.estimatedHours = estimatedHours ? parseFloat(estimatedHours) : null;
+    if (tags !== undefined) updates.tags = tags;
+    if (addedReason !== undefined) updates.addedReason = addedReason;
+    if (addedSource !== undefined) updates.addedSource = addedSource;
+    if (progressPct !== undefined) updates.progressPct = progressPct;
+
+    const task = await prisma.task.update({
+      where: { id },
+      data: updates,
+      include: {
+        primaryAssignee: { select: { id: true, name: true, avatar: true } },
+        backupAssignee: { select: { id: true, name: true, avatar: true } },
+        subTasks: true,
+        deliverables: true,
+      },
+    });
+
+    // Track due date changes
+    if (dueDate !== undefined && existing.dueDate?.toISOString() !== (dueDate ? new Date(dueDate).toISOString() : null)) {
+      await prisma.taskChange.create({
+        data: {
+          taskId: id,
+          changeType: "DELAY",
+          reason: body.changeReason ?? "截止日變更",
+          oldValue: existing.dueDate?.toISOString() ?? null,
+          newValue: dueDate ?? null,
+          changedBy: session.user.id,
+        },
+      });
+    }
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error("PUT /api/tasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    const { id } = await params;
+    await prisma.task.delete({ where: { id } });
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("DELETE /api/tasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    const { id } = await params;
+    const { status } = await req.json();
+
+    if (!status) {
+      return NextResponse.json({ error: "status 為必填" }, { status: 400 });
+    }
+
+    const task = await prisma.task.update({
+      where: { id },
+      data: { status },
+      include: {
+        primaryAssignee: { select: { id: true, name: true, avatar: true } },
+        backupAssignee: { select: { id: true, name: true, avatar: true } },
+      },
+    });
+
+    await prisma.taskActivity.create({
+      data: {
+        taskId: id,
+        userId: session.user.id,
+        action: "STATUS_CHANGED",
+        detail: { status },
+      },
+    });
+
+    return NextResponse.json(task);
+  } catch (error) {
+    console.error("PATCH /api/tasks/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { TaskStatus, Priority, TaskCategory } from "@prisma/client";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const assignee = searchParams.get("assignee");
+    const status = searchParams.get("status") as TaskStatus | null;
+    const priority = searchParams.get("priority") as Priority | null;
+    const category = searchParams.get("category") as TaskCategory | null;
+    const monthlyGoalId = searchParams.get("monthlyGoalId");
+
+    const where: Record<string, unknown> = {};
+    if (assignee) {
+      where.OR = [
+        { primaryAssigneeId: assignee },
+        { backupAssigneeId: assignee },
+      ];
+    }
+    if (status) where.status = status;
+    if (priority) where.priority = priority;
+    if (category) where.category = category;
+    if (monthlyGoalId) where.monthlyGoalId = monthlyGoalId;
+
+    const tasks = await prisma.task.findMany({
+      where,
+      include: {
+        primaryAssignee: { select: { id: true, name: true, avatar: true } },
+        backupAssignee: { select: { id: true, name: true, avatar: true } },
+        creator: { select: { id: true, name: true } },
+        monthlyGoal: { select: { id: true, title: true, month: true } },
+        subTasks: { orderBy: { order: "asc" } },
+        deliverables: true,
+        _count: { select: { subTasks: true, comments: true } },
+      },
+      orderBy: [{ priority: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
+    });
+
+    return NextResponse.json(tasks);
+  } catch (error) {
+    console.error("GET /api/tasks error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const {
+      title,
+      description,
+      status,
+      priority,
+      category,
+      primaryAssigneeId,
+      backupAssigneeId,
+      monthlyGoalId,
+      dueDate,
+      startDate,
+      estimatedHours,
+      tags,
+      addedReason,
+      addedSource,
+    } = body;
+
+    if (!title) {
+      return NextResponse.json({ error: "標題為必填" }, { status: 400 });
+    }
+
+    const task = await prisma.task.create({
+      data: {
+        title,
+        description,
+        status: status ?? "BACKLOG",
+        priority: priority ?? "P2",
+        category: category ?? "PLANNED",
+        primaryAssigneeId: primaryAssigneeId || null,
+        backupAssigneeId: backupAssigneeId || null,
+        creatorId: session.user.id,
+        monthlyGoalId: monthlyGoalId || null,
+        dueDate: dueDate ? new Date(dueDate) : null,
+        startDate: startDate ? new Date(startDate) : null,
+        estimatedHours: estimatedHours ? parseFloat(estimatedHours) : null,
+        tags: tags ?? [],
+        addedDate:
+          category === "ADDED" || category === "INCIDENT" ? new Date() : null,
+        addedReason: addedReason || null,
+        addedSource: addedSource || null,
+      },
+      include: {
+        primaryAssignee: { select: { id: true, name: true, avatar: true } },
+        backupAssignee: { select: { id: true, name: true, avatar: true } },
+        creator: { select: { id: true, name: true } },
+      },
+    });
+
+    return NextResponse.json(task, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/tasks error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+
+    const users = await prisma.user.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true, email: true, role: true, avatar: true },
+      orderBy: { name: "asc" },
+    });
+
+    return NextResponse.json(users);
+  } catch (error) {
+    console.error("GET /api/users error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/components/deliverable-list.tsx
+++ b/app/components/deliverable-list.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2, FileText, Monitor, BarChart2, Stamp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type DeliverableType = "DOCUMENT" | "SYSTEM" | "REPORT" | "APPROVAL";
+type DeliverableStatus = "NOT_STARTED" | "IN_PROGRESS" | "DELIVERED" | "ACCEPTED";
+
+type Deliverable = {
+  id: string;
+  title: string;
+  type: DeliverableType;
+  status: DeliverableStatus;
+  attachmentUrl?: string | null;
+};
+
+const typeConfig: Record<DeliverableType, { label: string; icon: React.ElementType }> = {
+  DOCUMENT: { label: "文件", icon: FileText },
+  SYSTEM: { label: "系統", icon: Monitor },
+  REPORT: { label: "報告", icon: BarChart2 },
+  APPROVAL: { label: "簽核單", icon: Stamp },
+};
+
+const statusConfig: Record<DeliverableStatus, { label: string; color: string }> = {
+  NOT_STARTED: { label: "未開始", color: "text-zinc-400 bg-zinc-800" },
+  IN_PROGRESS: { label: "進行中", color: "text-blue-400 bg-blue-400/10" },
+  DELIVERED: { label: "已交付", color: "text-orange-400 bg-orange-400/10" },
+  ACCEPTED: { label: "已驗收", color: "text-emerald-400 bg-emerald-400/10" },
+};
+
+const statusOrder: DeliverableStatus[] = ["NOT_STARTED", "IN_PROGRESS", "DELIVERED", "ACCEPTED"];
+
+interface DeliverableListProps {
+  deliverables: Deliverable[];
+  taskId: string;
+  onUpdate?: (deliverables: Deliverable[]) => void;
+}
+
+export function DeliverableList({ deliverables: initial, taskId, onUpdate }: DeliverableListProps) {
+  const [items, setItems] = useState<Deliverable[]>(initial);
+  const [showForm, setShowForm] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newType, setNewType] = useState<DeliverableType>("DOCUMENT");
+  const [saving, setSaving] = useState(false);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  async function cycleStatus(item: Deliverable) {
+    const idx = statusOrder.indexOf(item.status);
+    const next = statusOrder[(idx + 1) % statusOrder.length];
+    setUpdating(item.id);
+    try {
+      const res = await fetch(`/api/deliverables/${item.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+      if (res.ok) {
+        const updated = items.map((d) => (d.id === item.id ? { ...d, status: next } : d));
+        setItems(updated);
+        onUpdate?.(updated);
+      }
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  async function deleteItem(id: string) {
+    setUpdating(id);
+    try {
+      const res = await fetch(`/api/deliverables/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        const updated = items.filter((d) => d.id !== id);
+        setItems(updated);
+        onUpdate?.(updated);
+      }
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  async function addDeliverable() {
+    if (!newTitle.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/deliverables", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: newTitle.trim(), type: newType, taskId }),
+      });
+      if (res.ok) {
+        const created = await res.json();
+        const updated = [...items, created];
+        setItems(updated);
+        onUpdate?.(updated);
+        setNewTitle("");
+        setShowForm(false);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      {items.map((item) => {
+        const tConfig = typeConfig[item.type];
+        const sConfig = statusConfig[item.status];
+        const Icon = tConfig.icon;
+        return (
+          <div
+            key={item.id}
+            className={cn(
+              "flex items-center gap-2 group px-2 py-2 rounded-md hover:bg-zinc-800/50 transition-colors",
+              updating === item.id && "opacity-50"
+            )}
+          >
+            <Icon className="h-3.5 w-3.5 text-zinc-500 flex-shrink-0" />
+            <span className="flex-1 text-sm text-zinc-200 truncate">{item.title}</span>
+            <span className="text-[10px] text-zinc-500">{tConfig.label}</span>
+            <button
+              onClick={() => cycleStatus(item)}
+              disabled={updating === item.id}
+              className={cn("text-[10px] px-2 py-0.5 rounded-full font-medium cursor-pointer transition-opacity hover:opacity-80", sConfig.color)}
+            >
+              {sConfig.label}
+            </button>
+            <button
+              onClick={() => deleteItem(item.id)}
+              disabled={updating === item.id}
+              className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 transition-all"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        );
+      })}
+
+      {showForm ? (
+        <div className="flex items-center gap-2 mt-2 p-2 bg-zinc-800/50 rounded-md">
+          <input
+            type="text"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && addDeliverable()}
+            placeholder="交付項名稱..."
+            autoFocus
+            className="flex-1 bg-transparent text-sm text-zinc-300 placeholder:text-zinc-600 outline-none"
+          />
+          <select
+            value={newType}
+            onChange={(e) => setNewType(e.target.value as DeliverableType)}
+            className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-1.5 py-1 focus:outline-none"
+          >
+            {Object.entries(typeConfig).map(([k, v]) => (
+              <option key={k} value={k}>{v.label}</option>
+            ))}
+          </select>
+          <button
+            onClick={addDeliverable}
+            disabled={saving || !newTitle.trim()}
+            className="text-emerald-400 hover:text-emerald-300 disabled:opacity-30 text-xs font-medium transition-colors"
+          >
+            新增
+          </button>
+          <button
+            onClick={() => { setShowForm(false); setNewTitle(""); }}
+            className="text-zinc-500 hover:text-zinc-300 text-xs transition-colors"
+          >
+            取消
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowForm(true)}
+          className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors mt-1"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          新增交付項
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/components/plan-tree.tsx
+++ b/app/components/plan-tree.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight, ChevronDown, Target, Calendar, CheckCircle2, Circle, Clock, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type GoalStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+
+type MonthlyGoal = {
+  id: string;
+  month: number;
+  title: string;
+  status: GoalStatus;
+  progressPct: number;
+  _count?: { tasks: number };
+};
+
+type AnnualPlan = {
+  id: string;
+  year: number;
+  title: string;
+  progressPct: number;
+  monthlyGoals: MonthlyGoal[];
+  _count?: { monthlyGoals: number };
+};
+
+const goalStatusConfig: Record<GoalStatus, { icon: React.ElementType; color: string; label: string }> = {
+  NOT_STARTED: { icon: Circle, color: "text-zinc-500", label: "未開始" },
+  IN_PROGRESS: { icon: Clock, color: "text-blue-400", label: "進行中" },
+  COMPLETED: { icon: CheckCircle2, color: "text-emerald-400", label: "已完成" },
+  CANCELLED: { icon: XCircle, color: "text-zinc-600", label: "已取消" },
+};
+
+const monthNames = ["", "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
+
+interface PlanTreeProps {
+  plans: AnnualPlan[];
+  onSelectGoal?: (goalId: string) => void;
+  onSelectPlan?: (planId: string) => void;
+}
+
+export function PlanTree({ plans, onSelectGoal, onSelectPlan }: PlanTreeProps) {
+  const [expandedPlans, setExpandedPlans] = useState<Set<string>>(new Set(plans.map((p) => p.id)));
+
+  function togglePlan(planId: string) {
+    setExpandedPlans((prev) => {
+      const next = new Set(prev);
+      if (next.has(planId)) next.delete(planId);
+      else next.add(planId);
+      return next;
+    });
+  }
+
+  if (plans.length === 0) {
+    return (
+      <div className="text-center py-12 text-zinc-500 text-sm">
+        尚無年度計畫，請先建立
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {plans.map((plan) => {
+        const expanded = expandedPlans.has(plan.id);
+        return (
+          <div key={plan.id} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+            {/* Plan header */}
+            <div className="flex items-center gap-3 px-4 py-3">
+              <button
+                onClick={() => togglePlan(plan.id)}
+                className="text-zinc-400 hover:text-zinc-200 transition-colors flex-shrink-0"
+              >
+                {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              </button>
+              <Target className="h-4 w-4 text-blue-400 flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-zinc-500 font-mono">{plan.year}</span>
+                  <button
+                    onClick={() => onSelectPlan?.(plan.id)}
+                    className="text-sm font-medium text-zinc-200 hover:text-white truncate transition-colors text-left"
+                  >
+                    {plan.title}
+                  </button>
+                </div>
+                {/* Progress bar */}
+                <div className="flex items-center gap-2 mt-1.5">
+                  <div className="flex-1 h-1 bg-zinc-800 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-blue-500 rounded-full transition-all"
+                      style={{ width: `${plan.progressPct}%` }}
+                    />
+                  </div>
+                  <span className="text-[10px] text-zinc-500 tabular-nums w-8 text-right">
+                    {Math.round(plan.progressPct)}%
+                  </span>
+                </div>
+              </div>
+              <span className="text-xs text-zinc-500 flex-shrink-0">
+                {plan.monthlyGoals.length} 個月度目標
+              </span>
+            </div>
+
+            {/* Monthly goals */}
+            {expanded && plan.monthlyGoals.length > 0 && (
+              <div className="border-t border-zinc-800">
+                {plan.monthlyGoals.map((goal, idx) => {
+                  const sConfig = goalStatusConfig[goal.status];
+                  const StatusIcon = sConfig.icon;
+                  return (
+                    <div
+                      key={goal.id}
+                      className={cn(
+                        "flex items-center gap-3 px-4 py-2.5 hover:bg-zinc-800/50 transition-colors cursor-pointer",
+                        idx < plan.monthlyGoals.length - 1 && "border-b border-zinc-800/50"
+                      )}
+                      onClick={() => onSelectGoal?.(goal.id)}
+                    >
+                      {/* Indent */}
+                      <div className="w-4 flex-shrink-0" />
+                      <Calendar className="h-3.5 w-3.5 text-zinc-600 flex-shrink-0" />
+                      <span className="text-xs text-zinc-500 w-7 flex-shrink-0 font-mono">
+                        {monthNames[goal.month]}
+                      </span>
+                      <StatusIcon className={cn("h-3.5 w-3.5 flex-shrink-0", sConfig.color)} />
+                      <span className="flex-1 text-sm text-zinc-300 truncate">{goal.title}</span>
+                      {/* Mini progress */}
+                      <div className="flex items-center gap-1.5 flex-shrink-0">
+                        <div className="w-16 h-1 bg-zinc-800 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-emerald-500 rounded-full"
+                            style={{ width: `${goal.progressPct}%` }}
+                          />
+                        </div>
+                        <span className="text-[10px] text-zinc-500 tabular-nums w-6 text-right">
+                          {Math.round(goal.progressPct)}%
+                        </span>
+                      </div>
+                      {goal._count && (
+                        <span className="text-[10px] text-zinc-600 w-10 text-right flex-shrink-0">
+                          {goal._count.tasks} 項
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {expanded && plan.monthlyGoals.length === 0 && (
+              <div className="border-t border-zinc-800 px-4 py-3 text-xs text-zinc-600">
+                此計畫尚無月度目標
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -9,12 +9,14 @@ import {
   BookOpen,
   Clock,
   BarChart2,
+  Target,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
   { href: "/dashboard", label: "儀表板", icon: LayoutDashboard },
   { href: "/kanban", label: "看板", icon: KanbanSquare },
+  { href: "/plans", label: "年度計畫", icon: Target },
   { href: "/gantt", label: "甘特圖", icon: GanttChartSquare },
   { href: "/knowledge", label: "知識庫", icon: BookOpen },
   { href: "/timesheet", label: "工時紀錄", icon: Clock },
@@ -59,7 +61,7 @@ export function Sidebar() {
       {/* Version footer */}
       <div className="p-4 border-t border-sidebar-border">
         <p className="font-mono text-[11px] text-muted-foreground tabular-nums">
-          v0.1.0 — Sprint 1
+          v0.2.0 — Sprint 2
         </p>
       </div>
     </aside>

--- a/app/components/subtask-list.tsx
+++ b/app/components/subtask-list.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Trash2, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type SubTask = {
+  id: string;
+  title: string;
+  done: boolean;
+  order: number;
+};
+
+interface SubTaskListProps {
+  subtasks: SubTask[];
+  taskId: string;
+  onUpdate?: (subtasks: SubTask[]) => void;
+}
+
+export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskListProps) {
+  const [subtasks, setSubtasks] = useState<SubTask[]>(initial);
+  const [newTitle, setNewTitle] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [loading, setLoading] = useState<string | null>(null);
+
+  const doneCount = subtasks.filter((s) => s.done).length;
+  const total = subtasks.length;
+  const pct = total > 0 ? Math.round((doneCount / total) * 100) : 0;
+
+  async function toggleDone(subtask: SubTask) {
+    setLoading(subtask.id);
+    try {
+      const res = await fetch(`/api/subtasks/${subtask.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ done: !subtask.done }),
+      });
+      if (res.ok) {
+        const updated = subtasks.map((s) =>
+          s.id === subtask.id ? { ...s, done: !s.done } : s
+        );
+        setSubtasks(updated);
+        onUpdate?.(updated);
+      }
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function deleteSubtask(id: string) {
+    setLoading(id);
+    try {
+      const res = await fetch(`/api/subtasks/${id}`, { method: "DELETE" });
+      if (res.ok) {
+        const updated = subtasks.filter((s) => s.id !== id);
+        setSubtasks(updated);
+        onUpdate?.(updated);
+      }
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  async function addSubtask() {
+    if (!newTitle.trim()) return;
+    setAdding(true);
+    try {
+      const res = await fetch("/api/subtasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId, title: newTitle.trim(), order: subtasks.length }),
+      });
+      if (res.ok) {
+        const created = await res.json();
+        const updated = [...subtasks, created];
+        setSubtasks(updated);
+        onUpdate?.(updated);
+        setNewTitle("");
+      }
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Progress bar */}
+      {total > 0 && (
+        <div className="flex items-center gap-2 mb-3">
+          <div className="flex-1 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-emerald-500 rounded-full transition-all duration-300"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="text-xs text-zinc-400 tabular-nums">
+            {doneCount}/{total}
+          </span>
+        </div>
+      )}
+
+      {/* Subtask items */}
+      <div className="space-y-1">
+        {subtasks.map((subtask) => (
+          <div
+            key={subtask.id}
+            className={cn(
+              "flex items-center gap-2 group px-2 py-1.5 rounded-md hover:bg-zinc-800/50 transition-colors",
+              loading === subtask.id && "opacity-50"
+            )}
+          >
+            <button
+              onClick={() => toggleDone(subtask)}
+              disabled={loading === subtask.id}
+              className={cn(
+                "flex-shrink-0 h-4 w-4 rounded border transition-colors flex items-center justify-center",
+                subtask.done
+                  ? "bg-emerald-500 border-emerald-500"
+                  : "border-zinc-600 hover:border-zinc-400"
+              )}
+            >
+              {subtask.done && <Check className="h-3 w-3 text-white" />}
+            </button>
+            <span
+              className={cn(
+                "flex-1 text-sm",
+                subtask.done ? "line-through text-zinc-500" : "text-zinc-200"
+              )}
+            >
+              {subtask.title}
+            </span>
+            <button
+              onClick={() => deleteSubtask(subtask.id)}
+              disabled={loading === subtask.id}
+              className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 transition-all"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Add new subtask */}
+      <div className="flex items-center gap-2 mt-2">
+        <input
+          type="text"
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && addSubtask()}
+          placeholder="新增子任務..."
+          className="flex-1 bg-transparent border-b border-zinc-700 focus:border-zinc-500 text-sm text-zinc-300 placeholder:text-zinc-600 outline-none py-1 transition-colors"
+        />
+        <button
+          onClick={addSubtask}
+          disabled={adding || !newTitle.trim()}
+          className="text-zinc-500 hover:text-zinc-300 disabled:opacity-30 transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/task-card.tsx
+++ b/app/components/task-card.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+  AlertCircle,
+  ArrowUp,
+  Minus,
+  ArrowDown,
+  Calendar,
+  CheckSquare,
+  Zap,
+  Users,
+  BookOpen,
+  Clock,
+  Layers,
+} from "lucide-react";
+
+export type TaskCardData = {
+  id: string;
+  title: string;
+  priority: "P0" | "P1" | "P2" | "P3";
+  category: "PLANNED" | "ADDED" | "INCIDENT" | "SUPPORT" | "ADMIN" | "LEARNING";
+  status: "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
+  dueDate?: string | null;
+  estimatedHours?: number | null;
+  primaryAssignee?: { id: string; name: string; avatar?: string | null } | null;
+  backupAssignee?: { id: string; name: string; avatar?: string | null } | null;
+  subTasks?: { done: boolean }[];
+  _count?: { subTasks?: number; comments?: number };
+};
+
+const priorityConfig = {
+  P0: { label: "P0", icon: AlertCircle, color: "text-red-400 bg-red-400/10 border-red-400/20" },
+  P1: { label: "P1", icon: ArrowUp, color: "text-orange-400 bg-orange-400/10 border-orange-400/20" },
+  P2: { label: "P2", icon: Minus, color: "text-yellow-400 bg-yellow-400/10 border-yellow-400/20" },
+  P3: { label: "P3", icon: ArrowDown, color: "text-zinc-400 bg-zinc-400/10 border-zinc-400/20" },
+};
+
+const categoryConfig = {
+  PLANNED: { label: "規劃", icon: Layers, color: "text-blue-400" },
+  ADDED: { label: "追加", icon: CheckSquare, color: "text-purple-400" },
+  INCIDENT: { label: "突發", icon: Zap, color: "text-red-400" },
+  SUPPORT: { label: "支援", icon: Users, color: "text-green-400" },
+  ADMIN: { label: "行政", icon: BookOpen, color: "text-zinc-400" },
+  LEARNING: { label: "學習", icon: BookOpen, color: "text-teal-400" },
+};
+
+function Avatar({ name, avatar }: { name: string; avatar?: string | null }) {
+  return (
+    <div className="h-5 w-5 rounded-full bg-zinc-700 flex items-center justify-center text-[10px] font-medium text-zinc-300 overflow-hidden flex-shrink-0">
+      {avatar ? (
+        <img src={avatar} alt={name} className="h-full w-full object-cover" />
+      ) : (
+        name.charAt(0).toUpperCase()
+      )}
+    </div>
+  );
+}
+
+function formatDueDate(dateStr: string) {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diff = date.getTime() - now.getTime();
+  const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+  const mmdd = `${date.getMonth() + 1}/${date.getDate()}`;
+  if (days < 0) return { label: mmdd, overdue: true };
+  if (days <= 3) return { label: mmdd, soon: true };
+  return { label: mmdd, overdue: false, soon: false };
+}
+
+interface TaskCardProps {
+  task: TaskCardData;
+  onClick?: (task: TaskCardData) => void;
+  isDragging?: boolean;
+}
+
+export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
+  const pConfig = priorityConfig[task.priority];
+  const cConfig = categoryConfig[task.category];
+  const PIcon = pConfig.icon;
+  const CIcon = cConfig.icon;
+
+  const doneSubtasks = task.subTasks?.filter((s) => s.done).length ?? 0;
+  const totalSubtasks = task.subTasks?.length ?? task._count?.subTasks ?? 0;
+
+  const dueInfo = task.dueDate ? formatDueDate(task.dueDate) : null;
+
+  return (
+    <div
+      onClick={() => onClick?.(task)}
+      className={cn(
+        "bg-zinc-900 border border-zinc-800 rounded-lg p-3 cursor-pointer select-none",
+        "hover:border-zinc-600 hover:bg-zinc-800/80 transition-all duration-150",
+        isDragging && "opacity-50 rotate-1 scale-105 shadow-xl",
+        task.priority === "P0" && "border-l-2 border-l-red-500"
+      )}
+    >
+      {/* Header: priority + category */}
+      <div className="flex items-center gap-1.5 mb-2">
+        <span
+          className={cn(
+            "inline-flex items-center gap-0.5 text-[10px] font-medium px-1.5 py-0.5 rounded border",
+            pConfig.color
+          )}
+        >
+          <PIcon className="h-2.5 w-2.5" />
+          {pConfig.label}
+        </span>
+        <span className={cn("inline-flex items-center gap-0.5 text-[10px]", cConfig.color)}>
+          <CIcon className="h-2.5 w-2.5" />
+          {cConfig.label}
+        </span>
+      </div>
+
+      {/* Title */}
+      <p className="text-sm font-medium text-zinc-100 leading-snug line-clamp-2 mb-2">
+        {task.title}
+      </p>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {/* Assignees */}
+          {(task.primaryAssignee || task.backupAssignee) && (
+            <div className="flex items-center -space-x-1">
+              {task.primaryAssignee && (
+                <div title={`A角: ${task.primaryAssignee.name}`}>
+                  <Avatar name={task.primaryAssignee.name} avatar={task.primaryAssignee.avatar} />
+                </div>
+              )}
+              {task.backupAssignee && (
+                <div title={`B角: ${task.backupAssignee.name}`} className="opacity-60">
+                  <Avatar name={task.backupAssignee.name} avatar={task.backupAssignee.avatar} />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Subtask progress */}
+          {totalSubtasks > 0 && (
+            <span className="text-[10px] text-zinc-500 flex items-center gap-0.5">
+              <CheckSquare className="h-2.5 w-2.5" />
+              {doneSubtasks}/{totalSubtasks}
+            </span>
+          )}
+
+          {/* Estimated hours */}
+          {task.estimatedHours && (
+            <span className="text-[10px] text-zinc-500 flex items-center gap-0.5">
+              <Clock className="h-2.5 w-2.5" />
+              {task.estimatedHours}h
+            </span>
+          )}
+        </div>
+
+        {/* Due date */}
+        {dueInfo && (
+          <span
+            className={cn(
+              "text-[10px] flex items-center gap-0.5",
+              dueInfo.overdue ? "text-red-400 font-medium" : dueInfo.soon ? "text-orange-400" : "text-zinc-500"
+            )}
+          >
+            <Calendar className="h-2.5 w-2.5" />
+            {dueInfo.label}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { X, Save, Loader2, Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { SubTaskList } from "./subtask-list";
+import { DeliverableList } from "./deliverable-list";
+
+type User = { id: string; name: string; avatar?: string | null };
+type MonthlyGoal = { id: string; title: string; month: number };
+
+type TaskDetail = {
+  id: string;
+  title: string;
+  description?: string | null;
+  status: string;
+  priority: string;
+  category: string;
+  primaryAssigneeId?: string | null;
+  backupAssigneeId?: string | null;
+  monthlyGoalId?: string | null;
+  dueDate?: string | null;
+  estimatedHours?: number | null;
+  subTasks: { id: string; title: string; done: boolean; order: number }[];
+  deliverables: {
+    id: string;
+    title: string;
+    type: "DOCUMENT" | "SYSTEM" | "REPORT" | "APPROVAL";
+    status: "NOT_STARTED" | "IN_PROGRESS" | "DELIVERED" | "ACCEPTED";
+    attachmentUrl?: string | null;
+  }[];
+  primaryAssignee?: User | null;
+  backupAssignee?: User | null;
+  monthlyGoal?: MonthlyGoal | null;
+};
+
+interface TaskDetailModalProps {
+  taskId: string;
+  onClose: () => void;
+  onUpdated?: () => void;
+}
+
+const statusOptions = [
+  { value: "BACKLOG", label: "待辦清單" },
+  { value: "TODO", label: "待處理" },
+  { value: "IN_PROGRESS", label: "進行中" },
+  { value: "REVIEW", label: "審核中" },
+  { value: "DONE", label: "已完成" },
+];
+
+const priorityOptions = [
+  { value: "P0", label: "P0 緊急" },
+  { value: "P1", label: "P1 高" },
+  { value: "P2", label: "P2 中" },
+  { value: "P3", label: "P3 低" },
+];
+
+const categoryOptions = [
+  { value: "PLANNED", label: "原始規劃" },
+  { value: "ADDED", label: "追加任務" },
+  { value: "INCIDENT", label: "突發事件" },
+  { value: "SUPPORT", label: "用戶支援" },
+  { value: "ADMIN", label: "行政庶務" },
+  { value: "LEARNING", label: "學習成長" },
+];
+
+const inputCls =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-colors placeholder:text-zinc-600";
+
+const selectCls =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-colors cursor-pointer";
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <label className="block text-xs font-medium text-zinc-400 mb-1">{children}</label>;
+}
+
+export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalProps) {
+  const [task, setTask] = useState<TaskDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [users, setUsers] = useState<User[]>([]);
+  const [goals, setGoals] = useState<MonthlyGoal[]>([]);
+
+  // Editable fields
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState("");
+  const [priority, setPriority] = useState("");
+  const [category, setCategory] = useState("");
+  const [primaryAssigneeId, setPrimaryAssigneeId] = useState("");
+  const [backupAssigneeId, setBackupAssigneeId] = useState("");
+  const [monthlyGoalId, setMonthlyGoalId] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [estimatedHours, setEstimatedHours] = useState("");
+
+  const loadTask = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`);
+      if (res.ok) {
+        const data: TaskDetail = await res.json();
+        setTask(data);
+        setTitle(data.title);
+        setDescription(data.description ?? "");
+        setStatus(data.status);
+        setPriority(data.priority);
+        setCategory(data.category);
+        setPrimaryAssigneeId(data.primaryAssigneeId ?? "");
+        setBackupAssigneeId(data.backupAssigneeId ?? "");
+        setMonthlyGoalId(data.monthlyGoalId ?? "");
+        setDueDate(data.dueDate ? data.dueDate.split("T")[0] : "");
+        setEstimatedHours(data.estimatedHours?.toString() ?? "");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    loadTask();
+    fetch("/api/users").then((r) => r.json()).then((d) => setUsers(Array.isArray(d) ? d : [])).catch(() => {});
+    fetch("/api/goals").then((r) => r.json()).then((d) => setGoals(Array.isArray(d) ? d : [])).catch(() => {});
+  }, [loadTask]);
+
+  async function save() {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          description: description || null,
+          status,
+          priority,
+          category,
+          primaryAssigneeId: primaryAssigneeId || null,
+          backupAssigneeId: backupAssigneeId || null,
+          monthlyGoalId: monthlyGoalId || null,
+          dueDate: dueDate || null,
+          estimatedHours: estimatedHours ? parseFloat(estimatedHours) : null,
+        }),
+      });
+      if (res.ok) {
+        onUpdated?.();
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Close on backdrop click or Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 backdrop-blur-sm pt-12 pb-4 px-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-zinc-800 sticky top-0 bg-zinc-950 z-10">
+          <h2 className="text-sm font-medium text-zinc-300 tracking-wide">任務詳情</h2>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={save}
+              disabled={saving || loading}
+              className={cn(
+                "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                "bg-zinc-800 hover:bg-zinc-700 text-zinc-200 disabled:opacity-40"
+              )}
+            >
+              {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+              儲存
+            </button>
+            <button
+              onClick={onClose}
+              className="text-zinc-500 hover:text-zinc-200 transition-colors"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+          </div>
+        ) : task ? (
+          <div className="p-5 space-y-5">
+            {/* Title */}
+            <div>
+              <Label>標題</Label>
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+
+            {/* Description */}
+            <div>
+              <Label>描述</Label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                placeholder="任務描述..."
+                className={cn(inputCls, "resize-none")}
+              />
+            </div>
+
+            {/* Status / Priority / Category */}
+            <div className="grid grid-cols-3 gap-3">
+              <div>
+                <Label>狀態</Label>
+                <select value={status} onChange={(e) => setStatus(e.target.value)} className={selectCls}>
+                  {statusOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <Label>優先度</Label>
+                <select value={priority} onChange={(e) => setPriority(e.target.value)} className={selectCls}>
+                  {priorityOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <Label>分類</Label>
+                <select value={category} onChange={(e) => setCategory(e.target.value)} className={selectCls}>
+                  {categoryOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+              </div>
+            </div>
+
+            {/* A角 / B角 */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>A角（主要負責人）</Label>
+                <select value={primaryAssigneeId} onChange={(e) => setPrimaryAssigneeId(e.target.value)} className={selectCls}>
+                  <option value="">未指派</option>
+                  {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+                </select>
+              </div>
+              <div>
+                <Label>B角（備援負責人）</Label>
+                <select value={backupAssigneeId} onChange={(e) => setBackupAssigneeId(e.target.value)} className={selectCls}>
+                  <option value="">未指派</option>
+                  {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+                </select>
+              </div>
+            </div>
+
+            {/* Due date / Estimated hours */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label>截止日期</Label>
+                <input
+                  type="date"
+                  value={dueDate}
+                  onChange={(e) => setDueDate(e.target.value)}
+                  className={inputCls}
+                />
+              </div>
+              <div>
+                <Label>預估工時（小時）</Label>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  value={estimatedHours}
+                  onChange={(e) => setEstimatedHours(e.target.value)}
+                  placeholder="0"
+                  className={inputCls}
+                />
+              </div>
+            </div>
+
+            {/* Monthly Goal link */}
+            <div>
+              <Label>
+                <span className="flex items-center gap-1">
+                  <Link2 className="h-3 w-3" />
+                  連結月度目標
+                </span>
+              </Label>
+              <select value={monthlyGoalId} onChange={(e) => setMonthlyGoalId(e.target.value)} className={selectCls}>
+                <option value="">不連結</option>
+                {goals.map((g) => (
+                  <option key={g.id} value={g.id}>{g.month}月 — {g.title}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Subtasks */}
+            <div>
+              <h3 className="text-xs font-medium text-zinc-400 mb-2">子任務清單</h3>
+              <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">
+                <SubTaskList
+                  subtasks={task.subTasks}
+                  taskId={taskId}
+                />
+              </div>
+            </div>
+
+            {/* Deliverables */}
+            <div>
+              <h3 className="text-xs font-medium text-zinc-400 mb-2">交付項</h3>
+              <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">
+                <DeliverableList
+                  deliverables={task.deliverables}
+                  taskId={taskId}
+                />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="py-16 text-center text-zinc-500 text-sm">任務不存在</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Filter, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type TaskFilters = {
+  assignee: string;
+  priority: string;
+  category: string;
+};
+
+type User = { id: string; name: string };
+
+interface TaskFiltersProps {
+  filters: TaskFilters;
+  onChange: (filters: TaskFilters) => void;
+}
+
+const priorities = [
+  { value: "", label: "所有優先度" },
+  { value: "P0", label: "P0 緊急" },
+  { value: "P1", label: "P1 高" },
+  { value: "P2", label: "P2 中" },
+  { value: "P3", label: "P3 低" },
+];
+
+const categories = [
+  { value: "", label: "所有分類" },
+  { value: "PLANNED", label: "原始規劃" },
+  { value: "ADDED", label: "追加任務" },
+  { value: "INCIDENT", label: "突發事件" },
+  { value: "SUPPORT", label: "用戶支援" },
+  { value: "ADMIN", label: "行政庶務" },
+  { value: "LEARNING", label: "學習成長" },
+];
+
+export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch("/api/users")
+      .then((r) => r.json())
+      .then((data) => setUsers(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  const hasActiveFilters = filters.assignee || filters.priority || filters.category;
+
+  const clearFilters = () => onChange({ assignee: "", priority: "", category: "" });
+
+  const selectCls =
+    "bg-zinc-900 border border-zinc-700 text-zinc-300 text-sm rounded-md px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 cursor-pointer hover:border-zinc-600 transition-colors";
+
+  return (
+    <div className="flex items-center gap-2 flex-wrap">
+      <div className="flex items-center gap-1.5 text-zinc-400">
+        <Filter className="h-3.5 w-3.5" />
+        <span className="text-xs font-medium">篩選</span>
+      </div>
+
+      {/* Assignee */}
+      <select
+        value={filters.assignee}
+        onChange={(e) => onChange({ ...filters, assignee: e.target.value })}
+        className={selectCls}
+      >
+        <option value="">所有成員</option>
+        {users.map((u) => (
+          <option key={u.id} value={u.id}>
+            {u.name}
+          </option>
+        ))}
+      </select>
+
+      {/* Priority */}
+      <select
+        value={filters.priority}
+        onChange={(e) => onChange({ ...filters, priority: e.target.value })}
+        className={selectCls}
+      >
+        {priorities.map((p) => (
+          <option key={p.value} value={p.value}>
+            {p.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Category */}
+      <select
+        value={filters.category}
+        onChange={(e) => onChange({ ...filters, category: e.target.value })}
+        className={selectCls}
+      >
+        {categories.map((c) => (
+          <option key={c.value} value={c.value}>
+            {c.label}
+          </option>
+        ))}
+      </select>
+
+      {/* Clear */}
+      {hasActiveFilters && (
+        <button
+          onClick={clearFilters}
+          className={cn(
+            "flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors",
+            "px-2 py-1.5 rounded-md border border-zinc-700 hover:border-zinc-600 bg-zinc-900"
+          )}
+        >
+          <X className="h-3 w-3" />
+          清除篩選
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Task CRUD API with filters (assignee, status, priority, category, monthlyGoalId) + status PATCH for kanban drag
- Annual Plan / Monthly Goal / SubTask / Deliverable management APIs
- Users API for assignee dropdowns
- Kanban board with 5 columns and HTML5 drag-and-drop (optimistic updates + revert on error)
- Task detail modal with A/B角 assignment, subtask checklist, deliverable management, goal linking
- Plan hierarchy page with breadcrumb (年度→月度→個人), create forms, PlanTree component
- 5 reusable components: TaskCard, TaskFilters, SubTaskList, DeliverableList, PlanTree
- Sidebar updated with 年度計畫 nav link (v0.2.0)

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` passes (verified — zero errors)
- [ ] GET /api/tasks with various filter combinations
- [ ] POST /api/tasks, then PUT to update all fields
- [ ] PATCH /api/tasks/[id] status change (kanban drag flow)
- [ ] POST /api/plans with milestones, GET /api/plans/[id] returns full hierarchy
- [ ] POST /api/goals, GET /api/goals/[id] includes tasks
- [ ] POST /api/subtasks, PATCH to toggle done, DELETE
- [ ] POST /api/deliverables, PATCH to cycle status
- [ ] Kanban: drag card between columns, verify DB updated
- [ ] Click card → task detail modal opens, edits save correctly
- [ ] Plans page: create plan, create goal, click goal to see tasks

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)