### PR TITLE
refactor(#80): unified error handling

### DIFF
--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -1,49 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function PATCH(
+export const PATCH = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const body = await req.json();
+  const { id } = await context!.params;
+  const body = await req.json();
 
-    const deliverable = await prisma.deliverable.update({
-      where: { id },
-      data: {
-        ...(body.status !== undefined && { status: body.status }),
-        ...(body.title !== undefined && { title: body.title }),
-        ...(body.attachmentUrl !== undefined && { attachmentUrl: body.attachmentUrl }),
-        ...(body.acceptedBy !== undefined && { acceptedBy: body.acceptedBy }),
-        ...(body.acceptedAt !== undefined && { acceptedAt: body.acceptedAt ? new Date(body.acceptedAt) : null }),
-      },
-    });
+  const deliverable = await prisma.deliverable.update({
+    where: { id },
+    data: {
+      ...(body.status !== undefined && { status: body.status }),
+      ...(body.title !== undefined && { title: body.title }),
+      ...(body.attachmentUrl !== undefined && { attachmentUrl: body.attachmentUrl }),
+      ...(body.acceptedBy !== undefined && { acceptedBy: body.acceptedBy }),
+      ...(body.acceptedAt !== undefined && { acceptedAt: body.acceptedAt ? new Date(body.acceptedAt) : null }),
+    },
+  });
 
-    return NextResponse.json(deliverable);
-  } catch (error) {
-    console.error("PATCH /api/deliverables/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(deliverable);
+});
 
-export async function DELETE(
+export const DELETE = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    await prisma.deliverable.delete({ where: { id } });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error("DELETE /api/deliverables/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  const { id } = await context!.params;
+  await prisma.deliverable.delete({ where: { id } });
+  return success({ success: true });
+});

--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -1,34 +1,32 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, ValidationError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const body = await req.json();
-    const { title, type, taskId, kpiId, annualPlanId, monthlyGoalId, attachmentUrl } = body;
+  const body = await req.json();
+  const { title, type, taskId, kpiId, annualPlanId, monthlyGoalId, attachmentUrl } = body;
 
-    if (!title || !type) {
-      return NextResponse.json({ error: "標題和類型為必填" }, { status: 400 });
-    }
-
-    const deliverable = await prisma.deliverable.create({
-      data: {
-        title,
-        type,
-        taskId: taskId || null,
-        kpiId: kpiId || null,
-        annualPlanId: annualPlanId || null,
-        monthlyGoalId: monthlyGoalId || null,
-        attachmentUrl: attachmentUrl || null,
-      },
-    });
-
-    return NextResponse.json(deliverable, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/deliverables error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (!title || !type) {
+    throw new ValidationError("標題和類型為必填");
   }
-}
+
+  const deliverable = await prisma.deliverable.create({
+    data: {
+      title,
+      type,
+      taskId: taskId || null,
+      kpiId: kpiId || null,
+      annualPlanId: annualPlanId || null,
+      monthlyGoalId: monthlyGoalId || null,
+      attachmentUrl: attachmentUrl || null,
+    },
+  });
+
+  return success(deliverable, 201);
+});

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,104 +1,86 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError, NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateDocumentSchema } from "@/validators/document-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const doc = await prisma.document.findUnique({
-      where: { id },
-      include: {
-        creator: { select: { id: true, name: true } },
-        updater: { select: { id: true, name: true } },
-        children: {
-          select: { id: true, title: true, slug: true },
-          orderBy: { title: "asc" },
-        },
-      },
-    });
-    if (!doc) return NextResponse.json({ error: "文件不存在" }, { status: 404 });
-    return NextResponse.json(doc);
-  } catch (error) {
-    console.error("GET /api/documents/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-export async function PUT(
+  const { id } = await context!.params;
+  const doc = await prisma.document.findUnique({
+    where: { id },
+    include: {
+      creator: { select: { id: true, name: true } },
+      updater: { select: { id: true, name: true } },
+      children: {
+        select: { id: true, title: true, slug: true },
+        orderBy: { title: "asc" },
+      },
+    },
+  });
+
+  if (!doc) throw new NotFoundError("文件不存在");
+  return success(doc);
+});
+
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const raw = await req.json();
-    const { title, content, parentId } = validateBody(updateDocumentSchema, raw);
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const existing = await prisma.document.findUnique({ where: { id } });
-    if (!existing) return NextResponse.json({ error: "文件不存在" }, { status: 404 });
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { title, content, parentId } = validateBody(updateDocumentSchema, raw);
 
-    const newVersion = existing.version + 1;
+  const existing = await prisma.document.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("文件不存在");
 
-    await prisma.documentVersion.create({
-      data: {
-        documentId: id,
-        content: existing.content,
-        version: existing.version,
-        createdBy: session.user.id,
-      },
-    });
+  const newVersion = existing.version + 1;
 
-    const updates: Record<string, unknown> = { updatedBy: session.user.id, version: newVersion };
-    if (title !== undefined) updates.title = title;
-    if (content !== undefined) updates.content = content;
-    if (parentId !== undefined) updates.parentId = parentId || null;
+  await prisma.documentVersion.create({
+    data: {
+      documentId: id,
+      content: existing.content,
+      version: existing.version,
+      createdBy: session.user.id,
+    },
+  });
 
-    const doc = await prisma.document.update({
-      where: { id },
-      data: updates,
-      include: {
-        creator: { select: { id: true, name: true } },
-        updater: { select: { id: true, name: true } },
-      },
-    });
+  const updates: Record<string, unknown> = { updatedBy: session.user.id, version: newVersion };
+  if (title !== undefined) updates.title = title;
+  if (content !== undefined) updates.content = content;
+  if (parentId !== undefined) updates.parentId = parentId || null;
 
-    return NextResponse.json(doc);
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/documents/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  const doc = await prisma.document.update({
+    where: { id },
+    data: updates,
+    include: {
+      creator: { select: { id: true, name: true } },
+      updater: { select: { id: true, name: true } },
+    },
+  });
 
-export async function DELETE(
+  return success(doc);
+});
+
+export const DELETE = apiHandler(async (
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    await prisma.document.delete({ where: { id } });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error("DELETE /api/documents/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  await prisma.document.delete({ where: { id } });
+  return success({ success: true });
+});

--- a/app/api/documents/[id]/versions/route.ts
+++ b/app/api/documents/[id]/versions/route.ts
@@ -1,25 +1,23 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const versions = await prisma.documentVersion.findMany({
-      where: { documentId: id },
-      include: { creator: { select: { id: true, name: true } } },
-      orderBy: { version: "desc" },
-    });
-    return NextResponse.json(versions);
-  } catch (error) {
-    console.error("GET /api/documents/[id]/versions error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  const versions = await prisma.documentVersion.findMany({
+    where: { documentId: id },
+    include: { creator: { select: { id: true, name: true } } },
+    orderBy: { version: "desc" },
+  });
+
+  return success(versions);
+});

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,79 +1,64 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createDocumentSchema } from "@/validators/document-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET() {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async () => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const docs = await prisma.document.findMany({
-      select: {
-        id: true,
-        parentId: true,
-        title: true,
-        slug: true,
-        version: true,
-        createdAt: true,
-        updatedAt: true,
-        creator: { select: { id: true, name: true } },
-        updater: { select: { id: true, name: true } },
-        _count: { select: { children: true } },
-      },
-      orderBy: [{ parentId: "asc" }, { title: "asc" }],
-    });
+  const docs = await prisma.document.findMany({
+    select: {
+      id: true,
+      parentId: true,
+      title: true,
+      slug: true,
+      version: true,
+      createdAt: true,
+      updatedAt: true,
+      creator: { select: { id: true, name: true } },
+      updater: { select: { id: true, name: true } },
+      _count: { select: { children: true } },
+    },
+    orderBy: [{ parentId: "asc" }, { title: "asc" }],
+  });
 
-    return NextResponse.json(docs);
-  } catch (error) {
-    console.error("GET /api/documents error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(docs);
+});
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const raw = await req.json();
-    const { title, content, parentId } = validateBody(createDocumentSchema, raw);
+  const raw = await req.json();
+  const { title, content, parentId } = validateBody(createDocumentSchema, raw);
 
-    const base = title
-      .toLowerCase()
-      .replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
-      .replace(/^-|-$/g, "");
-    const timestamp = Date.now();
-    const slug = `${base}-${timestamp}`;
+  const base = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const timestamp = Date.now();
+  const slug = `${base}-${timestamp}`;
 
-    const doc = await prisma.document.create({
-      data: {
-        parentId: parentId || null,
-        title,
-        content: content ?? "",
-        slug,
-        createdBy: session.user.id,
-        updatedBy: session.user.id,
-        version: 1,
-      },
-      include: {
-        creator: { select: { id: true, name: true } },
-        updater: { select: { id: true, name: true } },
-      },
-    });
+  const doc = await prisma.document.create({
+    data: {
+      parentId: parentId || null,
+      title,
+      content: content ?? "",
+      slug,
+      createdBy: session.user.id,
+      updatedBy: session.user.id,
+      version: 1,
+    },
+    include: {
+      creator: { select: { id: true, name: true } },
+      updater: { select: { id: true, name: true } },
+    },
+  });
 
-    return NextResponse.json(doc, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/documents error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(doc, 201);
+});

--- a/app/api/documents/search/route.ts
+++ b/app/api/documents/search/route.ts
@@ -1,37 +1,32 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const q = searchParams.get("q")?.trim();
-    if (!q) return NextResponse.json([]);
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.trim();
+  if (!q) return success([]);
 
