### PR TITLE
refactor(#79): Zod input validation for all API endpoints

### DIFF
--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateDocumentSchema } from "@/validators/document-validators";
 
 export async function GET(
   _req: NextRequest,
@@ -41,15 +44,14 @@ export async function PUT(
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
     const { id } = await params;
-    const body = await req.json();
-    const { title, content, parentId } = body;
+    const raw = await req.json();
+    const { title, content, parentId } = validateBody(updateDocumentSchema, raw);
 
     const existing = await prisma.document.findUnique({ where: { id } });
     if (!existing) return NextResponse.json({ error: "文件不存在" }, { status: 404 });
 
     const newVersion = existing.version + 1;
 
-    // Save version snapshot before update
     await prisma.documentVersion.create({
       data: {
         documentId: id,
@@ -75,6 +77,9 @@ export async function PUT(
 
     return NextResponse.json(doc);
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("PUT /api/documents/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createDocumentSchema } from "@/validators/document-validators";
 
 export async function GET() {
   try {
@@ -9,7 +12,6 @@ export async function GET() {
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
 
-    // Return full tree — roots first, then children resolved client-side
     const docs = await prisma.document.findMany({
       select: {
         id: true,
@@ -40,14 +42,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
 
-    const body = await req.json();
-    const { parentId, title, content } = body;
+    const raw = await req.json();
+    const { title, content, parentId } = validateBody(createDocumentSchema, raw);
 
-    if (!title) {
-      return NextResponse.json({ error: "標題為必填" }, { status: 400 });
-    }
-
-    // Generate unique slug
     const base = title
       .toLowerCase()
       .replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
@@ -73,6 +70,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(doc, { status: 201 });
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("POST /api/documents error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateGoalSchema } from "@/validators/plan-validators";
 
 export async function GET(
   req: NextRequest,
@@ -45,8 +48,8 @@ export async function PUT(
     if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
 
     const { id } = await params;
-    const body = await req.json();
-    const { title, description, status, progressPct } = body;
+    const raw = await req.json();
+    const { title, description, status, progressPct } = validateBody(updateGoalSchema, raw);
 
     const goal = await prisma.monthlyGoal.update({
       where: { id },
@@ -64,6 +67,9 @@ export async function PUT(
 
     return NextResponse.json(goal);
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("PUT /api/goals/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createGoalSchema } from "@/validators/plan-validators";
 
 export async function GET(req: NextRequest) {
   try {
@@ -36,17 +39,13 @@ export async function POST(req: NextRequest) {
     const session = await getServerSession();
     if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
 
-    const body = await req.json();
-    const { annualPlanId, month, title, description } = body;
-
-    if (!annualPlanId || !month || !title) {
-      return NextResponse.json({ error: "計畫ID、月份和標題為必填" }, { status: 400 });
-    }
+    const raw = await req.json();
+    const { annualPlanId, month, title, description } = validateBody(createGoalSchema, raw);
 
     const goal = await prisma.monthlyGoal.create({
       data: {
         annualPlanId,
-        month: parseInt(month),
+        month,
         title,
         description: description || null,
       },
@@ -58,6 +57,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(goal, { status: 201 });
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("POST /api/goals error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateKpiSchema } from "@/validators/kpi-validators";
 
 export async function GET(
   req: NextRequest,
@@ -58,18 +61,18 @@ export async function PUT(
       return NextResponse.json({ error: "權限不足" }, { status: 403 });
     }
 
-    const body = await req.json();
+    const raw = await req.json();
     const { title, description, target, actual, weight, status, autoCalc } =
-      body;
+      validateBody(updateKpiSchema, raw);
 
     const kpi = await prisma.kPI.update({
       where: { id: params.id },
       data: {
         ...(title != null && { title }),
         ...(description != null && { description }),
-        ...(target != null && { target: parseFloat(target) }),
-        ...(actual != null && { actual: parseFloat(actual) }),
-        ...(weight != null && { weight: parseFloat(weight) }),
+        ...(target != null && { target }),
+        ...(actual != null && { actual }),
+        ...(weight != null && { weight }),
         ...(status != null && { status }),
         ...(autoCalc != null && { autoCalc }),
       },
@@ -77,6 +80,9 @@ export async function PUT(
 
     return NextResponse.json(kpi);
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("PUT /api/kpi/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createKpiSchema } from "@/validators/kpi-validators";
 
 export async function GET(req: NextRequest) {
   try {
@@ -53,21 +56,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "權限不足" }, { status: 403 });
     }
 
-    const body = await req.json();
-    const { year, code, title, description, target, weight, autoCalc } = body;
-
-    if (!year || !code || !title || target == null) {
-      return NextResponse.json({ error: "缺少必填欄位" }, { status: 400 });
-    }
+    const raw = await req.json();
+    const { year, code, title, description, target, weight, autoCalc } = validateBody(
+      createKpiSchema,
+      { ...raw, year: raw.year ? parseInt(raw.year) : raw.year }
+    );
 
     const kpi = await prisma.kPI.create({
       data: {
-        year: parseInt(year),
+        year,
         code,
         title,
         description: description || null,
-        target: parseFloat(target),
-        weight: weight != null ? parseFloat(weight) : 1,
+        target,
+        weight: weight ?? 1,
         autoCalc: autoCalc ?? false,
         createdBy: session.user.id,
       },
@@ -75,6 +77,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(kpi, { status: 201 });
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("POST /api/kpi error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updatePlanSchema } from "@/validators/plan-validators";
 
 export async function GET(
   req: NextRequest,
@@ -50,8 +53,8 @@ export async function PUT(
     if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
 
     const { id } = await params;
-    const body = await req.json();
-    const { title, description, implementationPlan, progressPct } = body;
+    const raw = await req.json();
+    const { title, description, implementationPlan, progressPct } = validateBody(updatePlanSchema, raw);
 
     const plan = await prisma.annualPlan.update({
       where: { id },
@@ -66,6 +69,9 @@ export async function PUT(
 
     return NextResponse.json(plan);
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("PUT /api/plans/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -3,6 +3,8 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { PlanService } from "@/services/plan-service";
 import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createPlanSchema } from "@/validators/plan-validators";
 
 const planService = new PlanService(prisma);
 
@@ -30,10 +32,13 @@ export async function POST(req: NextRequest) {
     const session = await getServerSession();
     if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
 
-    const body = await req.json();
+    const raw = await req.json();
+    const body = validateBody(createPlanSchema, {
+      ...raw,
+      year: raw.year ? parseInt(raw.year) : raw.year,
+    });
     const plan = await planService.createPlan({
       ...body,
-      year: body.year ? parseInt(body.year) : body.year,
       createdBy: session.user.id,
     });
 

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -3,6 +3,8 @@ import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TaskService } from "@/services/task-service";
 import { NotFoundError, ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateTaskSchema, updateTaskStatusSchema } from "@/validators/task-validators";
 
 const taskService = new TaskService(prisma);
 
@@ -37,7 +39,8 @@ export async function PUT(
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
     const { id } = await params;
-    const body = await req.json();
+    const raw = await req.json();
+    const body = validateBody(updateTaskSchema, raw);
     const task = await taskService.updateTask(id, body);
     return NextResponse.json(task);
   } catch (error) {
@@ -80,17 +83,16 @@ export async function PATCH(
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
     const { id } = await params;
-    const { status } = await req.json();
-
-    if (!status) {
-      return NextResponse.json({ error: "status 為必填" }, { status: 400 });
-    }
-
+    const raw = await req.json();
+    const { status } = validateBody(updateTaskStatusSchema, raw);
     const task = await taskService.updateTaskStatus(id, status, session.user.id);
     return NextResponse.json(task);
   } catch (error) {
     if (error instanceof NotFoundError) {
       return NextResponse.json({ error: "任務不存在" }, { status: 404 });
+    }
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
     console.error("PATCH /api/tasks/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -4,6 +4,8 @@ import { getServerSession } from "next-auth";
 import { TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { TaskService } from "@/services/task-service";
 import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createTaskSchema } from "@/validators/task-validators";
 
 const taskService = new TaskService(prisma);
 
@@ -37,7 +39,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
 
-    const body = await req.json();
+    const raw = await req.json();
+    const body = validateBody(createTaskSchema, raw);
     const task = await taskService.createTask({
       ...body,
       creatorId: session.user.id,

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateTimeEntrySchema } from "@/validators/time-entry-validators";
 
 export async function PUT(
   req: NextRequest,
@@ -13,13 +16,16 @@ export async function PUT(
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
     const { id } = await params;
-    const body = await req.json();
-    const { taskId, date, hours, category, description } = body;
+    const raw = await req.json();
+    const { taskId, date, hours, category, description } = validateBody(
+      updateTimeEntrySchema,
+      raw
+    );
 
     const updates: Record<string, unknown> = {};
     if (taskId !== undefined) updates.taskId = taskId || null;
     if (date !== undefined) updates.date = new Date(date);
-    if (hours !== undefined) updates.hours = parseFloat(hours);
+    if (hours !== undefined) updates.hours = hours;
     if (category !== undefined) updates.category = category as TimeCategory;
     if (description !== undefined) updates.description = description || null;
 
@@ -33,6 +39,9 @@ export async function PUT(
 
     return NextResponse.json(entry);
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("PUT /api/time-entries/[id] error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
+import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createTimeEntrySchema } from "@/validators/time-entry-validators";
 
 export async function GET(req: NextRequest) {
   try {
@@ -45,22 +48,18 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "未授權" }, { status: 401 });
     }
 
-    const body = await req.json();
-    const { taskId, date, hours, category, description } = body;
-
-    if (!date || hours === undefined || hours === null) {
-      return NextResponse.json({ error: "date 與 hours 為必填" }, { status: 400 });
-    }
-    if (hours < 0 || hours > 24) {
-      return NextResponse.json({ error: "工時需在 0–24 小時之間" }, { status: 400 });
-    }
+    const raw = await req.json();
+    const { taskId, date, hours, category, description } = validateBody(
+      createTimeEntrySchema,
+      raw
+    );
 
     const entry = await prisma.timeEntry.create({
       data: {
         taskId: taskId || null,
         userId: session.user.id,
         date: new Date(date),
-        hours: parseFloat(hours),
+        hours,
         category: (category as TimeCategory) ?? "PLANNED_TASK",
         description: description || null,
       },
@@ -71,6 +70,9 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(entry, { status: 201 });
   } catch (error) {
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     console.error("POST /api/time-entries error:", error);
     return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
   }

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -1,0 +1,15 @@
+import { ZodSchema, ZodError } from "zod";
+import { ValidationError } from "@/services/errors";
+
+/**
+ * Parses and validates request body against a Zod schema.
+ * Throws ValidationError (caught by route handlers) on failure.
+ */
+export function validateBody<T>(schema: ZodSchema<T>, body: unknown): T {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    const formatted = (result.error as ZodError).format();
+    throw new ValidationError(JSON.stringify(formatted));
+  }
+  return result.data;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "next-auth": "^4.24.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^2.6.0"
+        "tailwind-merge": "^2.6.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -12662,6 +12663,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "next-auth": "^4.24.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^2.6.0"
+    "tailwind-merge": "^2.6.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/validators/__tests__/document-validators.test.ts
+++ b/validators/__tests__/document-validators.test.ts
@@ -1,0 +1,81 @@
+import {
+  createDocumentSchema,
+  updateDocumentSchema,
+} from "../document-validators";
+
+describe("createDocumentSchema", () => {
+  const validInput = {
+    title: "Architecture Overview",
+    content: "## Overview\nThis is the architecture document.",
+  };
+
+  test("accepts valid document input", () => {
+    const result = createDocumentSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts document with optional parentId", () => {
+    const result = createDocumentSchema.safeParse({
+      ...validInput,
+      parentId: "doc-parent-id-123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts document without content (content defaults to empty)", () => {
+    const result = createDocumentSchema.safeParse({ title: "Untitled" });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const result = createDocumentSchema.safeParse({
+      content: "Some content",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createDocumentSchema.safeParse({ ...validInput, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string content", () => {
+    const result = createDocumentSchema.safeParse({
+      ...validInput,
+      content: 12345,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateDocumentSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updateDocumentSchema.safeParse({ title: "New Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with only content", () => {
+    const result = updateDocumentSchema.safeParse({ content: "Updated body" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with parentId", () => {
+    const result = updateDocumentSchema.safeParse({ parentId: "new-parent" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object", () => {
+    const result = updateDocumentSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty title in update", () => {
+    const result = updateDocumentSchema.safeParse({ title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-string content in update", () => {
+    const result = updateDocumentSchema.safeParse({ content: true });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/goal-validators.test.ts
+++ b/validators/__tests__/goal-validators.test.ts
@@ -1,0 +1,92 @@
+// goal-validators tests cover the MonthlyGoal model standalone operations
+import {
+  createMonthlyGoalSchema,
+  updateMonthlyGoalSchema,
+} from "../goal-validators";
+
+describe("createMonthlyGoalSchema", () => {
+  const validInput = {
+    annualPlanId: "plan-abc",
+    month: 3,
+    title: "Q1 milestones",
+  };
+
+  test("accepts valid monthly goal input", () => {
+    const result = createMonthlyGoalSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all 12 months", () => {
+    for (let m = 1; m <= 12; m++) {
+      const result = createMonthlyGoalSchema.safeParse({
+        ...validInput,
+        month: m,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects missing annualPlanId", () => {
+    const result = createMonthlyGoalSchema.safeParse({ month: 3, title: "T" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects month = 0", () => {
+    const result = createMonthlyGoalSchema.safeParse({
+      ...validInput,
+      month: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects month = 13", () => {
+    const result = createMonthlyGoalSchema.safeParse({
+      ...validInput,
+      month: 13,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createMonthlyGoalSchema.safeParse({
+      ...validInput,
+      title: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateMonthlyGoalSchema", () => {
+  test("accepts partial update with only status", () => {
+    const result = updateMonthlyGoalSchema.safeParse({ status: "IN_PROGRESS" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid GoalStatus values", () => {
+    const statuses = ["NOT_STARTED", "IN_PROGRESS", "COMPLETED", "CANCELLED"];
+    for (const status of statuses) {
+      const result = updateMonthlyGoalSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("accepts empty object", () => {
+    const result = updateMonthlyGoalSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid status", () => {
+    const result = updateMonthlyGoalSchema.safeParse({ status: "DONE" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects progressPct below 0", () => {
+    const result = updateMonthlyGoalSchema.safeParse({ progressPct: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects progressPct above 100", () => {
+    const result = updateMonthlyGoalSchema.safeParse({ progressPct: 200 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/kpi-validators.test.ts
+++ b/validators/__tests__/kpi-validators.test.ts
@@ -1,0 +1,104 @@
+import { createKpiSchema, updateKpiSchema } from "../kpi-validators";
+
+describe("createKpiSchema", () => {
+  const validInput = {
+    year: 2026,
+    code: "KPI-2026-01",
+    title: "Customer Satisfaction",
+    target: 95.0,
+  };
+
+  test("accepts valid KPI input", () => {
+    const result = createKpiSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts KPI with all optional fields", () => {
+    const result = createKpiSchema.safeParse({
+      ...validInput,
+      description: "NPS score target",
+      weight: 2.0,
+      autoCalc: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing year", () => {
+    const { year: _, ...rest } = validInput;
+    const result = createKpiSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing code", () => {
+    const { code: _, ...rest } = validInput;
+    const result = createKpiSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing title", () => {
+    const { title: _, ...rest } = validInput;
+    const result = createKpiSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing target", () => {
+    const { target: _, ...rest } = validInput;
+    const result = createKpiSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative target", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, target: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer year", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, year: 2026.5 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty code", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, code: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateKpiSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updateKpiSchema.safeParse({ title: "New Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts update with valid status", () => {
+    const result = updateKpiSchema.safeParse({ status: "ACHIEVED" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid KPIStatus values", () => {
+    const statuses = ["DRAFT", "ACTIVE", "ACHIEVED", "MISSED", "CANCELLED"];
+    for (const status of statuses) {
+      const result = updateKpiSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("accepts empty object", () => {
+    const result = updateKpiSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid status enum", () => {
+    const result = updateKpiSchema.safeParse({ status: "COMPLETED" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative target in update", () => {
+    const result = updateKpiSchema.safeParse({ target: -10 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative actual in update", () => {
+    const result = updateKpiSchema.safeParse({ actual: -5 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/plan-validators.test.ts
+++ b/validators/__tests__/plan-validators.test.ts
@@ -1,0 +1,150 @@
+import {
+  createPlanSchema,
+  updatePlanSchema,
+  createGoalSchema,
+  updateGoalSchema,
+} from "../plan-validators";
+
+describe("createPlanSchema", () => {
+  const validInput = {
+    year: 2026,
+    title: "2026 Annual Plan",
+  };
+
+  test("accepts valid plan input", () => {
+    const result = createPlanSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid plan with optional fields", () => {
+    const result = createPlanSchema.safeParse({
+      ...validInput,
+      description: "A description",
+      implementationPlan: "## Plan\n- Step 1",
+      copiedFromYear: 2025,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const result = createPlanSchema.safeParse({ year: 2026 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing year", () => {
+    const result = createPlanSchema.safeParse({ title: "Plan" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer year", () => {
+    const result = createPlanSchema.safeParse({ year: 20.5, title: "Plan" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects year out of reasonable range", () => {
+    const result = createPlanSchema.safeParse({ year: 1800, title: "Plan" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createPlanSchema.safeParse({ year: 2026, title: "" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updatePlanSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updatePlanSchema.safeParse({ title: "Updated Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts update with progressPct", () => {
+    const result = updatePlanSchema.safeParse({ progressPct: 50 });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object", () => {
+    const result = updatePlanSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects progressPct out of range (> 100)", () => {
+    const result = updatePlanSchema.safeParse({ progressPct: 150 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects progressPct out of range (< 0)", () => {
+    const result = updatePlanSchema.safeParse({ progressPct: -5 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createGoalSchema", () => {
+  const validInput = {
+    annualPlanId: "plan-id-123",
+    month: 6,
+    title: "June deliverables",
+  };
+
+  test("accepts valid goal input", () => {
+    const result = createGoalSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts goal with optional description", () => {
+    const result = createGoalSchema.safeParse({
+      ...validInput,
+      description: "June focus",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing annualPlanId", () => {
+    const { annualPlanId: _, ...rest } = validInput;
+    const result = createGoalSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects month out of range (0)", () => {
+    const result = createGoalSchema.safeParse({ ...validInput, month: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects month out of range (13)", () => {
+    const result = createGoalSchema.safeParse({ ...validInput, month: 13 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing title", () => {
+    const { title: _, ...rest } = validInput;
+    const result = createGoalSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateGoalSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updateGoalSchema.safeParse({ title: "New Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts update with valid status", () => {
+    const result = updateGoalSchema.safeParse({ status: "COMPLETED" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object", () => {
+    const result = updateGoalSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid status enum", () => {
+    const result = updateGoalSchema.safeParse({ status: "DONE" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects progressPct > 100", () => {
+    const result = updateGoalSchema.safeParse({ progressPct: 101 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/task-validators.test.ts
+++ b/validators/__tests__/task-validators.test.ts
@@ -1,0 +1,144 @@
+import {
+  createTaskSchema,
+  updateTaskSchema,
+  updateTaskStatusSchema,
+} from "../task-validators";
+
+describe("createTaskSchema", () => {
+  const validInput = {
+    title: "Implement login page",
+    status: "TODO",
+    priority: "P1",
+    category: "PLANNED",
+  };
+
+  test("accepts valid task input", () => {
+    const result = createTaskSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid task input with all optional fields", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      description: "Some desc",
+      monthlyGoalId: "goal-id-123",
+      primaryAssigneeId: "user-id-1",
+      backupAssigneeId: "user-id-2",
+      dueDate: "2026-12-31T00:00:00.000Z",
+      startDate: "2026-01-01T00:00:00.000Z",
+      estimatedHours: 8,
+      tags: ["frontend", "auth"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const { title: _title, ...rest } = validInput;
+    const result = createTaskSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createTaskSchema.safeParse({ ...validInput, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid status enum", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      status: "INVALID_STATUS",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid priority enum", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      priority: "P99",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid category enum", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      category: "UNKNOWN",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-date dueDate", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      dueDate: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative estimatedHours", () => {
+    const result = createTaskSchema.safeParse({
+      ...validInput,
+      estimatedHours: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateTaskSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updateTaskSchema.safeParse({ title: "New Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with only status", () => {
+    const result = updateTaskSchema.safeParse({ status: "DONE" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object (no fields)", () => {
+    const result = updateTaskSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid status in update", () => {
+    const result = updateTaskSchema.safeParse({ status: "FLYING" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid priority in update", () => {
+    const result = updateTaskSchema.safeParse({ priority: "HIGH" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative estimatedHours in update", () => {
+    const result = updateTaskSchema.safeParse({ estimatedHours: -5 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateTaskStatusSchema", () => {
+  test("accepts valid status BACKLOG", () => {
+    const result = updateTaskStatusSchema.safeParse({ status: "BACKLOG" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid status IN_PROGRESS", () => {
+    const result = updateTaskStatusSchema.safeParse({ status: "IN_PROGRESS" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid status DONE", () => {
+    const result = updateTaskStatusSchema.safeParse({ status: "DONE" });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid status", () => {
+    const result = updateTaskStatusSchema.safeParse({ status: "COMPLETED" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing status", () => {
+    const result = updateTaskStatusSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/time-entry-validators.test.ts
+++ b/validators/__tests__/time-entry-validators.test.ts
@@ -1,0 +1,103 @@
+import { createTimeEntrySchema, updateTimeEntrySchema } from "../time-entry-validators";
+
+describe("createTimeEntrySchema", () => {
+  const validInput = {
+    date: "2026-03-15",
+    hours: 8,
+  };
+
+  test("accepts valid time entry input", () => {
+    const result = createTimeEntrySchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts entry with all optional fields", () => {
+    const result = createTimeEntrySchema.safeParse({
+      ...validInput,
+      taskId: "task-id-123",
+      category: "PLANNED_TASK",
+      description: "Worked on login feature",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid TimeCategory values", () => {
+    const categories = [
+      "PLANNED_TASK",
+      "ADDED_TASK",
+      "INCIDENT",
+      "SUPPORT",
+      "ADMIN",
+      "LEARNING",
+    ];
+    for (const category of categories) {
+      const result = createTimeEntrySchema.safeParse({ ...validInput, category });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects missing date", () => {
+    const result = createTimeEntrySchema.safeParse({ hours: 4 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing hours", () => {
+    const result = createTimeEntrySchema.safeParse({ date: "2026-03-15" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative hours", () => {
+    const result = createTimeEntrySchema.safeParse({ ...validInput, hours: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects hours exceeding 24", () => {
+    const result = createTimeEntrySchema.safeParse({ ...validInput, hours: 25 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid date string", () => {
+    const result = createTimeEntrySchema.safeParse({ ...validInput, date: "not-a-date" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid category", () => {
+    const result = createTimeEntrySchema.safeParse({
+      ...validInput,
+      category: "OVERTIME",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateTimeEntrySchema", () => {
+  test("accepts partial update with only hours", () => {
+    const result = updateTimeEntrySchema.safeParse({ hours: 6 });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with only category", () => {
+    const result = updateTimeEntrySchema.safeParse({ category: "SUPPORT" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object", () => {
+    const result = updateTimeEntrySchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects negative hours in update", () => {
+    const result = updateTimeEntrySchema.safeParse({ hours: -2 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects hours > 24 in update", () => {
+    const result = updateTimeEntrySchema.safeParse({ hours: 30 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid category in update", () => {
+    const result = updateTimeEntrySchema.safeParse({ category: "INVALID" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/__tests__/user-validators.test.ts
+++ b/validators/__tests__/user-validators.test.ts
@@ -1,0 +1,129 @@
+import { createUserSchema, updateUserSchema, loginSchema } from "../user-validators";
+
+describe("createUserSchema", () => {
+  const validInput = {
+    name: "Alice Chen",
+    email: "alice@example.com",
+    password: "securepassword123",
+  };
+
+  test("accepts valid user input", () => {
+    const result = createUserSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts user with optional role", () => {
+    const result = createUserSchema.safeParse({
+      ...validInput,
+      role: "MANAGER",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts user with avatar", () => {
+    const result = createUserSchema.safeParse({
+      ...validInput,
+      avatar: "https://example.com/avatar.png",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing name", () => {
+    const { name: _, ...rest } = validInput;
+    const result = createUserSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing email", () => {
+    const { email: _, ...rest } = validInput;
+    const result = createUserSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid email format", () => {
+    const result = createUserSchema.safeParse({
+      ...validInput,
+      email: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing password", () => {
+    const { password: _, ...rest } = validInput;
+    const result = createUserSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects password too short (< 8 chars)", () => {
+    const result = createUserSchema.safeParse({ ...validInput, password: "short" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid role enum", () => {
+    const result = createUserSchema.safeParse({ ...validInput, role: "ADMIN" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateUserSchema", () => {
+  test("accepts partial update with only name", () => {
+    const result = updateUserSchema.safeParse({ name: "Bob" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with isActive", () => {
+    const result = updateUserSchema.safeParse({ isActive: false });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object", () => {
+    const result = updateUserSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid email in update", () => {
+    const result = updateUserSchema.safeParse({ email: "bad-email" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid role in update", () => {
+    const result = updateUserSchema.safeParse({ role: "SUPERUSER" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("loginSchema", () => {
+  test("accepts valid credentials", () => {
+    const result = loginSchema.safeParse({
+      email: "user@example.com",
+      password: "mypassword",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing email", () => {
+    const result = loginSchema.safeParse({ password: "mypassword" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing password", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid email format", () => {
+    const result = loginSchema.safeParse({
+      email: "notanemail",
+      password: "password",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty password", () => {
+    const result = loginSchema.safeParse({
+      email: "user@example.com",
+      password: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/document-validators.ts
+++ b/validators/document-validators.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const createDocumentSchema = z.object({
+  title: z.string().min(1),
+  content: z.string().optional().default(""),
+  parentId: z.string().optional(),
+});
+
+export const updateDocumentSchema = z.object({
+  title: z.string().min(1).optional(),
+  content: z.string().optional(),
+  parentId: z.string().optional(),
+});
+
+export type CreateDocumentInput = z.infer<typeof createDocumentSchema>;
+export type UpdateDocumentInput = z.infer<typeof updateDocumentSchema>;

--- a/validators/goal-validators.ts
+++ b/validators/goal-validators.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+const GoalStatusEnum = z.enum([
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "CANCELLED",
+]);
+
+export const createMonthlyGoalSchema = z.object({
+  annualPlanId: z.string().min(1),
+  month: z.number().int().min(1).max(12),
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export const updateMonthlyGoalSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  status: GoalStatusEnum.optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+});
+
+export type CreateMonthlyGoalInput = z.infer<typeof createMonthlyGoalSchema>;
+export type UpdateMonthlyGoalInput = z.infer<typeof updateMonthlyGoalSchema>;

--- a/validators/kpi-validators.ts
+++ b/validators/kpi-validators.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+const KpiStatusEnum = z.enum([
+  "DRAFT",
+  "ACTIVE",
+  "ACHIEVED",
+  "MISSED",
+  "CANCELLED",
+]);
+
+export const createKpiSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  code: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  target: z.number().nonnegative(),
+  weight: z.number().positive().optional().default(1),
+  autoCalc: z.boolean().optional().default(false),
+});
+
+export const updateKpiSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  target: z.number().nonnegative().optional(),
+  actual: z.number().nonnegative().optional(),
+  weight: z.number().positive().optional(),
+  status: KpiStatusEnum.optional(),
+  autoCalc: z.boolean().optional(),
+});
+
+export type CreateKpiInput = z.infer<typeof createKpiSchema>;
+export type UpdateKpiInput = z.infer<typeof updateKpiSchema>;

--- a/validators/plan-validators.ts
+++ b/validators/plan-validators.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+const GoalStatusEnum = z.enum([
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "CANCELLED",
+]);
+
+export const createPlanSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  implementationPlan: z.string().optional(),
+  copiedFromYear: z.number().int().optional(),
+});
+
+export const updatePlanSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  implementationPlan: z.string().optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+});
+
+export const createGoalSchema = z.object({
+  annualPlanId: z.string().min(1),
+  month: z.number().int().min(1).max(12),
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export const updateGoalSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  status: GoalStatusEnum.optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+});
+
+export type CreatePlanInput = z.infer<typeof createPlanSchema>;
+export type UpdatePlanInput = z.infer<typeof updatePlanSchema>;
+export type CreateGoalInput = z.infer<typeof createGoalSchema>;
+export type UpdateGoalInput = z.infer<typeof updateGoalSchema>;

--- a/validators/task-validators.ts
+++ b/validators/task-validators.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+const TaskStatusEnum = z.enum([
+  "BACKLOG",
+  "TODO",
+  "IN_PROGRESS",
+  "REVIEW",
+  "DONE",
+]);
+
+const PriorityEnum = z.enum(["P0", "P1", "P2", "P3"]);
+
+const TaskCategoryEnum = z.enum([
+  "PLANNED",
+  "ADDED",
+  "INCIDENT",
+  "SUPPORT",
+  "ADMIN",
+  "LEARNING",
+]);
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  primaryAssigneeId: z.string().optional(),
+  backupAssigneeId: z.string().optional(),
+  status: TaskStatusEnum.optional().default("BACKLOG"),
+  priority: PriorityEnum.optional().default("P2"),
+  category: TaskCategoryEnum.optional().default("PLANNED"),
+  dueDate: z.string().datetime().optional(),
+  startDate: z.string().datetime().optional(),
+  estimatedHours: z.number().nonnegative().optional(),
+  tags: z.array(z.string()).optional(),
+  addedDate: z.string().datetime().optional(),
+  addedReason: z.string().optional(),
+  addedSource: z.string().optional(),
+});
+
+export const updateTaskSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  primaryAssigneeId: z.string().optional(),
+  backupAssigneeId: z.string().optional(),
+  status: TaskStatusEnum.optional(),
+  priority: PriorityEnum.optional(),
+  category: TaskCategoryEnum.optional(),
+  dueDate: z.string().datetime().optional(),
+  startDate: z.string().datetime().optional(),
+  estimatedHours: z.number().nonnegative().optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+  tags: z.array(z.string()).optional(),
+  addedReason: z.string().optional(),
+  addedSource: z.string().optional(),
+});
+
+export const updateTaskStatusSchema = z.object({
+  status: TaskStatusEnum,
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;
+export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;
+export type UpdateTaskStatusInput = z.infer<typeof updateTaskStatusSchema>;

--- a/validators/time-entry-validators.ts
+++ b/validators/time-entry-validators.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const TimeCategoryEnum = z.enum([
+  "PLANNED_TASK",
+  "ADDED_TASK",
+  "INCIDENT",
+  "SUPPORT",
+  "ADMIN",
+  "LEARNING",
+]);
+
+export const createTimeEntrySchema = z.object({
+  date: z.string().date(),
+  hours: z.number().min(0).max(24),
+  taskId: z.string().optional(),
+  category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
+  description: z.string().optional(),
+});
+
+export const updateTimeEntrySchema = z.object({
+  date: z.string().date().optional(),
+  hours: z.number().min(0).max(24).optional(),
+  taskId: z.string().optional(),
+  category: TimeCategoryEnum.optional(),
+  description: z.string().optional(),
+});
+
+export type CreateTimeEntryInput = z.infer<typeof createTimeEntrySchema>;
+export type UpdateTimeEntryInput = z.infer<typeof updateTimeEntrySchema>;

--- a/validators/user-validators.ts
+++ b/validators/user-validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+const RoleEnum = z.enum(["MANAGER", "ENGINEER"]);
+
+export const createUserSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(8),
+  role: RoleEnum.optional().default("ENGINEER"),
+  avatar: z.string().optional(),
+});
+
+export const updateUserSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  avatar: z.string().optional(),
+  role: RoleEnum.optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export type CreateUserInput = z.infer<typeof createUserSchema>;
+export type UpdateUserInput = z.infer<typeof updateUserSchema>;
+export type LoginInput = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## Summary

- 7 Zod validator modules (`validators/`) covering Task, Plan, Goal, KPI, Document, TimeEntry, User — each matching the Prisma schema enums and constraints
- 117 validation tests written **first** (TDD RED → GREEN): valid input acceptance + 3–5 rejection cases per schema
- `lib/validate.ts` helper (`validateBody`) centralises parse/throw logic — routes stay clean
- All 12 API route handlers updated to call `validateBody()` before any DB access, replacing ad-hoc `if (!field)` guards

## Test plan

- [x] `npx jest validators/__tests__` — 7 suites, 117 tests, all pass
- [x] Pre-existing test failures (31 suites with JSX transform issues) confirmed identical on `main` before this branch — no regressions introduced

Closes #79
