### PR TITLE
feat(#83): milestone CRUD API

### DIFF
--- a/app/api/milestones/[id]/route.ts
+++ b/app/api/milestones/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { updateMilestoneSchema } from "@/validators/milestone-validators";
+import { MilestoneService } from "@/services/milestone-service";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+
+const getService = () => new MilestoneService(prisma);
+
+export const GET = apiHandler(async (
+  req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  const milestone = await getService().getMilestone(id);
+
+  return success(milestone);
+});
+
+export const PUT = apiHandler(async (
+  req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  const raw = await req.json();
+  const data = validateBody(updateMilestoneSchema, raw);
+
+  const milestone = await getService().updateMilestone(id, {
+    title: data.title,
+    description: data.description,
+    plannedStart: data.plannedStart,
+    plannedEnd: data.plannedEnd,
+    actualStart: data.actualStart,
+    actualEnd: data.actualEnd,
+    status: data.status,
+    order: data.order,
+  });
+
+  return success(milestone);
+});
+
+export const DELETE = apiHandler(async (
+  req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  await getService().deleteMilestone(id);
+
+  return success({ id });
+});

--- a/app/api/milestones/route.ts
+++ b/app/api/milestones/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+import { createMilestoneSchema } from "@/validators/milestone-validators";
+import { MilestoneService } from "@/services/milestone-service";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+
+const getService = () => new MilestoneService(prisma);
+
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session) throw new UnauthorizedError();
+
+  const { searchParams } = new URL(req.url);
+  const planId = searchParams.get("planId") ?? undefined;
+
+  const milestones = await getService().listMilestones({ planId });
+
+  return success(milestones);
+});
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const raw = await req.json();
+  const data = validateBody(createMilestoneSchema, raw);
+
+  const milestone = await getService().createMilestone({
+    annualPlanId: data.annualPlanId,
+    title: data.title,
+    description: data.description,
+    plannedStart: data.plannedStart,
+    plannedEnd: data.plannedEnd,
+    order: data.order,
+  });
+
+  return success(milestone, 201);
+});

--- a/services/__tests__/milestone-service.test.ts
+++ b/services/__tests__/milestone-service.test.ts
@@ -1,0 +1,129 @@
+import { MilestoneService } from "../milestone-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { NotFoundError, ValidationError } from "../errors";
+
+describe("MilestoneService", () => {
+  let service: MilestoneService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new MilestoneService(prisma as never);
+  });
+
+  test("listMilestones returns milestones for a plan", async () => {
+    const mockMilestones = [
+      { id: "ms-1", annualPlanId: "plan-1", title: "Q1 Launch" },
+    ];
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue(mockMilestones);
+
+    const result = await service.listMilestones({ planId: "plan-1" });
+
+    expect(prisma.milestone.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ annualPlanId: "plan-1" }),
+      })
+    );
+    expect(result).toEqual(mockMilestones);
+  });
+
+  test("getMilestone returns milestone by id", async () => {
+    const mockMilestone = { id: "ms-1", title: "Q1 Launch", annualPlanId: "plan-1" };
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue(mockMilestone);
+
+    const result = await service.getMilestone("ms-1");
+
+    expect(result).toEqual(mockMilestone);
+  });
+
+  test("getMilestone throws NotFoundError for invalid id", async () => {
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.getMilestone("nonexistent")).rejects.toThrow(NotFoundError);
+  });
+
+  test("createMilestone creates with required fields", async () => {
+    const input = {
+      annualPlanId: "plan-1",
+      title: "Q1 Launch",
+      plannedEnd: new Date("2025-03-31"),
+    };
+    const mockMilestone = { id: "ms-1", ...input };
+    (prisma.milestone.create as jest.Mock).mockResolvedValue(mockMilestone);
+
+    const result = await service.createMilestone(input);
+
+    expect(prisma.milestone.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          annualPlanId: "plan-1",
+          title: "Q1 Launch",
+        }),
+      })
+    );
+    expect(result).toEqual(mockMilestone);
+  });
+
+  test("createMilestone validates plannedStart < plannedEnd", async () => {
+    const input = {
+      annualPlanId: "plan-1",
+      title: "Bad Milestone",
+      plannedStart: new Date("2025-04-01"),
+      plannedEnd: new Date("2025-03-01"),
+    };
+
+    await expect(service.createMilestone(input)).rejects.toThrow(ValidationError);
+  });
+
+  test("updateMilestone updates only provided fields", async () => {
+    const existing = { id: "ms-1", title: "Old Title" };
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue(existing);
+    const updated = { id: "ms-1", title: "New Title" };
+    (prisma.milestone.update as jest.Mock).mockResolvedValue(updated);
+
+    const result = await service.updateMilestone("ms-1", { title: "New Title" });
+
+    expect(prisma.milestone.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "ms-1" },
+        data: expect.objectContaining({ title: "New Title" }),
+      })
+    );
+    expect(result).toEqual(updated);
+  });
+
+  test("updateMilestone can set actualStart/actualEnd", async () => {
+    const existing = { id: "ms-1", title: "Milestone" };
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue(existing);
+    const actualStart = new Date("2025-01-10");
+    const actualEnd = new Date("2025-03-25");
+    const updated = { id: "ms-1", actualStart, actualEnd };
+    (prisma.milestone.update as jest.Mock).mockResolvedValue(updated);
+
+    const result = await service.updateMilestone("ms-1", { actualStart, actualEnd });
+
+    expect(prisma.milestone.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ actualStart, actualEnd }),
+      })
+    );
+    expect(result).toEqual(updated);
+  });
+
+  test("deleteMilestone removes milestone", async () => {
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue({ id: "ms-1" });
+    (prisma.milestone.delete as jest.Mock).mockResolvedValue({ id: "ms-1" });
+
+    await service.deleteMilestone("ms-1");
+
+    expect(prisma.milestone.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "ms-1" } })
+    );
+  });
+
+  test("deleteMilestone throws NotFoundError for invalid id", async () => {
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.deleteMilestone("nonexistent")).rejects.toThrow(NotFoundError);
+  });
+});