-    // PostgreSQL full-text search using to_tsvector
-    const results = await prisma.$queryRaw<
-      { id: string; title: string; slug: string; parentId: string | null; snippet: string }[]
-    >`
-      SELECT
-        id,
-        title,
-        slug,
-        "parentId",
-        LEFT(content, 200) AS snippet
-      FROM documents
-      WHERE to_tsvector('simple', title || ' ' || content) @@ plainto_tsquery('simple', ${q})
-      ORDER BY ts_rank(to_tsvector('simple', title || ' ' || content), plainto_tsquery('simple', ${q})) DESC
-      LIMIT 20
-    `;
+  const results = await prisma.$queryRaw<
+    { id: string; title: string; slug: string; parentId: string | null; snippet: string }[]
+  >`
+    SELECT
+      id,
+      title,
+      slug,
+      "parentId",
+      LEFT(content, 200) AS snippet
+    FROM documents
+    WHERE to_tsvector('simple', title || ' ' || content) @@ plainto_tsquery('simple', ${q})
+    ORDER BY ts_rank(to_tsvector('simple', title || ' ' || content), plainto_tsquery('simple', ${q})) DESC
+    LIMIT 20
+  `;
 
-    return NextResponse.json(results);
-  } catch (error) {
-    console.error("GET /api/documents/search error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(results);
+});

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,76 +1,65 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError, NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateGoalSchema } from "@/validators/plan-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const goal = await prisma.monthlyGoal.findUnique({
-      where: { id },
-      include: {
-        annualPlan: { select: { id: true, title: true, year: true } },
-        tasks: {
-          include: {
-            primaryAssignee: { select: { id: true, name: true, avatar: true } },
-            backupAssignee: { select: { id: true, name: true, avatar: true } },
-            subTasks: true,
-            deliverables: true,
-          },
-          orderBy: [{ priority: "asc" }, { dueDate: "asc" }],
+  const { id } = await context!.params;
+  const goal = await prisma.monthlyGoal.findUnique({
+    where: { id },
+    include: {
+      annualPlan: { select: { id: true, title: true, year: true } },
+      tasks: {
+        include: {
+          primaryAssignee: { select: { id: true, name: true, avatar: true } },
+          backupAssignee: { select: { id: true, name: true, avatar: true } },
+          subTasks: true,
+          deliverables: true,
         },
-        deliverables: true,
+        orderBy: [{ priority: "asc" }, { dueDate: "asc" }],
       },
-    });
+      deliverables: true,
+    },
+  });
 
-    if (!goal) return NextResponse.json({ error: "目標不存在" }, { status: 404 });
-    return NextResponse.json(goal);
-  } catch (error) {
-    console.error("GET /api/goals/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  if (!goal) throw new NotFoundError("目標不存在");
+  return success(goal);
+});
 
-export async function PUT(
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const raw = await req.json();
-    const { title, description, status, progressPct } = validateBody(updateGoalSchema, raw);
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { title, description, status, progressPct } = validateBody(updateGoalSchema, raw);
 
-    const goal = await prisma.monthlyGoal.update({
-      where: { id },
-      data: {
-        ...(title !== undefined && { title }),
-        ...(description !== undefined && { description }),
-        ...(status !== undefined && { status }),
-        ...(progressPct !== undefined && { progressPct }),
-      },
-      include: {
-        annualPlan: { select: { id: true, title: true, year: true } },
-        tasks: true,
-      },
-    });
+  const goal = await prisma.monthlyGoal.update({
+    where: { id },
+    data: {
+      ...(title !== undefined && { title }),
+      ...(description !== undefined && { description }),
+      ...(status !== undefined && { status }),
+      ...(progressPct !== undefined && { progressPct }),
+    },
+    include: {
+      annualPlan: { select: { id: true, title: true, year: true } },
+      tasks: true,
+    },
+  });
 
-    return NextResponse.json(goal);
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/goals/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(goal);
+});

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,66 +1,55 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createGoalSchema } from "@/validators/plan-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const planId = searchParams.get("planId");
-    const month = searchParams.get("month");
+  const { searchParams } = new URL(req.url);
+  const planId = searchParams.get("planId");
+  const month = searchParams.get("month");
 
-    const goals = await prisma.monthlyGoal.findMany({
-      where: {
-        ...(planId && { annualPlanId: planId }),
-        ...(month && { month: parseInt(month) }),
-      },
-      include: {
-        annualPlan: { select: { id: true, title: true, year: true } },
-        _count: { select: { tasks: true } },
-        deliverables: true,
-      },
-      orderBy: [{ annualPlanId: "asc" }, { month: "asc" }],
-    });
+  const goals = await prisma.monthlyGoal.findMany({
+    where: {
+      ...(planId && { annualPlanId: planId }),
+      ...(month && { month: parseInt(month) }),
+    },
+    include: {
+      annualPlan: { select: { id: true, title: true, year: true } },
+      _count: { select: { tasks: true } },
+      deliverables: true,
+    },
+    orderBy: [{ annualPlanId: "asc" }, { month: "asc" }],
+  });
 
-    return NextResponse.json(goals);
-  } catch (error) {
-    console.error("GET /api/goals error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(goals);
+});
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const raw = await req.json();
-    const { annualPlanId, month, title, description } = validateBody(createGoalSchema, raw);
+  const raw = await req.json();
+  const { annualPlanId, month, title, description } = validateBody(createGoalSchema, raw);
 
-    const goal = await prisma.monthlyGoal.create({
-      data: {
-        annualPlanId,
-        month,
-        title,
-        description: description || null,
-      },
-      include: {
-        annualPlan: { select: { id: true, title: true, year: true } },
-        tasks: true,
-      },
-    });
+  const goal = await prisma.monthlyGoal.create({
+    data: {
+      annualPlanId,
+      month,
+      title,
+      description: description || null,
+    },
+    include: {
+      annualPlan: { select: { id: true, title: true, year: true } },
+      tasks: true,
+    },
+  });
 
-    return NextResponse.json(goal, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/goals error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(goal, 201);
+});

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -1,74 +1,62 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, NotFoundError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const kpi = await prisma.kPI.findUnique({
-      where: { id: params.id },
-      include: {
-        taskLinks: {
-          include: {
-            task: {
-              select: {
-                id: true,
-                title: true,
-                status: true,
-                progressPct: true,
-                estimatedHours: true,
-                actualHours: true,
-              },
+  const { id } = await context!.params;
+  const kpi = await prisma.kPI.findUnique({
+    where: { id },
+    include: {
+      taskLinks: {
+        include: {
+          task: {
+            select: {
+              id: true,
+              title: true,
+              status: true,
+              progressPct: true,
+              estimatedHours: true,
+              actualHours: true,
             },
           },
         },
       },
-    });
+    },
+  });
 
-    if (!kpi) {
-      return NextResponse.json({ error: "找不到 KPI" }, { status: 404 });
-    }
+  if (!kpi) throw new NotFoundError("找不到 KPI");
 
-    let achievementRate = 0;
-    if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-      const totalWeight = kpi.taskLinks.reduce(
-        (sum, link) => sum + link.weight,
-        0
-      );
-      const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
-        const progress =
-          link.task.status === "DONE" ? 100 : link.task.progressPct;
-        return sum + (progress * link.weight) / 100;
-      }, 0);
-      achievementRate =
-        totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
-    } else {
-      achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-    }
-
-    const linkedTaskCount = kpi.taskLinks.length;
-    const completedTaskCount = kpi.taskLinks.filter(
-      (l) => l.task.status === "DONE"
-    ).length;
-
-    return NextResponse.json({
-      kpiId: kpi.id,
-      target: kpi.target,
-      actual: kpi.actual,
-      achievementRate: Math.min(achievementRate, 100),
-      linkedTaskCount,
-      completedTaskCount,
-      autoCalc: kpi.autoCalc,
-    });
-  } catch (error) {
-    console.error("GET /api/kpi/[id]/achievement error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  let achievementRate = 0;
+  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+    const totalWeight = kpi.taskLinks.reduce((sum, link) => sum + link.weight, 0);
+    const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
+      const progress = link.task.status === "DONE" ? 100 : link.task.progressPct;
+      return sum + (progress * link.weight) / 100;
+    }, 0);
+    achievementRate = totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
+  } else {
+    achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
   }
-}
+
+  const linkedTaskCount = kpi.taskLinks.length;
+  const completedTaskCount = kpi.taskLinks.filter((l) => l.task.status === "DONE").length;
+
+  return success({
+    kpiId: kpi.id,
+    target: kpi.target,
+    actual: kpi.actual,
+    achievementRate: Math.min(achievementRate, 100),
+    linkedTaskCount,
+    completedTaskCount,
+    autoCalc: kpi.autoCalc,
+  });
+});

