### PR TITLE
fix(#129): auth defense in depth — Edge JWT + route-level DB

### DIFF
--- a/lib/__tests__/auth-depth.test.ts
+++ b/lib/__tests__/auth-depth.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Tests written FIRST (RED) before implementation.
+ * Issue #129: Auth Defense in Depth — Edge JWT + route-level DB session check
+ *
+ * Two-layer security model:
+ *   Layer 1 (Edge / middleware.ts): lightweight JWT verification via NEXTAUTH_SECRET
+ *   Layer 2 (Node.js / route handlers): full DB session check via withAuth/withManager
+ *
+ * These tests cover the Edge JWT middleware behaviour.
+ * Route-handler DB session tests confirm the existing withAuth/withManager still run.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mock jose (JWT verification) ────────────────────────────────────────────
+const mockJwtVerify = jest.fn();
+jest.mock("jose", () => ({
+  jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
+  createRemoteJWKSet: jest.fn(),
+}));
+
+// ── Mock next-auth (DB session — used by route handlers) ────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+// ── Mock logger ─────────────────────────────────────────────────────────────
+const mockLoggerWarn = jest.fn();
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ── Import after mocks ───────────────────────────────────────────────────────
+import { checkEdgeJwt } from "@/lib/auth-depth";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(
+  url = "http://localhost/api/tasks",
+  headers: Record<string, string> = {}
+): NextRequest {
+  return new NextRequest(url, { headers });
+}
+
+function bearerToken(token = "valid.jwt.token"): Record<string, string> {
+  return { authorization: `Bearer ${token}` };
+}
+
+function cookieToken(token = "valid.jwt.token"): Record<string, string> {
+  return { cookie: `next-auth.session-token=${token}` };
+}
+
+const VALID_PAYLOAD = {
+  sub: "user-1",
+  role: "ENGINEER",
+  iat: Math.floor(Date.now() / 1000) - 60,
+  exp: Math.floor(Date.now() / 1000) + 3600,
+};
+
+// ── describe: checkEdgeJwt ───────────────────────────────────────────────────
+
+describe("checkEdgeJwt — Edge JWT verification", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...OLD_ENV, NEXTAUTH_SECRET: "test-secret-32-chars-padded-x" };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  // ── Test 1: blocks request without JWT ──────────────────────────────────
+
+  test("blocks request without JWT — returns 401 NextResponse", async () => {
+    const req = makeRequest("http://localhost/api/tasks");
+    // no Authorization header, no cookie
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result!.status).toBe(401);
+  });
+
+  test("logs a warning when blocking request without JWT", async () => {
+    const req = makeRequest("http://localhost/api/tasks");
+
+    await checkEdgeJwt(req);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.any(String) }),
+      expect.stringContaining("middleware")
+    );
+  });
+
+  // ── Test 2: allows valid JWT ─────────────────────────────────────────────
+
+  test("allows request with valid JWT Bearer token — returns null (continue)", async () => {
+    mockJwtVerify.mockResolvedValue({ payload: VALID_PAYLOAD });
+    const req = makeRequest("http://localhost/api/tasks", bearerToken());
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeNull();
+  });
+
+  test("allows request with valid JWT in session cookie — returns null (continue)", async () => {
+    mockJwtVerify.mockResolvedValue({ payload: VALID_PAYLOAD });
+    const req = makeRequest("http://localhost/api/tasks", cookieToken());
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeNull();
+  });
+
+  // ── Test 3: expired JWT is rejected ──────────────────────────────────────
+
+  test("rejects expired JWT — returns 401 NextResponse", async () => {
+    mockJwtVerify.mockRejectedValue(
+      Object.assign(new Error("JWTExpired"), { code: "ERR_JWT_EXPIRED" })
+    );
+    const req = makeRequest("http://localhost/api/tasks", bearerToken("expired.jwt.token"));
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result!.status).toBe(401);
+  });
+
+  test("logs a warning when JWT is expired", async () => {
+    mockJwtVerify.mockRejectedValue(
+      Object.assign(new Error("JWTExpired"), { code: "ERR_JWT_EXPIRED" })
+    );
+    const req = makeRequest("http://localhost/api/tasks", bearerToken("expired.jwt.token"));
+
+    await checkEdgeJwt(req);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.any(String) }),
+      expect.stringContaining("middleware")
+    );
+  });
+
+  // ── Test 4: invalid JWT signature is rejected ─────────────────────────────
+
+  test("rejects JWT with invalid signature — returns 401 NextResponse", async () => {
+    mockJwtVerify.mockRejectedValue(
+      Object.assign(new Error("JWSSignatureVerificationFailed"), {
+        code: "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+      })
+    );
+    const req = makeRequest("http://localhost/api/tasks", bearerToken("tampered.jwt.token"));
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result!.status).toBe(401);
+  });
+
+  test("logs a warning when JWT signature is invalid", async () => {
+    mockJwtVerify.mockRejectedValue(
+      Object.assign(new Error("JWSSignatureVerificationFailed"), {
+        code: "ERR_JWS_SIGNATURE_VERIFICATION_FAILED",
+      })
+    );
+    const req = makeRequest("http://localhost/api/tasks", bearerToken("tampered.jwt.token"));
+
+    await checkEdgeJwt(req);
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ url: expect.any(String) }),
+      expect.stringContaining("middleware")
+    );
+  });
+
+  // ── Test 5: route handler still validates DB session (defense in depth) ───
+
+  test("route-handler DB session check still runs after Edge JWT passes", async () => {
+    // Simulate: Edge JWT passes (returns null) but route handler re-validates via DB
+    mockJwtVerify.mockResolvedValue({ payload: VALID_PAYLOAD });
+    mockGetServerSession.mockResolvedValue(null); // DB session does NOT exist
+
+    const req = makeRequest("http://localhost/api/tasks", bearerToken());
+
+    // Edge middleware passes (null = continue)
+    const edgeResult = await checkEdgeJwt(req);
+    expect(edgeResult).toBeNull();
+
+    // Route handler's DB session check is independent and would catch the missing session
+    const { requireAuth } = await import("@/lib/rbac");
+    await expect(requireAuth()).rejects.toThrow("未授權");
+  });
+
+  // ── Additional: NEXTAUTH_SECRET missing ──────────────────────────────────
+
+  test("blocks all requests when NEXTAUTH_SECRET is not configured", async () => {
+    delete process.env.NEXTAUTH_SECRET;
+    const req = makeRequest("http://localhost/api/tasks", bearerToken());
+
+    const result = await checkEdgeJwt(req);
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result!.status).toBe(401);
+  });
+});

