### PR TITLE
feat(#86): Deliverable GET endpoints with TDD

### DIFF
--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -4,6 +4,20 @@ import { getServerSession } from "next-auth";
 import { UnauthorizedError } from "@/services/errors";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { DeliverableService } from "@/services/deliverable-service";
+
+export const GET = apiHandler(async (
+  req: NextRequest,
+  context?: { params: Promise<Record<string, string>> }
+) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { id } = await context!.params;
+  const service = new DeliverableService(prisma);
+  const deliverable = await service.getDeliverable(id);
+  return success(deliverable);
+});
 
 export const PATCH = apiHandler(async (
   req: NextRequest,

--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -4,29 +4,44 @@ import { getServerSession } from "next-auth";
 import { UnauthorizedError, ValidationError } from "@/services/errors";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { DeliverableService } from "@/services/deliverable-service";
+import { listDeliverablesSchema, createDeliverableSchema } from "@/validators/deliverable-validators";
+
+export const GET = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const { searchParams } = new URL(req.url);
+  const query = listDeliverablesSchema.safeParse({
+    taskId: searchParams.get("taskId") ?? undefined,
+    kpiId: searchParams.get("kpiId") ?? undefined,
+    annualPlanId: searchParams.get("annualPlanId") ?? undefined,
+    monthlyGoalId: searchParams.get("monthlyGoalId") ?? undefined,
+    status: searchParams.get("status") ?? undefined,
+    type: searchParams.get("type") ?? undefined,
+  });
+
+  if (!query.success) {
+    throw new ValidationError(query.error.errors.map((e) => e.message).join(", "));
+  }
+
+  const service = new DeliverableService(prisma);
+  const deliverables = await service.listDeliverables(query.data);
+  return success(deliverables);
+});
 
 export const POST = apiHandler(async (req: NextRequest) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
   const body = await req.json();
-  const { title, type, taskId, kpiId, annualPlanId, monthlyGoalId, attachmentUrl } = body;
+  const parsed = createDeliverableSchema.safeParse(body);
 
-  if (!title || !type) {
-    throw new ValidationError("標題和類型為必填");
+  if (!parsed.success) {
+    throw new ValidationError(parsed.error.errors.map((e) => e.message).join(", "));
   }
 
-  const deliverable = await prisma.deliverable.create({
-    data: {
-      title,
-      type,
-      taskId: taskId || null,
-      kpiId: kpiId || null,
-      annualPlanId: annualPlanId || null,
-      monthlyGoalId: monthlyGoalId || null,
-      attachmentUrl: attachmentUrl || null,
-    },
-  });
-
+  const service = new DeliverableService(prisma);
+  const deliverable = await service.createDeliverable(parsed.data);
   return success(deliverable, 201);
 });