--- a/app/api/kpi/[id]/link/route.ts
+++ b/app/api/kpi/[id]/link/route.ts
@@ -1,47 +1,34 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, ForbiddenError, ValidationError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function POST(
+export const POST = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    if (session.user.role !== "MANAGER") {
-      return NextResponse.json({ error: "權限不足" }, { status: 403 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-    const body = await req.json();
-    const { taskId, weight, remove } = body;
+  const { id } = await context!.params;
+  const body = await req.json();
+  const { taskId, weight, remove } = body;
 
-    if (!taskId) {
-      return NextResponse.json({ error: "taskId 為必填" }, { status: 400 });
-    }
+  if (!taskId) throw new ValidationError("taskId 為必填");
 
-    if (remove) {
-      await prisma.kPITaskLink.deleteMany({
-        where: { kpiId: params.id, taskId },
-      });
-      return NextResponse.json({ message: "已移除連結" });
-    }
-
-    const link = await prisma.kPITaskLink.upsert({
-      where: { kpiId_taskId: { kpiId: params.id, taskId } },
-      update: { weight: weight != null ? parseFloat(weight) : 1 },
-      create: {
-        kpiId: params.id,
-        taskId,
-        weight: weight != null ? parseFloat(weight) : 1,
-      },
-    });
-
-    return NextResponse.json(link, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/kpi/[id]/link error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (remove) {
+    await prisma.kPITaskLink.deleteMany({ where: { kpiId: id, taskId } });
+    return success({ message: "已移除連結" });
   }
-}
+
+  const link = await prisma.kPITaskLink.upsert({
+    where: { kpiId_taskId: { kpiId: id, taskId } },
+    update: { weight: weight != null ? parseFloat(weight) : 1 },
+    create: { kpiId: id, taskId, weight: weight != null ? parseFloat(weight) : 1 },
+  });
+
+  return success(link, 201);
+});

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -1,89 +1,71 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError, ForbiddenError, NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateKpiSchema } from "@/validators/kpi-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const kpi = await prisma.kPI.findUnique({
-      where: { id: params.id },
-      include: {
-        taskLinks: {
-          include: {
-            task: {
-              select: {
-                id: true,
-                title: true,
-                status: true,
-                progressPct: true,
-                dueDate: true,
-                primaryAssignee: { select: { id: true, name: true } },
-              },
+  const { id } = await context!.params;
+  const kpi = await prisma.kPI.findUnique({
+    where: { id },
+    include: {
+      taskLinks: {
+        include: {
+          task: {
+            select: {
+              id: true,
+              title: true,
+              status: true,
+              progressPct: true,
+              dueDate: true,
+              primaryAssignee: { select: { id: true, name: true } },
             },
           },
         },
-        deliverables: true,
-        creator: { select: { id: true, name: true } },
       },
-    });
+      deliverables: true,
+      creator: { select: { id: true, name: true } },
+    },
+  });
 
-    if (!kpi) {
-      return NextResponse.json({ error: "找不到 KPI" }, { status: 404 });
-    }
+  if (!kpi) throw new NotFoundError("找不到 KPI");
+  return success(kpi);
+});
 
-    return NextResponse.json(kpi);
-  } catch (error) {
-    console.error("GET /api/kpi/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
-
-export async function PUT(
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    if (session.user.role !== "MANAGER") {
-      return NextResponse.json({ error: "權限不足" }, { status: 403 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-    const raw = await req.json();
-    const { title, description, target, actual, weight, status, autoCalc } =
-      validateBody(updateKpiSchema, raw);
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { title, description, target, actual, weight, status, autoCalc } =
+    validateBody(updateKpiSchema, raw);
 
-    const kpi = await prisma.kPI.update({
-      where: { id: params.id },
-      data: {
-        ...(title != null && { title }),
-        ...(description != null && { description }),
-        ...(target != null && { target }),
-        ...(actual != null && { actual }),
-        ...(weight != null && { weight }),
-        ...(status != null && { status }),
-        ...(autoCalc != null && { autoCalc }),
-      },
-    });
+  const kpi = await prisma.kPI.update({
+    where: { id },
+    data: {
+      ...(title != null && { title }),
+      ...(description != null && { description }),
+      ...(target != null && { target }),
+      ...(actual != null && { actual }),
+      ...(weight != null && { weight }),
+      ...(status != null && { status }),
+      ...(autoCalc != null && { autoCalc }),
+    },
+  });
 
-    return NextResponse.json(kpi);
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/kpi/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(kpi);
+});

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,86 +1,69 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError, ForbiddenError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createKpiSchema } from "@/validators/kpi-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const year = searchParams.get("year")
-      ? parseInt(searchParams.get("year")!)
-      : new Date().getFullYear();
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year")
+    ? parseInt(searchParams.get("year")!)
+    : new Date().getFullYear();
 
-    const kpis = await prisma.kPI.findMany({
-      where: { year },
-      include: {
-        taskLinks: {
-          include: {
-            task: {
-              select: {
-                id: true,
-                title: true,
-                status: true,
-                progressPct: true,
-                primaryAssignee: { select: { id: true, name: true } },
-              },
+  const kpis = await prisma.kPI.findMany({
+    where: { year },
+    include: {
+      taskLinks: {
+        include: {
+          task: {
+            select: {
+              id: true,
+              title: true,
+              status: true,
+              progressPct: true,
+              primaryAssignee: { select: { id: true, name: true } },
             },
           },
         },
-        deliverables: true,
-        creator: { select: { id: true, name: true } },
       },
-      orderBy: { code: "asc" },
-    });
+      deliverables: true,
+      creator: { select: { id: true, name: true } },
+    },
+    orderBy: { code: "asc" },
+  });
 
-    return NextResponse.json(kpis);
-  } catch (error) {
-    console.error("GET /api/kpi error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(kpis);
+});
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    if (session.user.role !== "MANAGER") {
-      return NextResponse.json({ error: "權限不足" }, { status: 403 });
-    }
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-    const raw = await req.json();
-    const { year, code, title, description, target, weight, autoCalc } = validateBody(
-      createKpiSchema,
-      { ...raw, year: raw.year ? parseInt(raw.year) : raw.year }
-    );
+  const raw = await req.json();
+  const { year, code, title, description, target, weight, autoCalc } = validateBody(
+    createKpiSchema,
+    { ...raw, year: raw.year ? parseInt(raw.year) : raw.year }
+  );
 
-    const kpi = await prisma.kPI.create({
-      data: {
-        year,
-        code,
-        title,
-        description: description || null,
-        target,
-        weight: weight ?? 1,
-        autoCalc: autoCalc ?? false,
-        createdBy: session.user.id,
-      },
-    });
+  const kpi = await prisma.kPI.create({
+    data: {
+      year,
+      code,
+      title,
+      description: description || null,
+      target,
+      weight: weight ?? 1,
+      autoCalc: autoCalc ?? false,
+      createdBy: session.user.id,
+    },
+  });
 
-    return NextResponse.json(kpi, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/kpi error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(kpi, 201);
+});

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -1,33 +1,28 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, NotFoundError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function PATCH(
+export const PATCH = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const notification = await prisma.notification.findUnique({
-      where: { id: params.id },
-    });
+  const { id } = await context!.params;
+  const notification = await prisma.notification.findUnique({ where: { id } });
 
-    if (!notification || notification.userId !== session.user.id) {
-      return NextResponse.json({ error: "找不到通知" }, { status: 404 });
-    }
-
-    const updated = await prisma.notification.update({
-      where: { id: params.id },
-      data: { isRead: true },
-    });
-
-    return NextResponse.json(updated);
-  } catch (error) {
-    console.error("PATCH /api/notifications/[id]/read error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (!notification || notification.userId !== session.user.id) {
+    throw new NotFoundError("找不到通知");
   }
-}
+
+  const updated = await prisma.notification.update({
+    where: { id },
+    data: { isRead: true },
+  });
+
+  return success(updated);
+});

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -1,30 +1,26 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const limit = parseInt(searchParams.get("limit") ?? "20");
+  const { searchParams } = new URL(req.url);
+  const limit = parseInt(searchParams.get("limit") ?? "20");
 
-    const notifications = await prisma.notification.findMany({
-      where: { userId: session.user.id },
-      orderBy: { createdAt: "desc" },
-      take: limit,
-    });
+  const notifications = await prisma.notification.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
 
-    const unreadCount = await prisma.notification.count({
-      where: { userId: session.user.id, isRead: false },
-    });
+  const unreadCount = await prisma.notification.count({
+    where: { userId: session.user.id, isRead: false },
+  });
 
-    return NextResponse.json({ notifications, unreadCount });
-  } catch (error) {
-    console.error("GET /api/notifications error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({ notifications, unreadCount });
+});

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,71 +1,56 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, ForbiddenError, ValidationError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    if (session.user.role !== "MANAGER") {
-      return NextResponse.json({ error: "權限不足" }, { status: 403 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-    const permissions = await prisma.permission.findMany({
-      include: {
-        grantee: { select: { id: true, name: true, email: true, role: true } },
-        granter: { select: { id: true, name: true } },
-      },
-      orderBy: { createdAt: "desc" },
-    });
+  const permissions = await prisma.permission.findMany({
+    include: {
+      grantee: { select: { id: true, name: true, email: true, role: true } },
+      granter: { select: { id: true, name: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
 
-    return NextResponse.json(permissions);
-  } catch (error) {
-    console.error("GET /api/permissions error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  return success(permissions);
+});
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
+
+  const body = await req.json();
+  const { granteeId, permType, targetId, expiresAt, revoke } = body;
+
+  if (!granteeId || !permType) {
+    throw new ValidationError("缺少必填欄位");
   }
-}
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    if (session.user.role !== "MANAGER") {
-      return NextResponse.json({ error: "權限不足" }, { status: 403 });
-    }
-
-    const body = await req.json();
-    const { granteeId, permType, targetId, expiresAt, revoke } = body;
-
-    if (!granteeId || !permType) {
-      return NextResponse.json({ error: "缺少必填欄位" }, { status: 400 });
-    }
-
-    if (revoke) {
-      await prisma.permission.updateMany({
-        where: { granteeId, permType, targetId: targetId || null },
-        data: { isActive: false },
-      });
-      return NextResponse.json({ message: "已撤銷授權" });
-    }
-
-    const permission = await prisma.permission.create({
-      data: {
-        granteeId,
-        granterId: session.user.id,
-        permType,
-        targetId: targetId || null,
-        expiresAt: expiresAt ? new Date(expiresAt) : null,
-        isActive: true,
-      },
+  if (revoke) {
+    await prisma.permission.updateMany({
+      where: { granteeId, permType, targetId: targetId || null },
+      data: { isActive: false },
     });
-
-    return NextResponse.json(permission, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/permissions error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+    return success({ message: "已撤銷授權" });
   }
-}
+
+  const permission = await prisma.permission.create({
+    data: {
+      granteeId,
+      granterId: session.user.id,
+      permType,
+      targetId: targetId || null,
+      expiresAt: expiresAt ? new Date(expiresAt) : null,
+      isActive: true,
+    },
+  });
+
+  return success(permission, 201);
+});

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -1,78 +1,67 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError, NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updatePlanSchema } from "@/validators/plan-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const plan = await prisma.annualPlan.findUnique({
-      where: { id },
-      include: {
-        creator: { select: { id: true, name: true } },
-        milestones: { orderBy: { order: "asc" } },
-        deliverables: true,
-        monthlyGoals: {
-          orderBy: { month: "asc" },
-          include: {
-            tasks: {
-              include: {
-                primaryAssignee: { select: { id: true, name: true, avatar: true } },
-                backupAssignee: { select: { id: true, name: true, avatar: true } },
-                _count: { select: { subTasks: true } },
-              },
+  const { id } = await context!.params;
+  const plan = await prisma.annualPlan.findUnique({
+    where: { id },
+    include: {
+      creator: { select: { id: true, name: true } },
+      milestones: { orderBy: { order: "asc" } },
+      deliverables: true,
+      monthlyGoals: {
+        orderBy: { month: "asc" },
+        include: {
+          tasks: {
+            include: {
+              primaryAssignee: { select: { id: true, name: true, avatar: true } },
+              backupAssignee: { select: { id: true, name: true, avatar: true } },
+              _count: { select: { subTasks: true } },
             },
-            deliverables: true,
           },
+          deliverables: true,
         },
       },
-    });
+    },
+  });
 
-    if (!plan) return NextResponse.json({ error: "計畫不存在" }, { status: 404 });
-    return NextResponse.json(plan);
-  } catch (error) {
-    console.error("GET /api/plans/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  if (!plan) throw new NotFoundError("計畫不存在");
+  return success(plan);
+});
 
-export async function PUT(
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const raw = await req.json();
-    const { title, description, implementationPlan, progressPct } = validateBody(updatePlanSchema, raw);
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { title, description, implementationPlan, progressPct } = validateBody(updatePlanSchema, raw);
 
-    const plan = await prisma.annualPlan.update({
-      where: { id },
-      data: {
-        ...(title !== undefined && { title }),
-        ...(description !== undefined && { description }),
-        ...(implementationPlan !== undefined && { implementationPlan }),
-        ...(progressPct !== undefined && { progressPct }),
-      },
-      include: { milestones: true, monthlyGoals: true },
-    });
+  const plan = await prisma.annualPlan.update({
+    where: { id },
+    data: {
+      ...(title !== undefined && { title }),
+      ...(description !== undefined && { description }),
+      ...(implementationPlan !== undefined && { implementationPlan }),
+      ...(progressPct !== undefined && { progressPct }),
+    },
+    include: { milestones: true, monthlyGoals: true },
+  });
 
-    return NextResponse.json(plan);
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/plans/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(plan);
+});

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -1,53 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { PlanService } from "@/services/plan-service";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createPlanSchema } from "@/validators/plan-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
 const planService = new PlanService(prisma);
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const year = searchParams.get("year");
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year");
 
-    const plans = await planService.listPlans({
-      year: year ? parseInt(year) : undefined,
-    });
+  const plans = await planService.listPlans({
+    year: year ? parseInt(year) : undefined,
+  });
 
-    return NextResponse.json(plans);
-  } catch (error) {
-    console.error("GET /api/plans error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(plans);
+});
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const raw = await req.json();
-    const body = validateBody(createPlanSchema, {
-      ...raw,
-      year: raw.year ? parseInt(raw.year) : raw.year,
-    });
-    const plan = await planService.createPlan({
-      ...body,
-      createdBy: session.user.id,
-    });
+  const raw = await req.json();
+  const body = validateBody(createPlanSchema, {
+    ...raw,
+    year: raw.year ? parseInt(raw.year) : raw.year,
+  });
+  const plan = await planService.createPlan({
+    ...body,
+    createdBy: session.user.id,
+  });
 
-    return NextResponse.json(plan, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/plans error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(plan, 201);
+});

--- a/app/api/reports/kpi/route.ts
+++ b/app/api/reports/kpi/route.ts
@@ -1,75 +1,58 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const year = searchParams.get("year")
-      ? parseInt(searchParams.get("year")!)
-      : new Date().getFullYear();
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year")
+    ? parseInt(searchParams.get("year")!)
+    : new Date().getFullYear();
 
-    const kpis = await prisma.kPI.findMany({
-      where: { year },
-      include: {
-        taskLinks: {
-          include: {
-            task: {
-              select: {
-                id: true,
-                title: true,
-                status: true,
-                progressPct: true,
-              },
-            },
+  const kpis = await prisma.kPI.findMany({
+    where: { year },
+    include: {
+      taskLinks: {
+        include: {
+          task: {
+            select: { id: true, title: true, status: true, progressPct: true },
           },
         },
       },
-      orderBy: { code: "asc" },
-    });
+    },
+    orderBy: { code: "asc" },
+  });
 
-    const kpisWithAchievement = kpis.map((kpi) => {
-      let achievementRate = 0;
-      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-        const totalWeight = kpi.taskLinks.reduce(
-          (sum, l) => sum + l.weight,
-          0
-        );
-        const weighted = kpi.taskLinks.reduce((sum, l) => {
-          const prog =
-            l.task.status === "DONE" ? 100 : l.task.progressPct;
-          return sum + (prog * l.weight) / 100;
-        }, 0);
-        achievementRate =
-          totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
-      } else {
-        achievementRate =
-          kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-      }
-      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
-    });
+  const kpisWithAchievement = kpis.map((kpi) => {
+    let achievementRate = 0;
+    if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+      const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
+      const weighted = kpi.taskLinks.reduce((sum, l) => {
+        const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
+        return sum + (prog * l.weight) / 100;
+      }, 0);
+      achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
+    } else {
+      achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+    }
+    return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
+  });
 
-    const avgAchievement =
-      kpisWithAchievement.length > 0
-        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) /
-          kpisWithAchievement.length
-        : 0;
+  const avgAchievement =
+    kpisWithAchievement.length > 0
+      ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length
+      : 0;
 
-    return NextResponse.json({
-      year,
-      kpis: kpisWithAchievement,
-      avgAchievement: Math.round(avgAchievement * 10) / 10,
-      achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100)
-        .length,
-      totalCount: kpisWithAchievement.length,
-    });
-  } catch (error) {
-    console.error("GET /api/reports/kpi error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({
+    year,
+    kpis: kpisWithAchievement,
+    avgAchievement: Math.round(avgAchievement * 10) / 10,
+    achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100).length,
+    totalCount: kpisWithAchievement.length,
+  });
+});

