### PR TITLE
fix(#123): IDOR protection on time entries with TDD

### DIFF
--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
-import { UnauthorizedError } from "@/services/errors";
+import { ForbiddenError, NotFoundError, UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateTimeEntrySchema } from "@/validators/time-entry-validators";
 import { apiHandler } from "@/lib/api-handler";
@@ -15,7 +15,18 @@ export const PUT = apiHandler(async (
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
+  const callerId = session.user.id;
   const { id } = await context.params;
+
+  // Fetch first to check ownership — single query, no N+1.
+  const existing = await prisma.timeEntry.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+  // IDOR: all roles (including MANAGER) may only write their own entries.
+  if (existing.userId !== callerId) {
+    throw new ForbiddenError("只能修改自己的時間記錄");
+  }
+
   const raw = await req.json();
   const { taskId, date, hours, category, description } = validateBody(updateTimeEntrySchema, raw);
 
@@ -44,7 +55,18 @@ export const DELETE = apiHandler(async (
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
+  const callerId = session.user.id;
   const { id } = await context.params;
+
+  // Fetch first to check ownership — single query, no N+1.
+  const existing = await prisma.timeEntry.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+  // IDOR: all roles (including MANAGER) may only delete their own entries.
+  if (existing.userId !== callerId) {
+    throw new ForbiddenError("只能刪除自己的時間記錄");
+  }
+
   await prisma.timeEntry.delete({ where: { id } });
   return success({ success: true });
 });

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -2,19 +2,35 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { TimeCategory } from "@prisma/client";
-import { UnauthorizedError } from "@/services/errors";
+import { ForbiddenError, UnauthorizedError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { createTimeEntrySchema } from "@/validators/time-entry-validators";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+import { TimeEntryService } from "@/services/time-entry-service";
+
+const READ_ALL_ROLES = new Set(["MANAGER", "ADMIN"]);
 
 export const GET = apiHandler(async (req: NextRequest) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
+  const callerId = session.user.id;
+  const callerRole = session.user.role ?? "ENGINEER";
+
   const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId") || session.user.id;
+  const requestedUserId = searchParams.get("userId");
   const weekStart = searchParams.get("weekStart");
+
+  // IDOR: non-privileged callers can only query their own entries.
+  if (requestedUserId && requestedUserId !== callerId && !READ_ALL_ROLES.has(callerRole)) {
+    throw new ForbiddenError("其他使用者的時間記錄無法存取");
+  }
+
+  // Scope to caller unless a privileged role requests a specific user.
+  const userId = READ_ALL_ROLES.has(callerRole) && requestedUserId
+    ? requestedUserId
+    : callerId;
 
   const where: Record<string, unknown> = { userId };
 
@@ -43,6 +59,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
   const raw = await req.json();
   const { taskId, date, hours, category, description } = validateBody(createTimeEntrySchema, raw);
 
+  // Always create entries owned by the caller — ignores any userId in body.
   const entry = await prisma.timeEntry.create({
     data: {
       taskId: taskId || null,

--- a/app/api/time-entries/stats/route.ts
+++ b/app/api/time-entries/stats/route.ts
@@ -1,18 +1,33 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
-import { UnauthorizedError } from "@/services/errors";
+import { ForbiddenError, UnauthorizedError } from "@/services/errors";
 import { apiHandler } from "@/lib/api-handler";
 import { success } from "@/lib/api-response";
+
+const READ_ALL_ROLES = new Set(["MANAGER", "ADMIN"]);
 
 export const GET = apiHandler(async (req: NextRequest) => {
   const session = await getServerSession();
   if (!session?.user?.id) throw new UnauthorizedError();
 
+  const callerId = session.user.id;
+  const callerRole = session.user.role ?? "ENGINEER";
+
   const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId") || session.user.id;
+  const requestedUserId = searchParams.get("userId");
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
+
+  // IDOR: non-privileged callers can only query their own stats.
+  if (requestedUserId && requestedUserId !== callerId && !READ_ALL_ROLES.has(callerRole)) {
+    throw new ForbiddenError("其他使用者的統計資料無法存取");
+  }
+
+  // Scope to caller unless a privileged role requests a specific user.
+  const userId = READ_ALL_ROLES.has(callerRole) && requestedUserId
+    ? requestedUserId
+    : callerId;
 
   const where: Record<string, unknown> = { userId };
   if (startDate || endDate) {

--- a/services/__tests__/idor-protection.test.ts
+++ b/services/__tests__/idor-protection.test.ts
@@ -1,0 +1,141 @@
+import { TimeEntryService } from "../time-entry-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { ForbiddenError } from "../errors";
+
+describe("TimeEntryService IDOR protection", () => {
+  let service: TimeEntryService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  const engineerEntry = { id: "te-1", userId: "user-engineer", hours: 2, category: "PLANNED_TASK" };
+  const otherEntry = { id: "te-2", userId: "user-other", hours: 3, category: "INCIDENT" };
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new TimeEntryService(prisma as never);
+  });
+
+  // ──────────────────────────────────────────────
+  // READ
+  // ──────────────────────────────────────────────
+
+  test("ENGINEER can only read own time entries", async () => {
+    (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([engineerEntry]);
+
+    await service.listTimeEntries({ userId: "user-engineer" }, "user-engineer", "ENGINEER");
+
+    expect(prisma.timeEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-engineer" }),
+      })
+    );
+  });
+
+  test("ENGINEER cannot read other users time entries", async () => {
+    await expect(
+      service.listTimeEntries({ userId: "user-other" }, "user-engineer", "ENGINEER")
+    ).rejects.toThrow(ForbiddenError);
+
+    expect(prisma.timeEntry.findMany).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────
+  // UPDATE
+  // ──────────────────────────────────────────────
+
+  test("ENGINEER can only update own time entries", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(engineerEntry);
+    (prisma.timeEntry.update as jest.Mock).mockResolvedValue({ ...engineerEntry, hours: 4 });
+
+    const result = await service.updateTimeEntry("te-1", { hours: 4 }, "user-engineer", "ENGINEER");
+
+    expect(result.hours).toBe(4);
+    expect(prisma.timeEntry.update).toHaveBeenCalled();
+  });
+
+  test("ENGINEER cannot update other users time entries", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+
+    await expect(
+      service.updateTimeEntry("te-2", { hours: 4 }, "user-engineer", "ENGINEER")
+    ).rejects.toThrow(ForbiddenError);
+
+    expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────
+  // DELETE
+  // ──────────────────────────────────────────────
+
+  test("ENGINEER cannot delete other users entries", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+
+    await expect(
+      service.deleteTimeEntry("te-2", "user-engineer", "ENGINEER")
+    ).rejects.toThrow(ForbiddenError);
+
+    expect(prisma.timeEntry.delete).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────
+  // MANAGER READ (exempt)
+  // ──────────────────────────────────────────────
+
+  test("MANAGER can read all time entries", async () => {
+    (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([engineerEntry, otherEntry]);
+
+    const result = await service.listTimeEntries({ userId: "user-other" }, "user-manager", "MANAGER");
+
+    expect(result).toHaveLength(2);
+    expect(prisma.timeEntry.findMany).toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────
+  // MANAGER WRITE (own only by default)
+  // ──────────────────────────────────────────────
+
+  test("MANAGER can only WRITE own entries by default", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+
+    await expect(
+      service.updateTimeEntry("te-2", { hours: 5 }, "user-manager", "MANAGER")
+    ).rejects.toThrow(ForbiddenError);
+
+    expect(prisma.timeEntry.update).not.toHaveBeenCalled();
+  });
+
+  // ──────────────────────────────────────────────
+  // 403 not 404
+  // ──────────────────────────────────────────────
+
+  test("return 403 not 404 for unauthorized access", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+
+    let caughtError: Error | undefined;
+    try {
+      await service.deleteTimeEntry("te-2", "user-engineer", "ENGINEER");
+    } catch (e) {
+      caughtError = e as Error;
+    }
+
+    expect(caughtError).toBeInstanceOf(ForbiddenError);
+    expect(caughtError?.name).toBe("ForbiddenError");
+  });
+
+  // ──────────────────────────────────────────────
+  // Batch operations
+  // ──────────────────────────────────────────────
+
+  test("batch operations respect ownership", async () => {
+    // When an ENGINEER filters without specifying userId,
+    // the query must be scoped to their own userId (not all entries)
+    (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([engineerEntry]);
+
+    await service.listTimeEntries({}, "user-engineer", "ENGINEER");
+
+    expect(prisma.timeEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: "user-engineer" }),
+      })
+    );
+  });
+});

--- a/services/__tests__/time-entry-service.test.ts
+++ b/services/__tests__/time-entry-service.test.ts
@@ -15,7 +15,7 @@ describe("TimeEntryService", () => {
     const mockEntries = [{ id: "te-1", userId: "user-1", hours: 2 }];
     (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue(mockEntries);
 
-    const result = await service.listTimeEntries({ userId: "user-1" });
+    const result = await service.listTimeEntries({ userId: "user-1" }, "user-1", "ENGINEER");
 
     expect(prisma.timeEntry.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -39,15 +39,15 @@ describe("TimeEntryService", () => {
     (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(null);
 
     await expect(
-      service.updateTimeEntry("nonexistent", { hours: 3 })
+      service.updateTimeEntry("nonexistent", { hours: 3 }, "user-1", "ENGINEER")
     ).rejects.toThrow(NotFoundError);
   });
 
   test("deleteTimeEntry removes entry", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({ id: "te-1" });
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({ id: "te-1", userId: "user-1" });
     (prisma.timeEntry.delete as jest.Mock).mockResolvedValue({ id: "te-1" });
 
-    await service.deleteTimeEntry("te-1");
+    await service.deleteTimeEntry("te-1", "user-1", "ENGINEER");
 
     expect(prisma.timeEntry.delete).toHaveBeenCalledWith(
       expect.objectContaining({ where: { id: "te-1" } })
@@ -61,7 +61,7 @@ describe("TimeEntryService", () => {
     ];
     (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue(mockEntries);
 
-    const result = await service.getStats({ userId: "user-1" });
+    const result = await service.getStats({ userId: "user-1" }, "user-1", "ENGINEER");
 
     expect(result.totalHours).toBe(5);
     expect(result).toHaveProperty("byCategory");

--- a/services/time-entry-service.ts
+++ b/services/time-entry-service.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, TimeCategory } from "@prisma/client";
-import { NotFoundError, ValidationError } from "./errors";
+import { ForbiddenError, NotFoundError, ValidationError } from "./errors";
 
 export interface ListTimeEntriesFilter {
   userId?: string;
@@ -18,6 +18,7 @@ export interface CreateTimeEntryInput {
 }
 
 export interface UpdateTimeEntryInput {
+  taskId?: string | null;
   hours?: number;
   category?: TimeCategory | string;
   description?: string | null;
@@ -29,12 +30,44 @@ export interface TimeEntryStats {
   byCategory: Record<string, number>;
 }
 
+/** Roles that exist in session.user.role */
+export type CallerRole = string;
+
+const READ_ALL_ROLES = new Set(["MANAGER", "ADMIN"]);
+
 export class TimeEntryService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async listTimeEntries(filter: ListTimeEntriesFilter) {
+  /**
+   * List time entries.
+   *
+   * IDOR rules:
+   * - MANAGER / ADMIN: may query any userId (read exemption).
+   * - All other roles: query is always scoped to callerId regardless of
+   *   what userId was passed in filter. Passing a different userId → 403.
+   */
+  async listTimeEntries(
+    filter: ListTimeEntriesFilter,
+    callerId: string,
+    callerRole: CallerRole
+  ) {
+    const canReadAll = READ_ALL_ROLES.has(callerRole);
+
+    // If a specific foreign userId was requested and the caller has no
+    // read-all privilege, that is an IDOR attempt → 403.
+    if (!canReadAll && filter.userId && filter.userId !== callerId) {
+      throw new ForbiddenError("其他使用者的時間記錄無法存取");
+    }
+
     const where: Record<string, unknown> = {};
-    if (filter.userId) where.userId = filter.userId;
+
+    // Non-privileged callers are always scoped to themselves.
+    if (!canReadAll) {
+      where.userId = callerId;
+    } else if (filter.userId) {
+      where.userId = filter.userId;
+    }
+
     if (filter.taskId) where.taskId = filter.taskId;
     if (filter.dateFrom || filter.dateTo) {
       where.date = {
@@ -53,6 +86,12 @@ export class TimeEntryService {
     });
   }
 
+  /**
+   * Create a time entry.
+   *
+   * The API layer always passes session.user.id as userId, so no extra
+   * ownership check is needed here — validation guards against empty/bad input.
+   */
   async createTimeEntry(input: CreateTimeEntryInput) {
     if (!input.userId?.trim()) {
       throw new ValidationError("使用者ID為必填");
@@ -77,9 +116,26 @@ export class TimeEntryService {
     });
   }
 
-  async updateTimeEntry(id: string, input: UpdateTimeEntryInput) {
+  /**
+   * Update a time entry.
+   *
+   * IDOR rules:
+   * - All roles (including MANAGER): must own the entry to write.
+   *   → Single query fetches the entry; ownership check in the same round-trip.
+   */
+  async updateTimeEntry(
+    id: string,
+    input: UpdateTimeEntryInput,
+    callerId: string,
+    callerRole: CallerRole
+  ) {
     const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+    // Write is always restricted to the owner regardless of role.
+    if (existing.userId !== callerId) {
+      throw new ForbiddenError("只能修改自己的時間記錄");
+    }
 
     const updates: Record<string, unknown> = {};
     if (input.hours !== undefined) updates.hours = input.hours;
@@ -97,15 +153,29 @@ export class TimeEntryService {
     });
   }
 
-  async deleteTimeEntry(id: string) {
+  /**
+   * Delete a time entry.
+   *
+   * IDOR rules:
+   * - All roles (including MANAGER): must own the entry to delete.
+   */
+  async deleteTimeEntry(id: string, callerId: string, callerRole: CallerRole) {
     const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+    if (existing.userId !== callerId) {
+      throw new ForbiddenError("只能刪除自己的時間記錄");
+    }
 
     return this.prisma.timeEntry.delete({ where: { id } });
   }
 
-  async getStats(filter: ListTimeEntriesFilter): Promise<TimeEntryStats> {
-    const entries = await this.listTimeEntries(filter);
+  async getStats(
+    filter: ListTimeEntriesFilter,
+    callerId: string,
+    callerRole: CallerRole
+  ): Promise<TimeEntryStats> {
+    const entries = await this.listTimeEntries(filter, callerId, callerRole);
 
     const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
     const byCategory = entries.reduce<Record<string, number>>((acc, e) => {


### PR DESCRIPTION
## Summary

- **C2 IDOR vulnerability fixed**: time entry endpoints previously allowed any authenticated user to read, update, or delete another user's records by supplying a foreign `userId` or entry `id`.
- **TDD**: `services/__tests__/idor-protection.test.ts` written first (9 tests, RED → GREEN), then implementation.
- **MANAGER read exemption** preserved; MANAGER write is still restricted to own entries.
- All ownership violations return **403 ForbiddenError**, never 404.
- Ownership check uses a single `findUnique` query — no N+1.

## Changes

| File | Change |
|---|---|
| `services/__tests__/idor-protection.test.ts` | New TDD test file (9 IDOR scenarios) |
| `services/__tests__/time-entry-service.test.ts` | Updated call-sites for new method signatures |
| `services/time-entry-service.ts` | All mutating methods now accept `callerId` + `callerRole`; ownership enforced |
| `app/api/time-entries/route.ts` | GET scoped to caller; POST always sets `userId = session.user.id` |
| `app/api/time-entries/[id]/route.ts` | PUT/DELETE check ownership before executing |
| `app/api/time-entries/stats/route.ts` | GET scoped to caller; privileged roles may pass `userId` param |

## Test plan

- [x] 9 new IDOR-specific tests pass (`idor-protection.test.ts`)
- [x] All 138 service tests pass (`npx jest services/__tests__/`)
- [ ] Manual: `GET /api/time-entries?userId=<other>` as ENGINEER → 403
- [ ] Manual: `PUT /api/time-entries/<other-id>` as ENGINEER → 403
- [ ] Manual: `DELETE /api/time-entries/<other-id>` as MANAGER → 403
- [ ] Manual: `GET /api/time-entries?userId=<other>` as MANAGER → 200

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)