--- a/lib/auth-depth.ts
+++ b/lib/auth-depth.ts
@@ -1,0 +1,90 @@
+/**
+ * Edge JWT verification for defense-in-depth auth — Issue #129
+ *
+ * Layer 1 (Edge): lightweight JWT check in middleware.ts using NEXTAUTH_SECRET.
+ * Layer 2 (Node.js): existing withAuth / withManager wrappers on route handlers
+ *   continue to validate the full DB-backed next-auth session. They are NOT removed.
+ *
+ * This module exports checkEdgeJwt(), which is called by middleware.ts for all
+ * /api/* routes (except /api/auth/*). It extracts the JWT from:
+ *   1. Authorization: Bearer <token> header
+ *   2. next-auth.session-token cookie (both secure and plain variants)
+ *
+ * Returns null to allow the request to continue, or a 401 NextResponse to block.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { jwtVerify } from "jose";
+import { logger } from "@/lib/logger";
+
+const SESSION_COOKIE_NAMES = [
+  "next-auth.session-token",
+  "__Secure-next-auth.session-token",
+];
+
+/**
+ * Extracts the raw JWT string from the request.
+ * Checks Authorization header first, then session cookies.
+ */
+function extractToken(req: NextRequest): string | null {
+  // 1. Authorization: Bearer <token>
+  const authHeader = req.headers.get("authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7).trim() || null;
+  }
+
+  // 2. next-auth session cookie
+  const cookieHeader = req.headers.get("cookie") ?? "";
+  for (const name of SESSION_COOKIE_NAMES) {
+    const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`));
+    if (match?.[1]) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Builds a Uint8Array secret from NEXTAUTH_SECRET for use with jose.
+ */
+function getSecretKey(): Uint8Array | null {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) return null;
+  return new TextEncoder().encode(secret);
+}
+
+/**
+ * Performs a lightweight Edge-compatible JWT verification.
+ *
+ * @returns null   — JWT valid, allow request to continue
+ * @returns NextResponse(401) — JWT missing, expired, or signature invalid
+ */
+export async function checkEdgeJwt(req: NextRequest): Promise<NextResponse | null> {
+  const url = req.url;
+
+  const secretKey = getSecretKey();
+  if (!secretKey) {
+    logger.warn({ url }, "[middleware] NEXTAUTH_SECRET not set — blocking request");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = extractToken(req);
+  if (!token) {
+    logger.warn({ url }, "[middleware] blocked request — no JWT token present");
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // next-auth v4 signs JWTs with HS256 using NEXTAUTH_SECRET
+    await jwtVerify(token, secretKey, { algorithms: ["HS256"] });
+    return null; // valid — allow the request to continue
+  } catch (err) {
+    const code = (err as { code?: string }).code ?? "UNKNOWN";
+    logger.warn(
+      { url, code },
+      "[middleware] blocked request — JWT verification failed"
+    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,49 @@
-export { default } from "next-auth/middleware";
+/**
+ * Next.js Edge Middleware — Auth Defense in Depth (Issue #129)
+ *
+ * Layer 1 (this file, Edge runtime): lightweight JWT verification.
+ *   - Applies to all /api/* routes except /api/auth/*
+ *   - Uses NEXTAUTH_SECRET to verify the JWT signature and expiry
+ *   - Blocks unauthenticated, expired, or tampered tokens with HTTP 401
+ *   - Logs every blocked request via the structured logger
+ *
+ * Layer 2 (route handlers, Node.js runtime): full DB session check.
+ *   - withAuth / withManager wrappers are kept on ALL route handlers (not removed)
+ *   - getServerSession() re-validates the session against the database on every call
+ *
+ * Neither layer alone is sufficient — both must pass for a request to succeed.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { checkEdgeJwt } from "@/lib/auth-depth";
+
+export async function middleware(req: NextRequest): Promise<NextResponse> {
+  const { pathname } = new URL(req.url);
+
+  // Skip auth routes — next-auth handles its own sign-in / callback / CSRF flows
+  if (pathname.startsWith("/api/auth/")) {
+    return NextResponse.next();
+  }
+
+  // Perform Edge JWT check for all other /api/* routes
+  const jwtResult = await checkEdgeJwt(req);
+  if (jwtResult !== null) {
+    return jwtResult; // 401 response — blocked at Edge before hitting Node.js
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
   matcher: [
+    // Page routes that require a session
     "/dashboard/:path*",
     "/kanban/:path*",
     "/gantt/:path*",
     "/knowledge/:path*",
     "/timesheet/:path*",
     "/reports/:path*",
+    // All API routes — auth routes are excluded inside the middleware function
+    "/api/:path*",
   ],
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `lib/auth-depth.ts` — `checkEdgeJwt()` verifies JWT signature/expiry at the Edge using `NEXTAUTH_SECRET` (via `jose`)
- Update `middleware.ts` to call `checkEdgeJwt()` for all `/api/*` routes except `/api/auth/*`, returning HTTP 401 and logging every blocked request
- Keep ALL existing `withAuth` / `withManager` wrappers on route handlers intact — two independent layers must both pass

## Two-Layer Defense in Depth

| Layer | Location | Runtime | What it checks |
|-------|----------|---------|----------------|
| 1 — Edge JWT | `middleware.ts` | Edge | JWT signature valid, not expired, `NEXTAUTH_SECRET` present |
| 2 — DB session | route handlers (`withAuth`/`withManager`) | Node.js | `getServerSession()` — full DB-backed next-auth session |

## TDD — `lib/__tests__/auth-depth.test.ts` (10 tests, all GREEN)

- Blocks request without JWT → 401
- Allows valid JWT Bearer token → null (continue)
- Allows valid JWT in session cookie → null (continue)
- Rejects expired JWT → 401
- Rejects invalid JWT signature → 401
- Logs warning on every blocked request
- Route handler DB session check still runs independently after Edge JWT passes
- Blocks all requests when `NEXTAUTH_SECRET` is not configured

## Test plan

- [x] New tests pass: 10/10 GREEN
- [x] No regressions: pre-existing 39 failures unchanged (verified by running suite before and after changes)
- [x] `jose` available as transitive dep of `next-auth` — no new production dependency added

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)