--- a/app/api/reports/monthly/route.ts
+++ b/app/api/reports/monthly/route.ts
@@ -1,106 +1,94 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const monthParam = searchParams.get("month"); // format: "2026-03"
-    const now = new Date();
-    const year = monthParam
-      ? parseInt(monthParam.split("-")[0])
-      : now.getFullYear();
-    const month = monthParam
-      ? parseInt(monthParam.split("-")[1])
-      : now.getMonth() + 1;
+  const { searchParams } = new URL(req.url);
+  const monthParam = searchParams.get("month"); // format: "2026-03"
+  const now = new Date();
+  const year = monthParam ? parseInt(monthParam.split("-")[0]) : now.getFullYear();
+  const month = monthParam ? parseInt(monthParam.split("-")[1]) : now.getMonth() + 1;
 
-    const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
-    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+  const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
+  const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
 
-    const isManager = session.user.role === "MANAGER";
-    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+  const isManager = session.user.role === "MANAGER";
+  const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
 
-    const allTasks = await prisma.task.findMany({
-      where: {
-        ...userFilter,
-        createdAt: { lte: monthEnd },
-        OR: [
-          { dueDate: { gte: monthStart, lte: monthEnd } },
-          { status: "DONE", updatedAt: { gte: monthStart, lte: monthEnd } },
-          { status: { notIn: ["DONE"] }, dueDate: null },
-        ],
+  const allTasks = await prisma.task.findMany({
+    where: {
+      ...userFilter,
+      createdAt: { lte: monthEnd },
+      OR: [
+        { dueDate: { gte: monthStart, lte: monthEnd } },
+        { status: "DONE", updatedAt: { gte: monthStart, lte: monthEnd } },
+        { status: { notIn: ["DONE"] }, dueDate: null },
+      ],
+    },
+    include: {
+      primaryAssignee: { select: { id: true, name: true } },
+      monthlyGoal: { select: { id: true, title: true, month: true } },
+    },
+  });
+
+  const completedTasks = allTasks.filter((t) => t.status === "DONE");
+  const completionRate =
+    allTasks.length > 0
+      ? Math.round((completedTasks.length / allTasks.length) * 100)
+      : 0;
+
+  const timeEntryFilter = isManager
+    ? { date: { gte: monthStart, lte: monthEnd } }
+    : { userId: session.user.id, date: { gte: monthStart, lte: monthEnd } };
+
+  const timeEntries = await prisma.timeEntry.findMany({
+    where: timeEntryFilter,
+    include: { user: { select: { id: true, name: true } } },
+  });
+
+  const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+  const hoursByCategory = timeEntries.reduce(
+    (acc, e) => {
+      acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
+
+  const monthlyGoals = await prisma.monthlyGoal.findMany({
+    where: { month, annualPlan: { year } },
+    include: {
+      tasks: {
+        where: userFilter,
+        select: { id: true, status: true, progressPct: true },
       },
-      include: {
-        primaryAssignee: { select: { id: true, name: true } },
-        monthlyGoal: { select: { id: true, title: true, month: true } },
-      },
-    });
+    },
+  });
 
-    const completedTasks = allTasks.filter((t) => t.status === "DONE");
-    const completionRate =
-      allTasks.length > 0
-        ? Math.round((completedTasks.length / allTasks.length) * 100)
-        : 0;
+  const changes = await prisma.taskChange.findMany({
+    where: { changedAt: { gte: monthStart, lte: monthEnd } },
+    include: {
+      task: { select: { id: true, title: true } },
+      changedByUser: { select: { id: true, name: true } },
+    },
+  });
 
-    const timeEntryFilter = isManager
-      ? { date: { gte: monthStart, lte: monthEnd } }
-      : { userId: session.user.id, date: { gte: monthStart, lte: monthEnd } };
-
-    const timeEntries = await prisma.timeEntry.findMany({
-      where: timeEntryFilter,
-      include: { user: { select: { id: true, name: true } } },
-    });
-
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const hoursByCategory = timeEntries.reduce(
-      (acc, e) => {
-        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
-
-    const monthlyGoals = await prisma.monthlyGoal.findMany({
-      where: {
-        month,
-        annualPlan: { year },
-      },
-      include: {
-        tasks: {
-          where: userFilter,
-          select: { id: true, status: true, progressPct: true },
-        },
-      },
-    });
-
-    const changes = await prisma.taskChange.findMany({
-      where: { changedAt: { gte: monthStart, lte: monthEnd } },
-      include: {
-        task: { select: { id: true, title: true } },
-        changedByUser: { select: { id: true, name: true } },
-      },
-    });
-
-    return NextResponse.json({
-      period: { year, month, start: monthStart, end: monthEnd },
-      totalTasks: allTasks.length,
-      completedTasks: completedTasks.length,
-      completionRate,
-      totalHours,
-      hoursByCategory,
-      monthlyGoals,
-      changes,
-      delayCount: changes.filter((c) => c.changeType === "DELAY").length,
-      scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE")
-        .length,
-    });
-  } catch (error) {
-    console.error("GET /api/reports/monthly error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({
+    period: { year, month, start: monthStart, end: monthEnd },
+    totalTasks: allTasks.length,
+    completedTasks: completedTasks.length,
+    completionRate,
+    totalHours,
+    hoursByCategory,
+    monthlyGoals,
+    changes,
+    delayCount: changes.filter((c) => c.changeType === "DELAY").length,
+    scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE").length,
+  });
+});

--- a/app/api/reports/weekly/route.ts
+++ b/app/api/reports/weekly/route.ts
@@ -1,100 +1,89 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const dateParam = searchParams.get("date");
-    const refDate = dateParam ? new Date(dateParam) : new Date();
+  const { searchParams } = new URL(req.url);
+  const dateParam = searchParams.get("date");
+  const refDate = dateParam ? new Date(dateParam) : new Date();
 
-    // Week bounds: Monday–Sunday
-    const day = refDate.getDay();
-    const diffToMon = day === 0 ? -6 : 1 - day;
-    const weekStart = new Date(refDate);
-    weekStart.setDate(refDate.getDate() + diffToMon);
-    weekStart.setHours(0, 0, 0, 0);
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekStart.getDate() + 6);
-    weekEnd.setHours(23, 59, 59, 999);
+  // Week bounds: Monday–Sunday
+  const day = refDate.getDay();
+  const diffToMon = day === 0 ? -6 : 1 - day;
+  const weekStart = new Date(refDate);
+  weekStart.setDate(refDate.getDate() + diffToMon);
+  weekStart.setHours(0, 0, 0, 0);
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekStart.getDate() + 6);
+  weekEnd.setHours(23, 59, 59, 999);
 
