### PR TITLE
feat(#91): dynamic permissions with TDD

### DIFF
--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,56 +1,77 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { UnauthorizedError, ForbiddenError, ValidationError } from "@/services/errors";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { PermissionService } from "@/services/permission-service";
+import { prisma } from "@/lib/prisma";
 
+const permissionService = new PermissionService(prisma);
+
+/** GET /api/permissions — list all permissions (MANAGER only) */
 export const GET = apiHandler(async (req: NextRequest) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
   if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-  const permissions = await prisma.permission.findMany({
-    include: {
-      grantee: { select: { id: true, name: true, email: true, role: true } },
-      granter: { select: { id: true, name: true } },
-    },
-    orderBy: { createdAt: "desc" },
+  const url = new URL(req.url);
+  const granteeId = url.searchParams.get("granteeId") ?? undefined;
+  const permType = url.searchParams.get("permType") ?? undefined;
+  const isActiveParam = url.searchParams.get("isActive");
+  const isActive =
+    isActiveParam === "true" ? true : isActiveParam === "false" ? false : undefined;
+
+  const permissions = await permissionService.listPermissions({
+    granteeId,
+    permType,
+    isActive,
   });
 
   return success(permissions);
 });
 
+/** POST /api/permissions — grant a permission (MANAGER only) */
 export const POST = apiHandler(async (req: NextRequest) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
   if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
   const body = await req.json();
-  const { granteeId, permType, targetId, expiresAt, revoke } = body;
+  const { granteeId, permType, targetId, expiresAt } = body;
 
   if (!granteeId || !permType) {
-    throw new ValidationError("缺少必填欄位");
+    throw new ValidationError("缺少必填欄位：granteeId, permType");
   }
 
-  if (revoke) {
-    await prisma.permission.updateMany({
-      where: { granteeId, permType, targetId: targetId || null },
-      data: { isActive: false },
-    });
-    return success({ message: "已撤銷授權" });
-  }
-
-  const permission = await prisma.permission.create({
-    data: {
-      granteeId,
-      granterId: session.user.id,
-      permType,
-      targetId: targetId || null,
-      expiresAt: expiresAt ? new Date(expiresAt) : null,
-      isActive: true,
-    },
+  const permission = await permissionService.grantPermission({
+    granteeId,
+    granterId: session.user.id,
+    permType,
+    targetId: targetId ?? null,
+    expiresAt: expiresAt ? new Date(expiresAt) : null,
   });
 
   return success(permission, 201);
+});
+
+/** DELETE /api/permissions — revoke a permission (MANAGER only) */
+export const DELETE = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+  if (session.user.role !== "MANAGER") throw new ForbiddenError();
+
+  const body = await req.json();
+  const { granteeId, permType, targetId } = body;
+
+  if (!granteeId || !permType) {
+    throw new ValidationError("缺少必填欄位：granteeId, permType");
+  }
+
+  await permissionService.revokePermission({
+    granteeId,
+    permType,
+    targetId: targetId ?? null,
+  });
+
+  return success({ message: "已撤銷授權" });
 });

--- a/services/__tests__/permission-service.test.ts
+++ b/services/__tests__/permission-service.test.ts
@@ -1,0 +1,121 @@
+import { PermissionService } from "../permission-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { ValidationError } from "../errors";
+
+describe("PermissionService", () => {
+  let service: PermissionService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new PermissionService(prisma as never);
+  });
+
+  test("grantPermission creates permission record", async () => {
+    const mockPermission = {
+      id: "perm-1",
+      granteeId: "user-1",
+      granterId: "manager-1",
+      permType: "VIEW_TEAM",
+      targetId: null,
+      expiresAt: null,
+      isActive: true,
+      createdAt: new Date(),
+    };
+    (prisma.permission.create as jest.Mock).mockResolvedValue(mockPermission);
+
+    const result = await service.grantPermission({
+      granteeId: "user-1",
+      granterId: "manager-1",
+      permType: "VIEW_TEAM",
+    });
+
+    expect(prisma.permission.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          granteeId: "user-1",
+          granterId: "manager-1",
+          permType: "VIEW_TEAM",
+          isActive: true,
+        }),
+      })
+    );
+    expect(result).toEqual(mockPermission);
+  });
+
+  test("revokePermission removes permission", async () => {
+    (prisma.permission.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    await service.revokePermission({ granteeId: "user-1", permType: "VIEW_TEAM" });
+
+    expect(prisma.permission.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          granteeId: "user-1",
+          permType: "VIEW_TEAM",
+        }),
+        data: { isActive: false },
+      })
+    );
+  });
+
+  test("listPermissions returns all for a user", async () => {
+    const mockPerms = [
+      { id: "perm-1", granteeId: "user-1", permType: "VIEW_TEAM", isActive: true },
+      { id: "perm-2", granteeId: "user-1", permType: "VIEW_TEAM", isActive: false },
+    ];
+    (prisma.permission.findMany as jest.Mock).mockResolvedValue(mockPerms);
+
+    const result = await service.listPermissions({ granteeId: "user-1" });
+
+    expect(prisma.permission.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ granteeId: "user-1" }),
+      })
+    );
+    expect(result).toEqual(mockPerms);
+  });
+
+  test("hasPermission returns true when granted", async () => {
+    const mockPerm = {
+      id: "perm-1",
+      granteeId: "user-1",
+      permType: "VIEW_TEAM",
+      isActive: true,
+      expiresAt: null,
+    };
+    (prisma.permission.findFirst as jest.Mock).mockResolvedValue(mockPerm);
+
+    const result = await service.hasPermission("user-1", "VIEW_TEAM");
+
+    expect(result).toBe(true);
+  });
+
+  test("hasPermission returns false when not granted", async () => {
+    (prisma.permission.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const result = await service.hasPermission("user-1", "VIEW_TEAM");
+
+    expect(result).toBe(false);
+  });
+
+  test("manager always has all permissions", async () => {
+    const mockUser = { id: "manager-1", role: "MANAGER" };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await service.hasPermissionForUser("manager-1", "VIEW_TEAM");
+
+    expect(prisma.permission.findFirst).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  test("grantPermission rejects invalid scope", async () => {
+    await expect(
+      service.grantPermission({
+        granteeId: "user-1",
+        granterId: "manager-1",
+        permType: "INVALID_SCOPE",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+});

--- a/services/permission-service.ts
+++ b/services/permission-service.ts
@@ -1,0 +1,121 @@
+import { PrismaClient } from "@prisma/client";
+import { ValidationError } from "./errors";
+
+export type PermissionScope = "VIEW_TEAM" | "VIEW_OWN";
+
+const VALID_SCOPES: PermissionScope[] = ["VIEW_TEAM", "VIEW_OWN"];
+
+export interface GrantPermissionInput {
+  granteeId: string;
+  granterId: string;
+  permType: string;
+  targetId?: string | null;
+  expiresAt?: Date | null;
+}
+
+export interface RevokePermissionInput {
+  granteeId: string;
+  permType: string;
+  targetId?: string | null;
+}
+
+export interface ListPermissionsFilter {
+  granteeId?: string;
+  granterId?: string;
+  permType?: string;
+  isActive?: boolean;
+}
+
+export class PermissionService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Grant a permission to a user.
+   * Throws ValidationError if permType is not a recognised scope.
+   */
+  async grantPermission(input: GrantPermissionInput) {
+    if (!VALID_SCOPES.includes(input.permType as PermissionScope)) {
+      throw new ValidationError(
+        `無效的 permType：${input.permType}，允許值：${VALID_SCOPES.join(", ")}`
+      );
+    }
+
+    return this.prisma.permission.create({
+      data: {
+        granteeId: input.granteeId,
+        granterId: input.granterId,
+        permType: input.permType,
+        targetId: input.targetId ?? null,
+        expiresAt: input.expiresAt ?? null,
+        isActive: true,
+      },
+    });
+  }
+
+  /**
+   * Revoke a permission by setting isActive = false.
+   */
+  async revokePermission(input: RevokePermissionInput) {
+    return this.prisma.permission.updateMany({
+      where: {
+        granteeId: input.granteeId,
+        permType: input.permType,
+        targetId: input.targetId ?? null,
+      },
+      data: { isActive: false },
+    });
+  }
+
+  /**
+   * List all permission records matching the given filter.
+   */
+  async listPermissions(filter: ListPermissionsFilter) {
+    const where: Record<string, unknown> = {};
+    if (filter.granteeId !== undefined) where.granteeId = filter.granteeId;
+    if (filter.granterId !== undefined) where.granterId = filter.granterId;
+    if (filter.permType !== undefined) where.permType = filter.permType;
+    if (filter.isActive !== undefined) where.isActive = filter.isActive;
+
+    return this.prisma.permission.findMany({
+      where,
+      include: {
+        grantee: { select: { id: true, name: true, email: true, role: true } },
+        granter: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  /**
+   * Check if a user has a given scope via an active, non-expired Permission row.
+   * Does NOT consider role — use hasPermissionForUser for role-aware checks.
+   */
+  async hasPermission(userId: string, scope: PermissionScope): Promise<boolean> {
+    const permission = await this.prisma.permission.findFirst({
+      where: {
+        granteeId: userId,
+        permType: scope,
+        isActive: true,
+        OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+      },
+    });
+    return permission !== null;
+  }
+
+  /**
+   * Role-aware permission check.
+   * MANAGER always returns true without hitting the Permission table.
+   * ENGINEER falls back to hasPermission.
+   */
+  async hasPermissionForUser(userId: string, scope: PermissionScope): Promise<boolean> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, role: true },
+    });
+
+    if (!user) return false;
+    if (user.role === "MANAGER") return true;
+
+    return this.hasPermission(userId, scope);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `PermissionService` class with `grantPermission`, `revokePermission`, `listPermissions`, `hasPermission`, and `hasPermissionForUser` methods
- TDD: 7 tests written first in `services/__tests__/permission-service.test.ts`, all passing
- Refactor `app/api/permissions/route.ts` to use the new service; add proper `DELETE` handler for revoke; add query-string filtering on `GET`
- MANAGER role short-circuits permission checks without hitting the DB

## Test plan

- [x] `services/__tests__/permission-service.test.ts` — 7 tests, all green
- [x] `grantPermission creates permission record`
- [x] `revokePermission removes permission`
- [x] `listPermissions returns all for a user`
- [x] `hasPermission returns true when granted`
- [x] `hasPermission returns false when not granted`
- [x] `manager always has all permissions`
- [x] `grantPermission rejects invalid scope`

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)