### PR TITLE
feat(#87): annual plan template copy with TDD

### DIFF
--- a/app/api/plans/copy-template/route.ts
+++ b/app/api/plans/copy-template/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { PlanService } from "@/services/plan-service";
+import { validateBody } from "@/lib/validate";
+import { copyTemplateSchema } from "@/validators/plan-validators";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+
+const planService = new PlanService(prisma);
+
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireAuth();
+
+  const raw = await req.json();
+  const body = validateBody(copyTemplateSchema, {
+    ...raw,
+    targetYear: raw.targetYear ? parseInt(raw.targetYear) : raw.targetYear,
+  });
+
+  const plan = await planService.copyTemplate(
+    body.sourcePlanId,
+    body.targetYear,
+    session.user.id
+  );
+
+  return success(plan, 201);
+});

--- a/services/__tests__/plan-template.test.ts
+++ b/services/__tests__/plan-template.test.ts
@@ -1,0 +1,173 @@
+import { PlanService } from "../plan-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { NotFoundError } from "../errors";
+
+describe("PlanService.copyTemplate", () => {
+  let service: PlanService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  const sourcePlan = {
+    id: "plan-2025",
+    year: 2025,
+    title: "2025年度計畫",
+    description: "2025 的描述",
+    implementationPlan: "執行計畫說明",
+    progressPct: 85,
+    copiedFromYear: null,
+    createdBy: "user-1",
+    createdAt: new Date("2025-01-01"),
+    updatedAt: new Date("2025-12-31"),
+    monthlyGoals: [
+      {
+        id: "goal-1",
+        annualPlanId: "plan-2025",
+        month: 1,
+        title: "Q1 目標",
+        description: "一月份目標說明",
+        status: "COMPLETED",
+        progressPct: 100,
+        tasks: [
+          { id: "task-1", title: "Task A", status: "DONE" },
+          { id: "task-2", title: "Task B", status: "DONE" },
+        ],
+      },
+      {
+        id: "goal-2",
+        annualPlanId: "plan-2025",
+        month: 6,
+        title: "Q2 目標",
+        description: null,
+        status: "IN_PROGRESS",
+        progressPct: 50,
+        tasks: [],
+      },
+    ],
+    milestones: [
+      {
+        id: "ms-1",
+        annualPlanId: "plan-2025",
+        title: "里程碑一",
+        description: "里程碑說明",
+        plannedStart: new Date("2025-03-01"),
+        plannedEnd: new Date("2025-06-30"),
+        actualStart: new Date("2025-03-05"),
+        actualEnd: new Date("2025-06-25"),
+        status: "COMPLETED",
+        order: 0,
+      },
+      {
+        id: "ms-2",
+        annualPlanId: "plan-2025",
+        title: "里程碑二",
+        description: null,
+        plannedStart: null,
+        plannedEnd: new Date("2025-12-31"),
+        actualStart: null,
+        actualEnd: null,
+        status: "PENDING",
+        order: 1,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new PlanService(prisma as never);
+  });
+
+  test("copies plan structure from previous year", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(sourcePlan);
+    const newPlan = { id: "plan-2026", year: 2026, title: "2025年度計畫", monthlyGoals: [], milestones: [] };
+    (prisma.annualPlan.create as jest.Mock).mockResolvedValue(newPlan);
+
+    const result = await service.copyTemplate("plan-2025", 2026, "user-2");
+
+    expect(prisma.annualPlan.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "plan-2025" } })
+    );
+    expect(prisma.annualPlan.create).toHaveBeenCalled();
+    expect(result).toEqual(newPlan);
+  });
+
+  test("copies monthly goals without tasks", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(sourcePlan);
+    (prisma.annualPlan.create as jest.Mock).mockResolvedValue({ id: "plan-2026", year: 2026 });
+
+    await service.copyTemplate("plan-2025", 2026, "user-2");
+
+    const createCall = (prisma.annualPlan.create as jest.Mock).mock.calls[0][0];
+    const goalsCreate = createCall.data.monthlyGoals.create;
+
+    // Goals should be copied
+    expect(goalsCreate).toHaveLength(2);
+    expect(goalsCreate[0]).toMatchObject({ month: 1, title: "Q1 目標", description: "一月份目標說明" });
+    expect(goalsCreate[1]).toMatchObject({ month: 6, title: "Q2 目標" });
+
+    // Tasks must NOT be included
+    expect(goalsCreate[0].tasks).toBeUndefined();
+    expect(goalsCreate[1].tasks).toBeUndefined();
+  });
+
+  test("copies milestones with reset dates", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(sourcePlan);
+    (prisma.annualPlan.create as jest.Mock).mockResolvedValue({ id: "plan-2026", year: 2026 });
+
+    await service.copyTemplate("plan-2025", 2026, "user-2");
+
+    const createCall = (prisma.annualPlan.create as jest.Mock).mock.calls[0][0];
+    const milestonesCreate = createCall.data.milestones.create;
+
+    expect(milestonesCreate).toHaveLength(2);
+    expect(milestonesCreate[0]).toMatchObject({ title: "里程碑一", order: 0 });
+    expect(milestonesCreate[1]).toMatchObject({ title: "里程碑二", order: 1 });
+
+    // Actual dates must be reset (null)
+    expect(milestonesCreate[0].actualStart).toBeNull();
+    expect(milestonesCreate[0].actualEnd).toBeNull();
+    expect(milestonesCreate[1].actualStart).toBeNull();
+    expect(milestonesCreate[1].actualEnd).toBeNull();
+  });
+
+  test("sets new year on copied plan", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(sourcePlan);
+    (prisma.annualPlan.create as jest.Mock).mockResolvedValue({ id: "plan-2026", year: 2026 });
+
+    await service.copyTemplate("plan-2025", 2026, "user-2");
+
+    const createCall = (prisma.annualPlan.create as jest.Mock).mock.calls[0][0];
+    expect(createCall.data.year).toBe(2026);
+    expect(createCall.data.copiedFromYear).toBe(2025);
+    expect(createCall.data.createdBy).toBe("user-2");
+  });
+
+  test("does not copy actual progress data", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(sourcePlan);
+    (prisma.annualPlan.create as jest.Mock).mockResolvedValue({ id: "plan-2026", year: 2026 });
+
+    await service.copyTemplate("plan-2025", 2026, "user-2");
+
+    const createCall = (prisma.annualPlan.create as jest.Mock).mock.calls[0][0];
+
+    // Plan-level progress must reset
+    expect(createCall.data.progressPct).toBeUndefined();
+
+    // Monthly goals: status resets to NOT_STARTED, progressPct resets to 0
+    const goalsCreate = createCall.data.monthlyGoals.create;
+    goalsCreate.forEach((g: { status: string; progressPct: number }) => {
+      expect(g.status).toBe("NOT_STARTED");
+      expect(g.progressPct).toBe(0);
+    });
+
+    // Milestones: status resets to PENDING
+    const milestonesCreate = createCall.data.milestones.create;
+    milestonesCreate.forEach((m: { status: string }) => {
+      expect(m.status).toBe("PENDING");
+    });
+  });
+
+  test("throws NotFoundError if source plan not found", async () => {
+    (prisma.annualPlan.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.copyTemplate("nonexistent", 2026, "user-2")).rejects.toThrow(NotFoundError);
+  });
+});