-    const isManager = session.user.role === "MANAGER";
-    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+  const isManager = session.user.role === "MANAGER";
+  const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
 
-    const completedTasks = await prisma.task.findMany({
-      where: {
-        ...userFilter,
-        status: "DONE",
-        updatedAt: { gte: weekStart, lte: weekEnd },
-      },
-      include: {
-        primaryAssignee: { select: { id: true, name: true } },
-      },
-      orderBy: { updatedAt: "desc" },
-    });
+  const completedTasks = await prisma.task.findMany({
+    where: {
+      ...userFilter,
+      status: "DONE",
+      updatedAt: { gte: weekStart, lte: weekEnd },
+    },
+    include: { primaryAssignee: { select: { id: true, name: true } } },
+    orderBy: { updatedAt: "desc" },
+  });
 
-    const timeEntryFilter = isManager
-      ? { date: { gte: weekStart, lte: weekEnd } }
-      : { userId: session.user.id, date: { gte: weekStart, lte: weekEnd } };
+  const timeEntryFilter = isManager
+    ? { date: { gte: weekStart, lte: weekEnd } }
+    : { userId: session.user.id, date: { gte: weekStart, lte: weekEnd } };
 
-    const timeEntries = await prisma.timeEntry.findMany({
-      where: timeEntryFilter,
-      include: {
-        user: { select: { id: true, name: true } },
-      },
-    });
+  const timeEntries = await prisma.timeEntry.findMany({
+    where: timeEntryFilter,
+    include: { user: { select: { id: true, name: true } } },
+  });
 
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const hoursByCategory = timeEntries.reduce(
-      (acc, e) => {
-        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
+  const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+  const hoursByCategory = timeEntries.reduce(
+    (acc, e) => {
+      acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 
-    const overdueTasks = await prisma.task.findMany({
-      where: {
-        ...userFilter,
-        status: { notIn: ["DONE"] },
-        dueDate: { lt: new Date() },
-      },
-      include: {
-        primaryAssignee: { select: { id: true, name: true } },
-      },
-      orderBy: { dueDate: "asc" },
-      take: 10,
-    });
+  const overdueTasks = await prisma.task.findMany({
+    where: {
+      ...userFilter,
+      status: { notIn: ["DONE"] },
+      dueDate: { lt: new Date() },
+    },
+    include: { primaryAssignee: { select: { id: true, name: true } } },
+    orderBy: { dueDate: "asc" },
+    take: 10,
+  });
 
-    const changes = await prisma.taskChange.findMany({
-      where: { changedAt: { gte: weekStart, lte: weekEnd } },
-      include: {
-        task: { select: { id: true, title: true } },
-        changedByUser: { select: { id: true, name: true } },
-      },
-      orderBy: { changedAt: "desc" },
-    });
+  const changes = await prisma.taskChange.findMany({
+    where: { changedAt: { gte: weekStart, lte: weekEnd } },
+    include: {
+      task: { select: { id: true, title: true } },
+      changedByUser: { select: { id: true, name: true } },
+    },
+    orderBy: { changedAt: "desc" },
+  });
 
-    return NextResponse.json({
-      period: { start: weekStart, end: weekEnd },
-      completedTasks,
-      completedCount: completedTasks.length,
-      totalHours,
-      hoursByCategory,
-      overdueTasks,
-      overdueCount: overdueTasks.length,
-      changes,
-      delayCount: changes.filter((c) => c.changeType === "DELAY").length,
-      scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE")
-        .length,
-    });
-  } catch (error) {
-    console.error("GET /api/reports/weekly error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({
+    period: { start: weekStart, end: weekEnd },
+    completedTasks,
+    completedCount: completedTasks.length,
+    totalHours,
+    hoursByCategory,
+    overdueTasks,
+    overdueCount: overdueTasks.length,
+    changes,
+    delayCount: changes.filter((c) => c.changeType === "DELAY").length,
+    scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE").length,
+  });
+});

--- a/app/api/reports/workload/route.ts
+++ b/app/api/reports/workload/route.ts
@@ -1,129 +1,97 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const startParam = searchParams.get("startDate");
-    const endParam = searchParams.get("endDate");
-    const now = new Date();
+  const { searchParams } = new URL(req.url);
+  const startParam = searchParams.get("startDate");
+  const endParam = searchParams.get("endDate");
+  const now = new Date();
 
-    const startDate = startParam
-      ? new Date(startParam)
-      : new Date(now.getFullYear(), now.getMonth(), 1);
-    const endDate = endParam
-      ? new Date(endParam)
-      : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+  const startDate = startParam
+    ? new Date(startParam)
+    : new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = endParam
+    ? new Date(endParam)
+    : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
 
-    const isManager = session.user.role === "MANAGER";
-    const timeEntryFilter = isManager
-      ? { date: { gte: startDate, lte: endDate } }
-      : { userId: session.user.id, date: { gte: startDate, lte: endDate } };
+  const isManager = session.user.role === "MANAGER";
+  const timeEntryFilter = isManager
+    ? { date: { gte: startDate, lte: endDate } }
+    : { userId: session.user.id, date: { gte: startDate, lte: endDate } };
 
-    const timeEntries = await prisma.timeEntry.findMany({
-      where: timeEntryFilter,
-      include: {
-        user: { select: { id: true, name: true } },
-        task: { select: { id: true, title: true, category: true } },
-      },
-    });
+  const timeEntries = await prisma.timeEntry.findMany({
+    where: timeEntryFilter,
+    include: {
+      user: { select: { id: true, name: true } },
+      task: { select: { id: true, title: true, category: true } },
+    },
+  });
 
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const plannedHours = timeEntries
-      .filter((e) => e.category === "PLANNED_TASK")
-      .reduce((sum, e) => sum + e.hours, 0);
-    const unplannedHours = timeEntries
-      .filter((e) =>
-        ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)
-      )
-      .reduce((sum, e) => sum + e.hours, 0);
+  const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+  const plannedHours = timeEntries
+    .filter((e) => e.category === "PLANNED_TASK")
+    .reduce((sum, e) => sum + e.hours, 0);
+  const unplannedHours = timeEntries
+    .filter((e) => ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
+    .reduce((sum, e) => sum + e.hours, 0);
 
-    const hoursByCategory = timeEntries.reduce(
-      (acc, e) => {
-        acc[e.category] = (acc[e.category] ?? 0) + e.hours;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
+  const hoursByCategory = timeEntries.reduce(
+    (acc, e) => {
+      acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 
-    // Per-person breakdown
-    const byPerson = timeEntries.reduce(
-      (acc, e) => {
-        const key = e.userId;
-        if (!acc[key]) {
-          acc[key] = {
-            userId: e.userId,
-            name: e.user.name,
-            total: 0,
-            planned: 0,
-            unplanned: 0,
-          };
-        }
-        acc[key].total += e.hours;
-        if (e.category === "PLANNED_TASK") acc[key].planned += e.hours;
-        if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
-          acc[key].unplanned += e.hours;
-        return acc;
-      },
-      {} as Record<
-        string,
-        {
-          userId: string;
-          name: string;
-          total: number;
-          planned: number;
-          unplanned: number;
-        }
-      >
-    );
+  const byPerson = timeEntries.reduce(
+    (acc, e) => {
+      const key = e.userId;
+      if (!acc[key]) {
+        acc[key] = { userId: e.userId, name: e.user.name, total: 0, planned: 0, unplanned: 0 };
+      }
+      acc[key].total += e.hours;
+      if (e.category === "PLANNED_TASK") acc[key].planned += e.hours;
+      if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)) acc[key].unplanned += e.hours;
+      return acc;
+    },
+    {} as Record<string, { userId: string; name: string; total: number; planned: number; unplanned: number }>
+  );
 
-    // Unplanned task source analysis
-    const unplannedTasks = await prisma.task.findMany({
-      where: {
-        ...(isManager ? {} : { primaryAssigneeId: session.user.id }),
-        category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
-        createdAt: { gte: startDate, lte: endDate },
-      },
-      include: {
-        primaryAssignee: { select: { id: true, name: true } },
-      },
-    });
+  const unplannedTasks = await prisma.task.findMany({
+    where: {
+      ...(isManager ? {} : { primaryAssigneeId: session.user.id }),
+      category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
+      createdAt: { gte: startDate, lte: endDate },
+    },
+    include: { primaryAssignee: { select: { id: true, name: true } } },
+  });
 
-    const unplannedBySource = unplannedTasks.reduce(
-      (acc, t) => {
-        const src = t.addedSource ?? "未填寫";
-        acc[src] = (acc[src] ?? 0) + 1;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
+  const unplannedBySource = unplannedTasks.reduce(
+    (acc, t) => {
+      const src = t.addedSource ?? "未填寫";
+      acc[src] = (acc[src] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>
+  );
 
-    return NextResponse.json({
-      period: { start: startDate, end: endDate },
-      totalHours,
-      plannedHours,
-      unplannedHours,
-      plannedRate:
-        totalHours > 0
-          ? Math.round((plannedHours / totalHours) * 100 * 10) / 10
-          : 0,
-      unplannedRate:
-        totalHours > 0
-          ? Math.round((unplannedHours / totalHours) * 100 * 10) / 10
-          : 0,
-      hoursByCategory,
-      byPerson: Object.values(byPerson),
-      unplannedTasks,
-      unplannedBySource,
-    });
-  } catch (error) {
-    console.error("GET /api/reports/workload error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({
+    period: { start: startDate, end: endDate },
+    totalHours,
+    plannedHours,
+    unplannedHours,
+    plannedRate: totalHours > 0 ? Math.round((plannedHours / totalHours) * 100 * 10) / 10 : 0,
+    unplannedRate: totalHours > 0 ? Math.round((unplannedHours / totalHours) * 100 * 10) / 10 : 0,
+    hoursByCategory,
+    byPerson: Object.values(byPerson),
+    unplannedTasks,
+    unplannedBySource,
+  });
+});

--- a/app/api/subtasks/[id]/route.ts
+++ b/app/api/subtasks/[id]/route.ts
@@ -1,48 +1,41 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function PATCH(
+export const PATCH = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    const body = await req.json();
+  const { id } = await context!.params;
+  const body = await req.json();
 
-    const subtask = await prisma.subTask.update({
-      where: { id },
-      data: {
-        ...(body.done !== undefined && { done: body.done }),
-        ...(body.title !== undefined && { title: body.title }),
-        ...(body.assigneeId !== undefined && { assigneeId: body.assigneeId || null }),
-        ...(body.dueDate !== undefined && { dueDate: body.dueDate ? new Date(body.dueDate) : null }),
-      },
-    });
+  const subtask = await prisma.subTask.update({
+    where: { id },
+    data: {
+      ...(body.done !== undefined && { done: body.done }),
+      ...(body.title !== undefined && { title: body.title }),
+      ...(body.assigneeId !== undefined && { assigneeId: body.assigneeId || null }),
+      ...(body.dueDate !== undefined && { dueDate: body.dueDate ? new Date(body.dueDate) : null }),
+    },
+  });
 
-    return NextResponse.json(subtask);
-  } catch (error) {
-    console.error("PATCH /api/subtasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(subtask);
+});
 
-export async function DELETE(
+export const DELETE = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { id } = await params;
-    await prisma.subTask.delete({ where: { id } });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error("DELETE /api/subtasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  const { id } = await context!.params;
+  await prisma.subTask.delete({ where: { id } });
+  return success({ success: true });
+});

--- a/app/api/subtasks/route.ts
+++ b/app/api/subtasks/route.ts
@@ -1,32 +1,30 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, ValidationError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const body = await req.json();
-    const { taskId, title, assigneeId, dueDate, order } = body;
+  const body = await req.json();
+  const { taskId, title, assigneeId, dueDate, order } = body;
 
-    if (!taskId || !title) {
-      return NextResponse.json({ error: "taskId 和標題為必填" }, { status: 400 });
-    }
-
-    const subtask = await prisma.subTask.create({
-      data: {
-        taskId,
-        title,
-        assigneeId: assigneeId || null,
-        dueDate: dueDate ? new Date(dueDate) : null,
-        order: order ?? 0,
-      },
-    });
-
-    return NextResponse.json(subtask, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/subtasks error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (!taskId || !title) {
+    throw new ValidationError("taskId 和標題為必填");
   }
-}
+
+  const subtask = await prisma.subTask.create({
+    data: {
+      taskId,
+      title,
+      assigneeId: assigneeId || null,
+      dueDate: dueDate ? new Date(dueDate) : null,
+      order: order ?? 0,
+    },
+  });
+
+  return success(subtask, 201);
+});

--- a/app/api/tasks/[id]/changes/route.ts
+++ b/app/api/tasks/[id]/changes/route.ts
@@ -1,69 +1,57 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError, ValidationError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const changes = await prisma.taskChange.findMany({
-      where: { taskId: params.id },
-      include: {
-        changedByUser: { select: { id: true, name: true } },
-      },
-      orderBy: { changedAt: "desc" },
-    });
+  const { id } = await context!.params;
+  const changes = await prisma.taskChange.findMany({
+    where: { taskId: id },
+    include: {
+      changedByUser: { select: { id: true, name: true } },
+    },
+    orderBy: { changedAt: "desc" },
+  });
 
-    return NextResponse.json(changes);
-  } catch (error) {
-    console.error("GET /api/tasks/[id]/changes error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(changes);
+});
 
-export async function POST(
+export const POST = apiHandler(async (
   req: NextRequest,
-  { params }: { params: { id: string } }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const body = await req.json();
-    const { changeType, reason, oldValue, newValue } = body;
+  const { id } = await context!.params;
+  const body = await req.json();
+  const { changeType, reason, oldValue, newValue } = body;
 
-    if (!changeType || !reason) {
-      return NextResponse.json(
-        { error: "changeType 和 reason 為必填" },
-        { status: 400 }
-      );
-    }
-
-    const change = await prisma.taskChange.create({
-      data: {
-        taskId: params.id,
-        changeType,
-        reason,
-        oldValue: oldValue || null,
-        newValue: newValue || null,
-        changedBy: session.user.id,
-      },
-      include: {
-        changedByUser: { select: { id: true, name: true } },
-      },
-    });
-
-    return NextResponse.json(change, { status: 201 });
-  } catch (error) {
-    console.error("POST /api/tasks/[id]/changes error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (!changeType || !reason) {
+    throw new ValidationError("changeType 和 reason 為必填");
   }
-}
+
+  const change = await prisma.taskChange.create({
+    data: {
+      taskId: id,
+      changeType,
+      reason,
+      oldValue: oldValue || null,
+      newValue: newValue || null,
+      changedBy: session.user.id,
+    },
+    include: {
+      changedByUser: { select: { id: true, name: true } },
+    },
+  });
+
+  return success(change, 201);
+});

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,100 +1,59 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TaskService } from "@/services/task-service";
-import { NotFoundError, ValidationError } from "@/services/errors";
+import { NotFoundError, ValidationError, UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateTaskSchema, updateTaskStatusSchema } from "@/validators/task-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
 const taskService = new TaskService(prisma);
 