--- a/services/milestone-service.ts
+++ b/services/milestone-service.ts
@@ -1,0 +1,112 @@
+import { PrismaClient, MilestoneStatus } from "@prisma/client";
+import { NotFoundError, ValidationError } from "./errors";
+
+export interface ListMilestonesFilter {
+  planId?: string;
+}
+
+export interface CreateMilestoneInput {
+  annualPlanId: string;
+  title: string;
+  description?: string | null;
+  plannedStart?: Date | null;
+  plannedEnd: Date;
+  order?: number;
+}
+
+export interface UpdateMilestoneInput {
+  title?: string;
+  description?: string | null;
+  plannedStart?: Date | null;
+  plannedEnd?: Date;
+  actualStart?: Date | null;
+  actualEnd?: Date | null;
+  status?: MilestoneStatus | string;
+  order?: number;
+}
+
+export class MilestoneService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listMilestones(filter: ListMilestonesFilter) {
+    return this.prisma.milestone.findMany({
+      where: {
+        ...(filter.planId && { annualPlanId: filter.planId }),
+      },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+      },
+      orderBy: [{ order: "asc" }, { plannedEnd: "asc" }],
+    });
+  }
+
+  async getMilestone(id: string) {
+    const milestone = await this.prisma.milestone.findUnique({
+      where: { id },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+      },
+    });
+
+    if (!milestone) throw new NotFoundError(`Milestone not found: ${id}`);
+    return milestone;
+  }
+
+  async createMilestone(input: CreateMilestoneInput) {
+    if (!input.annualPlanId?.trim()) {
+      throw new ValidationError("計畫ID為必填");
+    }
+    if (!input.title?.trim()) {
+      throw new ValidationError("標題為必填");
+    }
+    if (input.plannedStart && input.plannedEnd) {
+      if (input.plannedStart >= input.plannedEnd) {
+        throw new ValidationError("plannedStart 必須早於 plannedEnd");
+      }
+    }
+
+    return this.prisma.milestone.create({
+      data: {
+        annualPlanId: input.annualPlanId,
+        title: input.title,
+        description: input.description ?? null,
+        plannedStart: input.plannedStart ?? null,
+        plannedEnd: input.plannedEnd,
+        order: input.order ?? 0,
+      },
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+      },
+    });
+  }
+
+  async updateMilestone(id: string, input: UpdateMilestoneInput) {
+    const existing = await this.prisma.milestone.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundError(`Milestone not found: ${id}`);
+
+    const updates: Record<string, unknown> = {};
+    if (input.title !== undefined) updates.title = input.title;
+    if (input.description !== undefined) updates.description = input.description;
+    if (input.plannedStart !== undefined) updates.plannedStart = input.plannedStart;
+    if (input.plannedEnd !== undefined) updates.plannedEnd = input.plannedEnd;
+    if (input.actualStart !== undefined) updates.actualStart = input.actualStart;
+    if (input.actualEnd !== undefined) updates.actualEnd = input.actualEnd;
+    if (input.status !== undefined) updates.status = input.status;
+    if (input.order !== undefined) updates.order = input.order;
+
+    return this.prisma.milestone.update({
+      where: { id },
+      data: updates,
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true } },
+      },
+    });
+  }
+
+  async deleteMilestone(id: string) {
+    const milestone = await this.prisma.milestone.findUnique({ where: { id } });
+    if (!milestone) throw new NotFoundError(`Milestone not found: ${id}`);
+
+    return this.prisma.milestone.delete({ where: { id } });
+  }
+}

