### PR TITLE
feat(#92-#95): frontend quality polish — TITAN v1.1

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -2,9 +2,21 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
+import { Target } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 // ── Types ──────────────────────────────────────────────────────────────────
+
+interface KPIAchievement {
+  id: string;
+  code: string;
+  title: string;
+  target: number;
+  actual: number;
+  status: string;
+  achievementRate: number;
+}
 
 interface WorkloadPerson {
   userId: string;
@@ -35,6 +47,118 @@ interface Task {
   status: string;
   priority: string;
   dueDate: string | null;
+}
+
+// ── KPI Achievement Section ─────────────────────────────────────────────────
+
+const KPI_STATUS_COLOR: Record<string, string> = {
+  ON_TRACK: "text-green-400 bg-green-500/10",
+  AT_RISK:  "text-yellow-400 bg-yellow-500/10",
+  BEHIND:   "text-red-400 bg-red-500/10",
+  ACHIEVED: "text-blue-400 bg-blue-500/10",
+};
+const KPI_STATUS_LABEL: Record<string, string> = {
+  ON_TRACK: "進行中",
+  AT_RISK:  "風險",
+  BEHIND:   "落後",
+  ACHIEVED: "達成",
+};
+
+function KPIAchievementSection() {
+  const [kpis, setKpis] = useState<KPIAchievement[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchKPIs() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/kpi?year=${new Date().getFullYear()}`);
+      if (!res.ok) throw new Error("無法載入 KPI");
+      const data: Array<{
+        id: string; code: string; title: string; target: number; actual: number; status: string;
+        taskLinks: Array<{ weight: number; task: { status: string; progressPct: number } }>;
+        autoCalc: boolean;
+      }> = await res.json();
+      const mapped: KPIAchievement[] = (Array.isArray(data) ? data : []).map((k) => {
+        let rate = 0;
+        if (k.autoCalc && k.taskLinks.length > 0) {
+          const totalW = k.taskLinks.reduce((s, l) => s + l.weight, 0);
+          const weighted = k.taskLinks.reduce((s, l) => {
+            const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
+            return s + (prog * l.weight) / 100;
+          }, 0);
+          rate = totalW > 0 ? Math.min((weighted / totalW) * k.target, 100) : 0;
+        } else {
+          rate = k.target > 0 ? Math.min((k.actual / k.target) * 100, 100) : 0;
+        }
+        return { id: k.id, code: k.code, title: k.title, target: k.target, actual: k.actual, status: k.status, achievementRate: rate };
+      });
+      setKpis(mapped);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { fetchKPIs(); }, []);
+
+  if (loading) return <PageLoading message="載入 KPI..." className="py-8" />;
+  if (error) return <PageError message={error} onRetry={fetchKPIs} className="py-8" />;
+  if (kpis.length === 0) return (
+    <PageEmpty
+      icon={<Target className="h-8 w-8" />}
+      title="尚無 KPI"
+      description="本年度尚未建立 KPI 指標"
+      className="py-8"
+    />
+  );
+
+  return (
+    <div className="bg-card border border-border rounded-lg p-5">
+      <h2 className="text-sm font-medium mb-4 flex items-center gap-2">
+        <Target className="h-4 w-4 text-primary" />
+        KPI 達成狀況（{new Date().getFullYear()} 年度）
+      </h2>
+      <div className="space-y-3">
+        {kpis.map((kpi) => {
+          const barColor =
+            kpi.achievementRate >= 100 ? "bg-green-500" :
+            kpi.achievementRate >= 60  ? "bg-primary" :
+            kpi.achievementRate >= 30  ? "bg-yellow-500" : "bg-red-500";
+          return (
+            <div key={kpi.id} className="space-y-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-[10px] font-mono text-muted-foreground flex-shrink-0">{kpi.code}</span>
+                  <span className="text-sm text-foreground truncate">{kpi.title}</span>
+                  {kpi.status && (
+                    <span className={cn("text-[10px] px-1.5 py-0.5 rounded-full font-medium flex-shrink-0",
+                      KPI_STATUS_COLOR[kpi.status] ?? "text-muted-foreground bg-accent")}>
+                      {KPI_STATUS_LABEL[kpi.status] ?? kpi.status}
+                    </span>
+                  )}
+                </div>
+                <div className="text-right flex-shrink-0">
+                  <span className="text-sm font-semibold tabular-nums">{kpi.achievementRate.toFixed(0)}%</span>
+                  <span className="text-[10px] text-muted-foreground tabular-nums ml-1.5">
+                    {kpi.actual} / {kpi.target}
+                  </span>
+                </div>
+              </div>
+              <div className="h-1.5 w-full bg-accent rounded-full overflow-hidden">
+                <div
+                  className={cn("h-full rounded-full transition-all", barColor)}
+                  style={{ width: `${Math.min(kpi.achievementRate, 100)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 // ── Helper ─────────────────────────────────────────────────────────────────
@@ -78,30 +202,29 @@ function ManagerDashboard() {
   const [workload, setWorkload] = useState<WorkloadData | null>(null);
   const [weekly, setWeekly] = useState<WeeklyData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const [wl, wr] = await Promise.all([
-          fetch("/api/reports/workload").then((r) => r.json()),
-          fetch("/api/reports/weekly").then((r) => r.json()),
-        ]);
-        setWorkload(wl);
-        setWeekly(wr);
-      } finally {
-        setLoading(false);
-      }
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [wl, wr] = await Promise.all([
+        fetch("/api/reports/workload").then((r) => { if (!r.ok) throw new Error("工作負載載入失敗"); return r.json(); }),
+        fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
+      ]);
+      setWorkload(wl);
+      setWeekly(wr);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
     }
-    load();
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
-        載入中...
-      </div>
-    );
   }
+
+  useEffect(() => { load(); }, []);
+
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} onRetry={load} />;
 
   const maxPersonHours =
     workload?.byPerson?.length
@@ -203,30 +326,29 @@ function EngineerDashboard() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [weekly, setWeekly] = useState<WeeklyData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const [taskRes, wr] = await Promise.all([
-          fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => r.json()),
-          fetch("/api/reports/weekly").then((r) => r.json()),
-        ]);
-        setTasks(Array.isArray(taskRes) ? taskRes : taskRes.tasks ?? []);
-        setWeekly(wr);
-      } finally {
-        setLoading(false);
-      }
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [taskRes, wr] = await Promise.all([
+        fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => { if (!r.ok) throw new Error("任務載入失敗"); return r.json(); }),
+        fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
+      ]);
+      setTasks(Array.isArray(taskRes) ? taskRes : taskRes.tasks ?? []);
+      setWeekly(wr);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
     }