-export async function GET(
+export const GET = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const task = await taskService.getTask(id);
-    return NextResponse.json(task);
-  } catch (error) {
-    if (error instanceof NotFoundError) {
-      return NextResponse.json({ error: "任務不存在" }, { status: 404 });
-    }
-    console.error("GET /api/tasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
+  const { id } = await context!.params;
+  const task = await taskService.getTask(id);
+  return success(task);
+});
 
-export async function PUT(
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const raw = await req.json();
-    const body = validateBody(updateTaskSchema, raw);
-    const task = await taskService.updateTask(id, body);
-    return NextResponse.json(task);
-  } catch (error) {
-    if (error instanceof NotFoundError) {
-      return NextResponse.json({ error: "任務不存在" }, { status: 404 });
-    }
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/tasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const body = validateBody(updateTaskSchema, raw);
+  const task = await taskService.updateTask(id, body);
+  return success(task);
+});
 
-export async function DELETE(
+export const DELETE = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    await taskService.deleteTask(id);
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error("DELETE /api/tasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  const { id } = await context!.params;
+  await taskService.deleteTask(id);
+  return success({ success: true });
+});
 
-export async function PATCH(
+export const PATCH = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const raw = await req.json();
-    const { status } = validateBody(updateTaskStatusSchema, raw);
-    const task = await taskService.updateTaskStatus(id, status, session.user.id);
-    return NextResponse.json(task);
-  } catch (error) {
-    if (error instanceof NotFoundError) {
-      return NextResponse.json({ error: "任務不存在" }, { status: 404 });
-    }
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PATCH /api/tasks/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { status } = validateBody(updateTaskStatusSchema, raw);
+  const task = await taskService.updateTaskStatus(id, status, session.user.id);
+  return success(task);
+});