--- a/services/plan-service.ts
+++ b/services/plan-service.ts
@@ -129,4 +129,60 @@ export class PlanService {
 
     return this.prisma.annualPlan.delete({ where: { id } });
   }
+
+  async copyTemplate(sourcePlanId: string, targetYear: number, createdBy: string) {
+    const source = await this.prisma.annualPlan.findUnique({
+      where: { id: sourcePlanId },
+      include: {
+        monthlyGoals: {
+          orderBy: { month: "asc" },
+        },
+        milestones: {
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+
+    if (!source) throw new NotFoundError(`Plan not found: ${sourcePlanId}`);
+
+    return this.prisma.annualPlan.create({
+      data: {
+        year: targetYear,
+        title: source.title,
+        description: source.description ?? null,
+        implementationPlan: source.implementationPlan ?? null,
+        copiedFromYear: source.year,
+        createdBy,
+        monthlyGoals: source.monthlyGoals.length
+          ? {
+              create: source.monthlyGoals.map((g) => ({
+                month: g.month,
+                title: g.title,
+                description: g.description ?? null,
+                status: "NOT_STARTED" as const,
+                progressPct: 0,
+              })),
+            }
+          : undefined,
+        milestones: source.milestones.length
+          ? {
+              create: source.milestones.map((m) => ({
+                title: m.title,
+                description: m.description ?? null,
+                plannedStart: m.plannedStart ?? null,
+                plannedEnd: m.plannedEnd,
+                actualStart: null,
+                actualEnd: null,
+                status: "PENDING" as const,
+                order: m.order,
+              })),
+            }
+          : undefined,
+      },
+      include: {
+        monthlyGoals: true,
+        milestones: true,
+      },
+    });
+  }
 }

--- a/validators/plan-validators.ts
+++ b/validators/plan-validators.ts
@@ -36,7 +36,13 @@ export const updateGoalSchema = z.object({
   progressPct: z.number().min(0).max(100).optional(),
 });
 
+export const copyTemplateSchema = z.object({
+  sourcePlanId: z.string().min(1),
+  targetYear: z.number().int().min(2000).max(2100),
+});
+
 export type CreatePlanInput = z.infer<typeof createPlanSchema>;
 export type UpdatePlanInput = z.infer<typeof updatePlanSchema>;
 export type CreateGoalInput = z.infer<typeof createGoalSchema>;
 export type UpdateGoalInput = z.infer<typeof updateGoalSchema>;
+export type CopyTemplateInput = z.infer<typeof copyTemplateSchema>;


### PR DESCRIPTION
## Summary

- TDD: 先寫 6 個測試（全 Red），再實作至全 Green
- 新增 `PlanService.copyTemplate(sourcePlanId, targetYear, createdBy)` — 複製年度計畫結構（月度目標、里程碑），不複製任務與實際進度
- 新增 `POST /api/plans/copy-template` 路由，含 Zod 輸入驗證
- 新增 `copyTemplateSchema` validator

## Test plan

- [x] `copies plan structure from previous year` — 確認 findUnique + create 被呼叫
- [x] `copies monthly goals without tasks` — goals 複製，tasks 不複製
- [x] `copies milestones with reset dates` — actualStart/actualEnd 重置為 null
- [x] `sets new year on copied plan` — year、copiedFromYear、createdBy 正確寫入
- [x] `does not copy actual progress data` — progressPct/status 全部重置
- [x] `throws NotFoundError if source plan not found` — 來源不存在時拋出錯誤
- [x] 所有 service tests 通過（84/84）

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)