-    load();
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
-        載入中...
-      </div>
-    );
   }
+
+  useEffect(() => { load(); }, []);
+
+  if (loading) return <PageLoading />;
+  if (error) return <PageError message={error} onRetry={load} />;
 
   const weeklyPct = Math.min(((weekly?.totalHours ?? 0) / 40) * 100, 100);
   const today = new Date().toDateString();
@@ -358,13 +480,18 @@ export default function DashboardPage() {
       </div>
 
       {status === "loading" ? (
-        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
-          載入中...
-        </div>
+        <PageLoading />
       ) : isManager ? (
         <ManagerDashboard />
       ) : (
         <EngineerDashboard />
+      )}
+
+      {/* ── KPI Achievement Cards ── */}
+      {status !== "loading" && (
+        <div className="mt-8">
+          <KPIAchievementSection />
+        </div>
       )}
     </div>
   );

--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { ChevronLeft, ChevronRight, Loader2, Diamond } from "lucide-react";
+import { ChevronLeft, ChevronRight, Diamond, BarChart2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -176,16 +177,21 @@ export default function GanttPage() {
   const [assigneeFilter, setAssigneeFilter] = useState("");
   const [data, setData] = useState<{ annualPlan: AnnualPlan | null; year: number } | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [users, setUsers] = useState<User[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
+    setFetchError(null);
     try {
       const params = new URLSearchParams({ year: year.toString() });
       if (assigneeFilter) params.set("assignee", assigneeFilter);
       const res = await fetch(`/api/tasks/gantt?${params}`);
-      if (res.ok) setData(await res.json());
+      if (!res.ok) throw new Error("甘特圖資料載入失敗");
+      setData(await res.json());
+    } catch (e) {
+      setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoading(false);
     }
@@ -242,15 +248,20 @@ export default function GanttPage() {
       </div>
 
       {loading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+        <div className="flex-1">
+          <PageLoading message="載入甘特圖..." />
+        </div>
+      ) : fetchError ? (
+        <div className="flex-1">
+          <PageError message={fetchError} onRetry={fetchData} />
         </div>
       ) : !plan ? (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center text-zinc-600">
-            <p className="text-sm">找不到 {year} 年度計畫</p>
-            <p className="text-xs mt-1">請先在「年度計畫」頁面建立計畫</p>
-          </div>
+        <div className="flex-1">
+          <PageEmpty
+            icon={<BarChart2 className="h-10 w-10" />}
+            title={`找不到 ${year} 年度計畫`}
+            description="請先在「年度計畫」頁面建立計畫"
+          />
         </div>
       ) : (
         <div className="flex-1 overflow-auto">

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Plus, Loader2 } from "lucide-react";
+import { Plus, Kanban, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TaskCard, type TaskCardData } from "@/app/components/task-card";
 import { TaskFilters, type TaskFilters as FiltersType } from "@/app/components/task-filters";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
 
@@ -36,6 +37,7 @@ const columnHeaderBg: Record<TaskStatus, string> = {
 export default function KanbanPage() {
   const [tasks, setTasks] = useState<TaskCardData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [filters, setFilters] = useState<FiltersType>({ assignee: "", priority: "", category: "" });
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<TaskStatus | null>(null);
@@ -44,16 +46,18 @@ export default function KanbanPage() {
 
   const fetchTasks = useCallback(async () => {
     setLoading(true);
+    setFetchError(null);
     try {
       const params = new URLSearchParams();
       if (filters.assignee) params.set("assignee", filters.assignee);
       if (filters.priority) params.set("priority", filters.priority);
       if (filters.category) params.set("category", filters.category);
       const res = await fetch(`/api/tasks?${params}`);
-      if (res.ok) {
-        const data = await res.json();
-        setTasks(Array.isArray(data) ? data : []);
-      }
+      if (!res.ok) throw new Error("任務載入失敗");
+      const data = await res.json();
+      setTasks(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoading(false);
     }
@@ -130,8 +134,20 @@ export default function KanbanPage() {
 
       {/* Board */}
       {loading ? (
-        <div className="flex-1 flex items-center justify-center">
-          <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+        <div className="flex-1">
+          <PageLoading message="載入看板..." />
+        </div>
+      ) : fetchError ? (
+        <div className="flex-1">
+          <PageError message={fetchError} onRetry={fetchTasks} />
+        </div>
+      ) : tasks.length === 0 && !filters.assignee && !filters.priority && !filters.category ? (
+        <div className="flex-1">
+          <PageEmpty
+            icon={<Kanban className="h-10 w-10" />}
+            title="尚無任務"
+            description="目前沒有任何任務，請點擊「新增任務」開始"
+          />
         </div>
       ) : (
         <div className="flex-1 flex gap-3 overflow-x-auto pb-4 min-h-0">

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Loader2, Save, Plus } from "lucide-react";
+import { Loader2, Save, Plus, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DocumentTree, type DocNode } from "@/app/components/document-tree";
 import { MarkdownEditor } from "@/app/components/markdown-editor";
 import { DocumentSearch } from "@/app/components/document-search";
 import { VersionHistory } from "@/app/components/version-history";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 type DocDetail = {
   id: string;
@@ -23,6 +24,7 @@ type DocDetail = {
 export default function KnowledgePage() {
   const [docs, setDocs] = useState<DocNode[]>([]);
   const [loadingDocs, setLoadingDocs] = useState(true);
+  const [docsError, setDocsError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [docDetail, setDocDetail] = useState<DocDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
@@ -34,9 +36,13 @@ export default function KnowledgePage() {
   // Load doc tree
   const loadDocs = useCallback(async () => {
     setLoadingDocs(true);
+    setDocsError(null);
     try {
       const res = await fetch("/api/documents");
-      if (res.ok) setDocs(await res.json());
+      if (!res.ok) throw new Error("文件載入失敗");
+      setDocs(await res.json());
+    } catch (e) {
+      setDocsError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoadingDocs(false);
     }
@@ -149,7 +155,20 @@ export default function KnowledgePage() {
           {/* Tree */}
           {loadingDocs ? (
             <div className="flex-1 flex items-center justify-center">
-              <Loader2 className="h-4 w-4 animate-spin text-zinc-600" />
+              <PageLoading message="載入文件..." className="py-6" />
+            </div>
+          ) : docsError ? (
+            <div className="flex-1 flex items-center justify-center p-2">
+              <PageError message={docsError} onRetry={loadDocs} className="py-4" />
+            </div>
+          ) : docs.length === 0 ? (
+            <div className="flex-1 flex items-center justify-center p-2">
+              <PageEmpty
+                icon={<BookOpen className="h-7 w-7" />}
+                title="尚無文件"
+                description="點擊 + 新增文件"
+                className="py-4"
+              />
             </div>
           ) : (
             <div className="flex-1 overflow-hidden">

--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -2,8 +2,11 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import { Target, Plus, Link2, Unlink, ChevronDown, ChevronRight } from "lucide-react";
+import { Target, Plus, Unlink, ChevronDown, ChevronRight } from "lucide-react";
+import { z } from "zod";
 import { cn } from "@/lib/utils";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { FormError, FormBanner } from "@/app/components/form-error";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -80,6 +83,20 @@ const TASK_STATUS_LABEL: Record<string, string> = {
   BLOCKED: "封鎖",
 };
 
+// ── Zod schema for KPI form ─────────────────────────────────────────────────
+
+const createKpiFormSchema = z.object({
+  year: z.number().int().min(2000, "年度不得早於 2000").max(2100, "年度不得晚於 2100"),
+  code: z.string().min(1, "代碼為必填"),
+  title: z.string().min(1, "名稱為必填"),
+  description: z.string().optional(),
+  target: z.number().nonnegative("目標值不得為負數"),
+  weight: z.number().positive("權重必須大於 0"),
+  autoCalc: z.boolean(),
+});
+
+type KpiFormErrors = Partial<Record<keyof z.infer<typeof createKpiFormSchema>, string>>;
+
 // ── Create KPI Form ────────────────────────────────────────────────────────
 
 interface CreateFormProps {
@@ -99,25 +116,47 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
     autoCalc: false,
   });
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState("");
+  const [bannerError, setBannerError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<KpiFormErrors>({});
+
+  function validate(): z.infer<typeof createKpiFormSchema> | null {
+    const result = createKpiFormSchema.safeParse({
+      year: parseInt(form.year) || 0,
+      code: form.code,
+      title: form.title,
+      description: form.description || undefined,
+      target: parseFloat(form.target),
+      weight: parseFloat(form.weight),
+      autoCalc: form.autoCalc,
+    });
+    if (!result.success) {
+      const errs: KpiFormErrors = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0] as keyof KpiFormErrors;
+        if (field && !errs[field]) errs[field] = issue.message;
+      }
+      setFieldErrors(errs);
+      return null;
+    }
+    setFieldErrors({});
+    return result.data;
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!form.code || !form.title || !form.target) {
-      setError("代碼、名稱、目標值為必填");
-      return;
-    }
+    const parsed = validate();
+    if (!parsed) return;
     setSubmitting(true);
-    setError("");
+    setBannerError("");
     try {
       const res = await fetch("/api/kpi", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(form),
+        body: JSON.stringify(parsed),
       });
       if (!res.ok) {
         const data = await res.json();
-        setError(data.error ?? "建立失敗");
+        setBannerError(data.error ?? "建立失敗");
         return;
       }
       const kpi = await res.json();
@@ -130,7 +169,7 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
   return (
     <form onSubmit={handleSubmit} className="bg-card border border-border rounded-lg p-5 space-y-4">
       <h2 className="text-sm font-medium">新增 KPI</h2>
-      {error && <p className="text-xs text-red-400">{error}</p>}
+      <FormBanner message={bannerError} />
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">年度</label>
@@ -138,8 +177,10 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
             type="number"
             value={form.year}
             onChange={(e) => setForm((f) => ({ ...f, year: e.target.value }))}
-            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.year ? "border-red-500" : "border-border")}
           />
+          <FormError message={fieldErrors.year} />
         </div>
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">代碼 *</label>
@@ -148,8 +189,10 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
             placeholder="如 KPI-01"
             value={form.code}
             onChange={(e) => setForm((f) => ({ ...f, code: e.target.value }))}
-            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.code ? "border-red-500" : "border-border")}
           />
+          <FormError message={fieldErrors.code} />
         </div>
         <div className="col-span-2 space-y-1">
           <label className="text-xs text-muted-foreground">名稱 *</label>
@@ -158,8 +201,10 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
             placeholder="KPI 名稱"
             value={form.title}
             onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
-            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.title ? "border-red-500" : "border-border")}
           />
+          <FormError message={fieldErrors.title} />
         </div>
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">目標值 *</label>
@@ -168,8 +213,10 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
             placeholder="100"
             value={form.target}
             onChange={(e) => setForm((f) => ({ ...f, target: e.target.value }))}
-            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.target ? "border-red-500" : "border-border")}
           />
+          <FormError message={fieldErrors.target} />
         </div>
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">權重</label>
@@ -178,8 +225,10 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
             step="0.1"
             value={form.weight}
             onChange={(e) => setForm((f) => ({ ...f, weight: e.target.value }))}
-            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.weight ? "border-red-500" : "border-border")}
           />
+          <FormError message={fieldErrors.weight} />
         </div>
         <div className="col-span-2 space-y-1">
           <label className="text-xs text-muted-foreground">說明</label>
@@ -355,17 +404,20 @@ export default function KPIPage() {
 
   const [kpis, setKpis] = useState<KPI[]>([]);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const year = new Date().getFullYear();
 
   async function fetchKPIs() {
     setLoading(true);
+    setFetchError(null);
     try {
       const res = await fetch(`/api/kpi?year=${year}`);
-      if (res.ok) {
-        const data = await res.json();
-        setKpis(Array.isArray(data) ? data : []);
-      }
+      if (!res.ok) throw new Error("KPI 載入失敗");
+      const data = await res.json();
+      setKpis(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoading(false);
     }
@@ -453,14 +505,15 @@ export default function KPIPage() {
 
       {/* KPI List */}
       {loading ? (
-        <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
-          載入中...
-        </div>
+        <PageLoading message="載入 KPI..." />
+      ) : fetchError ? (
+        <PageError message={fetchError} onRetry={fetchKPIs} />
       ) : kpis.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-48 gap-3">
-          <Target className="h-8 w-8 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">尚無 KPI，{isManager ? "請點擊「新增 KPI」建立" : "請聯絡主管建立"}</p>
-        </div>
+        <PageEmpty
+          icon={<Target className="h-10 w-10" />}
+          title="尚無 KPI"
+          description={isManager ? "請點擊「新增 KPI」建立" : "請聯絡主管建立 KPI"}
+        />
       ) : (
         <div className="space-y-3">
           {kpis.map((kpi) => (

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Download, RefreshCw } from "lucide-react";
+import { Download, RefreshCw, BarChart3 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -73,16 +74,23 @@ interface WeeklyData {
 function WeeklyReport() {
   const [data, setData] = useState<WeeklyData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
     fetch("/api/reports/weekly")
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); })
       .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>;
-  if (!data) return <div className="py-12 text-center text-sm text-muted-foreground">無法載入週報</div>;
+  useEffect(() => { load(); }, [load]);
+
+  if (loading) return <PageLoading message="載入週報..." />;
+  if (error) return <PageError message={error} onRetry={load} />;
+  if (!data) return <PageEmpty title="無週報資料" description="本週尚無相關數據" />;
 
   const start = new Date(data.period.start).toLocaleDateString("zh-TW");
   const end = new Date(data.period.end).toLocaleDateString("zh-TW");
@@ -185,12 +193,15 @@ function MonthlyReport() {
   );
   const [data, setData] = useState<MonthlyData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
     setLoading(true);
+    setError(null);
     fetch(`/api/reports/monthly?month=${month}`)
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error("月報載入失敗"); return r.json(); })
       .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [month]);
 
@@ -223,9 +234,11 @@ function MonthlyReport() {
       </div>
 
       {loading ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+        <PageLoading message="載入月報..." />
+      ) : error ? (
+        <PageError message={error} onRetry={load} />
       ) : !data ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">無法載入月報</div>
+        <PageEmpty title="無月報資料" description="本月尚無相關數據" />
       ) : (
         <>
           <div className="bg-card border border-border rounded-lg p-4">
@@ -311,12 +324,15 @@ function KPIReport() {
   const [year, setYear] = useState(new Date().getFullYear());
   const [data, setData] = useState<KPIReportData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
     setLoading(true);
+    setError(null);
     fetch(`/api/reports/kpi?year=${year}`)
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error("KPI 報表載入失敗"); return r.json(); })
       .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [year]);
 
@@ -349,9 +365,15 @@ function KPIReport() {
       </div>
 
       {loading ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+        <PageLoading message="載入 KPI 報表..." />
+      ) : error ? (
+        <PageError message={error} onRetry={load} />
       ) : !data ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">無法載入 KPI 報表</div>
+        <PageEmpty
+          icon={<BarChart3 className="h-8 w-8" />}
+          title="無 KPI 報表資料"
+          description="本年度尚無 KPI 資料"
+        />
       ) : (
         <>
           <div className="grid grid-cols-3 gap-4">
@@ -438,12 +460,15 @@ function WorkloadReport() {
   );
   const [data, setData] = useState<WorkloadData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
     setLoading(true);
+    setError(null);
     fetch(`/api/reports/workload?startDate=${startDate}`)
-      .then((r) => r.json())
+      .then((r) => { if (!r.ok) throw new Error("負荷報表載入失敗"); return r.json(); })
       .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [startDate]);
 
@@ -479,9 +504,11 @@ function WorkloadReport() {
       </div>
 
       {loading ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">載入中...</div>
+        <PageLoading message="載入負荷報表..." />
+      ) : error ? (
+        <PageError message={error} onRetry={load} />
       ) : !data ? (
-        <div className="py-12 text-center text-sm text-muted-foreground">無法載入負荷報表</div>
+        <PageEmpty title="無負荷報表資料" description="所選期間尚無工時數據" />
       ) : (
         <>
           {/* Summary */}

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
 import { TimeSummary } from "@/app/components/time-summary";
 import { type TimeEntry } from "@/app/components/time-entry-cell";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -50,6 +51,7 @@ export default function TimesheetPage() {
   const [taskRows, setTaskRows] = useState<TaskRow[]>([FREE_ROW]);
   const [stats, setStats] = useState<StatsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [statsLoading, setStatsLoading] = useState(false);
 
   // Load users
@@ -63,31 +65,33 @@ export default function TimesheetPage() {
   // Load entries for the week
   const loadEntries = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const params = new URLSearchParams({
         weekStart: weekStart.toISOString().split("T")[0],
       });
       if (userFilter) params.set("userId", userFilter);
       const res = await fetch(`/api/time-entries?${params}`);
-      if (res.ok) {
-        const data: (TimeEntry & { task?: { id: string; title: string } | null })[] =
-          await res.json();
-        setEntries(data);
+      if (!res.ok) throw new Error("工時資料載入失敗");
+      const data: (TimeEntry & { task?: { id: string; title: string } | null })[] =
+        await res.json();
+      setEntries(data);
 
-        // Build task rows from entries + a free row
-        const seenTasks = new Map<string, string>();
-        for (const e of data) {
-          if (e.taskId && !seenTasks.has(e.taskId)) {
-            const label = (e as { task?: { title: string } | null }).task?.title ?? e.taskId;
-            seenTasks.set(e.taskId, label);
-          }
+      // Build task rows from entries + a free row
+      const seenTasks = new Map<string, string>();
+      for (const e of data) {
+        if (e.taskId && !seenTasks.has(e.taskId)) {
+          const label = (e as { task?: { title: string } | null }).task?.title ?? e.taskId;
+          seenTasks.set(e.taskId, label);
         }
-        const rows: TaskRow[] = [
-          ...Array.from(seenTasks.entries()).map(([taskId, label]) => ({ taskId, label })),
-          FREE_ROW,
-        ];
-        setTaskRows(rows);
       }
+      const rows: TaskRow[] = [
+        ...Array.from(seenTasks.entries()).map(([taskId, label]) => ({ taskId, label })),
+        FREE_ROW,
+      ];
+      setTaskRows(rows);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoading(false);
     }
@@ -240,9 +244,16 @@ export default function TimesheetPage() {
         {/* Grid */}
         <div className="border border-zinc-800 rounded-xl overflow-hidden bg-zinc-950">
           {loading ? (
-            <div className="flex items-center justify-center py-16">
-              <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
-            </div>
+            <PageLoading message="載入工時..." className="py-12" />
+          ) : loadError ? (
+            <PageError message={loadError} onRetry={loadEntries} className="py-12" />
+          ) : entries.length === 0 ? (
+            <PageEmpty
+              icon={<Clock className="h-8 w-8" />}
+              title="本週尚無工時記錄"
+              description="點擊格子可輸入工時"
+              className="py-10"
+            />
           ) : (
             <TimesheetGrid
               weekStart={weekStart}

--- a/app/api/notifications/generate/route.ts
+++ b/app/api/notifications/generate/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import { UnauthorizedError } from "@/services/errors";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { NotificationService } from "@/services/notification-service";
+
+/**
+ * POST /api/notifications/generate
+ *
+ * Checks tasks and milestones for upcoming due dates / overdue status
+ * and creates notification records for assigned users.
+ * Skips duplicates where an unread notification of the same type + relatedId
+ * already exists for the same user.
+ *
+ * Intended for use by a cron job or manual invocation.
+ */
+export const POST = apiHandler(async (req: NextRequest) => {
+  const session = await getServerSession();
+  if (!session?.user?.id) throw new UnauthorizedError();
+
+  const svc = new NotificationService(prisma);
+  const result = await svc.generateAll();
+
+  return success(result);
+});

--- a/app/components/form-error.tsx
+++ b/app/components/form-error.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── Inline field error ──────────────────────────────────────────────────────
+
+interface FormErrorProps {
+  message?: string | null;
+  className?: string;
+}
+
+export function FormError({ message, className }: FormErrorProps) {
+  if (!message) return null;
+  return (
+    <p className={cn("flex items-center gap-1.5 text-xs text-red-400 mt-1", className)}>
+      <AlertCircle className="h-3 w-3 flex-shrink-0" />
+      {message}
+    </p>
+  );
+}
+
+// ── Form-level error banner ─────────────────────────────────────────────────
+
+interface FormBannerProps {
+  message?: string | null;
+  className?: string;
+}
+
+export function FormBanner({ message, className }: FormBannerProps) {
+  if (!message) return null;
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 p-3 rounded-md bg-red-500/10 border border-red-500/20 text-red-400 text-sm",
+        className
+      )}
+    >
+      <AlertCircle className="h-4 w-4 flex-shrink-0 mt-0.5" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/app/components/page-states.tsx
+++ b/app/components/page-states.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { AlertCircle, Inbox, Loader2, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ── Loading ─────────────────────────────────────────────────────────────────
+
+interface LoadingProps {
+  message?: string;
+  className?: string;
+}
+
+export function PageLoading({ message = "載入中...", className }: LoadingProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground", className)}>
+      <Loader2 className="h-6 w-6 animate-spin" />
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}
+
+// ── Error ───────────────────────────────────────────────────────────────────
+
+interface ErrorProps {
+  message?: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function PageError({
+  message = "載入失敗，請稍後再試",
+  onRetry,
+  className,
+}: ErrorProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center gap-4 py-16", className)}>
+      <div className="flex flex-col items-center gap-2 text-red-400">
+        <AlertCircle className="h-7 w-7" />
+        <p className="text-sm font-medium">發生錯誤</p>
+      </div>
+      <p className="text-sm text-muted-foreground text-center max-w-xs">{message}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="flex items-center gap-2 px-4 py-2 text-sm bg-accent hover:bg-accent/80 text-foreground rounded-md transition-colors"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          重試
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Empty ───────────────────────────────────────────────────────────────────
+
+interface EmptyProps {
+  icon?: React.ReactNode;
+  title?: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function PageEmpty({
+  icon,
+  title = "尚無資料",
+  description,
+  action,
+  className,
+}: EmptyProps) {
+  return (
+    <div className={cn("flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground", className)}>
+      <div className="text-muted-foreground/60">
+        {icon ?? <Inbox className="h-10 w-10" />}
+      </div>
+      <div className="text-center">
+        <p className="text-sm font-medium text-foreground/70">{title}</p>
+        {description && (
+          <p className="text-xs text-muted-foreground mt-1">{description}</p>
+        )}
+      </div>
+      {action && <div className="mt-2">{action}</div>}
+    </div>
+  );
+}

--- a/services/__tests__/notification-service.test.ts
+++ b/services/__tests__/notification-service.test.ts
@@ -1,0 +1,218 @@
+import { NotificationService } from "../notification-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+describe("NotificationService", () => {
+  let service: NotificationService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  // Fixed "now" for deterministic date logic: 2026-03-24T00:00:00.000Z
+  const NOW = new Date("2026-03-24T00:00:00.000Z");
+  // Within 7-day window
+  const DUE_IN_3_DAYS = new Date("2026-03-27T00:00:00.000Z");
+  // Past due
+  const TWO_DAYS_AGO = new Date("2026-03-22T00:00:00.000Z");
+  // Outside 7-day window (8 days out)
+  const DUE_IN_8_DAYS = new Date("2026-04-01T00:00:00.000Z");
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new NotificationService(prisma as never);
+    // Default: no existing notifications
+    (prisma.notification.findMany as jest.Mock).mockResolvedValue([]);
+  });
+
+  // ── TASK_DUE_SOON ─────────────────────────────────────────────────────────
+
+  test("generates TASK_DUE_SOON for tasks due within 7 days", async () => {
+    const task = {
+      id: "task-1",
+      title: "完成報告",
+      dueDate: DUE_IN_3_DAYS,
+      primaryAssigneeId: "user-a",
+      backupAssigneeId: null,
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildDueSoonTaskNotifications(NOW, existingKeys);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      userId: "user-a",
+      type: "TASK_DUE_SOON",
+      relatedId: "task-1",
+      relatedType: "Task",
+    });
+    expect(result[0].title).toContain("完成報告");
+  });
+
+  test("generates TASK_DUE_SOON for both assignees when both are set", async () => {
+    const task = {
+      id: "task-2",
+      title: "雙人任務",
+      dueDate: DUE_IN_3_DAYS,
+      primaryAssigneeId: "user-a",
+      backupAssigneeId: "user-b",
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    const result = await service.buildDueSoonTaskNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(2);
+    const userIds = result.map((n) => n.userId);
+    expect(userIds).toContain("user-a");
+    expect(userIds).toContain("user-b");
+  });
+
+  // ── MILESTONE_DUE ─────────────────────────────────────────────────────────
+
+  test("generates MILESTONE_DUE for milestones due within 7 days", async () => {
+    const milestone = {
+      id: "ms-1",
+      title: "Phase 1 完成",
+      plannedEnd: DUE_IN_3_DAYS,
+    };
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([milestone]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { id: "user-a" },
+      { id: "user-b" },
+    ]);
+
+    const result = await service.buildDueSoonMilestoneNotifications(NOW, new Set());
+
+    // One notification per user per milestone
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      type: "MILESTONE_DUE",
+      relatedId: "ms-1",
+      relatedType: "Milestone",
+    });
+    expect(result[0].title).toContain("Phase 1 完成");
+  });
+
+  test("does not generate MILESTONE_DUE for completed milestones", async () => {
+    // prisma mock returns empty array (filtered by status in query)
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
+
+    const result = await service.buildDueSoonMilestoneNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(0);
+  });
+
+  // ── TASK_OVERDUE ──────────────────────────────────────────────────────────
+
+  test("generates TASK_OVERDUE for past-due tasks", async () => {
+    const task = {
+      id: "task-3",
+      title: "逾期任務",
+      dueDate: TWO_DAYS_AGO,
+      primaryAssigneeId: "user-c",
+      backupAssigneeId: null,
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildOverdueTaskNotifications(NOW, existingKeys);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      userId: "user-c",
+      type: "TASK_OVERDUE",
+      relatedId: "task-3",
+      relatedType: "Task",
+    });
+    expect(result[0].title).toContain("逾期任務");
+  });
+
+  test("does not generate TASK_OVERDUE for done tasks (filtered by query)", async () => {
+    // Prisma mock returns empty — query has status: { notIn: ["DONE"] }
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await service.buildOverdueTaskNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(0);
+  });
+
+  // ── Duplicate prevention ──────────────────────────────────────────────────
+
+  test("does not duplicate existing unread notifications", async () => {
+    const task = {
+      id: "task-4",
+      title: "已通知任務",
+      dueDate: DUE_IN_3_DAYS,
+      primaryAssigneeId: "user-a",
+      backupAssigneeId: null,
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    // Pre-seed existing key so duplicate check fires
+    const existingKeys = new Set<string>(["user-a:TASK_DUE_SOON:task-4"]);
+
+    const result = await service.buildDueSoonTaskNotifications(NOW, existingKeys);
+
+    expect(result).toHaveLength(0);
+  });
+
+  test("does not duplicate existing milestone notifications", async () => {
+    const milestone = { id: "ms-2", title: "重複里程碑", plannedEnd: DUE_IN_3_DAYS };
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([milestone]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
+
+    const existingKeys = new Set<string>(["user-a:MILESTONE_DUE:ms-2"]);
+    const result = await service.buildDueSoonMilestoneNotifications(NOW, existingKeys);
+
+    expect(result).toHaveLength(0);
+  });
+
+  // ── generateAll integration ───────────────────────────────────────────────
+
+  test("generateAll persists notifications and returns counts", async () => {
+    // Existing: none
+    (prisma.notification.findMany as jest.Mock).mockResolvedValue([]);
+
+    const dueSoonTask = {
+      id: "task-5",
+      title: "即將到期任務",
+      dueDate: DUE_IN_3_DAYS,
+      primaryAssigneeId: "user-a",
+      backupAssigneeId: null,
+    };
+    const overdueTask = {
+      id: "task-6",
+      title: "逾期任務",
+      dueDate: TWO_DAYS_AGO,
+      primaryAssigneeId: "user-b",
+      backupAssigneeId: null,
+    };
+
+    // task.findMany is called multiple times (due soon, then overdue)
+    (prisma.task.findMany as jest.Mock)
+      .mockResolvedValueOnce([dueSoonTask])  // due soon query
+      .mockResolvedValueOnce([overdueTask]); // overdue query
+
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+    const result = await service.generateAll(NOW);
+
+    expect(prisma.notification.createMany).toHaveBeenCalledTimes(1);
+    expect(result.created).toBe(2);
+    expect(result.dueSoonTasks).toBe(1);
+    expect(result.overdueTasks).toBe(1);
+    expect(result.dueSoonMilestones).toBe(0);
+  });
+
+  test("generateAll skips createMany when no new notifications", async () => {
+    (prisma.notification.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await service.generateAll(NOW);
+
+    expect(prisma.notification.createMany).not.toHaveBeenCalled();
+    expect(result.created).toBe(0);
+  });
+});

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -1,0 +1,211 @@
+import { PrismaClient } from "@prisma/client";
+
+const DAYS_AHEAD = 7;
+
+export type NotificationInput = {
+  userId: string;
+  type: "TASK_DUE_SOON" | "MILESTONE_DUE" | "TASK_OVERDUE";
+  title: string;
+  body: string;
+  relatedId: string;
+  relatedType: string;
+};
+
+export class NotificationService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  private addDays(date: Date, days: number): Date {
+    const d = new Date(date);
+    d.setDate(d.getDate() + days);
+    return d;
+  }
+
+  /**
+   * Returns existing unread notification keys (userId:type:relatedId)
+   * to allow duplicate detection without re-querying inside loops.
+   */
+  async getExistingKeys(): Promise<Set<string>> {
+    const existing = await this.prisma.notification.findMany({
+      where: {
+        isRead: false,
+        type: { in: ["TASK_DUE_SOON", "MILESTONE_DUE", "TASK_OVERDUE"] },
+      },
+      select: { userId: true, type: true, relatedId: true },
+    });
+    return new Set(existing.map((n) => `${n.userId}:${n.type}:${n.relatedId}`));
+  }
+
+  /**
+   * Builds notification payloads for tasks due within DAYS_AHEAD days.
+   */
+  async buildDueSoonTaskNotifications(
+    now: Date,
+    existingKeys: Set<string>
+  ): Promise<NotificationInput[]> {
+    const cutoff = this.addDays(now, DAYS_AHEAD);
+
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        status: { notIn: ["DONE"] },
+        dueDate: { gte: now, lte: cutoff },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        primaryAssigneeId: true,
+        backupAssigneeId: true,
+      },
+    });
+
+    const result: NotificationInput[] = [];
+    for (const task of tasks) {
+      const userIds = [task.primaryAssigneeId, task.backupAssigneeId].filter(
+        (id): id is string => id !== null && id !== undefined
+      );
+      const dueLabel = task.dueDate
+        ? new Date(task.dueDate).toLocaleDateString("zh-TW")
+        : "";
+
+      for (const userId of userIds) {
+        const key = `${userId}:TASK_DUE_SOON:${task.id}`;
+        if (!existingKeys.has(key)) {
+          result.push({
+            userId,
+            type: "TASK_DUE_SOON",
+            title: `任務即將到期：${task.title}`,
+            body: `到期日：${dueLabel}`,
+            relatedId: task.id,
+            relatedType: "Task",
+          });
+          existingKeys.add(key);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Builds notification payloads for milestones due within DAYS_AHEAD days.
+   * Notifies all users in the system.
+   */
+  async buildDueSoonMilestoneNotifications(
+    now: Date,
+    existingKeys: Set<string>
+  ): Promise<NotificationInput[]> {
+    const cutoff = this.addDays(now, DAYS_AHEAD);
+
+    const [milestones, allUsers] = await Promise.all([
+      this.prisma.milestone.findMany({
+        where: {
+          status: { notIn: ["COMPLETED", "CANCELLED"] },
+          plannedEnd: { gte: now, lte: cutoff },
+        },
+        select: { id: true, title: true, plannedEnd: true },
+      }),
+      this.prisma.user.findMany({ select: { id: true } }),
+    ]);
+
+    const result: NotificationInput[] = [];
+    for (const ms of milestones) {
+      const dueLabel = new Date(ms.plannedEnd).toLocaleDateString("zh-TW");
+      for (const user of allUsers) {
+        const key = `${user.id}:MILESTONE_DUE:${ms.id}`;
+        if (!existingKeys.has(key)) {
+          result.push({
+            userId: user.id,
+            type: "MILESTONE_DUE",
+            title: `里程碑即將到期：${ms.title}`,
+            body: `計畫結束日：${dueLabel}`,
+            relatedId: ms.id,
+            relatedType: "Milestone",
+          });
+          existingKeys.add(key);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Builds notification payloads for overdue tasks (past due date, not done).
+   */
+  async buildOverdueTaskNotifications(
+    now: Date,
+    existingKeys: Set<string>
+  ): Promise<NotificationInput[]> {
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        status: { notIn: ["DONE"] },
+        dueDate: { lt: now },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        primaryAssigneeId: true,
+        backupAssigneeId: true,
+      },
+    });
+
+    const result: NotificationInput[] = [];
+    for (const task of tasks) {
+      const userIds = [task.primaryAssigneeId, task.backupAssigneeId].filter(
+        (id): id is string => id !== null && id !== undefined
+      );
+      const dueLabel = task.dueDate
+        ? new Date(task.dueDate).toLocaleDateString("zh-TW")
+        : "";
+
+      for (const userId of userIds) {
+        const key = `${userId}:TASK_OVERDUE:${task.id}`;
+        if (!existingKeys.has(key)) {
+          result.push({
+            userId,
+            type: "TASK_OVERDUE",
+            title: `任務已逾期：${task.title}`,
+            body: `原定到期日：${dueLabel}`,
+            relatedId: task.id,
+            relatedType: "Task",
+          });
+          existingKeys.add(key);
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Full pipeline: build all notification payloads and persist them.
+   * Returns counts for observability.
+   */
+  async generateAll(now: Date = new Date()): Promise<{
+    created: number;
+    dueSoonTasks: number;
+    dueSoonMilestones: number;
+    overdueTasks: number;
+  }> {
+    const existingKeys = await this.getExistingKeys();
+
+    const [dueSoonTaskItems, milestoneItems, overdueItems] = await Promise.all([
+      this.buildDueSoonTaskNotifications(now, existingKeys),
+      this.buildDueSoonMilestoneNotifications(now, existingKeys),
+      this.buildOverdueTaskNotifications(now, existingKeys),
+    ]);
+
+    const toCreate = [...dueSoonTaskItems, ...milestoneItems, ...overdueItems];
+
+    let created = 0;
+    if (toCreate.length > 0) {
+      const result = await this.prisma.notification.createMany({ data: toCreate });
+      created = result.count;
+    }
+
+    return {
+      created,
+      dueSoonTasks: dueSoonTaskItems.length,
+      dueSoonMilestones: milestoneItems.length,
+      overdueTasks: overdueItems.length,
+    };
+  }
+}


### PR DESCRIPTION
Closes #92
Closes #93
Closes #94
Closes #95

## Summary

- **#92 Dashboard KPI achievement cards**: `KPIAchievementSection` fetches `/api/kpi`, renders progress bars with status badges, graceful empty state if no KPIs exist
- **#93 Loading/error/empty states**: Created `app/components/page-states.tsx` (`PageLoading`, `PageError`, `PageEmpty`) and applied consistently to all 7 pages (dashboard, kanban, gantt, knowledge, timesheet, reports, kpi); all fetch errors now surface a retry button
- **#94 Frontend form validation**: Created `app/components/form-error.tsx` (`FormError`, `FormBanner`); added Zod client-side schema to KPI create form with inline field errors and disabled submit while submitting
- **#95 Reminder notifications**: Created `services/notification-service.ts` with `generateAll()` pipeline; `POST /api/notifications/generate` route calls it; 10 unit tests covering TASK_DUE_SOON, MILESTONE_DUE, TASK_OVERDUE, and duplicate-prevention logic — all passing

## Test plan

- [ ] Run `npx jest --testPathPatterns="notification-service"` — 10 tests pass
- [ ] Visit `/dashboard` — KPI section appears below role dashboard; shows spinner then cards or empty state
- [ ] Kill network in devtools, reload any page — error state with retry button appears
- [ ] Open KPI page → New KPI form → submit blank → inline red errors under each required field
- [ ] `POST /api/notifications/generate` — returns `{ created, dueSoonTasks, dueSoonMilestones, overdueTasks }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)