--- a/app/api/tasks/gantt/route.ts
+++ b/app/api/tasks/gantt/route.ts
@@ -1,49 +1,44 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const year = searchParams.get("year") ? parseInt(searchParams.get("year")!) : new Date().getFullYear();
-    const assignee = searchParams.get("assignee");
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year") ? parseInt(searchParams.get("year")!) : new Date().getFullYear();
+  const assignee = searchParams.get("assignee");
 
-    // Fetch annual plan with milestones and monthly goals + tasks
-    const annualPlan = await prisma.annualPlan.findUnique({
-      where: { year },
-      include: {
-        milestones: { orderBy: { plannedEnd: "asc" } },
-        monthlyGoals: {
-          orderBy: { month: "asc" },
-          include: {
-            tasks: {
-              where: assignee
-                ? {
-                    OR: [
-                      { primaryAssigneeId: assignee },
-                      { backupAssigneeId: assignee },
-                    ],
-                  }
-                : undefined,
-              include: {
-                primaryAssignee: { select: { id: true, name: true } },
-                backupAssignee: { select: { id: true, name: true } },
-              },
-              orderBy: [{ priority: "asc" }, { startDate: "asc" }, { dueDate: "asc" }],
+  const annualPlan = await prisma.annualPlan.findUnique({
+    where: { year },
+    include: {
+      milestones: { orderBy: { plannedEnd: "asc" } },
+      monthlyGoals: {
+        orderBy: { month: "asc" },
+        include: {
+          tasks: {
+            where: assignee
+              ? {
+                  OR: [
+                    { primaryAssigneeId: assignee },
+                    { backupAssigneeId: assignee },
+                  ],
+                }
+              : undefined,
+            include: {
+              primaryAssignee: { select: { id: true, name: true } },
+              backupAssignee: { select: { id: true, name: true } },
             },
+            orderBy: [{ priority: "asc" }, { startDate: "asc" }, { dueDate: "asc" }],
           },
         },
       },
-    });
+    },
+  });
 
-    return NextResponse.json({ annualPlan: annualPlan ?? null, year });
-  } catch (error) {
-    console.error("GET /api/tasks/gantt error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success({ annualPlan: annualPlan ?? null, year });
+});

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,57 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { TaskService } from "@/services/task-service";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createTaskSchema } from "@/validators/task-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
 const taskService = new TaskService(prisma);
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const tasks = await taskService.listTasks({
-      assignee: searchParams.get("assignee") ?? undefined,
-      status: (searchParams.get("status") as TaskStatus) ?? undefined,
-      priority: (searchParams.get("priority") as Priority) ?? undefined,
-      category: (searchParams.get("category") as TaskCategory) ?? undefined,
-      monthlyGoalId: searchParams.get("monthlyGoalId") ?? undefined,
-    });
+  const { searchParams } = new URL(req.url);
+  const tasks = await taskService.listTasks({
+    assignee: searchParams.get("assignee") ?? undefined,
+    status: (searchParams.get("status") as TaskStatus) ?? undefined,
+    priority: (searchParams.get("priority") as Priority) ?? undefined,
+    category: (searchParams.get("category") as TaskCategory) ?? undefined,
+    monthlyGoalId: searchParams.get("monthlyGoalId") ?? undefined,
+  });
 
-    return NextResponse.json(tasks);
-  } catch (error) {
-    console.error("GET /api/tasks error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(tasks);
+});
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const raw = await req.json();
-    const body = validateBody(createTaskSchema, raw);
-    const task = await taskService.createTask({
-      ...body,
-      creatorId: session.user.id,
-    });
+  const raw = await req.json();
+  const body = validateBody(createTaskSchema, raw);
+  const task = await taskService.createTask({
+    ...body,
+    creatorId: session.user.id,
+  });
 
-    return NextResponse.json(task, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/tasks error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(task, 201);
+});

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -1,66 +1,50 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateTimeEntrySchema } from "@/validators/time-entry-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function PUT(
+export const PUT = apiHandler(async (
   req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    const raw = await req.json();
-    const { taskId, date, hours, category, description } = validateBody(
-      updateTimeEntrySchema,
-      raw
-    );
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const updates: Record<string, unknown> = {};
-    if (taskId !== undefined) updates.taskId = taskId || null;
-    if (date !== undefined) updates.date = new Date(date);
-    if (hours !== undefined) updates.hours = hours;
-    if (category !== undefined) updates.category = category as TimeCategory;
-    if (description !== undefined) updates.description = description || null;
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const { taskId, date, hours, category, description } = validateBody(updateTimeEntrySchema, raw);
 
-    const entry = await prisma.timeEntry.update({
-      where: { id },
-      data: updates,
-      include: {
-        task: { select: { id: true, title: true, category: true } },
-      },
-    });
+  const updates: Record<string, unknown> = {};
+  if (taskId !== undefined) updates.taskId = taskId || null;
+  if (date !== undefined) updates.date = new Date(date);
+  if (hours !== undefined) updates.hours = hours;
+  if (category !== undefined) updates.category = category as TimeCategory;
+  if (description !== undefined) updates.description = description || null;
 
-    return NextResponse.json(entry);
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("PUT /api/time-entries/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  const entry = await prisma.timeEntry.update({
+    where: { id },
+    data: updates,
+    include: {
+      task: { select: { id: true, title: true, category: true } },
+    },
+  });
 
-export async function DELETE(
+  return success(entry);
+});
+
+export const DELETE = apiHandler(async (
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
-    const { id } = await params;
-    await prisma.timeEntry.delete({ where: { id } });
-    return NextResponse.json({ success: true });
-  } catch (error) {
-    console.error("DELETE /api/time-entries/[id] error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  await prisma.timeEntry.delete({ where: { id } });
+  return success({ success: true });
+});

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -1,79 +1,61 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
-import { ValidationError } from "@/services/errors";
+import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createTimeEntrySchema } from "@/validators/time-entry-validators";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get("userId") || session.user.id;
-    const weekStart = searchParams.get("weekStart");
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId") || session.user.id;
+  const weekStart = searchParams.get("weekStart");
 
-    const where: Record<string, unknown> = { userId };
+  const where: Record<string, unknown> = { userId };
 
-    if (weekStart) {
-      const start = new Date(weekStart);
-      const end = new Date(start);
-      end.setDate(end.getDate() + 6);
-      where.date = { gte: start, lte: end };
-    }
-
-    const entries = await prisma.timeEntry.findMany({
-      where,
-      include: {
-        task: { select: { id: true, title: true, category: true } },
-      },
-      orderBy: [{ date: "asc" }, { createdAt: "asc" }],
-    });
-
-    return NextResponse.json(entries);
-  } catch (error) {
-    console.error("GET /api/time-entries error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  if (weekStart) {
+    const start = new Date(weekStart);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    where.date = { gte: start, lte: end };
   }
-}
 
-export async function POST(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+  const entries = await prisma.timeEntry.findMany({
+    where,
+    include: {
+      task: { select: { id: true, title: true, category: true } },
+    },
+    orderBy: [{ date: "asc" }, { createdAt: "asc" }],
+  });
 
-    const raw = await req.json();
-    const { taskId, date, hours, category, description } = validateBody(
-      createTimeEntrySchema,
-      raw
-    );
+  return success(entries);
+});
 
-    const entry = await prisma.timeEntry.create({
-      data: {
-        taskId: taskId || null,
-        userId: session.user.id,
-        date: new Date(date),
-        hours,
-        category: (category as TimeCategory) ?? "PLANNED_TASK",
-        description: description || null,
-      },
-      include: {
-        task: { select: { id: true, title: true, category: true } },
-      },
-    });
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    return NextResponse.json(entry, { status: 201 });
-  } catch (error) {
-    if (error instanceof ValidationError) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
-    console.error("POST /api/time-entries error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  const raw = await req.json();
+  const { taskId, date, hours, category, description } = validateBody(createTimeEntrySchema, raw);
+
+  const entry = await prisma.timeEntry.create({
+    data: {
+      taskId: taskId || null,
+      userId: session.user.id,
+      date: new Date(date),
+      hours,
+      category: (category as TimeCategory) ?? "PLANNED_TASK",
+      description: description || null,
+    },
+    include: {
+      task: { select: { id: true, title: true, category: true } },
+    },
+  });
+
+  return success(entry, 201);
+});

--- a/app/api/time-entries/stats/route.ts
+++ b/app/api/time-entries/stats/route.ts
@@ -1,63 +1,59 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "未授權" }, { status: 401 });
-    }
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
 
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get("userId") || session.user.id;
-    const startDate = searchParams.get("startDate");
-    const endDate = searchParams.get("endDate");
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("userId") || session.user.id;
+  const startDate = searchParams.get("startDate");
+  const endDate = searchParams.get("endDate");
 
