### PR TITLE
feat(#85): KPI/Plan/Goal DELETE endpoints with TDD

### DIFF
--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -6,6 +6,7 @@ import { validateBody } from "@/lib/validate";
 import { updateGoalSchema } from "@/validators/plan-validators";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
 
 export const GET = apiHandler(async (
   req: NextRequest,
@@ -62,4 +63,20 @@ export const PUT = apiHandler(async (
   });
 
   return success(goal);
+});
+
+export const DELETE = withManager(async (
+  _req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context!.params;
+  const existing = await prisma.monthlyGoal.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("目標不存在");
+
+  await prisma.task.updateMany({
+    where: { monthlyGoalId: id },
+    data: { monthlyGoalId: null },
+  });
+  await prisma.monthlyGoal.delete({ where: { id } });
+  return success({ deleted: true });
 });

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -38,6 +38,19 @@ export const GET = withAuth(async (
   return success(kpi);
 });
 
+export const DELETE = withManager(async (
+  _req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context!.params;
+  const existing = await prisma.kPI.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("找不到 KPI");
+
+  await prisma.kPITaskLink.deleteMany({ where: { kpiId: id } });
+  await prisma.kPI.delete({ where: { id } });
+  return success({ deleted: true });
+});
+
 export const PUT = withManager(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -38,6 +38,18 @@ export const GET = withAuth(async (
   return success(plan);
 });
 
+export const DELETE = withManager(async (
+  _req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context!.params;
+  const existing = await prisma.annualPlan.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("計畫不存在");
+
+  await prisma.annualPlan.delete({ where: { id } });
+  return success({ deleted: true });
+});
+
 export const PUT = withManager(async (
   req: NextRequest,
   context?: { params: Promise<Record<string, string>> }

--- a/services/__tests__/delete-operations.test.ts
+++ b/services/__tests__/delete-operations.test.ts
@@ -1,0 +1,120 @@
+import { KPIService } from "../kpi-service";
+import { PlanService } from "../plan-service";
+import { GoalService } from "../goal-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { NotFoundError } from "../errors";
+
+// ---------------------------------------------------------------------------
+// KPIService.deleteKPI
+// ---------------------------------------------------------------------------
+describe("KPIService.deleteKPI", () => {
+  let service: KPIService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new KPIService(prisma as never);
+  });
+
+  test("deletes KPI and its task links", async () => {
+    const mockKPI = { id: "kpi-1", year: 2026, title: "KPI 1" };
+    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
+    (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+    (prisma.kPI.delete as jest.Mock).mockResolvedValue(mockKPI);
+
+    const result = await service.deleteKPI("kpi-1");
+
+    expect(prisma.kPITaskLink.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { kpiId: "kpi-1" } })
+    );
+    expect(prisma.kPI.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "kpi-1" } })
+    );
+    expect(result).toEqual(mockKPI);
+  });
+
+  test("throws NotFoundError for invalid id", async () => {
+    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.deleteKPI("nonexistent")).rejects.toThrow(NotFoundError);
+    expect(prisma.kPITaskLink.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.kPI.delete).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PlanService.deletePlan
+// ---------------------------------------------------------------------------
+describe("PlanService.deletePlan", () => {
+  let service: PlanService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new PlanService(prisma as never);
+  });
+
+  test("deletes plan and cascades to goals", async () => {
+    const mockPlan = { id: "plan-1", year: 2026, title: "Plan 2026" };
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(mockPlan);
+    (prisma.annualPlan.delete as jest.Mock).mockResolvedValue(mockPlan);
+
+    const result = await service.deletePlan("plan-1");
+
+    expect(prisma.annualPlan.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "plan-1" } })
+    );
+    expect(prisma.annualPlan.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "plan-1" } })
+    );
+    expect(result).toEqual(mockPlan);
+  });
+
+  test("throws NotFoundError for invalid id", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.deletePlan("nonexistent")).rejects.toThrow(NotFoundError);
+    expect(prisma.annualPlan.delete).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GoalService.deleteGoal
+// ---------------------------------------------------------------------------
+describe("GoalService.deleteGoal", () => {
+  let service: GoalService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new GoalService(prisma as never);
+  });
+
+  test("deletes goal and reassigns orphan tasks", async () => {
+    const mockGoal = { id: "goal-1", annualPlanId: "plan-1", month: 3 };
+    (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(mockGoal);
+    (prisma.task.updateMany as jest.Mock).mockResolvedValue({ count: 3 });
+    (prisma.monthlyGoal.delete as jest.Mock).mockResolvedValue(mockGoal);
+
+    const result = await service.deleteGoal("goal-1");
+
+    expect(prisma.task.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { monthlyGoalId: "goal-1" },
+        data: { monthlyGoalId: null },
+      })
+    );
+    expect(prisma.monthlyGoal.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "goal-1" } })
+    );
+    expect(result).toEqual(mockGoal);
+  });
+
+  test("throws NotFoundError for invalid id", async () => {
+    (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.deleteGoal("nonexistent")).rejects.toThrow(NotFoundError);
+    expect(prisma.task.updateMany).not.toHaveBeenCalled();
+    expect(prisma.monthlyGoal.delete).not.toHaveBeenCalled();
+  });
+});

--- a/services/goal-service.ts
+++ b/services/goal-service.ts
@@ -104,6 +104,10 @@ export class GoalService {
     const goal = await this.prisma.monthlyGoal.findUnique({ where: { id } });
     if (!goal) throw new NotFoundError(`Goal not found: ${id}`);
 
+    await this.prisma.task.updateMany({
+      where: { monthlyGoalId: id },
+      data: { monthlyGoalId: null },
+    });
     return this.prisma.monthlyGoal.delete({ where: { id } });
   }
 }

--- a/services/kpi-service.ts
+++ b/services/kpi-service.ts
@@ -129,6 +129,14 @@ export class KPIService {
     });
   }
 
+  async deleteKPI(id: string) {
+    const existing = await this.prisma.kPI.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundError(`KPI not found: ${id}`);
+
+    await this.prisma.kPITaskLink.deleteMany({ where: { kpiId: id } });
+    return this.prisma.kPI.delete({ where: { id } });
+  }
+
   async calculateAchievement(kpiId: string) {
     const kpi = await this.prisma.kPI.findUnique({
       where: { id: kpiId },


### PR DESCRIPTION
## Summary

- 新增 `KPIService.deleteKPI`：先刪除所有 `kPITaskLink`，再刪除 KPI 本體
- 新增 `PlanService.deletePlan`：刪除計畫（DB cascade 處理子資源）
- 新增 `GoalService.deleteGoal`：先將孤立 tasks 的 `monthlyGoalId` 設為 null，再刪除目標
- 新增 DELETE routes：`/api/kpi/[id]`、`/api/plans/[id]`、`/api/goals/[id]`，全部加 `withManager` 保護

## TDD 流程

先撰寫 `services/__tests__/delete-operations.test.ts`（6 個測試），確認紅燈後實作，最終 22 個測試全數通過。

## Test plan

- [x] `KPIService.deleteKPI` — 刪除 KPI 及 task links
- [x] `KPIService.deleteKPI` — invalid id 拋出 NotFoundError
- [x] `PlanService.deletePlan` — 刪除計畫並 cascade goals
- [x] `PlanService.deletePlan` — invalid id 拋出 NotFoundError
- [x] `GoalService.deleteGoal` — 刪除目標並 reassign 孤立 tasks
- [x] `GoalService.deleteGoal` — invalid id 拋出 NotFoundError

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)