### PR TITLE
feat(#89): PDF/Excel export reports with TDD

### DIFF
--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -1,0 +1,225 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { ExportService } from "@/services/export-service";
+
+const exportService = new ExportService();
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const { searchParams } = new URL(req.url);
+
+  const type = searchParams.get("type") ?? "weekly";   // weekly | monthly | kpi | workload
+  const format = searchParams.get("format") ?? "xlsx"; // xlsx | pdf
+
+  const isManager = session.user.role === "MANAGER";
+
+  let result;
+
+  // ── weekly ───────────────────────────────────────────────────────────────
+  if (type === "weekly") {
+    const dateParam = searchParams.get("date");
+    const refDate = dateParam ? new Date(dateParam) : new Date();
+    const day = refDate.getDay();
+    const diffToMon = day === 0 ? -6 : 1 - day;
+    const weekStart = new Date(refDate);
+    weekStart.setDate(refDate.getDate() + diffToMon);
+    weekStart.setHours(0, 0, 0, 0);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setDate(weekStart.getDate() + 6);
+    weekEnd.setHours(23, 59, 59, 999);
+
+    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+
+    const completedTasks = await prisma.task.findMany({
+      where: { ...userFilter, status: "DONE", updatedAt: { gte: weekStart, lte: weekEnd } },
+      include: { primaryAssignee: { select: { id: true, name: true } } },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const timeEntryFilter = isManager
+      ? { date: { gte: weekStart, lte: weekEnd } }
+      : { userId: session.user.id, date: { gte: weekStart, lte: weekEnd } };
+
+    const timeEntries = await prisma.timeEntry.findMany({ where: timeEntryFilter });
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const hoursByCategory = timeEntries.reduce((acc, e) => {
+      acc[e.category] = (acc[e.category] ?? 0) + e.hours;
+      return acc;
+    }, {} as Record<string, number>);
+
+    result = exportService.exportWeeklyReport({
+      weekStart: weekStart.toISOString().split("T")[0],
+      weekEnd: weekEnd.toISOString().split("T")[0],
+      completedTasks,
+      totalHours,
+      hoursByCategory,
+    });
+
+  // ── monthly ──────────────────────────────────────────────────────────────
+  } else if (type === "monthly") {
+    const monthParam = searchParams.get("month");
+    const now = new Date();
+    const year = monthParam ? parseInt(monthParam.split("-")[0]) : now.getFullYear();
+    const month = monthParam ? parseInt(monthParam.split("-")[1]) : now.getMonth() + 1;
+
+    const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
+    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+    const userFilter = isManager ? {} : { primaryAssigneeId: session.user.id };
+
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...userFilter,
+        createdAt: { lte: monthEnd },
+        OR: [
+          { dueDate: { gte: monthStart, lte: monthEnd } },
+          { status: "DONE", updatedAt: { gte: monthStart, lte: monthEnd } },
+          { status: { notIn: ["DONE"] }, dueDate: null },
+        ],
+      },
+      select: { id: true, title: true, status: true, priority: true, dueDate: true },
+      orderBy: { updatedAt: "desc" },
+    });
+
+    const doneTasks = tasks.filter((t) => t.status === "DONE").length;
+    const completionRate = tasks.length > 0 ? Math.round((doneTasks / tasks.length) * 100) : 0;
+
+    result = exportService.exportMonthlyReport({
+      year,
+      month,
+      totalTasks: tasks.length,
+      doneTasks,
+      completionRate,
+      tasks,
+    });
+
+  // ── kpi ───────────────────────────────────────────────────────────────────
+  } else if (type === "kpi") {
+    const year = searchParams.get("year")
+      ? parseInt(searchParams.get("year")!)
+      : new Date().getFullYear();
+
+    const kpis = await prisma.kPI.findMany({
+      where: { year },
+      include: {
+        taskLinks: {
+          include: { task: { select: { id: true, status: true, progressPct: true } } },
+        },
+      },
+      orderBy: { code: "asc" },
+    });
+
+    const kpisWithAchievement = kpis.map((kpi) => {
+      let achievementRate = 0;
+      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+        const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
+        const weighted = kpi.taskLinks.reduce((sum, l) => {
+          const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
+          return sum + (prog * l.weight) / 100;
+        }, 0);
+        achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
+      } else {
+        achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+      }
+      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
+    });
+
+    const avgAchievement =
+      kpisWithAchievement.length > 0
+        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length
+        : 0;
+
+    result = exportService.exportKPIReport({
+      year,
+      avgAchievement: Math.round(avgAchievement * 10) / 10,
+      achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100).length,
+      totalCount: kpisWithAchievement.length,
+      kpis: kpisWithAchievement.map((k) => ({
+        id: k.id,
+        code: k.code,
+        title: k.title,
+        target: k.target,
+        actual: k.actual,
+        achievementRate: k.achievementRate,
+      })),
+    });
+
+  // ── workload ──────────────────────────────────────────────────────────────
+  } else {
+    const now = new Date();
+    const startParam = searchParams.get("startDate");
+    const endParam = searchParams.get("endDate");
+    const startDate = startParam
+      ? new Date(startParam)
+      : new Date(now.getFullYear(), now.getMonth(), 1);
+    const endDate = endParam
+      ? new Date(endParam)
+      : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+    const timeEntryFilter = isManager
+      ? { date: { gte: startDate, lte: endDate } }
+      : { userId: session.user.id, date: { gte: startDate, lte: endDate } };
+
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      include: { user: { select: { id: true, name: true } } },
+    });
+
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const plannedHours = timeEntries
+      .filter((e) => e.category === "PLANNED_TASK")
+      .reduce((sum, e) => sum + e.hours, 0);
+    const unplannedHours = timeEntries
+      .filter((e) => ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
+      .reduce((sum, e) => sum + e.hours, 0);
+
+    const byPersonMap = timeEntries.reduce((acc, e) => {
+      if (!acc[e.userId]) {
+        acc[e.userId] = { userId: e.userId, name: e.user.name, total: 0, planned: 0, unplanned: 0 };
+      }
+      acc[e.userId].total += e.hours;
+      if (e.category === "PLANNED_TASK") acc[e.userId].planned += e.hours;
+      if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
+        acc[e.userId].unplanned += e.hours;
+      return acc;
+    }, {} as Record<string, { userId: string; name: string; total: number; planned: number; unplanned: number }>);
+
+    result = exportService.exportWorkloadReport({
+      startDate: startDate.toISOString().split("T")[0],
+      endDate: endDate.toISOString().split("T")[0],
+      totalHours,
+      plannedHours,
+      unplannedHours,
+      byPerson: Object.values(byPersonMap),
+    });
+  }
+
+  // ── Render format ──────────────────────────────────────────────────────────
+  if (format === "pdf") {
+    const html = exportService.generatePDF(
+      result.rows as Record<string, unknown>[],
+      result.title,
+    );
+    return new NextResponse(html, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Disposition": `inline; filename="${type}-report.html"`,
+      },
+    });
+  }
+
+  // Default: xlsx
+  const buffer = exportService.generateExcel(
+    result.rows as Record<string, unknown>[],
+    result.columns,
+  );
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": `attachment; filename="${type}-report.xlsx"`,
+    },
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^2.6.0",
+        "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -4544,6 +4545,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5279,6 +5289,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5420,6 +5443,15 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
@@ -5503,6 +5535,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/create-require": {
@@ -6798,6 +6842,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -11272,6 +11325,18 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -12602,6 +12667,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -12710,6 +12793,27 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.6.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/services/__tests__/export-service.test.ts
+++ b/services/__tests__/export-service.test.ts
@@ -1,0 +1,171 @@
+import { ExportService } from "../export-service";
+
+describe("ExportService", () => {
+  let service: ExportService;
+
+  beforeEach(() => {
+    service = new ExportService();
+  });
+
+  // ── generateExcel ─────────────────────────────────────────────────────────
+
+  test("generateExcel creates valid xlsx buffer", () => {
+    const data = [
+      { name: "Alice", hours: 8, tasks: 3 },
+      { name: "Bob", hours: 6, tasks: 2 },
+    ];
+    const columns = [
+      { header: "Name", key: "name" },
+      { header: "Hours", key: "hours" },
+      { header: "Tasks", key: "tasks" },
+    ];
+
+    const buffer = service.generateExcel(data, columns);
+
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(0);
+    // XLSX files start with PK (zip magic bytes)
+    expect(buffer[0]).toBe(0x50); // 'P'
+    expect(buffer[1]).toBe(0x4b); // 'K'
+  });
+
+  test("generateExcel includes all report columns", () => {
+    const XLSX = require("xlsx");
+    const data = [{ col1: "val1", col2: 42, col3: true }];
+    const columns = [
+      { header: "Column One", key: "col1" },
+      { header: "Column Two", key: "col2" },
+      { header: "Column Three", key: "col3" },
+    ];
+
+    const buffer = service.generateExcel(data, columns);
+    const workbook = XLSX.read(buffer, { type: "buffer" });
+    const sheetName = workbook.SheetNames[0];
+    const sheet = workbook.Sheets[sheetName];
+    const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 }) as unknown[][];
+
+    // First row should be headers
+    expect(rows[0]).toEqual(["Column One", "Column Two", "Column Three"]);
+    // Second row should be data
+    expect(rows[1][0]).toBe("val1");
+    expect(rows[1][1]).toBe(42);
+  });
+
+  // ── generatePDF ───────────────────────────────────────────────────────────
+
+  test("generatePDF creates valid HTML string", () => {
+    const data = [
+      { name: "Alice", hours: 8 },
+      { name: "Bob", hours: 6 },
+    ];
+    const template = "Weekly Report";
+
+    const html = service.generatePDF(data, template);
+
+    expect(typeof html).toBe("string");
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("<html");
+    expect(html).toContain("</html>");
+    expect(html).toContain(template);
+    expect(html).toContain("@media print");
+  });
+
+  // ── exportWeeklyReport ────────────────────────────────────────────────────
+
+  test("exportWeeklyReport returns formatted data", () => {
+    const input = {
+      weekStart: "2026-03-16",
+      weekEnd: "2026-03-22",
+      completedTasks: [
+        { id: "t-1", title: "Task One", primaryAssignee: { name: "Alice" }, updatedAt: new Date("2026-03-17") },
+      ],
+      totalHours: 32,
+      hoursByCategory: { PLANNED_TASK: 24, ADDED_TASK: 8 },
+    };
+
+    const result = service.exportWeeklyReport(input);
+
+    expect(result).toHaveProperty("title");
+    expect(result).toHaveProperty("rows");
+    expect(result).toHaveProperty("columns");
+    expect(Array.isArray(result.rows)).toBe(true);
+    expect(Array.isArray(result.columns)).toBe(true);
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0]).toHaveProperty("title", "Task One");
+  });
+
+  // ── exportMonthlyReport ───────────────────────────────────────────────────
+
+  test("exportMonthlyReport returns formatted data", () => {
+    const input = {
+      year: 2026,
+      month: 3,
+      totalTasks: 20,
+      doneTasks: 15,
+      completionRate: 75,
+      tasks: [
+        { id: "t-1", title: "Monthly Task", status: "DONE", priority: "HIGH", dueDate: new Date("2026-03-20") },
+      ],
+    };
+
+    const result = service.exportMonthlyReport(input);
+
+    expect(result).toHaveProperty("title");
+    expect(result).toHaveProperty("rows");
+    expect(result).toHaveProperty("columns");
+    expect(result.rows.length).toBe(1);
+    expect(result.rows[0]).toHaveProperty("title", "Monthly Task");
+    expect(result.rows[0]).toHaveProperty("status", "DONE");
+  });
+
+  // ── exportKPIReport ───────────────────────────────────────────────────────
+
+  test("exportKPIReport returns formatted data", () => {
+    const input = {
+      year: 2026,
+      avgAchievement: 82.5,
+      achievedCount: 3,
+      totalCount: 4,
+      kpis: [
+        { id: "kpi-1", code: "KPI-2026-01", title: "Revenue", target: 100, actual: 85, achievementRate: 85 },
+        { id: "kpi-2", code: "KPI-2026-02", title: "Satisfaction", target: 95, actual: 96, achievementRate: 100 },
+      ],
+    };
+
+    const result = service.exportKPIReport(input);
+
+    expect(result).toHaveProperty("title");
+    expect(result).toHaveProperty("rows");
+    expect(result).toHaveProperty("columns");
+    expect(result.rows.length).toBe(2);
+    expect(result.rows[0]).toHaveProperty("code", "KPI-2026-01");
+    expect(result.rows[0]).toHaveProperty("achievementRate", 85);
+  });
+
+  // ── exportWorkloadReport ──────────────────────────────────────────────────
+
+  test("exportWorkloadReport returns formatted data", () => {
+    const input = {
+      startDate: "2026-03-01",
+      endDate: "2026-03-31",
+      totalHours: 160,
+      plannedHours: 120,
+      unplannedHours: 40,
+      byPerson: [
+        { userId: "u-1", name: "Alice", total: 80, planned: 60, unplanned: 20 },
+        { userId: "u-2", name: "Bob", total: 80, planned: 60, unplanned: 20 },
+      ],
+    };
+
+    const result = service.exportWorkloadReport(input);
+
+    expect(result).toHaveProperty("title");
+    expect(result).toHaveProperty("rows");
+    expect(result).toHaveProperty("columns");
+    expect(result.rows.length).toBe(2);
+    expect(result.rows[0]).toHaveProperty("name", "Alice");
+    expect(result.rows[0]).toHaveProperty("total", 80);
+    expect(result.rows[0]).toHaveProperty("planned", 60);
+    expect(result.rows[0]).toHaveProperty("unplanned", 20);
+  });
+});