-    const where: Record<string, unknown> = { userId };
-    if (startDate || endDate) {
-      where.date = {};
-      if (startDate) (where.date as Record<string, unknown>).gte = new Date(startDate);
-      if (endDate) (where.date as Record<string, unknown>).lte = new Date(endDate);
-    }
-
-    const entries = await prisma.timeEntry.findMany({ where });
-
-    const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
-
-    const byCategory: Record<string, number> = {};
-    for (const e of entries) {
-      byCategory[e.category] = (byCategory[e.category] ?? 0) + e.hours;
-    }
-
-    const categories = [
-      "PLANNED_TASK",
-      "ADDED_TASK",
-      "INCIDENT",
-      "SUPPORT",
-      "ADMIN",
-      "LEARNING",
-    ];
-
-    const breakdown = categories.map((cat) => ({
-      category: cat,
-      hours: byCategory[cat] ?? 0,
-      pct: totalHours > 0 ? Math.round(((byCategory[cat] ?? 0) / totalHours) * 100) : 0,
-    }));
-
-    const plannedHours = byCategory["PLANNED_TASK"] ?? 0;
-    const taskInvestmentRate = totalHours > 0
-      ? Math.round((plannedHours / totalHours) * 100)
-      : 0;
-
-    return NextResponse.json({
-      totalHours,
-      breakdown,
-      taskInvestmentRate,
-      entryCount: entries.length,
-    });
-  } catch (error) {
-    console.error("GET /api/time-entries/stats error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
+  const where: Record<string, unknown> = { userId };
+  if (startDate || endDate) {
+    where.date = {};
+    if (startDate) (where.date as Record<string, unknown>).gte = new Date(startDate);
+    if (endDate) (where.date as Record<string, unknown>).lte = new Date(endDate);
   }
-}
+
+  const entries = await prisma.timeEntry.findMany({ where });
+
+  const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
+
+  const byCategory: Record<string, number> = {};
+  for (const e of entries) {
+    byCategory[e.category] = (byCategory[e.category] ?? 0) + e.hours;
+  }
+
+  const categories = [
+    "PLANNED_TASK",
+    "ADDED_TASK",
+    "INCIDENT",
+    "SUPPORT",
+    "ADMIN",
+    "LEARNING",
+  ];
+
+  const breakdown = categories.map((cat) => ({
+    category: cat,
+    hours: byCategory[cat] ?? 0,
+    pct: totalHours > 0 ? Math.round(((byCategory[cat] ?? 0) / totalHours) * 100) : 0,
+  }));
+
+  const plannedHours = byCategory["PLANNED_TASK"] ?? 0;
+  const taskInvestmentRate = totalHours > 0
+    ? Math.round((plannedHours / totalHours) * 100)
+    : 0;
+
+  return success({
+    totalHours,
+    breakdown,
+    taskInvestmentRate,
+    entryCount: entries.length,
+  });
+});

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,21 +1,19 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
 
-export async function GET(req: NextRequest) {
-  try {
-    const session = await getServerSession();
-    if (!session) return NextResponse.json({ error: "未授權" }, { status: 401 });
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
 
-    const users = await prisma.user.findMany({
-      where: { isActive: true },
-      select: { id: true, name: true, email: true, role: true, avatar: true },
-      orderBy: { name: "asc" },
-    });
+  const users = await prisma.user.findMany({
+    where: { isActive: true },
+    select: { id: true, name: true, email: true, role: true, avatar: true },
+    orderBy: { name: "asc" },
+  });
 
-    return NextResponse.json(users);
-  } catch (error) {
-    console.error("GET /api/users error:", error);
-    return NextResponse.json({ error: "伺服器錯誤" }, { status: 500 });
-  }
-}
+  return success(users);
+});

--- a/lib/__tests__/api-handler.test.ts
+++ b/lib/__tests__/api-handler.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Tests written FIRST (RED) before implementation.
+ * Issue #80: Unified error handling middleware
+ */
+
+import { NextRequest } from "next/server";
+import {
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/services/errors";
+
+// ── Mock next/server ──────────────────────────────────────────────────────
+jest.mock("next/server", () => {
+  const actual = jest.requireActual("next/server");
+  return {
+    ...actual,
+    NextResponse: {
+      json: jest.fn((body: unknown, init?: { status?: number }) => ({
+        status: init?.status ?? 200,
+        _body: body,
+        json: async () => body,
+      })),
+    },
+  };
+});
+
+// ── Import after mocks ────────────────────────────────────────────────────
+import { apiHandler } from "@/lib/api-handler";
+import { success, error as errorResponse } from "@/lib/api-response";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function makeFakeRequest(url = "http://localhost/api/test"): NextRequest {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(),
+    json: jest.fn(),
+  } as unknown as NextRequest;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("apiHandler", () => {
+  const req = makeFakeRequest();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns 200 with data on success", async () => {
+    const handler = apiHandler(async () => success({ id: 1 }));
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({ id: 1 });
+  });
+
+  test("returns 400 with details on ValidationError", async () => {
+    const handler = apiHandler(async () => {
+      throw new ValidationError("invalid input");
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("ValidationError");
+    expect(body.message).toBe("invalid input");
+  });
+
+  test("returns 401 on UnauthorizedError", async () => {
+    const handler = apiHandler(async () => {
+      throw new UnauthorizedError();
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("UnauthorizedError");
+  });
+
+  test("returns 403 on ForbiddenError", async () => {
+    const handler = apiHandler(async () => {
+      throw new ForbiddenError();
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("ForbiddenError");
+  });
+
+  test("returns 404 on NotFoundError", async () => {
+    const handler = apiHandler(async () => {
+      throw new NotFoundError("resource not found");
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("NotFoundError");
+    expect(body.message).toBe("resource not found");
+  });
+
+  test("returns 500 on unexpected error", async () => {
+    const handler = apiHandler(async () => {
+      throw new Error("something broke");
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("InternalServerError");
+  });
+
+  test("response format is { ok, data, error, message }", async () => {
+    const handler = apiHandler(async () => success({ value: 42 }));
+    const res = await handler(req);
+    const body = await res.json();
+    expect(body).toHaveProperty("ok");
+    expect(body).toHaveProperty("data");
+    // error and message are optional — present only on error responses
+    expect(Object.keys(body)).toContain("ok");
+    expect(Object.keys(body)).toContain("data");
+  });
+
+  test("logs error details for 500 errors", async () => {
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const handler = apiHandler(async () => {
+      throw new Error("db crash");
+    });
+    await handler(req);
+    expect(consoleSpy).toHaveBeenCalled();
+    const callArgs = consoleSpy.mock.calls[0];
+    expect(callArgs.some((a) => String(a).includes("db crash") || a instanceof Error)).toBe(true);
+    consoleSpy.mockRestore();
+  });
+
+  test("does not expose stack trace in response", async () => {
+    const handler = apiHandler(async () => {
+      throw new Error("internal");
+    });
+    const res = await handler(req);
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toMatch(/at\s+\w+\s+\(.*\.ts/);
+    expect(body).not.toHaveProperty("stack");
+  });
+
+  test("handles async handler correctly", async () => {
+    const handler = apiHandler(async () => {
+      await Promise.resolve();
+      return success({ async: true });
+    });
+    const res = await handler(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual({ async: true });
+  });
+});
+
+// ── api-response helper tests ─────────────────────────────────────────────
+describe("success()", () => {
+  test("wraps data in { ok: true, data } with status 200", async () => {
+    const res = success({ name: "test" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({ name: "test" });
+  });
+
+  test("accepts custom status code", async () => {
+    const res = success({}, 201);
+    expect(res.status).toBe(201);
+  });
+});
+
+describe("errorResponse()", () => {
+  test("returns { ok: false, error, message } with given status", async () => {
+    const res = errorResponse("ValidationError", "bad input", 400);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("ValidationError");
+    expect(body.message).toBe("bad input");
+  });
+});

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  ValidationError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+} from "@/services/errors";
+import { success, error } from "@/lib/api-response";
+import type { ApiResponse } from "@/lib/api-response";
+
+type RouteHandler<TParams = undefined> = TParams extends undefined
+  ? (req: NextRequest) => Promise<NextResponse<ApiResponse>>
+  : (req: NextRequest, context: { params: Promise<TParams> }) => Promise<NextResponse<ApiResponse>>;
+
+/**
+ * Wraps a Next.js route handler with unified error handling.
+ *
+ * Maps custom error types to HTTP status codes and returns a consistent
+ * JSON shape: { ok, data?, error?, message? }
+ *
+ * Usage (simple):
+ *   export const GET = apiHandler(async (req) => {
+ *     return success(data);
+ *   });
+ *
+ * Usage (with dynamic params):
+ *   export const GET = apiHandler(async (req, { params }) => {
+ *     const { id } = await params;
+ *     return success(data);
+ *   });
+ */
+export function apiHandler(
+  fn: (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => Promise<NextResponse<ApiResponse>>
+): (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => Promise<NextResponse<ApiResponse>> {
+  return async (
+    req: NextRequest,
+    context?: { params: Promise<Record<string, string>> }
+  ): Promise<NextResponse<ApiResponse>> => {
+    try {
+      return await fn(req, context);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return error("ValidationError", err.message, 400);
+      }
+      if (err instanceof UnauthorizedError) {
+        return error("UnauthorizedError", err.message, 401);
+      }
+      if (err instanceof ForbiddenError) {
+        return error("ForbiddenError", err.message, 403);
+      }
+      if (err instanceof NotFoundError) {
+        return error("NotFoundError", err.message, 404);
+      }
+      // Unexpected error — log details server-side, never expose internals
+      console.error("[apiHandler] Unexpected error:", err);
+      return error("InternalServerError", "伺服器錯誤", 500);
+    }
+  };
+}

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+export interface ApiResponse<T = unknown> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+/**
+ * Returns a successful JSON response with consistent { ok, data } shape.
+ */
+export function success<T>(data: T, status = 200): NextResponse<ApiResponse<T>> {
+  return NextResponse.json({ ok: true, data }, { status });
+}
+
+/**
+ * Returns an error JSON response with consistent { ok, error, message } shape.
+ */
+export function error(
+  errorName: string,
+  message: string,
+  status: number
+): NextResponse<ApiResponse> {
+  return NextResponse.json({ ok: false, error: errorName, message }, { status });
+}


### PR DESCRIPTION
## Summary

- TDD approach: 13 tests written first (RED), then `apiHandler` + `api-response` implemented (GREEN)
- `lib/api-handler.ts`: wraps route handlers with try/catch, maps custom errors to HTTP status codes
- `lib/api-response.ts`: `success(data, status)` and `error(name, message, status)` helpers
- All 31 API routes migrated — consistent `{ ok, data?, error?, message? }` response shape
- 500 errors logged server-side; stack traces never exposed to clients

## Test plan

- [x] `npx jest lib/__tests__/api-handler.test.ts` — 13/13 pass
- [x] Confirmed pre-existing test failures on `main` branch are unchanged (JSX/path issues, not related to this PR)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)