### PR TITLE
fix(#120): params Promise type for Next.js 15

### DIFF
--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -8,12 +8,12 @@ import { DeliverableService } from "@/services/deliverable-service";
 
 export const GET = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const service = new DeliverableService(prisma);
   const deliverable = await service.getDeliverable(id);
   return success(deliverable);
@@ -21,12 +21,12 @@ export const GET = apiHandler(async (
 
 export const PATCH = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const body = await req.json();
 
   const deliverable = await prisma.deliverable.update({
@@ -45,12 +45,12 @@ export const PATCH = apiHandler(async (
 
 export const DELETE = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await prisma.deliverable.delete({ where: { id } });
   return success({ success: true });
 });

--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -22,7 +22,7 @@ export const GET = apiHandler(async (req: NextRequest) => {
   });
 
   if (!query.success) {
-    throw new ValidationError(query.error.errors.map((e) => e.message).join(", "));
+    throw new ValidationError(query.error.issues.map((e) => e.message).join(", "));
   }
 
   const service = new DeliverableService(prisma);
@@ -38,7 +38,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
   const parsed = createDeliverableSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new ValidationError(parsed.error.errors.map((e) => e.message).join(", "));
+    throw new ValidationError(parsed.error.issues.map((e) => e.message).join(", "));
   }
 
   const service = new DeliverableService(prisma);

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -9,12 +9,12 @@ import { success } from "@/lib/api-response";
 
 export const GET = apiHandler(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const doc = await prisma.document.findUnique({
     where: { id },
     include: {
@@ -33,12 +33,12 @@ export const GET = apiHandler(async (
 
 export const PUT = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { title, content, parentId } = validateBody(updateDocumentSchema, raw);
 
@@ -75,12 +75,12 @@ export const PUT = apiHandler(async (
 
 export const DELETE = apiHandler(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await prisma.document.delete({ where: { id } });
   return success({ success: true });
 });

--- a/app/api/documents/[id]/versions/route.ts
+++ b/app/api/documents/[id]/versions/route.ts
@@ -7,12 +7,12 @@ import { success } from "@/lib/api-response";
 
 export const GET = apiHandler(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const versions = await prisma.documentVersion.findMany({
     where: { documentId: id },
     include: { creator: { select: { id: true, name: true } } },

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -10,12 +10,12 @@ import { withManager } from "@/lib/auth-middleware";
 
 export const GET = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const goal = await prisma.monthlyGoal.findUnique({
     where: { id },
     include: {
@@ -39,12 +39,12 @@ export const GET = apiHandler(async (
 
 export const PUT = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { title, description, status, progressPct } = validateBody(updateGoalSchema, raw);
 
@@ -67,9 +67,9 @@ export const PUT = apiHandler(async (
 
 export const DELETE = withManager(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const existing = await prisma.monthlyGoal.findUnique({ where: { id } });
   if (!existing) throw new NotFoundError("目標不存在");
 

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -7,12 +7,12 @@ import { success } from "@/lib/api-response";
 
 export const GET = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const kpi = await prisma.kPI.findUnique({
     where: { id },
     include: {

--- a/app/api/kpi/[id]/link/route.ts
+++ b/app/api/kpi/[id]/link/route.ts
@@ -7,13 +7,13 @@ import { success } from "@/lib/api-response";
 
 export const POST = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
   if (session.user.role !== "MANAGER") throw new ForbiddenError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const body = await req.json();
   const { taskId, weight, remove } = body;
 

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -8,10 +8,10 @@ import { withAuth, withManager } from "@/lib/auth-middleware";
 
 export const GET = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const kpi = await prisma.kPI.findUnique({
     where: { id },
     include: {
@@ -40,9 +40,9 @@ export const GET = withAuth(async (
 
 export const DELETE = withManager(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const existing = await prisma.kPI.findUnique({ where: { id } });
   if (!existing) throw new NotFoundError("找不到 KPI");
 
@@ -53,9 +53,9 @@ export const DELETE = withManager(async (
 
 export const PUT = withManager(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { title, description, target, actual, weight, status, autoCalc } =
     validateBody(updateKpiSchema, raw);

--- a/app/api/milestones/[id]/route.ts
+++ b/app/api/milestones/[id]/route.ts
@@ -12,12 +12,12 @@ const getService = () => new MilestoneService(prisma);
 
 export const GET = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const milestone = await getService().getMilestone(id);
 
   return success(milestone);
@@ -25,12 +25,12 @@ export const GET = apiHandler(async (
 
 export const PUT = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const data = validateBody(updateMilestoneSchema, raw);
 
@@ -50,12 +50,12 @@ export const PUT = apiHandler(async (
 
 export const DELETE = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await getService().deleteMilestone(id);
 
   return success({ id });

--- a/app/api/notifications/[id]/read/route.ts
+++ b/app/api/notifications/[id]/read/route.ts
@@ -7,12 +7,12 @@ import { success } from "@/lib/api-response";
 
 export const PATCH = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const notification = await prisma.notification.findUnique({ where: { id } });
 
   if (!notification || notification.userId !== session.user.id) {

--- a/app/api/plans/[id]/route.ts
+++ b/app/api/plans/[id]/route.ts
@@ -8,10 +8,10 @@ import { withAuth, withManager } from "@/lib/auth-middleware";
 
 export const GET = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const plan = await prisma.annualPlan.findUnique({
     where: { id },
     include: {
@@ -40,9 +40,9 @@ export const GET = withAuth(async (
 
 export const DELETE = withManager(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const existing = await prisma.annualPlan.findUnique({ where: { id } });
   if (!existing) throw new NotFoundError("計畫不存在");
 
@@ -52,9 +52,9 @@ export const DELETE = withManager(async (
 
 export const PUT = withManager(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { title, description, implementationPlan, progressPct } = validateBody(updatePlanSchema, raw);
 

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -215,7 +215,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     result.rows as Record<string, unknown>[],
     result.columns,
   );
-  return new NextResponse(buffer, {
+  return new NextResponse(new Uint8Array(buffer), {
     status: 200,
     headers: {
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",

--- a/app/api/subtasks/[id]/route.ts
+++ b/app/api/subtasks/[id]/route.ts
@@ -7,12 +7,12 @@ import { success } from "@/lib/api-response";
 
 export const PATCH = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const body = await req.json();
 
   const subtask = await prisma.subTask.update({
@@ -30,12 +30,12 @@ export const PATCH = apiHandler(async (
 
 export const DELETE = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await prisma.subTask.delete({ where: { id } });
   return success({ success: true });
 });

--- a/app/api/tasks/[id]/changes/route.ts
+++ b/app/api/tasks/[id]/changes/route.ts
@@ -10,12 +10,12 @@ const changeTracker = new ChangeTrackingService(prisma);
 
 export const GET = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const changes = await changeTracker.getChangeHistory(id);
   const delayCount = changes.filter((c) => c.changeType === "DELAY").length;
   const scopeChangeCount = changes.filter((c) => c.changeType === "SCOPE_CHANGE").length;
@@ -25,12 +25,12 @@ export const GET = apiHandler(async (
 
 export const POST = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const body = await req.json();
   const { changeType, reason, oldValue, newValue } = body;
 

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -11,18 +11,18 @@ const taskService = new TaskService(prisma);
 
 export const GET = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const task = await taskService.getTask(id);
   return success(task);
 });
 
 export const PUT = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const body = validateBody(updateTaskSchema, raw);
   const task = await taskService.updateTask(id, body);
@@ -31,19 +31,19 @@ export const PUT = withAuth(async (
 
 export const DELETE = withManager(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await taskService.deleteTask(id);
   return success({ success: true });
 });
 
 export const PATCH = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await requireAuth();
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { status } = validateBody(updateTaskStatusSchema, raw);
   const task = await taskService.updateTaskStatus(id, status, session.user.id);

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -10,12 +10,12 @@ import { success } from "@/lib/api-response";
 
 export const PUT = apiHandler(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const { taskId, date, hours, category, description } = validateBody(updateTimeEntrySchema, raw);
 
@@ -39,12 +39,12 @@ export const PUT = apiHandler(async (
 
 export const DELETE = apiHandler(async (
   _req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
-  const { id } = await context!.params;
+  const { id } = await context.params;
   await prisma.timeEntry.delete({ where: { id } });
   return success({ success: true });
 });

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -10,18 +10,18 @@ const userService = new UserService(prisma);
 
 export const GET = withAuth(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const user = await userService.getUser(id);
   return success(user);
 });
 
 export const PUT = withManager(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const raw = await req.json();
   const body = validateBody(updateUserSchema, raw);
   const user = await userService.updateUser(id, body);
@@ -30,9 +30,9 @@ export const PUT = withManager(async (
 
 export const DELETE = withManager(async (
   req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
+  context: { params: Promise<Record<string, string>> }
 ) => {
-  const { id } = await context!.params;
+  const { id } = await context.params;
   const { searchParams } = new URL(req.url);
   const action = searchParams.get("action");
 

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -10,9 +10,7 @@ import type { ApiResponse } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { requestLogger } from "@/lib/request-logger";
 
-type RouteHandler<TParams = undefined> = TParams extends undefined
-  ? (req: NextRequest) => Promise<NextResponse<ApiResponse>>
-  : (req: NextRequest, context: { params: Promise<TParams> }) => Promise<NextResponse<ApiResponse>>;
+export type RouteContext = { params: Promise<Record<string, string>> };
 
 /**
  * Wraps a Next.js route handler with unified error handling.
@@ -20,23 +18,24 @@ type RouteHandler<TParams = undefined> = TParams extends undefined
  * Maps custom error types to HTTP status codes and returns a consistent
  * JSON shape: { ok, data?, error?, message? }
  *
- * Usage (simple):
+ * Usage (simple, non-dynamic route):
  *   export const GET = apiHandler(async (req) => {
  *     return success(data);
  *   });
  *
- * Usage (with dynamic params):
- *   export const GET = apiHandler(async (req, { params }) => {
- *     const { id } = await params;
+ * Usage (with dynamic params, Next.js 15 — context is required, not optional):
+ *   export const GET = apiHandler(async (req, context) => {
+ *     const { id } = await context.params;
  *     return success(data);
  *   });
  */
-export function apiHandler(
-  fn: (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => Promise<NextResponse<ApiResponse>>
-): (req: NextRequest, context?: { params: Promise<Record<string, string>> }) => Promise<NextResponse<ApiResponse>> {
-  return async (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function apiHandler<T extends (...args: any[]) => Promise<NextResponse<ApiResponse>>>(
+  fn: T
+): T {
+  const wrapped = async (
     req: NextRequest,
-    context?: { params: Promise<Record<string, string>> }
+    context?: RouteContext
   ): Promise<NextResponse<ApiResponse>> => {
     return requestLogger(req, async () => {
       try {
@@ -60,4 +59,5 @@ export function apiHandler(
       }
     }) as Promise<NextResponse<ApiResponse>>;
   };
+  return wrapped as unknown as T;
 }

--- a/lib/auth-middleware.ts
+++ b/lib/auth-middleware.ts
@@ -6,39 +6,40 @@
  *     return success(data);
  *   });
  *
- *   export const POST = withManager(async (req) => {
+ *   export const POST = withManager(async (req, context) => {
+ *     const { id } = await context.params;
  *     return success(data);
  *   });
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, requireRole } from "@/lib/rbac";
-import { apiHandler } from "@/lib/api-handler";
+import { apiHandler, RouteContext } from "@/lib/api-handler";
 import type { ApiResponse } from "@/lib/api-response";
 
-type RouteHandler = (
-  req: NextRequest,
-  context?: { params: Promise<Record<string, string>> }
-) => Promise<NextResponse<ApiResponse>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHandler = (req: NextRequest, context?: any) => Promise<NextResponse<ApiResponse>>;
 
 /**
  * Wraps a route handler with requireAuth check + unified error handling.
  * Any authenticated user (MANAGER or ENGINEER) may access.
  */
-export function withAuth(fn: RouteHandler): RouteHandler {
-  return apiHandler(async (req, context) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function withAuth<T extends AnyHandler>(fn: T): T {
+  return apiHandler(async (req: NextRequest, context?: RouteContext) => {
     await requireAuth();
     return fn(req, context);
-  });
+  }) as unknown as T;
 }
 
 /**
  * Wraps a route handler with requireRole('MANAGER') check + error handling.
  * Only MANAGER role may access.
  */
-export function withManager(fn: RouteHandler): RouteHandler {
-  return apiHandler(async (req, context) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function withManager<T extends AnyHandler>(fn: T): T {
+  return apiHandler(async (req: NextRequest, context?: RouteContext) => {
     await requireRole("MANAGER");
     return fn(req, context);
-  });
+  }) as unknown as T;
 }


### PR DESCRIPTION
## Summary

- Remove optional marker (`?`) from `context` in all 15 `[id]` route handlers so the exported type satisfies Next.js 15's required `RouteContext`
- Refactor `apiHandler` to a generic `<T>` wrapper that preserves the caller's exact function type, handling both simple (non-dynamic) and dynamic-segment routes without overloads
- Refactor `withAuth` / `withManager` with matching generic `<T>` signature
- Replace `context!.params` non-null assertions with plain `context.params` throughout
- Fix pre-existing `ZodError.errors` → `.issues` (Zod v4 API) in `app/api/deliverables/route.ts`
- Fix pre-existing `Buffer` → `new Uint8Array(buffer)` in `app/api/reports/export/route.ts` so `NextResponse` body type is satisfied

## Files changed

- `lib/api-handler.ts` — generic wrapper, exported `RouteContext` type
- `lib/auth-middleware.ts` — generic `withAuth` / `withManager`
- 15 × `app/api/**/[id]/route.ts` — `context?` → `context`, `context!.params` → `context.params`
- `app/api/deliverables/route.ts` — Zod v4 `.issues` fix
- `app/api/reports/export/route.ts` — `Buffer` → `Uint8Array` fix

## Test plan

- [x] `npm run build` passes with zero type errors (verified locally)
- [ ] Smoke-test dynamic API routes (`GET /api/tasks/[id]`, `GET /api/deliverables/[id]`, etc.) return correct responses

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)