### PR TITLE
feat(#90): delay/change tracking with TDD

### DIFF
--- a/app/api/tasks/[id]/changes/route.ts
+++ b/app/api/tasks/[id]/changes/route.ts
@@ -4,6 +4,9 @@ import { getServerSession } from "next-auth";
 import { UnauthorizedError, ValidationError } from "@/services/errors";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { ChangeTrackingService } from "@/services/change-tracking-service";
+
+const changeTracker = new ChangeTrackingService(prisma);
 
 export const GET = apiHandler(async (
   req: NextRequest,
@@ -13,15 +16,11 @@ export const GET = apiHandler(async (
   if (!session?.user?.id) throw new UnauthorizedError();
 
   const { id } = await context!.params;
-  const changes = await prisma.taskChange.findMany({
-    where: { taskId: id },
-    include: {
-      changedByUser: { select: { id: true, name: true } },
-    },
-    orderBy: { changedAt: "desc" },
-  });
+  const changes = await changeTracker.getChangeHistory(id);
+  const delayCount = changes.filter((c) => c.changeType === "DELAY").length;
+  const scopeChangeCount = changes.filter((c) => c.changeType === "SCOPE_CHANGE").length;
 
-  return success(changes);
+  return success({ changes, delayCount, scopeChangeCount });
 });
 
 export const POST = apiHandler(async (

--- a/services/__tests__/change-tracking.test.ts
+++ b/services/__tests__/change-tracking.test.ts
@@ -1,0 +1,301 @@
+import { ChangeTrackingService } from "../change-tracking-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+describe("ChangeTrackingService", () => {
+  let service: ChangeTrackingService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  const mockUser = { id: "user-1", name: "Alice" };
+  const baseTask = {
+    id: "task-1",
+    title: "Original Title",
+    description: "Original description",
+    dueDate: new Date("2026-04-01"),
+    status: "TODO",
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ChangeTrackingService(prisma as never);
+  });
+
+  describe("detectDelay", () => {
+    test("detectDelay creates DELAY record when dueDate changes", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const mockChange = {
+        id: "change-1",
+        taskId: "task-1",
+        changeType: "DELAY",
+        reason: "Due date extended",
+        oldValue: oldDate.toISOString(),
+        newValue: newDate.toISOString(),
+        changedBy: "user-1",
+        changedAt: new Date(),
+      };
+
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue(mockChange);
+
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: oldDate,
+        newDueDate: newDate,
+        changedBy: "user-1",
+        reason: "Due date extended",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          taskId: "task-1",
+          changeType: "DELAY",
+          reason: "Due date extended",
+          oldValue: oldDate.toISOString(),
+          newValue: newDate.toISOString(),
+          changedBy: "user-1",
+        }),
+        include: expect.objectContaining({
+          changedByUser: expect.any(Object),
+        }),
+      });
+      expect(result).toEqual(mockChange);
+    });
+
+    test("no record created when dueDate does not change", async () => {
+      const sameDate = new Date("2026-04-01");
+
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: sameDate,
+        newDueDate: sameDate,
+        changedBy: "user-1",
+        reason: "No change",
+      });
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    test("no record created when new dueDate is earlier (not a delay)", async () => {
+      const oldDate = new Date("2026-04-15");
+      const newDate = new Date("2026-04-01"); // earlier — not a delay
+
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: oldDate,
+        newDueDate: newDate,
+        changedBy: "user-1",
+        reason: "Moved up",
+      });
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("detectScopeChange", () => {
+    test("detectScopeChange creates SCOPE_CHANGE when description changes", async () => {
+      const mockChange = {
+        id: "change-2",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        reason: "Scope updated",
+        oldValue: "Original description",
+        newValue: "Updated description with more details",
+        changedBy: "user-1",
+        changedAt: new Date(),
+      };
+
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue(mockChange);
+
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Same Title",
+        newTitle: "Same Title",
+        oldDescription: "Original description",
+        newDescription: "Updated description with more details",
+        changedBy: "user-1",
+        reason: "Scope updated",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          taskId: "task-1",
+          changeType: "SCOPE_CHANGE",
+          reason: "Scope updated",
+          changedBy: "user-1",
+        }),
+        include: expect.any(Object),
+      });
+      expect(result).toEqual(mockChange);
+    });
+
+    test("detectScopeChange creates SCOPE_CHANGE when title changes significantly", async () => {
+      const mockChange = {
+        id: "change-3",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        reason: "Title changed",
+        oldValue: "Build login page",
+        newValue: "Build authentication system with OAuth",
+        changedBy: "user-1",
+        changedAt: new Date(),
+      };
+
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue(mockChange);
+
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Build login page",
+        newTitle: "Build authentication system with OAuth",
+        oldDescription: "Same description",
+        newDescription: "Same description",
+        changedBy: "user-1",
+        reason: "Title changed",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          taskId: "task-1",
+          changeType: "SCOPE_CHANGE",
+          changedBy: "user-1",
+        }),
+        include: expect.any(Object),
+      });
+      expect(result).toEqual(mockChange);
+    });
+
+    test("no record created when status changes (not a delay/change)", async () => {
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Same Title",
+        newTitle: "Same Title",
+        oldDescription: "Same description",
+        newDescription: "Same description",
+        changedBy: "user-1",
+        reason: "Status updated",
+      });
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getChangeHistory", () => {
+    test("getChangeHistory returns all changes for a task", async () => {
+      const mockChanges = [
+        {
+          id: "change-1",
+          taskId: "task-1",
+          changeType: "DELAY",
+          reason: "Due date extended",
+          changedAt: new Date("2026-03-20"),
+          changedByUser: { id: "user-1", name: "Alice" },
+        },
+        {
+          id: "change-2",
+          taskId: "task-1",
+          changeType: "SCOPE_CHANGE",
+          reason: "Description changed",
+          changedAt: new Date("2026-03-22"),
+          changedByUser: { id: "user-1", name: "Alice" },
+        },
+      ];
+
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue(mockChanges);
+
+      const result = await service.getChangeHistory("task-1");
+
+      expect(prisma.taskChange.findMany).toHaveBeenCalledWith({
+        where: { taskId: "task-1" },
+        include: {
+          changedByUser: { select: { id: true, name: true } },
+        },
+        orderBy: { changedAt: "desc" },
+      });
+      expect(result).toEqual(mockChanges);
+      expect(result).toHaveLength(2);
+    });
+
+    test("getChangeHistory returns empty array when no changes", async () => {
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getChangeHistory("task-99");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getDelayCount", () => {
+    test("getDelayCount returns count for date range", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(5);
+
+      const start = new Date("2026-03-01");
+      const end = new Date("2026-03-31");
+
+      const result = await service.getDelayCount({ start, end });
+
+      expect(prisma.taskChange.count).toHaveBeenCalledWith({
+        where: {
+          changeType: "DELAY",
+          changedAt: { gte: start, lte: end },
+        },
+      });
+      expect(result).toBe(5);
+    });
+
+    test("getDelayCount filters by taskId when provided", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(2);
+
+      const start = new Date("2026-03-01");
+      const end = new Date("2026-03-31");
+
+      const result = await service.getDelayCount({ start, end, taskId: "task-1" });
+
+      expect(prisma.taskChange.count).toHaveBeenCalledWith({
+        where: {
+          changeType: "DELAY",
+          changedAt: { gte: start, lte: end },
+          taskId: "task-1",
+        },
+      });
+      expect(result).toBe(2);
+    });
+  });
+
+  describe("getChangeCount", () => {
+    test("getChangeCount returns count for date range", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(3);
+
+      const start = new Date("2026-03-01");
+      const end = new Date("2026-03-31");
+
+      const result = await service.getChangeCount({ start, end });
+
+      expect(prisma.taskChange.count).toHaveBeenCalledWith({
+        where: {
+          changeType: "SCOPE_CHANGE",
+          changedAt: { gte: start, lte: end },
+        },
+      });
+      expect(result).toBe(3);
+    });
+
+    test("getChangeCount filters by taskId when provided", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(1);
+
+      const start = new Date("2026-03-01");
+      const end = new Date("2026-03-31");
+
+      const result = await service.getChangeCount({ start, end, taskId: "task-1" });
+
+      expect(prisma.taskChange.count).toHaveBeenCalledWith({
+        where: {
+          changeType: "SCOPE_CHANGE",
+          changedAt: { gte: start, lte: end },
+          taskId: "task-1",
+        },
+      });
+      expect(result).toBe(1);
+    });
+  });
+});