--- a/validators/__tests__/milestone-validators.test.ts
+++ b/validators/__tests__/milestone-validators.test.ts
@@ -1,0 +1,90 @@
+import {
+  createMilestoneSchema,
+  updateMilestoneSchema,
+} from "../milestone-validators";
+
+describe("createMilestoneSchema", () => {
+  const validInput = {
+    annualPlanId: "plan-abc",
+    title: "Q1 Launch",
+    plannedEnd: "2025-03-31T00:00:00.000Z",
+  };
+
+  test("accepts valid input", () => {
+    const result = createMilestoneSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid input with optional fields", () => {
+    const result = createMilestoneSchema.safeParse({
+      ...validInput,
+      description: "Launch milestone for Q1",
+      plannedStart: "2025-01-01T00:00:00.000Z",
+      order: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const result = createMilestoneSchema.safeParse({
+      annualPlanId: "plan-abc",
+      plannedEnd: "2025-03-31T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing annualPlanId", () => {
+    const result = createMilestoneSchema.safeParse({
+      title: "Q1 Launch",
+      plannedEnd: "2025-03-31T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid dates", () => {
+    const result = createMilestoneSchema.safeParse({
+      ...validInput,
+      plannedEnd: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects plannedEnd before plannedStart", () => {
+    const result = createMilestoneSchema.safeParse({
+      ...validInput,
+      plannedStart: "2025-04-01T00:00:00.000Z",
+      plannedEnd: "2025-03-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateMilestoneSchema", () => {
+  test("accepts empty object", () => {
+    const result = updateMilestoneSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with title only", () => {
+    const result = updateMilestoneSchema.safeParse({ title: "Updated Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid status values", () => {
+    const statuses = ["PENDING", "IN_PROGRESS", "COMPLETED", "DELAYED", "CANCELLED"];
+    for (const status of statuses) {
+      const result = updateMilestoneSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid status", () => {
+    const result = updateMilestoneSchema.safeParse({ status: "UNKNOWN" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid date string", () => {
+    const result = updateMilestoneSchema.safeParse({ actualStart: "not-a-date" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/milestone-validators.ts
+++ b/validators/milestone-validators.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+const MilestoneStatusEnum = z.enum([
+  "PENDING",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "DELAYED",
+  "CANCELLED",
+]);
+
+export const createMilestoneSchema = z
+  .object({
+    annualPlanId: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().optional(),
+    plannedStart: z.coerce.date().optional(),
+    plannedEnd: z.coerce.date(),
+    order: z.number().int().min(0).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.plannedStart && data.plannedEnd) {
+        return data.plannedStart < data.plannedEnd;
+      }
+      return true;
+    },
+    { message: "plannedStart 必須早於 plannedEnd", path: ["plannedStart"] }
+  );
+
+export const updateMilestoneSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  plannedStart: z.coerce.date().optional(),
+  plannedEnd: z.coerce.date().optional(),
+  actualStart: z.coerce.date().optional(),
+  actualEnd: z.coerce.date().optional(),
+  status: MilestoneStatusEnum.optional(),
+  order: z.number().int().min(0).optional(),
+});
+
+export type CreateMilestoneInput = z.infer<typeof createMilestoneSchema>;
+export type UpdateMilestoneInput = z.infer<typeof updateMilestoneSchema>;


### PR DESCRIPTION
## Summary

- TDD: 測試先寫（RED），再實作（GREEN）
- `MilestoneService`：完整 CRUD（list/get/create/update/delete），含 NotFoundError / ValidationError
- `milestone-validators.ts`：Zod schema，含 `plannedStart < plannedEnd` 跨欄位驗證
- API routes：`GET/POST /api/milestones`，`GET/PUT/DELETE /api/milestones/[id]`
- 20 個測試全數通過，現有 232 個測試維持不變

## Test plan

- [x] `services/__tests__/milestone-service.test.ts` — 9 tests（listMilestones, getMilestone, createMilestone, updateMilestone, deleteMilestone）
- [x] `validators/__tests__/milestone-validators.test.ts` — 11 tests（createMilestoneSchema, updateMilestoneSchema）
- [x] `npx jest --testPathPatterns="milestone"` → 20 passed, 0 failed

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)