--- a/services/__tests__/deliverable-service.test.ts
+++ b/services/__tests__/deliverable-service.test.ts
@@ -1,0 +1,137 @@
+import { DeliverableService } from "../deliverable-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { NotFoundError, ValidationError } from "../errors";
+
+describe("DeliverableService", () => {
+  let service: DeliverableService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new DeliverableService(prisma as never);
+  });
+
+  test("listDeliverables returns all for a task", async () => {
+    const mockDeliverables = [
+      { id: "d-1", title: "Doc A", type: "DOCUMENT", taskId: "task-1" },
+      { id: "d-2", title: "Report B", type: "REPORT", taskId: "task-1" },
+    ];
+    (prisma.deliverable.findMany as jest.Mock).mockResolvedValue(mockDeliverables);
+
+    const result = await service.listDeliverables({ taskId: "task-1" });
+
+    expect(prisma.deliverable.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ taskId: "task-1" }),
+      })
+    );
+    expect(result).toEqual(mockDeliverables);
+  });
+
+  test("listDeliverables filters by status", async () => {
+    (prisma.deliverable.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.listDeliverables({ status: "IN_PROGRESS" });
+
+    expect(prisma.deliverable.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "IN_PROGRESS" }),
+      })
+    );
+  });
+
+  test("listDeliverables filters by type", async () => {
+    (prisma.deliverable.findMany as jest.Mock).mockResolvedValue([]);
+
+    await service.listDeliverables({ type: "DOCUMENT" });
+
+    expect(prisma.deliverable.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ type: "DOCUMENT" }),
+      })
+    );
+  });
+
+  test("getDeliverable returns by id", async () => {
+    const mockDeliverable = {
+      id: "d-1",
+      title: "Doc A",
+      type: "DOCUMENT",
+      status: "NOT_STARTED",
+      taskId: "task-1",
+    };
+    (prisma.deliverable.findUnique as jest.Mock).mockResolvedValue(mockDeliverable);
+
+    const result = await service.getDeliverable("d-1");
+
+    expect(prisma.deliverable.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "d-1" } })
+    );
+    expect(result).toEqual(mockDeliverable);
+  });
+
+  test("getDeliverable throws NotFoundError", async () => {
+    (prisma.deliverable.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.getDeliverable("nonexistent")).rejects.toThrow(NotFoundError);
+  });
+
+  test("createDeliverable with required fields", async () => {
+    const mockDeliverable = {
+      id: "d-new",
+      title: "New Doc",
+      type: "DOCUMENT",
+      status: "NOT_STARTED",
+    };
+    (prisma.deliverable.create as jest.Mock).mockResolvedValue(mockDeliverable);
+
+    const result = await service.createDeliverable({ title: "New Doc", type: "DOCUMENT" });
+
+    expect(prisma.deliverable.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ title: "New Doc", type: "DOCUMENT" }),
+      })
+    );
+    expect(result).toEqual(mockDeliverable);
+  });
+
+  test("createDeliverable throws ValidationError when title is missing", async () => {
+    await expect(
+      service.createDeliverable({ title: "", type: "DOCUMENT" })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("updateDeliverable changes status", async () => {
+    const existing = { id: "d-1", title: "Doc A", status: "NOT_STARTED" };
+    const updated = { id: "d-1", title: "Doc A", status: "IN_PROGRESS" };
+    (prisma.deliverable.findUnique as jest.Mock).mockResolvedValue(existing);
+    (prisma.deliverable.update as jest.Mock).mockResolvedValue(updated);
+
+    const result = await service.updateDeliverable("d-1", { status: "IN_PROGRESS" });
+
+    expect(prisma.deliverable.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "d-1" },
+        data: expect.objectContaining({ status: "IN_PROGRESS" }),
+      })
+    );
+    expect(result).toEqual(updated);
+  });
+
+  test("deleteDeliverable removes", async () => {
+    (prisma.deliverable.findUnique as jest.Mock).mockResolvedValue({ id: "d-1" });
+    (prisma.deliverable.delete as jest.Mock).mockResolvedValue({ id: "d-1" });
+
+    await service.deleteDeliverable("d-1");
+
+    expect(prisma.deliverable.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "d-1" } })
+    );
+  });
+
+  test("deleteDeliverable throws NotFoundError when not found", async () => {
+    (prisma.deliverable.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.deleteDeliverable("nonexistent")).rejects.toThrow(NotFoundError);
+  });
+});

