### PR TITLE
fix(#126): audit logging for sensitive operations with TDD

### DIFF
--- a/__mocks__/prisma.ts
+++ b/__mocks__/prisma.ts
@@ -33,6 +33,7 @@ export const mockPrisma = {
   permission: createMockModel(),
   notification: createMockModel(),
   deliverable: createMockModel(),
+  auditLog: createMockModel(),
   $transaction: jest.fn(),
   $connect: jest.fn(),
   $disconnect: jest.fn(),

--- a/app/api/audit/route.ts
+++ b/app/api/audit/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { AuditService } from "@/services/audit-service";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+
+const auditService = new AuditService(prisma);
+
+/**
+ * GET /api/audit
+ * Returns paginated audit log entries. MANAGER only.
+ *
+ * Query params:
+ *   action        — filter by action string (optional)
+ *   userId        — filter by userId (optional)
+ *   resourceType  — filter by resourceType (optional)
+ *   limit         — max results (optional, default 200)
+ */
+export const GET = withManager(async (req: NextRequest) => {
+  const session = await requireRole("MANAGER");
+
+  const { searchParams } = new URL(req.url);
+  const limitParam = searchParams.get("limit");
+
+  const logs = await auditService.queryLogs({
+    callerId: session.user.id,
+    callerRole: session.user.role,
+    action: searchParams.get("action") ?? undefined,
+    userId: searchParams.get("userId") ?? undefined,
+    resourceType: searchParams.get("resourceType") ?? undefined,
+    limit: limitParam ? parseInt(limitParam, 10) : undefined,
+  });
+
+  return success(logs);
+});

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -39,6 +39,7 @@ export function createMockPrisma(): MockPrismaClient {
     permission: createMockModel(),
     notification: createMockModel(),
     deliverable: createMockModel(),
+    auditLog: createMockModel(),
     $transaction: jest.fn(),
     $connect: jest.fn(),
     $disconnect: jest.fn(),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -472,3 +472,20 @@ model DocumentVersion {
 
   @@map("document_versions")
 }
+
+// ═══════════════════════════════════════
+// 稽核日誌 (Audit Log — C8)
+// ═══════════════════════════════════════
+
+model AuditLog {
+  id           String   @id @default(cuid())
+  userId       String?  // null for unauthenticated events (e.g. login failures)
+  action       String   // e.g. DELETE_TASK, ROLE_CHANGE, PASSWORD_CHANGE, LOGIN_FAILURE
+  resourceType String   // e.g. Task, User, Auth
+  resourceId   String?  // nullable for non-resource events
+  detail       String?  // human-readable or JSON-serialised description
+  ipAddress    String?
+  createdAt    DateTime @default(now())
+
+  @@map("audit_logs")
+}

--- a/services/__tests__/audit-service.test.ts
+++ b/services/__tests__/audit-service.test.ts
@@ -1,0 +1,276 @@
+import { AuditService } from "../audit-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { ForbiddenError } from "../errors";
+
+describe("AuditService", () => {
+  let service: AuditService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new AuditService(prisma as never);
+  });
+
+  // ─── log() ───────────────────────────────────────────────────────────────
+
+  describe("log", () => {
+    test("logs DELETE operations with required fields", async () => {
+      const entry = {
+        id: "audit-1",
+        userId: "user-1",
+        action: "DELETE_TASK",
+        resourceType: "Task",
+        resourceId: "task-1",
+        detail: "Deleted task: Fix bug",
+        ipAddress: "127.0.0.1",
+        createdAt: new Date("2026-03-24T00:00:00.000Z"),
+      };
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue(entry);
+
+      const result = await service.log({
+        userId: "user-1",
+        action: "DELETE_TASK",
+        resourceType: "Task",
+        resourceId: "task-1",
+        detail: "Deleted task: Fix bug",
+        ipAddress: "127.0.0.1",
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: "user-1",
+            action: "DELETE_TASK",
+            resourceType: "Task",
+            resourceId: "task-1",
+            detail: "Deleted task: Fix bug",
+            ipAddress: "127.0.0.1",
+          }),
+        })
+      );
+      expect(result).toEqual(entry);
+    });
+
+    test("logs role changes with userId, action, timestamp, and detail", async () => {
+      const now = new Date("2026-03-24T00:00:00.000Z");
+      const entry = {
+        id: "audit-2",
+        userId: "manager-1",
+        action: "ROLE_CHANGE",
+        resourceType: "User",
+        resourceId: "user-2",
+        detail: JSON.stringify({ from: "ENGINEER", to: "MANAGER" }),
+        ipAddress: null,
+        createdAt: now,
+      };
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue(entry);
+
+      const result = await service.log({
+        userId: "manager-1",
+        action: "ROLE_CHANGE",
+        resourceType: "User",
+        resourceId: "user-2",
+        detail: JSON.stringify({ from: "ENGINEER", to: "MANAGER" }),
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: "manager-1",
+            action: "ROLE_CHANGE",
+            resourceType: "User",
+            resourceId: "user-2",
+          }),
+        })
+      );
+      expect(result.action).toBe("ROLE_CHANGE");
+      expect(result.createdAt).toBeDefined();
+    });
+
+    test("logs password changes", async () => {
+      const entry = {
+        id: "audit-3",
+        userId: "manager-1",
+        action: "PASSWORD_CHANGE",
+        resourceType: "User",
+        resourceId: "user-3",
+        detail: "Password changed",
+        ipAddress: "10.0.0.1",
+        createdAt: new Date("2026-03-24T00:00:00.000Z"),
+      };
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue(entry);
+
+      const result = await service.log({
+        userId: "manager-1",
+        action: "PASSWORD_CHANGE",
+        resourceType: "User",
+        resourceId: "user-3",
+        detail: "Password changed",
+        ipAddress: "10.0.0.1",
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: "PASSWORD_CHANGE",
+            resourceType: "User",
+            resourceId: "user-3",
+          }),
+        })
+      );
+      expect(result.action).toBe("PASSWORD_CHANGE");
+    });
+
+    test("logs login failures", async () => {
+      const entry = {
+        id: "audit-4",
+        userId: null,
+        action: "LOGIN_FAILURE",
+        resourceType: "Auth",
+        resourceId: null,
+        detail: "Failed login attempt for bad@example.com",
+        ipAddress: "203.0.113.1",
+        createdAt: new Date("2026-03-24T00:00:00.000Z"),
+      };
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue(entry);
+
+      const result = await service.log({
+        userId: null,
+        action: "LOGIN_FAILURE",
+        resourceType: "Auth",
+        resourceId: null,
+        detail: "Failed login attempt for bad@example.com",
+        ipAddress: "203.0.113.1",
+      });
+
+      expect(prisma.auditLog.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: "LOGIN_FAILURE",
+            resourceType: "Auth",
+          }),
+        })
+      );
+      expect(result.action).toBe("LOGIN_FAILURE");
+    });
+
+    test("audit log entry includes userId, action, timestamp, and detail", async () => {
+      const timestamp = new Date("2026-03-24T12:00:00.000Z");
+      const entry = {
+        id: "audit-5",
+        userId: "user-1",
+        action: "DELETE_TASK",
+        resourceType: "Task",
+        resourceId: "task-5",
+        detail: "Task removed",
+        ipAddress: null,
+        createdAt: timestamp,
+      };
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue(entry);
+
+      const result = await service.log({
+        userId: "user-1",
+        action: "DELETE_TASK",
+        resourceType: "Task",
+        resourceId: "task-5",
+        detail: "Task removed",
+      });
+
+      // Must have userId
+      expect(result.userId).toBe("user-1");
+      // Must have action
+      expect(result.action).toBe("DELETE_TASK");
+      // Must have timestamp (server-side UTC)
+      expect(result.createdAt).toBeInstanceOf(Date);
+      // Must have detail
+      expect(result.detail).toBe("Task removed");
+    });
+  });
+
+  // ─── queryLogs() ─────────────────────────────────────────────────────────
+
+  describe("queryLogs (read-only enforcement)", () => {
+    test("audit log service has no update method", () => {
+      // Audit logs must be read-only — no update exposed
+      expect(typeof (service as unknown as Record<string, unknown>)["updateLog"]).toBe("undefined");
+    });
+
+    test("audit log service has no delete method", () => {
+      // Audit logs must be read-only — no delete exposed
+      expect(typeof (service as unknown as Record<string, unknown>)["deleteLog"]).toBe("undefined");
+    });
+
+    test("queryLogs is callable (returns array)", async () => {
+      const entries = [
+        {
+          id: "audit-1",
+          userId: "user-1",
+          action: "DELETE_TASK",
+          resourceType: "Task",
+          resourceId: "task-1",
+          detail: "x",
+          ipAddress: null,
+          createdAt: new Date(),
+        },
+      ];
+      (prisma.auditLog.findMany as jest.Mock).mockResolvedValue(entries);
+
+      const result = await service.queryLogs({ callerId: "mgr-1", callerRole: "MANAGER" });
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalled();
+      expect(result).toEqual(entries);
+    });
+
+    test("only MANAGER can query audit logs — ENGINEER is rejected", async () => {
+      await expect(
+        service.queryLogs({ callerId: "eng-1", callerRole: "ENGINEER" })
+      ).rejects.toThrow(ForbiddenError);
+
+      expect(prisma.auditLog.findMany).not.toHaveBeenCalled();
+    });
+
+    test("queryLogs accepts optional filter by action", async () => {
+      (prisma.auditLog.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.queryLogs({
+        callerId: "mgr-1",
+        callerRole: "MANAGER",
+        action: "DELETE_TASK",
+      });
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ action: "DELETE_TASK" }),
+        })
+      );
+    });
+
+    test("queryLogs accepts optional filter by userId", async () => {
+      (prisma.auditLog.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.queryLogs({
+        callerId: "mgr-1",
+        callerRole: "MANAGER",
+        userId: "user-99",
+      });
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ userId: "user-99" }),
+        })
+      );
+    });
+
+    test("queryLogs results are ordered by createdAt descending", async () => {
+      (prisma.auditLog.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.queryLogs({ callerId: "mgr-1", callerRole: "MANAGER" });
+
+      expect(prisma.auditLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: "desc" },
+        })
+      );
+    });
+  });
+});

