### PR TITLE
fix(#125): CSRF protection with TDD

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,26 @@ import { compare } from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 
 const handler = NextAuth({
+  cookies: {
+    sessionToken: {
+      name: "next-auth.session-token",
+      options: {
+        httpOnly: true,
+        sameSite: "strict",
+        path: "/",
+        secure: process.env.NODE_ENV === "production",
+      },
+    },
+    csrfToken: {
+      name: "next-auth.csrf-token",
+      options: {
+        httpOnly: true,
+        sameSite: "strict",
+        path: "/",
+        secure: process.env.NODE_ENV === "production",
+      },
+    },
+  },
   providers: [
     CredentialsProvider({
       name: "Credentials",

--- a/lib/__tests__/csrf.test.ts
+++ b/lib/__tests__/csrf.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Tests written FIRST (RED) before implementation.
+ * Issue #125: CSRF protection — Origin validation + SameSite cookie
+ */
+
+import { NextRequest } from "next/server";
+
+// ── Mock next/server ──────────────────────────────────────────────────────
+jest.mock("next/server", () => {
+  const actual = jest.requireActual("next/server");
+  return {
+    ...actual,
+    NextResponse: {
+      json: jest.fn((body: unknown, init?: { status?: number }) => ({
+        status: init?.status ?? 200,
+        _body: body,
+        json: async () => body,
+      })),
+    },
+  };
+});
+
+// ── Import after mocks ────────────────────────────────────────────────────
+import { validateCsrf, CsrfError } from "@/lib/csrf";
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function makeRequest(overrides: {
+  url?: string;
+  origin?: string | null;
+  host?: string | null;
+  method?: string;
+}): NextRequest {
+  const url = overrides.url ?? "http://localhost:3000/api/test";
+  const headers = new Headers();
+  if (overrides.origin !== undefined && overrides.origin !== null) {
+    headers.set("origin", overrides.origin);
+  }
+  if (overrides.host !== undefined && overrides.host !== null) {
+    headers.set("host", overrides.host);
+  }
+  return {
+    url,
+    method: overrides.method ?? "POST",
+    headers,
+    json: jest.fn(),
+  } as unknown as NextRequest;
+}
+
+// ── Test: same-origin request passes ─────────────────────────────────────
+
+describe("validateCsrf — same-origin", () => {
+  it("passes when Origin matches Host", () => {
+    const req = makeRequest({
+      url: "http://localhost:3000/api/users",
+      origin: "http://localhost:3000",
+      host: "localhost:3000",
+    });
+    // Should not throw
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+
+  it("passes when Origin matches production host", () => {
+    const req = makeRequest({
+      url: "https://titan.example.com/api/users",
+      origin: "https://titan.example.com",
+      host: "titan.example.com",
+    });
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+
+  it("passes for GET requests regardless of Origin (safe method)", () => {
+    const req = makeRequest({
+      method: "GET",
+      origin: "https://evil.com",
+      host: "titan.example.com",
+    });
+    // GET is a safe/idempotent method — CSRF protection is not needed
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+
+  it("passes for HEAD requests (safe method)", () => {
+    const req = makeRequest({
+      method: "HEAD",
+      origin: "https://evil.com",
+      host: "titan.example.com",
+    });
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+});
+
+// ── Test: cross-origin request blocked with 403 ───────────────────────────
+
+describe("validateCsrf — cross-origin blocked", () => {
+  it("throws CsrfError when Origin does not match Host on POST", () => {
+    const req = makeRequest({
+      url: "http://localhost:3000/api/users",
+      origin: "https://evil.com",
+      host: "localhost:3000",
+    });
+    expect(() => validateCsrf(req)).toThrow(CsrfError);
+  });
+
+  it("throws CsrfError when Origin does not match Host on PUT", () => {
+    const req = makeRequest({
+      method: "PUT",
+      url: "https://titan.example.com/api/users/1",
+      origin: "https://attacker.io",
+      host: "titan.example.com",
+    });
+    expect(() => validateCsrf(req)).toThrow(CsrfError);
+  });
+
+  it("throws CsrfError when Origin does not match Host on DELETE", () => {
+    const req = makeRequest({
+      method: "DELETE",
+      url: "https://titan.example.com/api/users/1",
+      origin: "https://attacker.io",
+      host: "titan.example.com",
+    });
+    expect(() => validateCsrf(req)).toThrow(CsrfError);
+  });
+
+  it("throws CsrfError when Origin does not match Host on PATCH", () => {
+    const req = makeRequest({
+      method: "PATCH",
+      url: "https://titan.example.com/api/users/1",
+      origin: "https://attacker.io",
+      host: "titan.example.com",
+    });
+    expect(() => validateCsrf(req)).toThrow(CsrfError);
+  });
+
+  it("CsrfError has status 403", () => {
+    const req = makeRequest({
+      origin: "https://evil.com",
+      host: "localhost:3000",
+    });
+    try {
+      validateCsrf(req);
+      fail("Expected CsrfError to be thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CsrfError);
+      expect((err as CsrfError).statusCode).toBe(403);
+    }
+  });
+});
+
+// ── Test: request without Origin header handled safely ────────────────────
+
+describe("validateCsrf — missing Origin header", () => {
+  it("passes when Origin header is absent on POST (server-to-server / curl)", () => {
+    // Requests without an Origin header are typically direct server calls or
+    // same-origin form submissions from older browsers. We allow them because
+    // a browser CSRF attack will always include the Origin header.
+    const req = makeRequest({
+      url: "http://localhost:3000/api/test",
+      origin: null,
+      host: "localhost:3000",
+      method: "POST",
+    });
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+
+  it("passes when both Origin and Host headers are absent", () => {
+    const req = makeRequest({
+      url: "http://localhost:3000/api/test",
+      origin: null,
+      host: null,
+      method: "POST",
+    });
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+});
+
+// ── Test: NextAuth CSRF token validation ─────────────────────────────────
+
+describe("validateCsrf — NextAuth CSRF token", () => {
+  it("CsrfError message mentions CSRF", () => {
+    const req = makeRequest({
+      origin: "https://evil.com",
+      host: "titan.example.com",
+      method: "POST",
+    });
+    try {
+      validateCsrf(req);
+    } catch (err) {
+      expect(err).toBeInstanceOf(CsrfError);
+      expect((err as CsrfError).message).toMatch(/csrf/i);
+    }
+  });
+
+  it("validateCsrf is a function", () => {
+    expect(typeof validateCsrf).toBe("function");
+  });
+
+  it("CsrfError is a class extending Error", () => {
+    const e = new CsrfError("test");
+    expect(e).toBeInstanceOf(Error);
+    expect(e).toBeInstanceOf(CsrfError);
+    expect(e.message).toBe("test");
+  });
+
+  it("passes NextAuth own routes (/api/auth/*) regardless of origin", () => {
+    // NextAuth handles its own CSRF internally via csrfToken cookie
+    const req = makeRequest({
+      url: "http://localhost:3000/api/auth/csrf",
+      origin: "https://evil.com",
+      host: "localhost:3000",
+      method: "POST",
+    });
+    // NextAuth routes should be excluded from our custom CSRF check
+    expect(() => validateCsrf(req)).not.toThrow();
+  });
+});

--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -9,6 +9,7 @@ import { success, error } from "@/lib/api-response";
 import type { ApiResponse } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { requestLogger } from "@/lib/request-logger";
+import { validateCsrf, CsrfError } from "@/lib/csrf";
 
 export type RouteContext = { params: Promise<Record<string, string>> };
 
@@ -39,8 +40,12 @@ export function apiHandler<T extends (...args: any[]) => Promise<NextResponse<Ap
   ): Promise<NextResponse<ApiResponse>> => {
     return requestLogger(req, async () => {
       try {
+        validateCsrf(req);
         return await fn(req, context);
       } catch (err) {
+        if (err instanceof CsrfError) {
+          return error("ForbiddenError", err.message, 403);
+        }
         if (err instanceof ValidationError) {
           return error("ValidationError", err.message, 400);
         }

--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -1,0 +1,89 @@
+/**
+ * CSRF protection middleware — Issue #125
+ *
+ * Strategy: Origin header validation (same-origin check).
+ *
+ * Rules:
+ *  1. Safe HTTP methods (GET, HEAD, OPTIONS) are always allowed — they must
+ *     not mutate state and are not CSRF-eligible.
+ *  2. NextAuth's own routes (/api/auth/*) are excluded — NextAuth manages its
+ *     own csrfToken cookie internally.
+ *  3. If the Origin header is absent we allow the request: server-to-server
+ *     calls and same-origin form posts from older browsers don't send Origin.
+ *     A browser CSRF attack from a foreign page will always include Origin.
+ *  4. If Origin is present it must match the Host header (same-origin). A
+ *     mismatch throws CsrfError (→ 403).
+ *
+ * Cookie hardening (SameSite=Strict) is applied via NextAuth authOptions in
+ * app/api/auth/[...nextauth]/route.ts.
+ */
+
+import type { NextRequest } from "next/server";
+
+/** HTTP methods that do not mutate state — exempt from CSRF checks. */
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/** URL prefix handled by NextAuth — has its own csrfToken mechanism. */
+const NEXTAUTH_PREFIX = "/api/auth/";
+
+/**
+ * Typed error thrown when CSRF validation fails.
+ * apiHandler maps this to a 403 ForbiddenError response.
+ */
+export class CsrfError extends Error {
+  readonly statusCode = 403;
+
+  constructor(message = "CSRF 驗證失敗") {
+    super(message);
+    this.name = "CsrfError";
+    // Maintain correct prototype chain in transpiled environments
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Validates the incoming request against CSRF attacks.
+ *
+ * Throws CsrfError (403) for state-mutating cross-origin requests.
+ * Returns void on success (no-throw = pass).
+ */
+export function validateCsrf(req: NextRequest): void {
+  const { method, url, headers } = req;
+
+  // 1. Safe methods are never CSRF-vulnerable
+  if (SAFE_METHODS.has(method.toUpperCase())) {
+    return;
+  }
+
+  // 2. NextAuth manages its own CSRF — skip our check for /api/auth/*
+  const pathname = new URL(url).pathname;
+  if (pathname.startsWith(NEXTAUTH_PREFIX)) {
+    return;
+  }
+
+  // 3. If Origin header is absent, allow (non-browser / same-origin fallback)
+  const origin = headers.get("origin");
+  if (!origin) {
+    return;
+  }
+
+  // 4. Compare Origin against Host — must match to be same-origin
+  const host = headers.get("host");
+  if (!host) {
+    // No Host header — can't validate, but Origin is present and we can't
+    // confirm legitimacy. Block to be safe.
+    throw new CsrfError("CSRF 驗證失敗：無法確認請求來源");
+  }
+
+  // Extract the host portion from the Origin URL (strips scheme + trailing slash)
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    throw new CsrfError("CSRF 驗證失敗：Origin 格式無效");
+  }
+
+  if (originHost !== host) {
+    throw new CsrfError(`CSRF 驗證失敗：Origin "${originHost}" 與 Host "${host}" 不符`);
+  }
+}


### PR DESCRIPTION
## Summary

- 新增 `lib/csrf.ts`：Origin header 驗證 middleware，對 POST/PUT/PATCH/DELETE 等狀態修改方法進行 same-origin 檢查，違規拋出 `CsrfError` (403)
- 新增 `lib/__tests__/csrf.test.ts`：TDD 測試（先寫測試再實作），15 個測試案例涵蓋 same-origin pass、cross-origin block、缺少 Origin header、NextAuth 路由豁免
- 修改 `lib/api-handler.ts`：整合 `validateCsrf`，在每個 API 請求最前端執行 CSRF 檢查
- 修改 `app/api/auth/[...nextauth]/route.ts`：為 session token 與 CSRF token cookie 加入 `sameSite: "strict"` 與 `httpOnly: true`

## Test plan

- [x] `npx jest lib/__tests__/csrf.test.ts` — 15/15 passed (GREEN)
- [x] `npx jest lib/__tests__/` — 56/56 passed，無迴歸

## Design decisions

| 情境 | 行為 | 原因 |
|------|------|------|
| GET/HEAD/OPTIONS | 允許 | 安全方法不修改狀態 |
| `/api/auth/*` | 允許 | NextAuth 自管 csrfToken cookie |
| 無 Origin header | 允許 | server-to-server / curl，瀏覽器 CSRF 一定帶 Origin |
| Origin ≠ Host | 403 CsrfError | 跨來源狀態修改請求 |

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)