--- a/services/deliverable-service.ts
+++ b/services/deliverable-service.ts
@@ -1,0 +1,119 @@
+import { PrismaClient, DeliverableStatus, DeliverableType } from "@prisma/client";
+import { NotFoundError, ValidationError } from "./errors";
+
+export interface ListDeliverablesFilter {
+  taskId?: string;
+  kpiId?: string;
+  annualPlanId?: string;
+  monthlyGoalId?: string;
+  status?: DeliverableStatus | string;
+  type?: DeliverableType | string;
+}
+
+export interface CreateDeliverableInput {
+  title: string;
+  type: string;
+  taskId?: string | null;
+  kpiId?: string | null;
+  annualPlanId?: string | null;
+  monthlyGoalId?: string | null;
+  attachmentUrl?: string | null;
+}
+
+export interface UpdateDeliverableInput {
+  title?: string;
+  status?: string;
+  attachmentUrl?: string | null;
+  acceptedBy?: string | null;
+  acceptedAt?: Date | string | null;
+}
+
+export class DeliverableService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listDeliverables(filter: ListDeliverablesFilter) {
+    const where: Record<string, unknown> = {};
+
+    if (filter.taskId) where.taskId = filter.taskId;
+    if (filter.kpiId) where.kpiId = filter.kpiId;
+    if (filter.annualPlanId) where.annualPlanId = filter.annualPlanId;
+    if (filter.monthlyGoalId) where.monthlyGoalId = filter.monthlyGoalId;
+    if (filter.status) where.status = filter.status;
+    if (filter.type) where.type = filter.type;
+
+    return this.prisma.deliverable.findMany({
+      where,
+      include: {
+        task: { select: { id: true, title: true } },
+        kpi: { select: { id: true, code: true, title: true } },
+        annualPlan: { select: { id: true, title: true, year: true } },
+        monthlyGoal: { select: { id: true, title: true, month: true } },
+        acceptor: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async getDeliverable(id: string) {
+    const deliverable = await this.prisma.deliverable.findUnique({
+      where: { id },
+      include: {
+        task: { select: { id: true, title: true } },
+        kpi: { select: { id: true, code: true, title: true } },
+        annualPlan: { select: { id: true, title: true, year: true } },
+        monthlyGoal: { select: { id: true, title: true, month: true } },
+        acceptor: { select: { id: true, name: true, avatar: true } },
+      },
+    });
+
+    if (!deliverable) throw new NotFoundError(`Deliverable not found: ${id}`);
+    return deliverable;
+  }
+
+  async createDeliverable(input: CreateDeliverableInput) {
+    if (!input.title?.trim()) {
+      throw new ValidationError("標題為必填");
+    }
+    if (!input.type?.trim()) {
+      throw new ValidationError("類型為必填");
+    }
+
+    return this.prisma.deliverable.create({
+      data: {
+        title: input.title,
+        type: input.type as DeliverableType,
+        taskId: input.taskId ?? null,
+        kpiId: input.kpiId ?? null,
+        annualPlanId: input.annualPlanId ?? null,
+        monthlyGoalId: input.monthlyGoalId ?? null,
+        attachmentUrl: input.attachmentUrl ?? null,
+      },
+    });
+  }
+
+  async updateDeliverable(id: string, input: UpdateDeliverableInput) {
+    const existing = await this.prisma.deliverable.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundError(`Deliverable not found: ${id}`);
+
+    const updates: Record<string, unknown> = {};
+    if (input.title !== undefined) updates.title = input.title;
+    if (input.status !== undefined) updates.status = input.status;
+    if (input.attachmentUrl !== undefined) updates.attachmentUrl = input.attachmentUrl ?? null;
+    if (input.acceptedBy !== undefined) updates.acceptedBy = input.acceptedBy ?? null;
+    if (input.acceptedAt !== undefined) {
+      updates.acceptedAt = input.acceptedAt ? new Date(input.acceptedAt as string) : null;
+    }
+
+    return this.prisma.deliverable.update({
+      where: { id },
+      data: updates,
+    });
+  }
+
+  async deleteDeliverable(id: string) {
+    const existing = await this.prisma.deliverable.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundError(`Deliverable not found: ${id}`);
+
+    return this.prisma.deliverable.delete({ where: { id } });
+  }
+}

--- a/validators/deliverable-validators.ts
+++ b/validators/deliverable-validators.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+const DeliverableTypeEnum = z.enum([
+  "DOCUMENT",
+  "SYSTEM",
+  "REPORT",
+  "APPROVAL",
+]);
+
+const DeliverableStatusEnum = z.enum([
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "DELIVERED",
+  "ACCEPTED",
+]);
+
+export const createDeliverableSchema = z.object({
+  title: z.string().min(1),
+  type: DeliverableTypeEnum,
+  taskId: z.string().optional(),
+  kpiId: z.string().optional(),
+  annualPlanId: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  attachmentUrl: z.string().url().optional(),
+});
+
+export const updateDeliverableSchema = z.object({
+  title: z.string().min(1).optional(),
+  status: DeliverableStatusEnum.optional(),
+  attachmentUrl: z.string().url().nullable().optional(),
+  acceptedBy: z.string().nullable().optional(),
+  acceptedAt: z.string().datetime().nullable().optional(),
+});
+
+export const listDeliverablesSchema = z.object({
+  taskId: z.string().optional(),
+  kpiId: z.string().optional(),
+  annualPlanId: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  status: DeliverableStatusEnum.optional(),
+  type: DeliverableTypeEnum.optional(),
+});
+
+export type CreateDeliverableInput = z.infer<typeof createDeliverableSchema>;
+export type UpdateDeliverableInput = z.infer<typeof updateDeliverableSchema>;
+export type ListDeliverablesQuery = z.infer<typeof listDeliverablesSchema>;


### PR DESCRIPTION
## Summary

- Add `DeliverableService` with full CRUD (`listDeliverables`, `getDeliverable`, `createDeliverable`, `updateDeliverable`, `deleteDeliverable`)
- Add `validators/deliverable-validators.ts` with Zod schemas for list/create/update
- Add `GET /api/deliverables` — list with filters: `taskId`, `kpiId`, `annualPlanId`, `monthlyGoalId`, `status`, `type`
- Add `GET /api/deliverables/[id]` — detail with full relations

## TDD

Tests written first (`services/__tests__/deliverable-service.test.ts`), 10 tests covering:
- `listDeliverables` — returns all for a task, filters by status, filters by type
- `getDeliverable` — returns by id, throws `NotFoundError`
- `createDeliverable` — required fields, `ValidationError` on missing title
- `updateDeliverable` — changes status
- `deleteDeliverable` — removes, throws `NotFoundError` when not found

All 10 tests pass. Existing 246 tests unaffected.

## Test plan

- [ ] `GET /api/deliverables?taskId=<id>` returns deliverables for a task
- [ ] `GET /api/deliverables?status=IN_PROGRESS` filters by status
- [ ] `GET /api/deliverables?type=DOCUMENT` filters by type
- [ ] `GET /api/deliverables/<id>` returns detail with relations
- [ ] `GET /api/deliverables/<nonexistent>` returns 404
- [ ] Unauthenticated requests return 401

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)