--- a/services/audit-service.ts
+++ b/services/audit-service.ts
@@ -1,0 +1,63 @@
+import { PrismaClient } from "@prisma/client";
+import { ForbiddenError } from "./errors";
+
+export interface LogAuditInput {
+  userId: string | null;
+  action: string;
+  resourceType: string;
+  resourceId?: string | null;
+  detail?: string | null;
+  ipAddress?: string | null;
+}
+
+export interface QueryAuditLogsInput {
+  callerId: string;
+  callerRole: string;
+  action?: string;
+  userId?: string;
+  resourceType?: string;
+  limit?: number;
+}
+
+export class AuditService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Persist an audit log entry. All timestamps are generated server-side (UTC).
+   * This method has no update/delete counterpart — audit logs are immutable.
+   */
+  async log(input: LogAuditInput) {
+    return this.prisma.auditLog.create({
+      data: {
+        userId: input.userId ?? null,
+        action: input.action,
+        resourceType: input.resourceType,
+        resourceId: input.resourceId ?? null,
+        detail: input.detail ?? null,
+        ipAddress: input.ipAddress ?? null,
+        // createdAt is server-side UTC via Prisma @default(now())
+      },
+    });
+  }
+
+  /**
+   * Query audit logs. Only MANAGER role may call this.
+   * Audit logs are read-only — no update or delete methods are exposed.
+   */
+  async queryLogs(input: QueryAuditLogsInput) {
+    if (input.callerRole !== "MANAGER") {
+      throw new ForbiddenError("權限不足：僅限管理員查詢稽核日誌");
+    }
+
+    const where: Record<string, unknown> = {};
+    if (input.action) where.action = input.action;
+    if (input.userId) where.userId = input.userId;
+    if (input.resourceType) where.resourceType = input.resourceType;
+
+    return this.prisma.auditLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      take: input.limit ?? 200,
+    });
+  }
+}

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { NotFoundError, ValidationError } from "./errors";
 import { ChangeTrackingService } from "./change-tracking-service";
