### PR TITLE
refactor(#81): RBAC permission middleware

### DIFF
--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError, ForbiddenError, NotFoundError } from "@/services/errors";
+import { NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateKpiSchema } from "@/validators/kpi-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
 
-export const GET = apiHandler(async (
+export const GET = withAuth(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
 
   const { id } = await context!.params;
   const kpi = await prisma.kPI.findUnique({
@@ -41,14 +38,10 @@ export const GET = apiHandler(async (
   return success(kpi);
 });
 
-export const PUT = apiHandler(async (
+export const PUT = withManager(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
-  if (session.user.role !== "MANAGER") throw new ForbiddenError();
-
   const { id } = await context!.params;
   const raw = await req.json();
   const { title, description, target, actual, weight, status, autoCalc } =

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -1,15 +1,12 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError, ForbiddenError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createKpiSchema } from "@/validators/kpi-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const year = searchParams.get("year")
@@ -41,10 +38,8 @@ export const GET = apiHandler(async (req: NextRequest) => {
   return success(kpis);
 });
 
-export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
-  if (session.user.role !== "MANAGER") throw new ForbiddenError();
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const raw = await req.json();
   const { year, code, title, description, target, weight, autoCalc } = validateBody(

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -1,18 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError, NotFoundError } from "@/services/errors";
+import { NotFoundError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updatePlanSchema } from "@/validators/plan-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
 
-export const GET = apiHandler(async (
+export const GET = withAuth(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session) throw new UnauthorizedError();
 
   const { id } = await context!.params;
   const plan = await prisma.annualPlan.findUnique({
@@ -41,13 +38,10 @@ export const GET = apiHandler(async (
   return success(plan);
 });
 
-export const PUT = apiHandler(async (
+export const PUT = withManager(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
-
   const { id } = await context!.params;
   const raw = await req.json();
   const { title, description, implementationPlan, progressPct } = validateBody(updatePlanSchema, raw);

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -1,19 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
 import { PlanService } from "@/services/plan-service";
-import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createPlanSchema } from "@/validators/plan-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
 const planService = new PlanService(prisma);
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session) throw new UnauthorizedError();
-
+export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const year = searchParams.get("year");
 
@@ -24,9 +20,8 @@ export const GET = apiHandler(async (req: NextRequest) => {
   return success(plans);
 });
 
-export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const raw = await req.json();
   const body = validateBody(createPlanSchema, {

--- a/app/api/reports/kpi/route.ts
+++ b/app/api/reports/kpi/route.ts
@@ -1,13 +1,9 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const year = searchParams.get("year")

--- a/app/api/reports/monthly/route.ts
+++ b/app/api/reports/monthly/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const { searchParams } = new URL(req.url);
   const monthParam = searchParams.get("month"); // format: "2026-03"

--- a/app/api/reports/weekly/route.ts
+++ b/app/api/reports/weekly/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const { searchParams } = new URL(req.url);
   const dateParam = searchParams.get("date");

--- a/app/api/reports/workload/route.ts
+++ b/app/api/reports/workload/route.ts
@@ -1,13 +1,11 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const { searchParams } = new URL(req.url);
   const startParam = searchParams.get("startDate");

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,32 +1,27 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
 import { TaskService } from "@/services/task-service";
-import { NotFoundError, ValidationError, UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateTaskSchema, updateTaskStatusSchema } from "@/validators/task-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
 const taskService = new TaskService(prisma);
 
-export const GET = apiHandler(async (
+export const GET = withAuth(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session) throw new UnauthorizedError();
   const { id } = await context!.params;
   const task = await taskService.getTask(id);
   return success(task);
 });
 
-export const PUT = apiHandler(async (
+export const PUT = withAuth(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
   const { id } = await context!.params;
   const raw = await req.json();
   const body = validateBody(updateTaskSchema, raw);
@@ -34,23 +29,20 @@ export const PUT = apiHandler(async (
   return success(task);
 });
 
-export const DELETE = apiHandler(async (
+export const DELETE = withManager(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
   const { id } = await context!.params;
   await taskService.deleteTask(id);
   return success({ success: true });
 });
 
-export const PATCH = apiHandler(async (
+export const PATCH = withAuth(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }
 ) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+  const session = await requireAuth();
   const { id } = await context!.params;
   const raw = await req.json();
   const { status } = validateBody(updateTaskStatusSchema, raw);

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,20 +1,16 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
 import { TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { TaskService } from "@/services/task-service";
-import { UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createTaskSchema } from "@/validators/task-validators";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
 const taskService = new TaskService(prisma);
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session) throw new UnauthorizedError();
-
+export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const tasks = await taskService.listTasks({
     assignee: searchParams.get("assignee") ?? undefined,
@@ -27,9 +23,8 @@ export const GET = apiHandler(async (req: NextRequest) => {
   return success(tasks);
 });
 
-export const POST = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session?.user?.id) throw new UnauthorizedError();
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const raw = await req.json();
   const body = validateBody(createTaskSchema, raw);

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,13 +1,9 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
-import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  const session = await getServerSession();
-  if (!session) throw new UnauthorizedError();
+export const GET = withAuth(async (req: NextRequest) => {
 
   const users = await prisma.user.findMany({
     where: { isActive: true },

--- a/lib/__tests__/rbac.test.ts
+++ b/lib/__tests__/rbac.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Tests written FIRST (RED) before implementation.
+ * Issue #81: RBAC permission middleware
+ */
+
+import { NextRequest } from "next/server";
+import { UnauthorizedError, ForbiddenError } from "@/services/errors";
+
+// ── Mock next-auth ─────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+// ── Mock prisma ────────────────────────────────────────────────────────────
+const mockPermissionFindFirst = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    permission: {
+      findFirst: (...args: unknown[]) => mockPermissionFindFirst(...args),
+    },
+  },
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────
+import {
+  requireAuth,
+  requireRole,
+  requireOwnerOrManager,
+  checkPermission,
+} from "@/lib/rbac";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function makeManagerSession(id = "manager-1") {
+  return { user: { id, name: "Manager", email: "mgr@example.com", role: "MANAGER" }, expires: "2099-01-01" };
+}
+
+function makeEngineerSession(id = "engineer-1") {
+  return { user: { id, name: "Engineer", email: "eng@example.com", role: "ENGINEER" }, expires: "2099-01-01" };
+}
+
+function makeFakeRequest(url = "http://localhost/api/test"): NextRequest {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(),
+    json: jest.fn(),
+  } as unknown as NextRequest;
+}
+
+// ── describe: requireAuth ──────────────────────────────────────────────────
+
+describe("requireAuth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns session when user is authenticated", async () => {
+    const session = makeEngineerSession();
+    mockGetServerSession.mockResolvedValue(session);
+
+    const result = await requireAuth();
+    expect(result).toBe(session);
+  });
+
+  test("throws UnauthorizedError when no session exists", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(requireAuth()).rejects.toThrow(UnauthorizedError);
+  });
+
+  test("throws UnauthorizedError with 401-appropriate message", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(requireAuth()).rejects.toThrow("未授權");
+  });
+});
+
+// ── describe: requireRole ──────────────────────────────────────────────────
+
+describe("requireRole", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("allows MANAGER to access manager-only route", async () => {
+    mockGetServerSession.mockResolvedValue(makeManagerSession());
+
+    const session = await requireRole("MANAGER");
+    expect(session.user.role).toBe("MANAGER");
+  });
+
+  test("rejects ENGINEER from manager-only route with ForbiddenError", async () => {
+    mockGetServerSession.mockResolvedValue(makeEngineerSession());
+
+    await expect(requireRole("MANAGER")).rejects.toThrow(ForbiddenError);
+  });
+
+  test("allows any authenticated user to access general route (ENGINEER role)", async () => {
+    mockGetServerSession.mockResolvedValue(makeEngineerSession());
+
+    const session = await requireRole("ENGINEER");
+    expect(session.user.role).toBe("ENGINEER");
+  });
+
+  test("rejects unauthenticated request with UnauthorizedError", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(requireRole("MANAGER")).rejects.toThrow(UnauthorizedError);
+  });
+
+  test("rejects unauthenticated request before checking role (401 not 403)", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(requireRole("MANAGER")).rejects.toThrow(UnauthorizedError);
+    // Ensure it's UnauthorizedError specifically, not ForbiddenError
+    await expect(requireRole("MANAGER")).rejects.not.toThrow(ForbiddenError);
+  });
+});
+
+// ── describe: requireOwnerOrManager ───────────────────────────────────────
+
+describe("requireOwnerOrManager", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("allows task owner to access their own task", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+
+    const result = await requireOwnerOrManager("engineer-1");
+    expect(result).toBe(session);
+  });
+
+  test("allows MANAGER to access any task", async () => {
+    const session = makeManagerSession("manager-1");
+    mockGetServerSession.mockResolvedValue(session);
+
+    // Manager accessing a task owned by a different user
+    const result = await requireOwnerOrManager("engineer-99");
+    expect(result.user.role).toBe("MANAGER");
+  });
+
+  test("rejects ENGINEER from accessing another user's task with ForbiddenError", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+
+    await expect(requireOwnerOrManager("engineer-2")).rejects.toThrow(ForbiddenError);
+  });
+
+  test("rejects unauthenticated request with UnauthorizedError", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    await expect(requireOwnerOrManager("engineer-1")).rejects.toThrow(UnauthorizedError);
+  });
+});
+
+// ── describe: checkPermission ──────────────────────────────────────────────
+
+describe("checkPermission", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("MANAGER can view all team data (VIEW_TEAM scope)", async () => {
+    const session = makeManagerSession("manager-1");
+    mockGetServerSession.mockResolvedValue(session);
+    mockPermissionFindFirst.mockResolvedValue(null); // no explicit Permission row needed
+
+    const result = await checkPermission("manager-1", "VIEW_TEAM");
+    expect(result).toBe(true);
+  });
+
+  test("ENGINEER cannot view team data by default (VIEW_TEAM scope)", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+    // No permission record for this engineer
+    mockPermissionFindFirst.mockResolvedValue(null);
+
+    const result = await checkPermission("engineer-1", "VIEW_TEAM");
+    expect(result).toBe(false);
+  });
+
+  test("ENGINEER with VIEW_TEAM permission can view team data", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+    // Active VIEW_TEAM permission exists
+    mockPermissionFindFirst.mockResolvedValue({
+      id: "perm-1",
+      granteeId: "engineer-1",
+      permType: "VIEW_TEAM",
+      isActive: true,
+      expiresAt: null,
+    });
+
+    const result = await checkPermission("engineer-1", "VIEW_TEAM");
+    expect(result).toBe(true);
+  });
+
+  test("respects dynamic Permission table entries — expired permission is rejected", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+    // Expired permission should not be found (query filters it out)
+    mockPermissionFindFirst.mockResolvedValue(null);
+
+    const result = await checkPermission("engineer-1", "VIEW_TEAM");
+    expect(result).toBe(false);
+  });
+
+  test("ENGINEER can always view own data (VIEW_OWN scope)", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+
+    const result = await checkPermission("engineer-1", "VIEW_OWN");
+    expect(result).toBe(true);
+  });
+
+  test("ENGINEER cannot view other user data with VIEW_OWN scope", async () => {
+    const session = makeEngineerSession("engineer-1");
+    mockGetServerSession.mockResolvedValue(session);
+
+    // engineer-1 trying to check VIEW_OWN for engineer-2
+    const result = await checkPermission("engineer-2", "VIEW_OWN");
+    expect(result).toBe(false);
+  });
+});

--- a/lib/auth-middleware.ts
+++ b/lib/auth-middleware.ts
@@ -1,0 +1,44 @@
+/**
+ * Higher-order auth middleware wrappers for API route handlers — Issue #81
+ *
+ * Usage:
+ *   export const GET = withAuth(async (req) => {
+ *     return success(data);
+ *   });
+ *
+ *   export const POST = withManager(async (req) => {
+ *     return success(data);
+ *   });
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireRole } from "@/lib/rbac";
+import { apiHandler } from "@/lib/api-handler";
+import type { ApiResponse } from "@/lib/api-response";
+
+type RouteHandler = (
+  req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => Promise<NextResponse<ApiResponse>>;
+
+/**
+ * Wraps a route handler with requireAuth check + unified error handling.
+ * Any authenticated user (MANAGER or ENGINEER) may access.
+ */
+export function withAuth(fn: RouteHandler): RouteHandler {
+  return apiHandler(async (req, context) => {
+    await requireAuth();
+    return fn(req, context);
+  });
+}
+
+/**
+ * Wraps a route handler with requireRole('MANAGER') check + error handling.
+ * Only MANAGER role may access.
+ */
+export function withManager(fn: RouteHandler): RouteHandler {
+  return apiHandler(async (req, context) => {
+    await requireRole("MANAGER");
+    return fn(req, context);
+  });
+}

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -1,0 +1,126 @@
+/**
+ * RBAC permission middleware — Issue #81
+ *
+ * Provides API-layer permission helpers that throw typed errors caught by
+ * apiHandler. All functions require an active next-auth session.
+ *
+ * Roles (from Prisma schema):
+ *   MANAGER — full access to all resources, team data, and mutations
+ *   ENGINEER — read own data; elevated access via Permission table
+ *
+ * PermissionScope values:
+ *   VIEW_TEAM — access all team members' data
+ *   VIEW_OWN  — access only own data (default for ENGINEER)
+ */
+
+import { getServerSession } from "next-auth";
+import { UnauthorizedError, ForbiddenError } from "@/services/errors";
+import { prisma } from "@/lib/prisma";
+
+export type PermissionScope = "VIEW_TEAM" | "VIEW_OWN";
+
+export interface SessionUser {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  role: string;
+}
+
+export interface AuthSession {
+  user: SessionUser;
+  expires: string;
+}
+
+/**
+ * Asserts an active session exists.
+ * Throws UnauthorizedError (→ 401) if not authenticated.
+ */
+export async function requireAuth(): Promise<AuthSession> {
+  const session = await getServerSession();
+  if (!session || !session.user) {
+    throw new UnauthorizedError("未授權");
+  }
+  return session as AuthSession;
+}
+
+/**
+ * Asserts session exists AND user has the required role.
+ * Throws UnauthorizedError (→ 401) if not authenticated.
+ * Throws ForbiddenError (→ 403) if authenticated but wrong role.
+ */
+export async function requireRole(role: string): Promise<AuthSession> {
+  const session = await requireAuth();
+  if (session.user.role !== role) {
+    throw new ForbiddenError("權限不足");
+  }
+  return session;
+}
+
+/**
+ * Asserts session exists AND (user owns the resource OR user is MANAGER).
+ * Throws UnauthorizedError (→ 401) if not authenticated.
+ * Throws ForbiddenError (→ 403) if ENGINEER accessing another user's resource.
+ */
+export async function requireOwnerOrManager(resourceOwnerId: string): Promise<AuthSession> {
+  const session = await requireAuth();
+  const { id, role } = session.user;
+
+  if (role === "MANAGER") {
+    return session;
+  }
+
+  if (id === resourceOwnerId) {
+    return session;
+  }
+
+  throw new ForbiddenError("權限不足：僅限資源擁有者或管理員");
+}
+
+/**
+ * Checks whether `userId` has `scope` access.
+ *
+ * Rules:
+ *   - MANAGER always has VIEW_TEAM and VIEW_OWN
+ *   - ENGINEER always has VIEW_OWN for their own userId (session.user.id === userId)
+ *   - ENGINEER has VIEW_TEAM only if an active Permission row exists
+ *   - Expired permissions (expiresAt < now) are excluded via the DB query
+ *
+ * Returns true/false without throwing — callers decide how to respond.
+ */
+export async function checkPermission(userId: string, scope: PermissionScope): Promise<boolean> {
+  const session = await getServerSession();
+  if (!session || !session.user) {
+    return false;
+  }
+
+  const currentUser = session.user as SessionUser;
+
+  // MANAGER has unrestricted access
+  if (currentUser.role === "MANAGER") {
+    return true;
+  }
+
+  // VIEW_OWN: ENGINEER can only see their own data
+  if (scope === "VIEW_OWN") {
+    return currentUser.id === userId;
+  }
+
+  // VIEW_TEAM: check Permission table for an active, non-expired grant
+  if (scope === "VIEW_TEAM") {
+    const permission = await prisma.permission.findFirst({
+      where: {
+        granteeId: currentUser.id,
+        permType: "VIEW_TEAM",
+        isActive: true,
+        OR: [
+          { expiresAt: null },
+          { expiresAt: { gt: new Date() } },
+        ],
+      },
+    });
+    return permission !== null;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

- TDD: 18 tests written first (RED), then `lib/rbac.ts` implemented (GREEN)
- `requireAuth` / `requireRole` / `requireOwnerOrManager` / `checkPermission` in `lib/rbac.ts`
- `withAuth` / `withManager` HOF wrappers in `lib/auth-middleware.ts` for clean route-level RBAC
- Applied to all sensitive API routes: tasks, plans, kpi, reports/*, users
- DELETE operations elevated to MANAGER-only across the board

## Test plan

- [x] `lib/__tests__/rbac.test.ts` — 18 tests covering all RBAC helpers
- [x] `lib/__tests__/api-handler.test.ts` — 13 existing tests still passing
- [x] Total: 31 lib tests passing, 0 regressions introduced

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)