--- a/services/change-tracking-service.ts
+++ b/services/change-tracking-service.ts
@@ -1,0 +1,141 @@
+import { PrismaClient } from "@prisma/client";
+
+export interface DetectDelayInput {
+  taskId: string;
+  oldDueDate: Date | null;
+  newDueDate: Date | null;
+  changedBy: string;
+  reason?: string;
+}
+
+export interface DetectScopeChangeInput {
+  taskId: string;
+  oldTitle: string;
+  newTitle: string;
+  oldDescription: string | null;
+  newDescription: string | null;
+  changedBy: string;
+  reason?: string;
+}
+
+export interface DateRangeFilter {
+  start: Date;
+  end: Date;
+  taskId?: string;
+}
+
+const TITLE_SIGNIFICANT_CHANGE_THRESHOLD = 0.4; // 40% difference ratio
+
+function isTitleSignificantlyChanged(oldTitle: string, newTitle: string): boolean {
+  if (oldTitle === newTitle) return false;
+  const maxLen = Math.max(oldTitle.length, newTitle.length);
+  if (maxLen === 0) return false;
+  // Use simple character-level difference heuristic
+  const minLen = Math.min(oldTitle.length, newTitle.length);
+  let commonChars = 0;
+  for (let i = 0; i < minLen; i++) {
+    if (oldTitle[i] === newTitle[i]) commonChars++;
+  }
+  const similarity = commonChars / maxLen;
+  return similarity < (1 - TITLE_SIGNIFICANT_CHANGE_THRESHOLD);
+}
+
+export class ChangeTrackingService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Detects if a dueDate change represents a delay (new date is later than old date).
+   * Creates a DELAY TaskChange record if so.
+   */
+  async detectDelay(input: DetectDelayInput) {
+    const { taskId, oldDueDate, newDueDate, changedBy, reason } = input;
+
+    // No change or not a delay (new date not later than old date)
+    if (!oldDueDate || !newDueDate) return null;
+    if (newDueDate.getTime() <= oldDueDate.getTime()) return null;
+
+    return this.prisma.taskChange.create({
+      data: {
+        taskId,
+        changeType: "DELAY",
+        reason: reason ?? "Due date extended",
+        oldValue: oldDueDate.toISOString(),
+        newValue: newDueDate.toISOString(),
+        changedBy,
+      },
+      include: {
+        changedByUser: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  /**
+   * Detects if a title or description change represents a scope change.
+   * Creates a SCOPE_CHANGE TaskChange record if so.
+   */
+  async detectScopeChange(input: DetectScopeChangeInput) {
+    const { taskId, oldTitle, newTitle, oldDescription, newDescription, changedBy, reason } = input;
+
+    const titleChanged = isTitleSignificantlyChanged(oldTitle ?? "", newTitle ?? "");
+    const descriptionChanged =
+      (oldDescription ?? "") !== (newDescription ?? "");
+
+    if (!titleChanged && !descriptionChanged) return null;
+
+    const oldValue = titleChanged ? oldTitle : (oldDescription ?? "");
+    const newValue = titleChanged ? newTitle : (newDescription ?? "");
+
+    return this.prisma.taskChange.create({
+      data: {
+        taskId,
+        changeType: "SCOPE_CHANGE",
+        reason: reason ?? "Scope changed",
+        oldValue,
+        newValue,
+        changedBy,
+      },
+      include: {
+        changedByUser: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  /**
+   * Returns all change history for a task, ordered by most recent first.
+   */
+  async getChangeHistory(taskId: string) {
+    return this.prisma.taskChange.findMany({
+      where: { taskId },
+      include: {
+        changedByUser: { select: { id: true, name: true } },
+      },
+      orderBy: { changedAt: "desc" },
+    });
+  }
+
+  /**
+   * Returns the count of DELAY records within a date range.
+   */
+  async getDelayCount(filter: DateRangeFilter): Promise<number> {
+    const where: Record<string, unknown> = {
+      changeType: "DELAY",
+      changedAt: { gte: filter.start, lte: filter.end },
+    };
+    if (filter.taskId) where.taskId = filter.taskId;
+
+    return this.prisma.taskChange.count({ where });
+  }
+
+  /**
+   * Returns the count of SCOPE_CHANGE records within a date range.
+   */
+  async getChangeCount(filter: DateRangeFilter): Promise<number> {
+    const where: Record<string, unknown> = {
+      changeType: "SCOPE_CHANGE",
+      changedAt: { gte: filter.start, lte: filter.end },
+    };
+    if (filter.taskId) where.taskId = filter.taskId;
+
+    return this.prisma.taskChange.count({ where });
+  }
+}

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { NotFoundError, ValidationError } from "./errors";
+import { ChangeTrackingService } from "./change-tracking-service";
 
 export interface ListTasksFilter {
   assignee?: string;
@@ -44,10 +45,15 @@ export interface UpdateTaskInput {
   addedSource?: string | null;
   progressPct?: number;
   changeReason?: string;
+  changedBy?: string;
 }
 
 export class TaskService {
-  constructor(private readonly prisma: PrismaClient) {}
+  private readonly changeTracker: ChangeTrackingService;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.changeTracker = new ChangeTrackingService(prisma);
+  }
 
   async listTasks(filter: ListTasksFilter) {
     const where: Record<string, unknown> = {};
@@ -179,6 +185,35 @@ export class TaskService {
         deliverables: true,
       },
     });
+
+    // Auto-detect delay/scope-change and record if changedBy is provided
+    if (input.changedBy) {
+      const reason = input.changeReason;
+
+      if (input.dueDate !== undefined) {
+        const oldDueDate = existing.dueDate ?? null;
+        const newDueDate = input.dueDate ? new Date(input.dueDate as string) : null;
+        await this.changeTracker.detectDelay({
+          taskId: id,
+          oldDueDate,
+          newDueDate,
+          changedBy: input.changedBy,
+          reason,
+        });
+      }
+
+      if (input.title !== undefined || input.description !== undefined) {
+        await this.changeTracker.detectScopeChange({
+          taskId: id,
+          oldTitle: existing.title,
+          newTitle: input.title ?? existing.title,
+          oldDescription: existing.description ?? null,
+          newDescription: input.description !== undefined ? (input.description ?? null) : (existing.description ?? null),
+          changedBy: input.changedBy,
+          reason,
+        });
+      }
+    }
 
     return task;
   }


### PR DESCRIPTION
## Summary

- Implements `ChangeTrackingService` with TDD (tests written first, all 12 pass)
- Auto-detects DELAY when `dueDate` is extended in `TaskService.updateTask`
- Auto-detects SCOPE_CHANGE when `title` or `description` changes significantly
- Updates `GET /api/tasks/[id]/changes` to return change history with `delayCount` and `scopeChangeCount` via `ChangeTrackingService`

## Test plan

- [x] `detectDelay` creates DELAY record when dueDate moves later
- [x] `detectDelay` skips when date is unchanged or moves earlier
- [x] `detectScopeChange` creates SCOPE_CHANGE when description changes
- [x] `detectScopeChange` creates SCOPE_CHANGE when title changes significantly
- [x] `detectScopeChange` skips when only status changes
- [x] `getChangeHistory` returns all changes ordered by most recent
- [x] `getDelayCount` returns count for date range (with optional taskId filter)
- [x] `getChangeCount` returns count for date range (with optional taskId filter)
- [x] All 15 service test suites pass (112 tests total)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)