+import { AuditService } from "./audit-service";
 
 export interface ListTasksFilter {
   assignee?: string;
@@ -50,9 +51,11 @@ export interface UpdateTaskInput {
 
 export class TaskService {
   private readonly changeTracker: ChangeTrackingService;
+  private readonly auditor: AuditService;
 
   constructor(private readonly prisma: PrismaClient) {
     this.changeTracker = new ChangeTrackingService(prisma);
+    this.auditor = new AuditService(prisma);
   }
 
   async listTasks(filter: ListTasksFilter) {
@@ -240,7 +243,19 @@ export class TaskService {
     return task;
   }
 
-  async deleteTask(id: string) {
-    return this.prisma.task.delete({ where: { id } });
+  async deleteTask(id: string, deletedBy?: string, ipAddress?: string) {
+    const task = await this.prisma.task.findUnique({ where: { id }, select: { id: true, title: true } });
+    const result = await this.prisma.task.delete({ where: { id } });
+
+    await this.auditor.log({
+      userId: deletedBy ?? null,
+      action: "DELETE_TASK",
+      resourceType: "Task",
+      resourceId: id,
+      detail: task ? `Deleted task: ${task.title}` : `Deleted task: ${id}`,
+      ipAddress: ipAddress ?? null,
+    });
+
+    return result;
   }
 }

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -1,6 +1,7 @@
 import { PrismaClient, Role } from "@prisma/client";
 import { hash } from "bcryptjs";
 import { NotFoundError, ValidationError } from "./errors";
+import { AuditService } from "./audit-service";
 
 export interface ListUsersFilter {
   role?: Role | string;
@@ -23,10 +24,16 @@ export interface UpdateUserInput {
   role?: Role | string;
   avatar?: string | null;
   isActive?: boolean;
+  updatedBy?: string;
+  ipAddress?: string;
 }
 
 export class UserService {
-  constructor(private readonly prisma: PrismaClient) {}
+  private readonly auditor: AuditService;
+
+  constructor(private readonly prisma: PrismaClient) {
+    this.auditor = new AuditService(prisma);
+  }
 
   async listUsers(filter: ListUsersFilter) {
     const where: Record<string, unknown> = {};
@@ -133,7 +140,7 @@ export class UserService {
       updates.password = await hash(input.password, 10);
     }
 
-    return this.prisma.user.update({
+    const updated = await this.prisma.user.update({
       where: { id },
       data: updates,
       select: {
@@ -145,6 +152,32 @@ export class UserService {
         isActive: true,
       },
     });
+
+    // Emit audit log for role change
+    if (input.role !== undefined && input.role !== existing.role) {
+      await this.auditor.log({
+        userId: input.updatedBy ?? null,
+        action: "ROLE_CHANGE",
+        resourceType: "User",
+        resourceId: id,
+        detail: JSON.stringify({ from: existing.role, to: input.role }),
+        ipAddress: input.ipAddress ?? null,
+      });
+    }
+
+    // Emit audit log for password change
+    if (input.password !== undefined) {
+      await this.auditor.log({
+        userId: input.updatedBy ?? null,
+        action: "PASSWORD_CHANGE",
+        resourceType: "User",
+        resourceId: id,
+        detail: "Password changed",
+        ipAddress: input.ipAddress ?? null,
+      });
+    }
+
+    return updated;
   }
 
   async suspendUser(id: string) {


### PR DESCRIPTION
## Summary

- Add `AuditLog` Prisma model (schema only, no migrate) and run `prisma generate`
- Create `AuditService` with `log()` and read-only `queryLogs()` (MANAGER-only guard via `ForbiddenError`)
- Create `GET /api/audit` route protected by `withManager` middleware
- Integrate into `TaskService.deleteTask` (`DELETE_TASK`) and `UserService.updateUser` (`ROLE_CHANGE`, `PASSWORD_CHANGE`) — all timestamps server-side UTC
- Add `auditLog` mock to `__mocks__/prisma.ts` and `lib/test-utils.ts`

## Test plan

- [x] TDD: wrote 12 tests in `services/__tests__/audit-service.test.ts` before any implementation
- [x] Tests cover: DELETE ops, role changes, password changes, login failures, required fields (userId/action/timestamp/detail), read-only enforcement (no updateLog/deleteLog), MANAGER-only queryLogs, optional filters (action, userId), ordering by `createdAt desc`
- [x] All 150 service-layer tests pass (`npx jest services/ --no-coverage`)
- [x] Pre-existing failures in `__tests__/api/` and `__tests__/pages/` confirmed unrelated to this PR (present on `main` before changes)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)