--- a/services/export-service.ts
+++ b/services/export-service.ts
@@ -1,0 +1,234 @@
+import * as XLSX from "xlsx";
+
+export interface ExportColumn {
+  header: string;
+  key: string;
+}
+
+export interface ExportResult {
+  title: string;
+  columns: ExportColumn[];
+  rows: Record<string, unknown>[];
+}
+
+export class ExportService {
+  /**
+   * Generates an XLSX buffer from an array of data objects and column definitions.
+   */
+  generateExcel(data: Record<string, unknown>[], columns: ExportColumn[]): Buffer {
+    const headerRow = columns.map((c) => c.header);
+    const dataRows = data.map((row) => columns.map((c) => row[c.key] ?? ""));
+
+    const worksheetData = [headerRow, ...dataRows];
+    const worksheet = XLSX.utils.aoa_to_sheet(worksheetData);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "Report");
+
+    const xlsxBuffer = XLSX.write(workbook, { type: "buffer", bookType: "xlsx" }) as Buffer;
+    return Buffer.from(xlsxBuffer);
+  }
+
+  /**
+   * Generates a printable HTML string from data and a template title.
+   * The returned HTML includes @media print styles so it can be saved/printed as PDF.
+   */
+  generatePDF(data: Record<string, unknown>[], template: string): string {
+    const keys = data.length > 0 ? Object.keys(data[0]) : [];
+
+    const headerCells = keys.map((k) => `<th>${escapeHtml(String(k))}</th>`).join("");
+    const bodyRows = data
+      .map((row) => {
+        const cells = keys.map((k) => `<td>${escapeHtml(String(row[k] ?? ""))}</td>`).join("");
+        return `<tr>${cells}</tr>`;
+      })
+      .join("\n");
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${escapeHtml(template)}</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; color: #333; }
+    h1 { font-size: 1.4rem; margin-bottom: 16px; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 8px 12px; text-align: left; font-size: 0.875rem; }
+    th { background: #f0f0f0; font-weight: 600; }
+    tr:nth-child(even) { background: #fafafa; }
+    @media print {
+      body { margin: 0; }
+      button, nav { display: none; }
+      table { page-break-inside: auto; }
+      tr { page-break-inside: avoid; page-break-after: auto; }
+    }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(template)}</h1>
+  <table>
+    <thead><tr>${headerCells}</tr></thead>
+    <tbody>
+${bodyRows}
+    </tbody>
+  </table>
+</body>
+</html>`;
+  }
+
+  // ── Report-specific formatters ─────────────────────────────────────────────
+
+  exportWeeklyReport(input: {
+    weekStart: string;
+    weekEnd: string;
+    completedTasks: Array<{
+      id: string;
+      title: string;
+      primaryAssignee?: { name: string } | null;
+      updatedAt: Date;
+    }>;
+    totalHours: number;
+    hoursByCategory: Record<string, number>;
+  }): ExportResult {
+    const columns: ExportColumn[] = [
+      { header: "Task ID", key: "id" },
+      { header: "Title", key: "title" },
+      { header: "Assignee", key: "assignee" },
+      { header: "Completed At", key: "completedAt" },
+    ];
+
+    const rows = input.completedTasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      assignee: t.primaryAssignee?.name ?? "",
+      completedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString().split("T")[0] : String(t.updatedAt),
+    }));
+
+    return {
+      title: `Weekly Report: ${input.weekStart} – ${input.weekEnd}`,
+      columns,
+      rows,
+    };
+  }
+
+  exportMonthlyReport(input: {
+    year: number;
+    month: number;
+    totalTasks: number;
+    doneTasks: number;
+    completionRate: number;
+    tasks: Array<{
+      id: string;
+      title: string;
+      status: string;
+      priority: string;
+      dueDate?: Date | null;
+    }>;
+  }): ExportResult {
+    const columns: ExportColumn[] = [
+      { header: "Task ID", key: "id" },
+      { header: "Title", key: "title" },
+      { header: "Status", key: "status" },
+      { header: "Priority", key: "priority" },
+      { header: "Due Date", key: "dueDate" },
+    ];
+
+    const rows = input.tasks.map((t) => ({
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      priority: t.priority,
+      dueDate: t.dueDate instanceof Date ? t.dueDate.toISOString().split("T")[0] : (t.dueDate ?? ""),
+    }));
+
+    const monthStr = String(input.month).padStart(2, "0");
+    return {
+      title: `Monthly Report: ${input.year}-${monthStr}`,
+      columns,
+      rows,
+    };
+  }
+
+  exportKPIReport(input: {
+    year: number;
+    avgAchievement: number;
+    achievedCount: number;
+    totalCount: number;
+    kpis: Array<{
+      id: string;
+      code: string;
+      title: string;
+      target: number;
+      actual: number;
+      achievementRate: number;
+    }>;
+  }): ExportResult {
+    const columns: ExportColumn[] = [
+      { header: "Code", key: "code" },
+      { header: "Title", key: "title" },
+      { header: "Target", key: "target" },
+      { header: "Actual", key: "actual" },
+      { header: "Achievement Rate (%)", key: "achievementRate" },
+    ];
+
+    const rows = input.kpis.map((k) => ({
+      code: k.code,
+      title: k.title,
+      target: k.target,
+      actual: k.actual,
+      achievementRate: k.achievementRate,
+    }));
+
+    return {
+      title: `KPI Report: ${input.year}`,
+      columns,
+      rows,
+    };
+  }
+
+  exportWorkloadReport(input: {
+    startDate: string;
+    endDate: string;
+    totalHours: number;
+    plannedHours: number;
+    unplannedHours: number;
+    byPerson: Array<{
+      userId: string;
+      name: string;
+      total: number;
+      planned: number;
+      unplanned: number;
+    }>;
+  }): ExportResult {
+    const columns: ExportColumn[] = [
+      { header: "Member", key: "name" },
+      { header: "Total Hours", key: "total" },
+      { header: "Planned Hours", key: "planned" },
+      { header: "Unplanned Hours", key: "unplanned" },
+    ];
+
+    const rows = input.byPerson.map((p) => ({
+      name: p.name,
+      total: p.total,
+      planned: p.planned,
+      unplanned: p.unplanned,
+    }));
+
+    return {
+      title: `Workload Report: ${input.startDate} – ${input.endDate}`,
+      columns,
+      rows,
+    };
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}


### PR DESCRIPTION
## Summary

- Adds `ExportService` with `generateExcel` (returns xlsx `Buffer` via the `xlsx` package) and `generatePDF` (returns printable HTML string with `@media print` styles)
- Adds four report formatters: `exportWeeklyReport`, `exportMonthlyReport`, `exportKPIReport`, `exportWorkloadReport`
- Adds `GET /api/reports/export?type=weekly|monthly|kpi|workload&format=xlsx|pdf` route — xlsx responds with `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, pdf responds with `text/html`

## TDD

Tests were written **before** implementation. All 7 tests pass:

- `generateExcel creates valid xlsx buffer`
- `generateExcel includes all report columns`
- `generatePDF creates valid HTML string`
- `exportWeeklyReport returns formatted data`
- `exportMonthlyReport returns formatted data`
- `exportKPIReport returns formatted data`
- `exportWorkloadReport returns formatted data`

## Test plan

- [ ] `npx jest services/__tests__/export-service.test.ts` — all 7 pass
- [ ] `GET /api/reports/export?type=weekly&format=xlsx` — downloads `.xlsx` file
- [ ] `GET /api/reports/export?type=kpi&format=pdf` — returns printable HTML page
- [ ] Verify `@media print` styles hide nav/buttons when printing

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>