### PR TITLE
feat(sprint4): dashboard, KPI, reports, notifications — TITAN v1.0

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,8 +1,371 @@
-export default function DashboardPage() {
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { cn } from "@/lib/utils";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface WorkloadPerson {
+  userId: string;
+  name: string;
+  total: number;
+  planned: number;
+  unplanned: number;
+}
+
+interface WorkloadData {
+  byPerson: WorkloadPerson[];
+  plannedRate: number;
+  unplannedRate: number;
+  totalHours: number;
+}
+
+interface WeeklyData {
+  completedCount: number;
+  overdueCount: number;
+  delayCount: number;
+  scopeChangeCount: number;
+  totalHours: number;
+}
+
+interface Task {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  dueDate: string | null;
+}
+
+// ── Helper ─────────────────────────────────────────────────────────────────
+
+function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-medium tracking-[-0.04em]">儀表板</h1>
-      <p className="text-muted-foreground mt-1">開發中...</p>
+    <div className="h-2 w-full bg-accent rounded-full overflow-hidden">
+      <div
+        className={cn("h-full rounded-full transition-all", color)}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string | number;
+  sub?: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-lg p-4 flex flex-col gap-1">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className={cn("text-2xl font-semibold tabular-nums", accent && "text-red-400")}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+// ── Manager Dashboard ──────────────────────────────────────────────────────
+
+function ManagerDashboard() {
+  const [workload, setWorkload] = useState<WorkloadData | null>(null);
+  const [weekly, setWeekly] = useState<WeeklyData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [wl, wr] = await Promise.all([
+          fetch("/api/reports/workload").then((r) => r.json()),
+          fetch("/api/reports/weekly").then((r) => r.json()),
+        ]);
+        setWorkload(wl);
+        setWeekly(wr);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        載入中...
+      </div>
+    );
+  }
+
+  const maxPersonHours =
+    workload?.byPerson?.length
+      ? Math.max(...workload.byPerson.map((p) => p.total), 1)
+      : 1;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Stats cards ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatCard label="本週完成任務" value={weekly?.completedCount ?? "—"} />
+        <StatCard label="本週總工時 (h)" value={weekly ? weekly.totalHours.toFixed(1) : "—"} />
+        <StatCard
+          label="逾期任務"
+          value={weekly?.overdueCount ?? "—"}
+          accent={(weekly?.overdueCount ?? 0) > 0}
+        />
+        <StatCard label="本月計畫外比例" value={workload ? `${workload.unplannedRate}%` : "—"} />
+      </div>
+
+      {/* ── Team workload ── */}
+      <div className="bg-card border border-border rounded-lg p-5">
+        <h2 className="text-sm font-medium mb-4">團隊工時分佈（本月）</h2>
+        {workload?.byPerson?.length ? (
+          <div className="space-y-3">
+            {workload.byPerson.slice(0, 5).map((p) => {
+              const pct = (p.total / maxPersonHours) * 100;
+              const unplannedPct = p.total > 0 ? (p.unplanned / p.total) * 100 : 0;
+              return (
+                <div key={p.userId} className="space-y-1">
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-foreground font-medium">{p.name}</span>
+                    <span className="tabular-nums text-muted-foreground">
+                      {p.total.toFixed(1)} h
+                    </span>
+                  </div>
+                  <ProgressBar pct={pct} />
+                  {unplannedPct > 0 && (
+                    <p className="text-[11px] text-muted-foreground tabular-nums">
+                      計畫外 {unplannedPct.toFixed(0)}%
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">本月尚無工時紀錄</p>
+        )}
+      </div>
+
+      {/* ── 投入率 ── */}
+      <div className="bg-card border border-border rounded-lg p-5">
+        <h2 className="text-sm font-medium mb-4">投入率分析（計畫任務 vs 加入任務）</h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1">
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">計畫內投入</span>
+              <span className="tabular-nums font-medium text-green-400">
+                {workload?.plannedRate ?? 0}%
+              </span>
+            </div>
+            <ProgressBar pct={workload?.plannedRate ?? 0} color="bg-green-500" />
+          </div>
+          <div className="space-y-1">
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">計畫外投入</span>
+              <span className="tabular-nums font-medium text-orange-400">
+                {workload?.unplannedRate ?? 0}%
+              </span>
+            </div>
+            <ProgressBar pct={workload?.unplannedRate ?? 0} color="bg-orange-500" />
+          </div>
+        </div>
+      </div>
+
+      {/* ── This month ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <StatCard label="本週延遲次數" value={weekly?.delayCount ?? "—"} accent={(weekly?.delayCount ?? 0) > 0} />
+        <StatCard label="本週範疇變更" value={weekly?.scopeChangeCount ?? "—"} />
+        <StatCard
+          label="計畫外負荷率"
+          value={workload ? `${workload.unplannedRate}%` : "—"}
+          sub="(ADDED+INCIDENT+SUPPORT)"
+        />
+        <StatCard
+          label="計畫投入率"
+          value={workload ? `${workload.plannedRate}%` : "—"}
+          sub="(PLANNED_TASK)"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Engineer Dashboard ─────────────────────────────────────────────────────
+
+function EngineerDashboard() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [weekly, setWeekly] = useState<WeeklyData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [taskRes, wr] = await Promise.all([
+          fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => r.json()),
+          fetch("/api/reports/weekly").then((r) => r.json()),
+        ]);
+        setTasks(Array.isArray(taskRes) ? taskRes : taskRes.tasks ?? []);
+        setWeekly(wr);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+        載入中...
+      </div>
+    );
+  }
+
+  const weeklyPct = Math.min(((weekly?.totalHours ?? 0) / 40) * 100, 100);
+  const today = new Date().toDateString();
+  const overdue = tasks.filter(
+    (t) => t.dueDate && new Date(t.dueDate) < new Date() && t.status !== "DONE"
+  );
+
+  const PRIORITY_LABEL: Record<string, string> = {
+    URGENT: "緊急",
+    HIGH: "高",
+    MEDIUM: "中",
+    LOW: "低",
+  };
+  const PRIORITY_COLOR: Record<string, string> = {
+    URGENT: "text-red-400",
+    HIGH: "text-orange-400",
+    MEDIUM: "text-yellow-400",
+    LOW: "text-muted-foreground",
+  };
+  const STATUS_LABEL: Record<string, string> = {
+    TODO: "待辦",
+    IN_PROGRESS: "進行中",
+    DONE: "完成",
+    BLOCKED: "封鎖",
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* ── Summary cards ── */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <StatCard label="進行中任務" value={tasks.length} />
+        <StatCard label="逾期任務" value={overdue.length} accent={overdue.length > 0} />
+        <StatCard
+          label="本週工時 (h)"
+          value={`${(weekly?.totalHours ?? 0).toFixed(1)} / 40`}
+          sub={`進度 ${weeklyPct.toFixed(0)}%`}
+        />
+      </div>
+
+      {/* ── Weekly hours bar ── */}
+      <div className="bg-card border border-border rounded-lg p-5">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium">本週工時進度</h2>
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {(weekly?.totalHours ?? 0).toFixed(1)} / 40 h
+          </span>
+        </div>
+        <ProgressBar
+          pct={weeklyPct}
+          color={weeklyPct >= 90 ? "bg-green-500" : weeklyPct >= 60 ? "bg-primary" : "bg-yellow-500"}
+        />
+      </div>
+
+      {/* ── My tasks today ── */}
+      <div className="bg-card border border-border rounded-lg p-5">
+        <h2 className="text-sm font-medium mb-4">我的任務（待辦 + 進行中）</h2>
+        {tasks.length === 0 ? (
+          <p className="text-sm text-muted-foreground">目前沒有待處理的任務</p>
+        ) : (
+          <div className="space-y-2">
+            {tasks.map((t) => (
+              <div
+                key={t.id}
+                className="flex items-center gap-3 p-3 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors"
+              >
+                <span
+                  className={cn(
+                    "text-[11px] font-medium w-8 flex-shrink-0",
+                    PRIORITY_COLOR[t.priority] ?? "text-muted-foreground"
+                  )}
+                >
+                  {PRIORITY_LABEL[t.priority] ?? t.priority}
+                </span>
+                <span className="flex-1 text-sm text-foreground truncate">{t.title}</span>
+                <span className="text-[11px] text-muted-foreground flex-shrink-0">
+                  {STATUS_LABEL[t.status] ?? t.status}
+                </span>
+                {t.dueDate && (
+                  <span
+                    className={cn(
+                      "text-[11px] tabular-nums flex-shrink-0",
+                      new Date(t.dueDate) < new Date()
+                        ? "text-red-400"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {new Date(t.dueDate).toLocaleDateString("zh-TW")}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* ── Overdue ── */}
+      {overdue.length > 0 && (
+        <div className="bg-card border border-red-500/30 rounded-lg p-5">
+          <h2 className="text-sm font-medium text-red-400 mb-3">逾期任務</h2>
+          <div className="space-y-2">
+            {overdue.map((t) => (
+              <div key={t.id} className="flex items-center justify-between text-sm">
+                <span className="text-foreground truncate">{t.title}</span>
+                <span className="text-red-400 tabular-nums text-xs flex-shrink-0 ml-2">
+                  {t.dueDate ? new Date(t.dueDate).toLocaleDateString("zh-TW") : ""}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────
+
+export default function DashboardPage() {
+  const { data: session, status } = useSession();
+  const isManager = session?.user?.role === "MANAGER";
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-medium tracking-[-0.04em]">儀表板</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {isManager ? "主管視角 — 團隊整體狀況" : "工程師視角 — 我的工作狀況"}
+        </p>
+      </div>
+
+      {status === "loading" ? (
+        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+          載入中...
+        </div>
+      ) : isManager ? (
+        <ManagerDashboard />
+      ) : (
+        <EngineerDashboard />
+      )}
     </div>
   );
 }

--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { Target, Plus, Link2, Unlink, ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface KPITaskLink {
+  taskId: string;
+  weight: number;
+  task: {
+    id: string;
+    title: string;
+    status: string;
+    progressPct: number;
+    primaryAssignee?: { id: string; name: string } | null;
+  };
+}
+
+interface KPI {
+  id: string;
+  year: number;
+  code: string;
+  title: string;
+  description?: string | null;
+  target: number;
+  actual: number;
+  weight: number;
+  status: string;
+  autoCalc: boolean;
+  taskLinks: KPITaskLink[];
+  creator?: { id: string; name: string } | null;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function achievementRate(kpi: KPI): number {
+  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+    const totalWeight = kpi.taskLinks.reduce((s, l) => s + l.weight, 0);
+    const weighted = kpi.taskLinks.reduce((s, l) => {
+      const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
+      return s + (prog * l.weight) / 100;
+    }, 0);
+    return totalWeight > 0
+      ? Math.min((weighted / totalWeight) * kpi.target, 100)
+      : 0;
+  }
+  return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
+}
+
+function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {
+  return (
+    <div className="h-1.5 w-full bg-accent rounded-full overflow-hidden">
+      <div
+        className={cn("h-full rounded-full transition-all", color)}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  ON_TRACK: "進行中",
+  AT_RISK: "風險",
+  BEHIND: "落後",
+  ACHIEVED: "達成",
+};
+const STATUS_COLOR: Record<string, string> = {
+  ON_TRACK: "text-green-400 bg-green-500/10",
+  AT_RISK: "text-yellow-400 bg-yellow-500/10",
+  BEHIND: "text-red-400 bg-red-500/10",
+  ACHIEVED: "text-blue-400 bg-blue-500/10",
+};
+const TASK_STATUS_LABEL: Record<string, string> = {
+  TODO: "待辦",
+  IN_PROGRESS: "進行中",
+  DONE: "完成",
+  BLOCKED: "封鎖",
+};
+
+// ── Create KPI Form ────────────────────────────────────────────────────────
+
+interface CreateFormProps {
+  onCreated: (kpi: KPI) => void;
+  onCancel: () => void;
+}
+
+function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
+  const year = new Date().getFullYear();
+  const [form, setForm] = useState({
+    year: String(year),
+    code: "",
+    title: "",
+    description: "",
+    target: "",
+    weight: "1",
+    autoCalc: false,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.code || !form.title || !form.target) {
+      setError("代碼、名稱、目標值為必填");
+      return;
+    }
+    setSubmitting(true);
+    setError("");
+    try {
+      const res = await fetch("/api/kpi", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error ?? "建立失敗");
+        return;
+      }
+      const kpi = await res.json();
+      onCreated(kpi);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-card border border-border rounded-lg p-5 space-y-4">
+      <h2 className="text-sm font-medium">新增 KPI</h2>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">年度</label>
+          <input
+            type="number"
+            value={form.year}
+            onChange={(e) => setForm((f) => ({ ...f, year: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">代碼 *</label>
+          <input
+            type="text"
+            placeholder="如 KPI-01"
+            value={form.code}
+            onChange={(e) => setForm((f) => ({ ...f, code: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="col-span-2 space-y-1">
+          <label className="text-xs text-muted-foreground">名稱 *</label>
+          <input
+            type="text"
+            placeholder="KPI 名稱"
+            value={form.title}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">目標值 *</label>
+          <input
+            type="number"
+            placeholder="100"
+            value={form.target}
+            onChange={(e) => setForm((f) => ({ ...f, target: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">權重</label>
+          <input
+            type="number"
+            step="0.1"
+            value={form.weight}
+            onChange={(e) => setForm((f) => ({ ...f, weight: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="col-span-2 space-y-1">
+          <label className="text-xs text-muted-foreground">說明</label>
+          <textarea
+            placeholder="描述此 KPI..."
+            value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+            rows={2}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary resize-none"
+          />
+        </div>
+        <div className="col-span-2 flex items-center gap-2">
+          <input
+            id="autoCalc"
+            type="checkbox"
+            checked={form.autoCalc}
+            onChange={(e) => setForm((f) => ({ ...f, autoCalc: e.target.checked }))}
+            className="rounded"
+          />
+          <label htmlFor="autoCalc" className="text-xs text-muted-foreground">
+            自動從連結任務計算進度
+          </label>
+        </div>
+      </div>
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors"
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {submitting ? "建立中..." : "建立 KPI"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── KPI Card ───────────────────────────────────────────────────────────────
+
+interface KPICardProps {
+  kpi: KPI;
+  isManager: boolean;
+  onUnlink: (kpiId: string, taskId: string) => Promise<void>;
+  onRefresh: () => void;
+}
+
+function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const rate = achievementRate(kpi);
+
+  const barColor =
+    rate >= 100
+      ? "bg-green-500"
+      : rate >= 60
+      ? "bg-primary"
+      : rate >= 30
+      ? "bg-yellow-500"
+      : "bg-red-500";
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      {/* Header */}
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full text-left p-4 hover:bg-accent/40 transition-colors"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            {expanded ? (
+              <ChevronDown className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+            )}
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-mono text-muted-foreground">{kpi.code}</span>
+                {kpi.status && (
+                  <span
+                    className={cn(
+                      "text-[10px] px-1.5 py-0.5 rounded-full font-medium",
+                      STATUS_COLOR[kpi.status] ?? "text-muted-foreground bg-accent"
+                    )}
+                  >
+                    {STATUS_LABEL[kpi.status] ?? kpi.status}
+                  </span>
+                )}
+              </div>
+              <p className="text-sm font-medium text-foreground mt-0.5">{kpi.title}</p>
+              {kpi.description && (
+                <p className="text-xs text-muted-foreground mt-0.5 truncate">{kpi.description}</p>
+              )}
+            </div>
+          </div>
+          <div className="text-right flex-shrink-0">
+            <p className="text-lg font-semibold tabular-nums">{rate.toFixed(0)}%</p>
+            <p className="text-[10px] text-muted-foreground tabular-nums">
+              {kpi.actual} / {kpi.target}
+            </p>
+          </div>
+        </div>
+        <div className="mt-3 px-6">
+          <ProgressBar pct={rate} color={barColor} />
+        </div>
+        <div className="mt-2 px-6 flex items-center justify-between text-[11px] text-muted-foreground">
+          <span>連結任務 {kpi.taskLinks.length} 項</span>
+          <span>權重 {kpi.weight}</span>
+        </div>
+      </button>
+
+      {/* Expanded: linked tasks */}
+      {expanded && (
+        <div className="border-t border-border px-4 pb-4 pt-3 space-y-2">
+          <p className="text-xs font-medium text-muted-foreground mb-2">連結任務</p>
+          {kpi.taskLinks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">尚未連結任務</p>
+          ) : (
+            kpi.taskLinks.map((link) => (
+              <div
+                key={link.taskId}
+                className="flex items-center gap-3 p-2.5 bg-accent/40 rounded-md"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-foreground truncate">{link.task.title}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-[10px] text-muted-foreground">
+                      {TASK_STATUS_LABEL[link.task.status] ?? link.task.status}
+                    </span>
+                    {link.task.primaryAssignee && (
+                      <span className="text-[10px] text-muted-foreground">
+                        {link.task.primaryAssignee.name}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="text-right">
+                    <p className="text-xs tabular-nums font-medium">
+                      {link.task.status === "DONE" ? 100 : link.task.progressPct}%
+                    </p>
+                    <p className="text-[10px] text-muted-foreground">w:{link.weight}</p>
+                  </div>
+                  {isManager && (
+                    <button
+                      onClick={() => onUnlink(kpi.id, link.taskId)}
+                      className="p-1 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                      title="移除連結"
+                    >
+                      <Unlink className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────
+
+export default function KPIPage() {
+  const { data: session } = useSession();
+  const isManager = session?.user?.role === "MANAGER";
+
+  const [kpis, setKpis] = useState<KPI[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const year = new Date().getFullYear();
+
+  async function fetchKPIs() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/kpi?year=${year}`);
+      if (res.ok) {
+        const data = await res.json();
+        setKpis(Array.isArray(data) ? data : []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchKPIs();
+  }, []);
+
+  async function handleUnlink(kpiId: string, taskId: string) {
+    const res = await fetch(`/api/kpi/${kpiId}/link`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ taskId, remove: true }),
+    });
+    if (res.ok) {
+      setKpis((prev) =>
+        prev.map((k) =>
+          k.id === kpiId
+            ? { ...k, taskLinks: k.taskLinks.filter((l) => l.taskId !== taskId) }
+            : k
+        )
+      );
+    }
+  }
+
+  function handleCreated(kpi: KPI) {
+    setKpis((prev) => [...prev, { ...kpi, taskLinks: [] }]);
+    setShowForm(false);
+  }
+
+  const avgRate =
+    kpis.length > 0
+      ? kpis.reduce((s, k) => s + achievementRate(k), 0) / kpis.length
+      : 0;
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-medium tracking-[-0.04em] flex items-center gap-2">
+            <Target className="h-6 w-6 text-primary" />
+            KPI 管理
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">{year} 年度關鍵績效指標</p>
+        </div>
+        {isManager && (
+          <button
+            onClick={() => setShowForm((v) => !v)}
+            className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground text-sm rounded-md hover:bg-primary/90 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            新增 KPI
+          </button>
+        )}
+      </div>
+
+      {/* Summary */}
+      {kpis.length > 0 && (
+        <div className="grid grid-cols-3 gap-4 mb-6">
+          <div className="bg-card border border-border rounded-lg p-4 text-center">
+            <p className="text-2xl font-semibold tabular-nums">{kpis.length}</p>
+            <p className="text-xs text-muted-foreground mt-1">KPI 總數</p>
+          </div>
+          <div className="bg-card border border-border rounded-lg p-4 text-center">
+            <p className="text-2xl font-semibold tabular-nums text-green-400">
+              {kpis.filter((k) => achievementRate(k) >= 100).length}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">已達成</p>
+          </div>
+          <div className="bg-card border border-border rounded-lg p-4 text-center">
+            <p className="text-2xl font-semibold tabular-nums">{avgRate.toFixed(0)}%</p>
+            <p className="text-xs text-muted-foreground mt-1">平均達成率</p>
+          </div>
+        </div>
+      )}
+
+      {/* Create form */}
+      {showForm && (
+        <div className="mb-6">
+          <CreateKPIForm onCreated={handleCreated} onCancel={() => setShowForm(false)} />
+        </div>
+      )}
+
+      {/* KPI List */}
+      {loading ? (
+        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+          載入中...
+        </div>
+      ) : kpis.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-48 gap-3">
+          <Target className="h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">尚無 KPI，{isManager ? "請點擊「新增 KPI」建立" : "請聯絡主管建立"}</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {kpis.map((kpi) => (
+            <KPICard
+              key={kpi.id}
+              kpi={kpi}
+              isManager={isManager}
+              onUnlink={handleUnlink}
+              onRefresh={fetchKPIs}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -1,8 +1,629 @@
-export default function ReportsPage() {
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Download, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+type TabId = "weekly" | "monthly" | "kpi" | "workload";
+
+interface Tab {
+  id: TabId;
+  label: string;
+}
+
+const TABS: Tab[] = [
+  { id: "weekly", label: "週報" },
+  { id: "monthly", label: "月報" },
+  { id: "kpi", label: "KPI 報表" },
+  { id: "workload", label: "計畫外負荷" },
+];
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">{children}</h3>;
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-medium tracking-[-0.04em]">報表</h1>
-      <p className="text-muted-foreground mt-1">開發中...</p>
+    <div className="flex items-center justify-between py-2 border-b border-border/50">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {
+  return (
+    <div className="h-1.5 w-full bg-accent rounded-full overflow-hidden">
+      <div
+        className={cn("h-full rounded-full transition-all", color)}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function exportJSON(data: unknown, filename: string) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Weekly Report ──────────────────────────────────────────────────────────
+
+interface WeeklyData {
+  period: { start: string; end: string };
+  completedCount: number;
+  totalHours: number;
+  hoursByCategory: Record<string, number>;
+  overdueCount: number;
+  delayCount: number;
+  scopeChangeCount: number;
+  completedTasks: Array<{ id: string; title: string; primaryAssignee?: { name: string } | null }>;
+  overdueTasks: Array<{ id: string; title: string; dueDate: string; primaryAssignee?: { name: string } | null }>;
+}
+
+function WeeklyReport() {
+  const [data, setData] = useState<WeeklyData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/reports/weekly")
+      .then((r) => r.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>;
+  if (!data) return <div className="py-12 text-center text-sm text-muted-foreground">無法載入週報</div>;
+
+  const start = new Date(data.period.start).toLocaleDateString("zh-TW");
+  const end = new Date(data.period.end).toLocaleDateString("zh-TW");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">{start} — {end}</p>
+        <button
+          onClick={() => exportJSON(data, `weekly-report-${start}.json`)}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-accent hover:bg-accent/80 rounded-md transition-colors"
+        >
+          <Download className="h-3.5 w-3.5" />
+          匯出
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="bg-card border border-border rounded-lg p-4">
+        <SectionTitle>本週摘要</SectionTitle>
+        <StatRow label="完成任務數" value={data.completedCount} />
+        <StatRow label="總工時 (h)" value={data.totalHours.toFixed(1)} />
+        <StatRow label="逾期任務數" value={data.overdueCount} />
+        <StatRow label="延遲次數" value={data.delayCount} />
+        <StatRow label="範疇變更次數" value={data.scopeChangeCount} />
+      </div>
+
+      {/* Hours by category */}
+      {Object.keys(data.hoursByCategory).length > 0 && (
+        <div className="bg-card border border-border rounded-lg p-4">
+          <SectionTitle>工時分類</SectionTitle>
+          <div className="space-y-2">
+            {Object.entries(data.hoursByCategory).map(([cat, hours]) => (
+              <div key={cat} className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground font-mono text-xs">{cat}</span>
+                <span className="tabular-nums">{hours.toFixed(1)} h</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Completed tasks */}
+      {data.completedTasks.length > 0 && (
+        <div className="bg-card border border-border rounded-lg p-4">
+          <SectionTitle>本週完成任務</SectionTitle>
+          <div className="space-y-1.5">
+            {data.completedTasks.map((t) => (
+              <div key={t.id} className="flex items-center justify-between text-sm">
+                <span className="text-foreground truncate">{t.title}</span>
+                {t.primaryAssignee && (
+                  <span className="text-xs text-muted-foreground flex-shrink-0 ml-2">
+                    {t.primaryAssignee.name}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Overdue tasks */}
+      {data.overdueTasks.length > 0 && (
+        <div className="bg-card border border-red-500/30 rounded-lg p-4">
+          <SectionTitle>逾期任務</SectionTitle>
+          <div className="space-y-1.5">
+            {data.overdueTasks.map((t) => (
+              <div key={t.id} className="flex items-center justify-between text-sm">
+                <span className="text-foreground truncate">{t.title}</span>
+                <span className="text-xs text-red-400 flex-shrink-0 ml-2 tabular-nums">
+                  {new Date(t.dueDate).toLocaleDateString("zh-TW")}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Monthly Report ─────────────────────────────────────────────────────────
+
+interface MonthlyData {
+  period: { year: number; month: number };
+  totalTasks: number;
+  completedTasks: number;
+  completionRate: number;
+  totalHours: number;
+  hoursByCategory: Record<string, number>;
+  delayCount: number;
+  scopeChangeCount: number;
+  monthlyGoals: Array<{ id: string; title: string; tasks: Array<{ status: string }> }>;
+}
+
+function MonthlyReport() {
+  const now = new Date();
+  const [month, setMonth] = useState(
+    `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`
+  );
+  const [data, setData] = useState<MonthlyData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetch(`/api/reports/monthly?month=${month}`)
+      .then((r) => r.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [month]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <input
+          type="month"
+          value={month}
+          onChange={(e) => setMonth(e.target.value)}
+          className="bg-accent border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+        <button
+          onClick={load}
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+        {data && (
+          <button
+            onClick={() => exportJSON(data, `monthly-report-${month}.json`)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-accent hover:bg-accent/80 rounded-md transition-colors ml-auto"
+          >
+            <Download className="h-3.5 w-3.5" />
+            匯出
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+      ) : !data ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">無法載入月報</div>
+      ) : (
+        <>
+          <div className="bg-card border border-border rounded-lg p-4">
+            <SectionTitle>
+              {data.period.year} 年 {data.period.month} 月摘要
+            </SectionTitle>
+            <StatRow label="總任務數" value={data.totalTasks} />
+            <StatRow label="完成任務數" value={data.completedTasks} />
+            <StatRow label="完成率" value={`${data.completionRate}%`} />
+            <StatRow label="總工時 (h)" value={data.totalHours.toFixed(1)} />
+            <StatRow label="延遲次數" value={data.delayCount} />
+            <StatRow label="範疇變更次數" value={data.scopeChangeCount} />
+          </div>
+
+          <div className="bg-card border border-border rounded-lg p-4">
+            <SectionTitle>任務完成率</SectionTitle>
+            <div className="space-y-1">
+              <div className="flex justify-between text-xs mb-1">
+                <span className="text-muted-foreground">完成進度</span>
+                <span className="tabular-nums font-medium">{data.completionRate}%</span>
+              </div>
+              <ProgressBar
+                pct={data.completionRate}
+                color={data.completionRate >= 80 ? "bg-green-500" : data.completionRate >= 50 ? "bg-primary" : "bg-yellow-500"}
+              />
+            </div>
+          </div>
+
+          {data.monthlyGoals.length > 0 && (
+            <div className="bg-card border border-border rounded-lg p-4">
+              <SectionTitle>月度目標</SectionTitle>
+              <div className="space-y-3">
+                {data.monthlyGoals.map((g) => {
+                  const done = g.tasks.filter((t) => t.status === "DONE").length;
+                  const total = g.tasks.length;
+                  const pct = total > 0 ? (done / total) * 100 : 0;
+                  return (
+                    <div key={g.id}>
+                      <div className="flex justify-between text-sm mb-1">
+                        <span className="text-foreground">{g.title}</span>
+                        <span className="tabular-nums text-muted-foreground text-xs">{done}/{total}</span>
+                      </div>
+                      <ProgressBar pct={pct} />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── KPI Report ─────────────────────────────────────────────────────────────
+
+interface KPIReportData {
+  year: number;
+  avgAchievement: number;
+  achievedCount: number;
+  totalCount: number;
+  kpis: Array<{
+    id: string;
+    code: string;
+    title: string;
+    target: number;
+    actual: number;
+    weight: number;
+    status: string;
+    achievementRate: number;
+  }>;
+}
+
+const KPI_STATUS_LABEL: Record<string, string> = {
+  ON_TRACK: "進行中",
+  AT_RISK: "風險",
+  BEHIND: "落後",
+  ACHIEVED: "達成",
+};
+
+function KPIReport() {
+  const [year, setYear] = useState(new Date().getFullYear());
+  const [data, setData] = useState<KPIReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetch(`/api/reports/kpi?year=${year}`)
+      .then((r) => r.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [year]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <input
+          type="number"
+          value={year}
+          onChange={(e) => setYear(parseInt(e.target.value))}
+          className="w-24 bg-accent border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+        <button
+          onClick={load}
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+        {data && (
+          <button
+            onClick={() => exportJSON(data, `kpi-report-${year}.json`)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-accent hover:bg-accent/80 rounded-md transition-colors ml-auto"
+          >
+            <Download className="h-3.5 w-3.5" />
+            匯出
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+      ) : !data ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">無法載入 KPI 報表</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums">{data.totalCount}</p>
+              <p className="text-xs text-muted-foreground mt-1">KPI 總數</p>
+            </div>
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums text-green-400">{data.achievedCount}</p>
+              <p className="text-xs text-muted-foreground mt-1">已達成</p>
+            </div>
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums">{data.avgAchievement}%</p>
+              <p className="text-xs text-muted-foreground mt-1">平均達成率</p>
+            </div>
+          </div>
+
+          <div className="bg-card border border-border rounded-lg p-4">
+            <SectionTitle>各 KPI 達成狀況</SectionTitle>
+            <div className="space-y-4">
+              {data.kpis.map((kpi) => (
+                <div key={kpi.id}>
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-xs font-mono text-muted-foreground flex-shrink-0">{kpi.code}</span>
+                      <span className="text-sm text-foreground truncate">{kpi.title}</span>
+                      {kpi.status && (
+                        <span className="text-[10px] text-muted-foreground flex-shrink-0">
+                          {KPI_STATUS_LABEL[kpi.status] ?? kpi.status}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-sm font-medium tabular-nums flex-shrink-0 ml-2">
+                      {kpi.achievementRate.toFixed(0)}%
+                    </span>
+                  </div>
+                  <ProgressBar
+                    pct={kpi.achievementRate}
+                    color={
+                      kpi.achievementRate >= 100
+                        ? "bg-green-500"
+                        : kpi.achievementRate >= 60
+                        ? "bg-primary"
+                        : "bg-yellow-500"
+                    }
+                  />
+                  <p className="text-[11px] text-muted-foreground mt-0.5 tabular-nums">
+                    實績 {kpi.actual} / 目標 {kpi.target}　權重 {kpi.weight}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Workload Report ────────────────────────────────────────────────────────
+
+interface WorkloadData {
+  period: { start: string; end: string };
+  totalHours: number;
+  plannedHours: number;
+  unplannedHours: number;
+  plannedRate: number;
+  unplannedRate: number;
+  hoursByCategory: Record<string, number>;
+  byPerson: Array<{
+    userId: string;
+    name: string;
+    total: number;
+    planned: number;
+    unplanned: number;
+  }>;
+  unplannedBySource: Record<string, number>;
+}
+
+function WorkloadReport() {
+  const now = new Date();
+  const [startDate, setStartDate] = useState(
+    `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-01`
+  );
+  const [data, setData] = useState<WorkloadData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    fetch(`/api/reports/workload?startDate=${startDate}`)
+      .then((r) => r.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [startDate]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>起始日</span>
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="bg-accent border border-border rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <button
+          onClick={load}
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+        {data && (
+          <button
+            onClick={() => exportJSON(data, `workload-report-${startDate}.json`)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-accent hover:bg-accent/80 rounded-md transition-colors ml-auto"
+          >
+            <Download className="h-3.5 w-3.5" />
+            匯出
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+      ) : !data ? (
+        <div className="py-12 text-center text-sm text-muted-foreground">無法載入負荷報表</div>
+      ) : (
+        <>
+          {/* Summary */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-xl font-semibold tabular-nums">{data.totalHours.toFixed(1)}</p>
+              <p className="text-xs text-muted-foreground mt-1">總工時 (h)</p>
+            </div>
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-xl font-semibold tabular-nums text-green-400">{data.plannedRate}%</p>
+              <p className="text-xs text-muted-foreground mt-1">計畫投入率</p>
+            </div>
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-xl font-semibold tabular-nums text-orange-400">{data.unplannedRate}%</p>
+              <p className="text-xs text-muted-foreground mt-1">計畫外負荷率</p>
+            </div>
+            <div className="bg-card border border-border rounded-lg p-4 text-center">
+              <p className="text-xl font-semibold tabular-nums">{data.unplannedHours.toFixed(1)}</p>
+              <p className="text-xs text-muted-foreground mt-1">計畫外工時 (h)</p>
+            </div>
+          </div>
+
+          {/* Planned vs Unplanned */}
+          <div className="bg-card border border-border rounded-lg p-4">
+            <SectionTitle>計畫 vs 計畫外</SectionTitle>
+            <div className="space-y-3">
+              <div>
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-muted-foreground">計畫內 ({data.plannedHours.toFixed(1)} h)</span>
+                  <span className="tabular-nums text-green-400">{data.plannedRate}%</span>
+                </div>
+                <ProgressBar pct={data.plannedRate} color="bg-green-500" />
+              </div>
+              <div>
+                <div className="flex justify-between text-xs mb-1">
+                  <span className="text-muted-foreground">計畫外 ({data.unplannedHours.toFixed(1)} h)</span>
+                  <span className="tabular-nums text-orange-400">{data.unplannedRate}%</span>
+                </div>
+                <ProgressBar pct={data.unplannedRate} color="bg-orange-500" />
+              </div>
+            </div>
+          </div>
+
+          {/* Per person */}
+          {data.byPerson.length > 0 && (
+            <div className="bg-card border border-border rounded-lg p-4">
+              <SectionTitle>個人負荷分析</SectionTitle>
+              <div className="space-y-4">
+                {data.byPerson.map((p) => {
+                  const unplannedPct = p.total > 0 ? (p.unplanned / p.total) * 100 : 0;
+                  return (
+                    <div key={p.userId}>
+                      <div className="flex justify-between text-sm mb-1">
+                        <span className="text-foreground">{p.name}</span>
+                        <span className="text-xs text-muted-foreground tabular-nums">
+                          計畫外 {unplannedPct.toFixed(0)}% | 共 {p.total.toFixed(1)} h
+                        </span>
+                      </div>
+                      <div className="flex gap-0.5 h-2 rounded-full overflow-hidden">
+                        {p.total > 0 && (
+                          <>
+                            <div
+                              className="bg-green-500"
+                              style={{ width: `${(p.planned / p.total) * 100}%` }}
+                            />
+                            <div
+                              className="bg-orange-500"
+                              style={{ width: `${(p.unplanned / p.total) * 100}%` }}
+                            />
+                          </>
+                        )}
+                        {p.total === 0 && <div className="bg-accent w-full" />}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Unplanned source */}
+          {Object.keys(data.unplannedBySource).length > 0 && (
+            <div className="bg-card border border-border rounded-lg p-4">
+              <SectionTitle>計畫外任務來源</SectionTitle>
+              <div className="space-y-2">
+                {Object.entries(data.unplannedBySource)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([src, count]) => (
+                    <div key={src} className="flex justify-between text-sm">
+                      <span className="text-muted-foreground">{src}</span>
+                      <span className="tabular-nums font-medium">{count} 件</span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────
+
+const TAB_COMPONENTS: Record<TabId, React.ComponentType> = {
+  weekly: WeeklyReport,
+  monthly: MonthlyReport,
+  kpi: KPIReport,
+  workload: WorkloadReport,
+};
+
+export default function ReportsPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("weekly");
+  const ActiveComponent = TAB_COMPONENTS[activeTab];
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-medium tracking-[-0.04em]">報表</h1>
+        <p className="text-sm text-muted-foreground mt-1">週報、月報、KPI、計畫外負荷分析</p>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 p-1 bg-accent/50 rounded-lg mb-6">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={cn(
+              "flex-1 py-2 px-3 text-sm rounded-md transition-colors",
+              activeTab === tab.id
+                ? "bg-card text-foreground font-medium shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <ActiveComponent />
     </div>
   );
 }

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const kpi = await prisma.kPI.findUnique({
+      where: { id: params.id },
+      include: {
+        taskLinks: {
+          include: {
+            task: {
+              select: {
+                id: true,
+                title: true,
+                status: true,
+                progressPct: true,
+                estimatedHours: true,
+                actualHours: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!kpi) {
+      return NextResponse.json({ error: "找不到 KPI" }, { status: 404 });
+    }
+
+    let achievementRate = 0;
+    if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+      const totalWeight = kpi.taskLinks.reduce(
+        (sum, link) => sum + link.weight,
+        0
+      );
+      const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
+        const progress =
+          link.task.status === "DONE" ? 100 : link.task.progressPct;
+        return sum + (progress * link.weight) / 100;
+      }, 0);
+      achievementRate =
+        totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
+    } else {
+      achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+    }
+
+    const linkedTaskCount = kpi.taskLinks.length;
+    const completedTaskCount = kpi.taskLinks.filter(
+      (l) => l.task.status === "DONE"
+    ).length;
+
+    return NextResponse.json({
+      kpiId: kpi.id,
+      target: kpi.target,
+      actual: kpi.actual,
+      achievementRate: Math.min(achievementRate, 100),
+      linkedTaskCount,
+      completedTaskCount,
+      autoCalc: kpi.autoCalc,
+    });
+  } catch (error) {
+    console.error("GET /api/kpi/[id]/achievement error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/kpi/[id]/link/route.ts
+++ b/app/api/kpi/[id]/link/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    if (session.user.role !== "MANAGER") {
+      return NextResponse.json({ error: "權限不足" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { taskId, weight, remove } = body;
+
+    if (!taskId) {
+      return NextResponse.json({ error: "taskId 為必填" }, { status: 400 });
+    }
+
+    if (remove) {
+      await prisma.kPITaskLink.deleteMany({
+        where: { kpiId: params.id, taskId },
+      });
+      return NextResponse.json({ message: "已移除連結" });
+    }
+
+    const link = await prisma.kPITaskLink.upsert({
+      where: { kpiId_taskId: { kpiId: params.id, taskId } },
+      update: { weight: weight != null ? parseFloat(weight) : 1 },
+      create: {
+        kpiId: params.id,
+        taskId,
+        weight: weight != null ? parseFloat(weight) : 1,
+      },
+    });
+
+    return NextResponse.json(link, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/kpi/[id]/link error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const kpi = await prisma.kPI.findUnique({
+      where: { id: params.id },
+      include: {
+        taskLinks: {
+          include: {
+            task: {
+              select: {
+                id: true,
+                title: true,
+                status: true,
+                progressPct: true,
+                dueDate: true,
+                primaryAssignee: { select: { id: true, name: true } },
+              },
+            },
+          },
+        },
+        deliverables: true,
+        creator: { select: { id: true, name: true } },
+      },
+    });
+
+    if (!kpi) {
+      return NextResponse.json({ error: "找不到 KPI" }, { status: 404 });
+    }
+
+    return NextResponse.json(kpi);
+  } catch (error) {
+    console.error("GET /api/kpi/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    if (session.user.role !== "MANAGER") {
+      return NextResponse.json({ error: "權限不足" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { title, description, target, actual, weight, status, autoCalc } =
+      body;
+
+    const kpi = await prisma.kPI.update({
+      where: { id: params.id },
+      data: {
+        ...(title != null && { title }),
+        ...(description != null && { description }),
+        ...(target != null && { target: parseFloat(target) }),
+        ...(actual != null && { actual: parseFloat(actual) }),
+        ...(weight != null && { weight: parseFloat(weight) }),
+        ...(status != null && { status }),
+        ...(autoCalc != null && { autoCalc }),
+      },
+    });
+
+    return NextResponse.json(kpi);
+  } catch (error) {
+    console.error("PUT /api/kpi/[id] error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const year = searchParams.get("year")
+      ? parseInt(searchParams.get("year")!)
+      : new Date().getFullYear();
+
+    const kpis = await prisma.kPI.findMany({
+      where: { year },
+      include: {
+        taskLinks: {
+          include: {
+            task: {
+              select: {
+                id: true,
+                title: true,
+                status: true,
+                progressPct: true,
+                primaryAssignee: { select: { id: true, name: true } },
+              },
+            },
+          },
+        },
+        deliverables: true,
+        creator: { select: { id: true, name: true } },
+      },
+      orderBy: { code: "asc" },
+    });
+
+    return NextResponse.json(kpis);
+  } catch (error) {
+    console.error("GET /api/kpi error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    if (session.user.role !== "MANAGER") {
+      return NextResponse.json({ error: "權限不足" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { year, code, title, description, target, weight, autoCalc } = body;
+
+    if (!year || !code || !title || target == null) {
+      return NextResponse.json({ error: "缺少必填欄位" }, { status: 400 });
+    }
+
+    const kpi = await prisma.kPI.create({
+      data: {
+        year: parseInt(year),
+        code,
+        title,
+        description: description || null,
+        target: parseFloat(target),
+        weight: weight != null ? parseFloat(weight) : 1,
+        autoCalc: autoCalc ?? false,
+        createdBy: session.user.id,
+      },
+    });
+
+    return NextResponse.json(kpi, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/kpi error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const notification = await prisma.notification.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!notification || notification.userId !== session.user.id) {
+      return NextResponse.json({ error: "找不到通知" }, { status: 404 });
+    }
+
+    const updated = await prisma.notification.update({
+      where: { id: params.id },
+      data: { isRead: true },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("PATCH /api/notifications/[id]/read error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const limit = parseInt(searchParams.get("limit") ?? "20");
+
+    const notifications = await prisma.notification.findMany({
+      where: { userId: session.user.id },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+    });
+
+    const unreadCount = await prisma.notification.count({
+      where: { userId: session.user.id, isRead: false },
+    });
+
+    return NextResponse.json({ notifications, unreadCount });
+  } catch (error) {
+    console.error("GET /api/notifications error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    if (session.user.role !== "MANAGER") {
+      return NextResponse.json({ error: "權限不足" }, { status: 403 });
+    }
+
+    const permissions = await prisma.permission.findMany({
+      include: {
+        grantee: { select: { id: true, name: true, email: true, role: true } },
+        granter: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return NextResponse.json(permissions);
+  } catch (error) {
+    console.error("GET /api/permissions error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+    if (session.user.role !== "MANAGER") {
+      return NextResponse.json({ error: "權限不足" }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const { granteeId, permType, targetId, expiresAt, revoke } = body;
+
+    if (!granteeId || !permType) {
+      return NextResponse.json({ error: "缺少必填欄位" }, { status: 400 });
+    }
+
+    if (revoke) {
+      await prisma.permission.updateMany({
+        where: { granteeId, permType, targetId: targetId || null },
+        data: { isActive: false },
+      });
+      return NextResponse.json({ message: "已撤銷授權" });
+    }
+
+    const permission = await prisma.permission.create({
+      data: {
+        granteeId,
+        granterId: session.user.id,
+        permType,
+        targetId: targetId || null,
+        expiresAt: expiresAt ? new Date(expiresAt) : null,
+        isActive: true,
+      },
+    });
+
+    return NextResponse.json(permission, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/permissions error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/reports/kpi/route.ts
+++ b/app/api/reports/kpi/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const year = searchParams.get("year")
+      ? parseInt(searchParams.get("year")!)
+      : new Date().getFullYear();
+
+    const kpis = await prisma.kPI.findMany({
+      where: { year },
+      include: {
+        taskLinks: {
+          include: {
+            task: {
+              select: {
+                id: true,
+                title: true,
+                status: true,
+                progressPct: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { code: "asc" },
+    });
+
+    const kpisWithAchievement = kpis.map((kpi) => {
+      let achievementRate = 0;
+      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+        const totalWeight = kpi.taskLinks.reduce(
+          (sum, l) => sum + l.weight,
+          0
+        );
+        const weighted = kpi.taskLinks.reduce((sum, l) => {
+          const prog =
+            l.task.status === "DONE" ? 100 : l.task.progressPct;
+          return sum + (prog * l.weight) / 100;
+        }, 0);
+        achievementRate =
+          totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
+      } else {
+        achievementRate =
+          kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+      }
+      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
+    });
+
+    const avgAchievement =
+      kpisWithAchievement.length > 0
+        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) /
+          kpisWithAchievement.length
+        : 0;
+
+    return NextResponse.json({
+      year,
+      kpis: kpisWithAchievement,
+      avgAchievement: Math.round(avgAchievement * 10) / 10,
+      achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100)
+        .length,
+      totalCount: kpisWithAchievement.length,
+    });
+  } catch (error) {
+    console.error("GET /api/reports/kpi error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/reports/monthly/route.ts
+++ b/app/api/reports/monthly/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const monthParam = searchParams.get("month"); // format: "2026-03"
+    const now = new Date();
+    const year = monthParam
+      ? parseInt(monthParam.split("-")[0])
+      : now.getFullYear();
+    const month = monthParam
+      ? parseInt(monthParam.split("-")[1])
+      : now.getMonth() + 1;
+
+    const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+
+    const isManager = session.user.role === "MANAGER";
+    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+
+    const allTasks = await prisma.task.findMany({
+      where: {
+        ...userFilter,
+        createdAt: { lte: monthEnd },
+        OR: [
+          { dueDate: { gte: monthStart, lte: monthEnd } },
+          { status: "DONE", updatedAt: { gte: monthStart, lte: monthEnd } },
+          { status: { notIn: ["DONE"] }, dueDate: null },
+        ],
+      },
+      include: {
+        primaryAssignee: { select: { id: true, name: true } },
+        monthlyGoal: { select: { id: true, title: true, month: true } },
+      },
+    });
+
+    const completedTasks = allTasks.filter((t) => t.status === "DONE");
+    const completionRate =
+      allTasks.length > 0
+        ? Math.round((completedTasks.length / allTasks.length) * 100)
+        : 0;
+
+    const timeEntryFilter = isManager
+      ? { date: { gte: monthStart, lte: monthEnd } }
+      : { userId: session.user.id, date: { gte: monthStart, lte: monthEnd } };
+
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      include: { user: { select: { id: true, name: true } } },
+    });
+
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const hoursByCategory = timeEntries.reduce(
+      (acc, e) => {
+        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    const monthlyGoals = await prisma.monthlyGoal.findMany({
+      where: {
+        month,
+        annualPlan: { year },
+      },
+      include: {
+        tasks: {
+          where: userFilter,
+          select: { id: true, status: true, progressPct: true },
+        },
+      },
+    });
+
+    const changes = await prisma.taskChange.findMany({
+      where: { changedAt: { gte: monthStart, lte: monthEnd } },
+      include: {
+        task: { select: { id: true, title: true } },
+        changedByUser: { select: { id: true, name: true } },
+      },
+    });
+
+    return NextResponse.json({
+      period: { year, month, start: monthStart, end: monthEnd },
+      totalTasks: allTasks.length,
+      completedTasks: completedTasks.length,
+      completionRate,
+      totalHours,
+      hoursByCategory,
+      monthlyGoals,
+      changes,
+      delayCount: changes.filter((c) => c.changeType === "DELAY").length,
+      scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE")
+        .length,
+    });
+  } catch (error) {
+    console.error("GET /api/reports/monthly error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/reports/weekly/route.ts
+++ b/app/api/reports/weekly/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const dateParam = searchParams.get("date");
+    const refDate = dateParam ? new Date(dateParam) : new Date();
+
+    // Week bounds: Monday–Sunday
+    const day = refDate.getDay();
+    const diffToMon = day === 0 ? -6 : 1 - day;
+    const weekStart = new Date(refDate);
+    weekStart.setDate(refDate.getDate() + diffToMon);
+    weekStart.setHours(0, 0, 0, 0);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+    weekEnd.setHours(23, 59, 59, 999);
+
+    const isManager = session.user.role === "MANAGER";
+    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+
+    const completedTasks = await prisma.task.findMany({
+      where: {
+        ...userFilter,
+        status: "DONE",
+        updatedAt: { gte: weekStart, lte: weekEnd },
+      },
+      include: {
+        primaryAssignee: { select: { id: true, name: true } },
+      },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const timeEntryFilter = isManager
+      ? { date: { gte: weekStart, lte: weekEnd } }
+      : { userId: session.user.id, date: { gte: weekStart, lte: weekEnd } };
+
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      include: {
+        user: { select: { id: true, name: true } },
+      },
+    });
+
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const hoursByCategory = timeEntries.reduce(
+      (acc, e) => {
+        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    const overdueTasks = await prisma.task.findMany({
+      where: {
+        ...userFilter,
+        status: { notIn: ["DONE"] },
+        dueDate: { lt: new Date() },
+      },
+      include: {
+        primaryAssignee: { select: { id: true, name: true } },
+      },
+      orderBy: { dueDate: "asc" },
+      take: 10,
+    });
+
+    const changes = await prisma.taskChange.findMany({
+      where: { changedAt: { gte: weekStart, lte: weekEnd } },
+      include: {
+        task: { select: { id: true, title: true } },
+        changedByUser: { select: { id: true, name: true } },
+      },
+      orderBy: { changedAt: "desc" },
+    });
+
+    return NextResponse.json({
+      period: { start: weekStart, end: weekEnd },
+      completedTasks,
+      completedCount: completedTasks.length,
+      totalHours,
+      hoursByCategory,
+      overdueTasks,
+      overdueCount: overdueTasks.length,
+      changes,
+      delayCount: changes.filter((c) => c.changeType === "DELAY").length,
+      scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE")
+        .length,
+    });
+  } catch (error) {
+    console.error("GET /api/reports/weekly error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/reports/workload/route.ts
+++ b/app/api/reports/workload/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const startParam = searchParams.get("startDate");
+    const endParam = searchParams.get("endDate");
+    const now = new Date();
+
+    const startDate = startParam
+      ? new Date(startParam)
+      : new Date(now.getFullYear(), now.getMonth(), 1);
+    const endDate = endParam
+      ? new Date(endParam)
+      : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+    const isManager = session.user.role === "MANAGER";
+    const timeEntryFilter = isManager
+      ? { date: { gte: startDate, lte: endDate } }
+      : { userId: session.user.id, date: { gte: startDate, lte: endDate } };
+
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      include: {
+        user: { select: { id: true, name: true } },
+        task: { select: { id: true, title: true, category: true } },
+      },
+    });
+
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const plannedHours = timeEntries
+      .filter((e) => e.category === "PLANNED_TASK")
+      .reduce((sum, e) => sum + e.hours, 0);
+    const unplannedHours = timeEntries
+      .filter((e) =>
+        ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)
+      )
+      .reduce((sum, e) => sum + e.hours, 0);
+
+    const hoursByCategory = timeEntries.reduce(
+      (acc, e) => {
+        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    // Per-person breakdown
+    const byPerson = timeEntries.reduce(
+      (acc, e) => {
+        const key = e.userId;
+        if (!acc[key]) {
+          acc[key] = {
+            userId: e.userId,
+            name: e.user.name,
+            total: 0,
+            planned: 0,
+            unplanned: 0,
+          };
+        }
+        acc[key].total += e.hours;
+        if (e.category === "PLANNED_TASK") acc[key].planned += e.hours;
+        if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
+          acc[key].unplanned += e.hours;
+        return acc;
+      },
+      {} as Record<
+        string,
+        {
+          userId: string;
+          name: string;
+          total: number;
+          planned: number;
+          unplanned: number;
+        }
+      >
+    );
+
+    // Unplanned task source analysis
+    const unplannedTasks = await prisma.task.findMany({
+      where: {
+        ...(isManager ? {} : { primaryAssigneeId: session.user.id }),
+        category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
+        createdAt: { gte: startDate, lte: endDate },
+      },
+      include: {
+        primaryAssignee: { select: { id: true, name: true } },
+      },
+    });
+
+    const unplannedBySource = unplannedTasks.reduce(
+      (acc, t) => {
+        const src = t.addedSource ?? "未填寫";
+        acc[src] = (acc[src] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+
+    return NextResponse.json({
+      period: { start: startDate, end: endDate },
+      totalHours,
+      plannedHours,
+      unplannedHours,
+      plannedRate:
+        totalHours > 0
+          ? Math.round((plannedHours / totalHours) * 100 * 10) / 10
+          : 0,
+      unplannedRate:
+        totalHours > 0
+          ? Math.round((unplannedHours / totalHours) * 100 * 10) / 10
+          : 0,
+      hoursByCategory,
+      byPerson: Object.values(byPerson),
+      unplannedTasks,
+      unplannedBySource,
+    });
+  } catch (error) {
+    console.error("GET /api/reports/workload error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/api/tasks/[id]/changes/route.ts
+++ b/app/api/tasks/[id]/changes/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const changes = await prisma.taskChange.findMany({
+      where: { taskId: params.id },
+      include: {
+        changedByUser: { select: { id: true, name: true } },
+      },
+      orderBy: { changedAt: "desc" },
+    });
+
+    return NextResponse.json(changes);
+  } catch (error) {
+    console.error("GET /api/tasks/[id]/changes error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "未授權" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const { changeType, reason, oldValue, newValue } = body;
+
+    if (!changeType || !reason) {
+      return NextResponse.json(
+        { error: "changeType 和 reason 為必填" },
+        { status: 400 }
+      );
+    }
+
+    const change = await prisma.taskChange.create({
+      data: {
+        taskId: params.id,
+        changeType,
+        reason,
+        oldValue: oldValue || null,
+        newValue: newValue || null,
+        changedBy: session.user.id,
+      },
+      include: {
+        changedByUser: { select: { id: true, name: true } },
+      },
+    });
+
+    return NextResponse.json(change, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/tasks/[id]/changes error:", error);
+    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  }
+}

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { Bell, CheckCheck, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  body?: string | null;
+  isRead: boolean;
+  createdAt: string;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  TASK_ASSIGNED: "任務指派",
+  TASK_DUE_SOON: "即將到期",
+  TASK_OVERDUE: "已逾期",
+  TASK_COMMENTED: "新留言",
+  MILESTONE_DUE: "里程碑提醒",
+  BACKUP_ACTIVATED: "B 角啟動",
+  TASK_CHANGED: "任務變更",
+  DELIVERABLE_PENDING: "交付項待辦",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  TASK_ASSIGNED: "bg-blue-500",
+  TASK_DUE_SOON: "bg-yellow-500",
+  TASK_OVERDUE: "bg-red-500",
+  TASK_COMMENTED: "bg-green-500",
+  MILESTONE_DUE: "bg-purple-500",
+  BACKUP_ACTIVATED: "bg-orange-500",
+  TASK_CHANGED: "bg-cyan-500",
+  DELIVERABLE_PENDING: "bg-pink-500",
+};
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "剛剛";
+  if (mins < 60) return `${mins} 分鐘前`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} 小時前`;
+  const days = Math.floor(hours / 24);
+  return `${days} 天前`;
+}
+
+export function NotificationBell() {
+  const [open, setOpen] = useState(false);
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  async function fetchNotifications() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/notifications?limit=15");
+      if (res.ok) {
+        const data = await res.json();
+        setNotifications(data.notifications ?? []);
+        setUnreadCount(data.unreadCount ?? 0);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function markRead(id: string) {
+    const res = await fetch(`/api/notifications/${id}/read`, {
+      method: "PATCH",
+    });
+    if (res.ok) {
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, isRead: true } : n))
+      );
+      setUnreadCount((prev) => Math.max(0, prev - 1));
+    }
+  }
+
+  async function markAllRead() {
+    const unread = notifications.filter((n) => !n.isRead);
+    await Promise.all(unread.map((n) => markRead(n.id)));
+  }
+
+  useEffect(() => {
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, 60000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    if (open) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={() => {
+          setOpen((prev) => !prev);
+          if (!open) fetchNotifications();
+        }}
+        className="relative p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        aria-label="通知"
+      >
+        <Bell className="h-4 w-4" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[16px] h-4 bg-red-500 text-white text-[10px] font-bold rounded-full flex items-center justify-center px-0.5 tabular-nums">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-10 w-80 bg-card border border-border rounded-lg shadow-xl z-50 overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+            <span className="text-sm font-medium">
+              通知
+              {unreadCount > 0 && (
+                <span className="ml-2 text-xs bg-red-500/20 text-red-400 px-1.5 py-0.5 rounded-full">
+                  {unreadCount} 未讀
+                </span>
+              )}
+            </span>
+            <div className="flex items-center gap-1">
+              {unreadCount > 0 && (
+                <button
+                  onClick={markAllRead}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                  title="全部標為已讀"
+                >
+                  <CheckCheck className="h-3.5 w-3.5" />
+                </button>
+              )}
+              <button
+                onClick={() => setOpen(false)}
+                className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+
+          {/* List */}
+          <div className="max-h-80 overflow-y-auto">
+            {loading && notifications.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                載入中...
+              </div>
+            ) : notifications.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                目前沒有通知
+              </div>
+            ) : (
+              notifications.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => !n.isRead && markRead(n.id)}
+                  className={cn(
+                    "w-full text-left px-4 py-3 border-b border-border/50 hover:bg-accent/50 transition-colors flex gap-3",
+                    !n.isRead && "bg-primary/5"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mt-1.5 w-2 h-2 rounded-full flex-shrink-0",
+                      TYPE_COLORS[n.type] ?? "bg-muted-foreground",
+                      n.isRead && "opacity-30"
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="text-[11px] font-medium text-muted-foreground">
+                        {TYPE_LABELS[n.type] ?? n.type}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground flex-shrink-0 tabular-nums">
+                        {timeAgo(n.createdAt)}
+                      </span>
+                    </div>
+                    <p
+                      className={cn(
+                        "text-sm mt-0.5 truncate",
+                        n.isRead ? "text-muted-foreground" : "text-foreground"
+                      )}
+                    >
+                      {n.title}
+                    </p>
+                    {n.body && (
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                        {n.body}
+                      </p>
+                    )}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Clock,
   BarChart2,
   Target,
+  Crosshair,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -20,6 +21,7 @@ const navItems = [
   { href: "/gantt", label: "甘特圖", icon: GanttChartSquare },
   { href: "/knowledge", label: "知識庫", icon: BookOpen },
   { href: "/timesheet", label: "工時紀錄", icon: Clock },
+  { href: "/kpi", label: "KPI", icon: Crosshair },
   { href: "/reports", label: "報表", icon: BarChart2 },
 ];
 
@@ -61,7 +63,7 @@ export function Sidebar() {
       {/* Version footer */}
       <div className="p-4 border-t border-sidebar-border">
         <p className="font-mono text-[11px] text-muted-foreground tabular-nums">
-          v0.2.0 — Sprint 2
+          v1.0.0 — Sprint 4
         </p>
       </div>
     </aside>

--- a/app/components/topbar.tsx
+++ b/app/components/topbar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useSession, signOut } from "next-auth/react";
-import { Bell, LogOut, User } from "lucide-react";
+import { LogOut, User } from "lucide-react";
+import { NotificationBell } from "@/app/components/notification-bell";
 
 export function Topbar() {
   const { data: session } = useSession();
@@ -14,14 +15,7 @@ export function Topbar() {
       {/* Right: notification + user */}
       <div className="flex items-center gap-3">
         {/* Notification bell */}
-        <button
-          className="relative p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-          aria-label="通知"
-        >
-          <Bell className="h-4 w-4" />
-          {/* Unread badge placeholder */}
-          <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 bg-primary rounded-full" />
-        </button>
+        <NotificationBell />
 
         {/* User info */}
         <div className="flex items-center gap-2 pl-3 border-l border-border">


### PR DESCRIPTION
## Summary

- 儀表板 (`/dashboard`): 依角色分流，主管顯示團隊工時分佈、投入率、計畫外負荷；工程師顯示待辦任務、本週工時進度、逾期任務
- KPI 頁面 (`/kpi`): 列表含進度條、主管可新增 KPI、展開查看連結任務並解除連結
- 報表頁面 (`/reports`): 4 分頁（週報、月報、KPI、計畫外負荷），每頁含匯出按鈕
- Topbar: 以 `NotificationBell` 元件取代通知佔位符（即時輪詢、未讀計數、標為已讀）
- Sidebar: 新增 KPI 連結（Crosshair 圖示），版本更新至 v1.0.0

## Test plan

- [ ] 以 MANAGER 角色登入 → 儀表板顯示團隊視角
- [ ] 以 ENGINEER 角色登入 → 儀表板顯示個人視角
- [ ] 前往 `/kpi` → 可看到 KPI 列表與新增表單（主管）
- [ ] 展開 KPI → 顯示連結任務，主管可點擊移除連結
- [ ] 前往 `/reports` → 可切換 4 個分頁，各頁「匯出」下載 JSON
- [ ] 點擊通知鈴 → 彈出通知列表，可標記已讀

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)