### PR TITLE
fix(#155): missing endpoints + copy template button

### DIFF
--- a/__tests__/api/notifications.test.ts
+++ b/__tests__/api/notifications.test.ts
@@ -36,7 +36,8 @@ describe("GET /api/notifications", () => {
     const { GET } = await import("@/app/api/notifications/route");
     const res = await GET(createMockRequest("/api/notifications"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data.notifications).toHaveLength(1);
     expect(data.unreadCount).toBe(1);
   });
@@ -60,7 +61,8 @@ describe("GET /api/notifications", () => {
     const { GET } = await import("@/app/api/notifications/route");
     const res = await GET(createMockRequest("/api/notifications"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data.unreadCount).toBe(0);
   });
 
@@ -84,7 +86,8 @@ describe("PATCH /api/notifications/[id]/read", () => {
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
     const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: { id: "notif-1" } });
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data.isRead).toBe(true);
   });
 
@@ -107,5 +110,64 @@ describe("PATCH /api/notifications/[id]/read", () => {
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
     const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: { id: "notif-1" } });
     expect(res.status).toBe(401);
+  });
+});
+
+describe("PATCH /api/notifications/read-all", () => {
+  const mockUpdateMany = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    mockUpdateMany.mockResolvedValue({ count: 3 });
+    // Extend the mock to include updateMany
+    (mockNotification as Record<string, jest.Mock>).updateMany = mockUpdateMany;
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { PATCH } = await import("@/app/api/notifications/read-all/route");
+    const res = await PATCH(createMockRequest("/api/notifications/read-all", { method: "PATCH" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("marks all notifications as read for the current user", async () => {
+    mockUpdateMany.mockResolvedValue({ count: 5 });
+    const { PATCH } = await import("@/app/api/notifications/read-all/route");
+    const res = await PATCH(createMockRequest("/api/notifications/read-all", { method: "PATCH" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const data = body.data;
+    expect(data).toHaveProperty("updatedCount");
+    expect(data.updatedCount).toBe(5);
+  });
+
+  it("only marks the authenticated user's notifications", async () => {
+    mockUpdateMany.mockResolvedValue({ count: 2 });
+    const { PATCH } = await import("@/app/api/notifications/read-all/route");
+    await PATCH(createMockRequest("/api/notifications/read-all", { method: "PATCH" }));
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ userId: SESSION.user.id }),
+        data: expect.objectContaining({ isRead: true }),
+      })
+    );
+  });
+
+  it("returns updatedCount of 0 when no unread notifications exist", async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+    const { PATCH } = await import("@/app/api/notifications/read-all/route");
+    const res = await PATCH(createMockRequest("/api/notifications/read-all", { method: "PATCH" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const data = body.data;
+    expect(data.updatedCount).toBe(0);
+  });
+
+  it("returns 500 on database error", async () => {
+    mockUpdateMany.mockRejectedValue(new Error("DB error"));
+    const { PATCH } = await import("@/app/api/notifications/read-all/route");
+    const res = await PATCH(createMockRequest("/api/notifications/read-all", { method: "PATCH" }));
+    expect(res.status).toBe(500);
   });
 });

--- a/__tests__/api/plans.test.ts
+++ b/__tests__/api/plans.test.ts
@@ -36,7 +36,8 @@ describe("GET /api/plans", () => {
     const { GET } = await import("@/app/api/plans/route");
     const res = await GET(createMockRequest("/api/plans"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data[0].id).toBe("plan-1");
   });
 
@@ -103,5 +104,80 @@ describe("POST /api/plans", () => {
       body: { year: 2025, title: "Plan", milestones: [{ title: "Q1", plannedEnd: "2025-03-31" }] },
     }));
     expect(res.status).toBe(201);
+  });
+});
+
+describe("POST /api/plans/copy-template", () => {
+  const mockPlanService = {
+    copyTemplate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockPlanService.copyTemplate.mockResolvedValue({ ...MOCK_PLAN, year: 2025, copiedFromYear: 2024 });
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { POST } = await import("@/app/api/plans/copy-template/route");
+    const res = await POST(
+      createMockRequest("/api/plans/copy-template", {
+        method: "POST",
+        body: { sourcePlanId: "plan-1", targetYear: 2025 },
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when non-manager calls copy-template", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u1", role: "MEMBER" }, expires: "2099" });
+    const { POST } = await import("@/app/api/plans/copy-template/route");
+    const res = await POST(
+      createMockRequest("/api/plans/copy-template", {
+        method: "POST",
+        body: { sourcePlanId: "plan-1", targetYear: 2025 },
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when sourcePlanId is missing", async () => {
+    const { POST } = await import("@/app/api/plans/copy-template/route");
+    const res = await POST(
+      createMockRequest("/api/plans/copy-template", {
+        method: "POST",
+        body: { targetYear: 2025 },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when targetYear is missing", async () => {
+    const { POST } = await import("@/app/api/plans/copy-template/route");
+    const res = await POST(
+      createMockRequest("/api/plans/copy-template", {
+        method: "POST",
+        body: { sourcePlanId: "plan-1" },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("copies plan template and returns 201 with the new plan", async () => {
+    const copiedPlan = { ...MOCK_PLAN, id: "plan-2", year: 2025, copiedFromYear: 2024 };
+    mockAnnualPlan.findUnique.mockResolvedValue({ ...MOCK_PLAN, milestones: [], monthlyGoals: [] });
+    mockAnnualPlan.create.mockResolvedValue(copiedPlan);
+    const { POST } = await import("@/app/api/plans/copy-template/route");
+    const res = await POST(
+      createMockRequest("/api/plans/copy-template", {
+        method: "POST",
+        body: { sourcePlanId: "plan-1", targetYear: 2025 },
+      })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    const data = body.data;
+    expect(data.year).toBe(2025);
   });
 });

--- a/__tests__/api/reports.test.ts
+++ b/__tests__/api/reports.test.ts
@@ -46,7 +46,8 @@ describe("GET /api/reports/weekly", () => {
     const { GET } = await import("@/app/api/reports/weekly/route");
     const res = await GET(createMockRequest("/api/reports/weekly"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data).toHaveProperty("period");
     expect(data).toHaveProperty("completedTasks");
     expect(data).toHaveProperty("totalHours");
@@ -79,7 +80,8 @@ describe("GET /api/reports/weekly", () => {
     ]);
     const { GET } = await import("@/app/api/reports/weekly/route");
     const res = await GET(createMockRequest("/api/reports/weekly"));
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data.delayCount).toBe(1);
     expect(data.scopeChangeCount).toBe(1);
   });
@@ -96,7 +98,8 @@ describe("GET /api/reports/monthly", () => {
     const { GET } = await import("@/app/api/reports/monthly/route");
     const res = await GET(createMockRequest("/api/reports/monthly"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data).toHaveProperty("period");
     expect(data).toHaveProperty("completionRate");
   });
@@ -126,7 +129,8 @@ describe("GET /api/reports/workload", () => {
     const { GET } = await import("@/app/api/reports/workload/route");
     const res = await GET(createMockRequest("/api/reports/workload"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data).toHaveProperty("totalHours");
     expect(data).toHaveProperty("byPerson");
   });
@@ -152,7 +156,8 @@ describe("GET /api/reports/kpi", () => {
     const { GET } = await import("@/app/api/reports/kpi/route");
     const res = await GET(createMockRequest("/api/reports/kpi"));
     expect(res.status).toBe(200);
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data).toHaveProperty("year");
     expect(data).toHaveProperty("kpis");
     expect(data).toHaveProperty("avgAchievement");
@@ -171,7 +176,92 @@ describe("GET /api/reports/kpi", () => {
     ]);
     const { GET } = await import("@/app/api/reports/kpi/route");
     const res = await GET(createMockRequest("/api/reports/kpi"));
-    const data = await res.json();
+    const body = await res.json();
+    const data = body.data;
     expect(data.achievedCount).toBe(1);
+  });
+});
+
+describe("GET /api/reports/delay-change", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    setupMocks();
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(createMockRequest("/api/reports/delay-change"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns delay and change counts when authenticated", async () => {
+    mockTaskChange.findMany.mockResolvedValue([
+      { changeType: "DELAY", changedAt: new Date("2024-01-10") },
+      { changeType: "DELAY", changedAt: new Date("2024-01-11") },
+      { changeType: "SCOPE_CHANGE", changedAt: new Date("2024-01-12") },
+    ]);
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(createMockRequest("/api/reports/delay-change"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const data = body.data;
+    expect(data).toHaveProperty("delayCount");
+    expect(data).toHaveProperty("scopeChangeCount");
+    expect(data).toHaveProperty("total");
+    expect(data.delayCount).toBe(2);
+    expect(data.scopeChangeCount).toBe(1);
+    expect(data.total).toBe(3);
+  });
+
+  it("accepts startDate and endDate query params", async () => {
+    mockTaskChange.findMany.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(
+      createMockRequest("/api/reports/delay-change", {
+        searchParams: { startDate: "2024-01-01", endDate: "2024-01-31" },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockTaskChange.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          changedAt: expect.objectContaining({ gte: expect.any(Date), lte: expect.any(Date) }),
+        }),
+      })
+    );
+  });
+
+  it("groups changes by date in byDate field", async () => {
+    mockTaskChange.findMany.mockResolvedValue([
+      { changeType: "DELAY", changedAt: new Date("2024-01-10T10:00:00Z") },
+      { changeType: "SCOPE_CHANGE", changedAt: new Date("2024-01-10T14:00:00Z") },
+      { changeType: "DELAY", changedAt: new Date("2024-01-11T09:00:00Z") },
+    ]);
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(createMockRequest("/api/reports/delay-change"));
+    const body = await res.json();
+    const data = body.data;
+    expect(data).toHaveProperty("byDate");
+    expect(Array.isArray(data.byDate)).toBe(true);
+  });
+
+  it("returns 500 on database error", async () => {
+    mockTaskChange.findMany.mockRejectedValue(new Error("DB error"));
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(createMockRequest("/api/reports/delay-change"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns empty result when no changes exist", async () => {
+    mockTaskChange.findMany.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/reports/delay-change/route");
+    const res = await GET(createMockRequest("/api/reports/delay-change"));
+    const body = await res.json();
+    const data = body.data;
+    expect(data.delayCount).toBe(0);
+    expect(data.scopeChangeCount).toBe(0);
+    expect(data.total).toBe(0);
   });
 });

--- a/__tests__/api/users-workload.test.ts
+++ b/__tests__/api/users-workload.test.ts
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API route tests: GET /api/users/[id]/workload
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+const mockTask = { findMany: jest.fn(), count: jest.fn() };
+const mockTimeEntry = { findMany: jest.fn() };
+const mockUser = { findUnique: jest.fn() };
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: { task: mockTask, timeEntry: mockTimeEntry, user: mockUser },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+
+const SESSION = { user: { id: "u1", name: "Test", email: "t@e.com", role: "MEMBER" }, expires: "2099" };
+const MANAGER_SESSION = { user: { id: "mgr1", name: "Mgr", email: "m@e.com", role: "MANAGER" }, expires: "2099" };
+
+const MOCK_USER = { id: "u1", name: "Test User", email: "t@e.com", role: "MEMBER", isActive: true };
+
+describe("GET /api/users/[id]/workload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    mockUser.findUnique.mockResolvedValue(MOCK_USER);
+    mockTask.findMany.mockResolvedValue([
+      { id: "t1", status: "TODO", estimatedHours: 4 },
+      { id: "t2", status: "IN_PROGRESS", estimatedHours: 8 },
+      { id: "t3", status: "DONE", estimatedHours: 3 },
+    ]);
+    mockTask.count.mockResolvedValue(3);
+    mockTimeEntry.findMany.mockResolvedValue([
+      { hours: 2 },
+      { hours: 3 },
+    ]);
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when user not found (manager context)", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockUser.findUnique.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/nonexistent/workload"),
+      { params: Promise.resolve({ id: "nonexistent" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns workload data with taskCount, totalHours, and loadPct", async () => {
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const data = body.data;
+    expect(data).toHaveProperty("taskCount");
+    expect(data).toHaveProperty("totalHours");
+    expect(data).toHaveProperty("loadPct");
+    expect(data).toHaveProperty("userId");
+  });
+
+  it("calculates taskCount from active tasks only (excluding DONE)", async () => {
+    mockTask.findMany.mockResolvedValue([
+      { id: "t1", status: "TODO", estimatedHours: 4 },
+      { id: "t2", status: "IN_PROGRESS", estimatedHours: 8 },
+    ]);
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    const body = await res.json();
+    const data = body.data;
+    expect(data.taskCount).toBe(2);
+  });
+
+  it("returns totalHours summed from time entries", async () => {
+    mockTimeEntry.findMany.mockResolvedValue([
+      { hours: 5 },
+      { hours: 7 },
+    ]);
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    const body = await res.json();
+    const data = body.data;
+    expect(data.totalHours).toBe(12);
+  });
+
+  it("allows manager to view any user's workload", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("allows user to view own workload", async () => {
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 when member tries to view another user's workload", async () => {
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/other-user/workload"),
+      { params: Promise.resolve({ id: "other-user" }) }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts startDate and endDate params for time entry range", async () => {
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload", {
+        searchParams: { startDate: "2024-01-01", endDate: "2024-01-31" },
+      }),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(200);
+    expect(mockTimeEntry.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          date: expect.objectContaining({ gte: expect.any(Date), lte: expect.any(Date) }),
+        }),
+      })
+    );
+  });
+
+  it("returns 500 on database error", async () => {
+    mockTask.findMany.mockRejectedValue(new Error("DB error"));
+    const { GET } = await import("@/app/api/users/[id]/workload/route");
+    const res = await GET(
+      createMockRequest("/api/users/u1/workload"),
+      { params: Promise.resolve({ id: "u1" }) }
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Plus, Loader2, ChevronRight, X, Target } from "lucide-react";
+import { Plus, Loader2, ChevronRight, X, Target, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PlanTree } from "@/app/components/plan-tree";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
@@ -75,6 +75,13 @@ export default function PlansPage() {
   const [newGoalTitle, setNewGoalTitle] = useState("");
   const [creatingGoal, setCreatingGoal] = useState(false);
 
+  // Copy template form
+  const [showCopyForm, setShowCopyForm] = useState(false);
+  const [copySourcePlanId, setCopySourcePlanId] = useState("");
+  const [copyTargetYear, setCopyTargetYear] = useState((new Date().getFullYear() + 1).toString());
+  const [copyingTemplate, setCopyingTemplate] = useState(false);
+  const [copyError, setCopyError] = useState("");
+
   const fetchPlans = useCallback(async () => {
     setLoading(true);
     try {
@@ -141,6 +148,29 @@ export default function PlansPage() {
     }
   }
 
+  async function copyTemplate() {
+    if (!copySourcePlanId || !copyTargetYear) return;
+    setCopyingTemplate(true);
+    setCopyError("");
+    try {
+      const res = await fetch("/api/plans/copy-template", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ sourcePlanId: copySourcePlanId, targetYear: parseInt(copyTargetYear) }),
+      });
+      if (res.ok) {
+        setCopySourcePlanId("");
+        setShowCopyForm(false);
+        fetchPlans();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setCopyError(data?.error ?? "複製失敗，請再試一次");
+      }
+    } finally {
+      setCopyingTemplate(false);
+    }
+  }
+
   const inputCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors placeholder:text-zinc-600";
   const selectCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors cursor-pointer";
 
@@ -172,6 +202,13 @@ export default function PlansPage() {
           >
             <Plus className="h-3.5 w-3.5" />
             新增月度目標
+          </button>
+          <button
+            onClick={() => { setShowCopyForm((v) => !v); setShowPlanForm(false); setCopyError(""); }}
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700"
+          >
+            <Copy className="h-3.5 w-3.5" />
+            從上年複製
           </button>
           <button
             onClick={() => setShowPlanForm(true)}
@@ -217,6 +254,48 @@ export default function PlansPage() {
               {creatingPlan ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
             </button>
           </div>
+        </div>
+      )}
+
+      {/* Copy template form */}
+      {showCopyForm && (
+        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-zinc-200">從上年複製計畫</h3>
+            <button onClick={() => setShowCopyForm(false)} className="text-zinc-500 hover:text-zinc-200">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <p className="text-xs text-zinc-500">選擇來源計畫，系統將複製其架構（月度目標與里程碑）到新年度。</p>
+          <div className="flex gap-3 flex-wrap">
+            <select
+              value={copySourcePlanId}
+              onChange={(e) => setCopySourcePlanId(e.target.value)}
+              className={cn(selectCls, "flex-1 min-w-48")}
+            >
+              <option value="">選擇來源計畫</option>
+              {plans.map((p) => (
+                <option key={p.id} value={p.id}>{p.year} — {p.title}</option>
+              ))}
+            </select>
+            <input
+              type="number"
+              value={copyTargetYear}
+              onChange={(e) => setCopyTargetYear(e.target.value)}
+              placeholder="目標年份"
+              className={cn(inputCls, "w-28")}
+            />
+            <button
+              onClick={copyTemplate}
+              disabled={copyingTemplate || !copySourcePlanId || !copyTargetYear}
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+            >
+              {copyingTemplate ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <><Copy className="h-3.5 w-3.5" />複製</>}
+            </button>
+          </div>
+          {copyError && (
+            <p className="text-xs text-red-400">{copyError}</p>
+          )}
         </div>
       )}
 

--- a/app/api/notifications/read-all/route.ts
+++ b/app/api/notifications/read-all/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+export const PATCH = withAuth(async (_req: NextRequest) => {
+  const session = await requireAuth();
+
+  const result = await prisma.notification.updateMany({
+    where: { userId: session.user.id, isRead: false },
+    data: { isRead: true },
+  });
+
+  return success({ updatedCount: result.count });
+});

--- a/app/api/reports/delay-change/route.ts
+++ b/app/api/reports/delay-change/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const startParam = searchParams.get("startDate");
+  const endParam = searchParams.get("endDate");
+  const now = new Date();
+
+  const startDate = startParam
+    ? new Date(startParam)
+    : new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = endParam
+    ? new Date(endParam)
+    : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+  const changes = await prisma.taskChange.findMany({
+    where: {
+      changedAt: { gte: startDate, lte: endDate },
+    },
+    include: {
+      task: { select: { id: true, title: true } },
+      changedByUser: { select: { id: true, name: true } },
+    },
+    orderBy: { changedAt: "asc" },
+  });
+
+  const delayChanges = changes.filter((c) => c.changeType === "DELAY");
+  const scopeChanges = changes.filter((c) => c.changeType === "SCOPE_CHANGE");
+
+  // Group by date (YYYY-MM-DD)
+  const byDateMap = changes.reduce(
+    (acc, c) => {
+      const dateKey = c.changedAt.toISOString().slice(0, 10);
+      if (!acc[dateKey]) {
+        acc[dateKey] = { date: dateKey, delayCount: 0, scopeChangeCount: 0, total: 0 };
+      }
+      if (c.changeType === "DELAY") acc[dateKey].delayCount += 1;
+      if (c.changeType === "SCOPE_CHANGE") acc[dateKey].scopeChangeCount += 1;
+      acc[dateKey].total += 1;
+      return acc;
+    },
+    {} as Record<string, { date: string; delayCount: number; scopeChangeCount: number; total: number }>
+  );
+
+  return success({
+    period: { start: startDate, end: endDate },
+    delayCount: delayChanges.length,
+    scopeChangeCount: scopeChanges.length,
+    total: changes.length,
+    byDate: Object.values(byDateMap).sort((a, b) => a.date.localeCompare(b.date)),
+    changes,
+  });
+});

--- a/app/api/users/[id]/workload/route.ts
+++ b/app/api/users/[id]/workload/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { NotFoundError, ForbiddenError } from "@/services/errors";
+
+// Standard working hours per month used for load percentage calculation
+const STANDARD_MONTHLY_HOURS = 160;
+
+export const GET = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+
+  // Members can only view their own workload; managers can view any
+  if (session.user.role !== "MANAGER" && session.user.id !== id) {
+    throw new ForbiddenError("無法查看其他使用者的工作負荷");
+  }
+
+  const user = await prisma.user.findUnique({ where: { id } });
+  if (!user) {
+    throw new NotFoundError("找不到使用者");
+  }
+
+  const { searchParams } = new URL(req.url);
+  const startParam = searchParams.get("startDate");
+  const endParam = searchParams.get("endDate");
+  const now = new Date();
+
+  const startDate = startParam
+    ? new Date(startParam)
+    : new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = endParam
+    ? new Date(endParam)
+    : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+  // Active tasks (exclude DONE) assigned to this user
+  const activeTasks = await prisma.task.findMany({
+    where: {
+      primaryAssigneeId: id,
+      status: { notIn: ["DONE"] },
+    },
+    select: {
+      id: true,
+      title: true,
+      status: true,
+      priority: true,
+      estimatedHours: true,
+      dueDate: true,
+    },
+  });
+
+  // Time entries within the date range
+  const timeEntries = await prisma.timeEntry.findMany({
+    where: {
+      userId: id,
+      date: { gte: startDate, lte: endDate },
+    },
+    select: {
+      id: true,
+      hours: true,
+      category: true,
+      date: true,
+    },
+  });
+
+  const taskCount = activeTasks.length;
+  const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+  const estimatedHours = activeTasks.reduce((sum, t) => sum + (t.estimatedHours ?? 0), 0);
+  const loadPct = Math.round((totalHours / STANDARD_MONTHLY_HOURS) * 100 * 10) / 10;
+
+  return success({
+    userId: id,
+    userName: user.name,
+    period: { start: startDate, end: endDate },
+    taskCount,
+    totalHours,
+    estimatedHours,
+    loadPct,
+    activeTasks,
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@testing-library/dom": "^10.4.1",
         "bcryptjs": "^2.4.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -96,7 +97,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -298,7 +298,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2312,14 +2311,14 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2333,14 +2332,14 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -2352,7 +2351,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
@@ -3858,9 +3857,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3879,9 +3876,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3893,9 +3888,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3904,9 +3897,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3920,9 +3911,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -4022,9 +4011,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4184,7 +4171,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4194,7 +4181,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4894,7 +4881,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5889,7 +5875,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6064,9 +6050,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6138,9 +6122,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7158,6 +7140,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9409,7 +9392,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9684,9 +9666,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10830,7 +10810,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@testing-library/dom": "^10.4.1",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/validators/__tests__/deliverable-validators.test.ts
+++ b/validators/__tests__/deliverable-validators.test.ts
@@ -1,0 +1,208 @@
+import {
+  createDeliverableSchema,
+  updateDeliverableSchema,
+  listDeliverablesSchema,
+} from "../deliverable-validators";
+
+describe("createDeliverableSchema", () => {
+  const validInput = {
+    title: "Q1 Report",
+    type: "REPORT",
+  };
+
+  test("accepts valid deliverable with required fields only", () => {
+    const result = createDeliverableSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts all valid type values", () => {
+    for (const type of ["DOCUMENT", "SYSTEM", "REPORT", "APPROVAL"]) {
+      const result = createDeliverableSchema.safeParse({ ...validInput, type });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("accepts optional taskId", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, taskId: "task-123" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts optional kpiId", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, kpiId: "kpi-123" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts optional annualPlanId", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, annualPlanId: "plan-123" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts optional monthlyGoalId", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, monthlyGoalId: "goal-123" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid attachmentUrl", () => {
+    const result = createDeliverableSchema.safeParse({
+      ...validInput,
+      attachmentUrl: "https://example.com/file.pdf",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const result = createDeliverableSchema.safeParse({ type: "REPORT" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing type", () => {
+    const result = createDeliverableSchema.safeParse({ title: "My deliverable" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid type enum", () => {
+    const result = createDeliverableSchema.safeParse({ ...validInput, type: "INVALID" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid attachmentUrl (not a URL)", () => {
+    const result = createDeliverableSchema.safeParse({
+      ...validInput,
+      attachmentUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateDeliverableSchema", () => {
+  test("accepts empty object (all fields optional)", () => {
+    const result = updateDeliverableSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with only title", () => {
+    const result = updateDeliverableSchema.safeParse({ title: "Updated Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid status values", () => {
+    for (const status of ["NOT_STARTED", "IN_PROGRESS", "DELIVERED", "ACCEPTED"]) {
+      const result = updateDeliverableSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid status enum", () => {
+    const result = updateDeliverableSchema.safeParse({ status: "DONE" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts null attachmentUrl (clearing the URL)", () => {
+    const result = updateDeliverableSchema.safeParse({ attachmentUrl: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty title string", () => {
+    const result = updateDeliverableSchema.safeParse({ title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts valid attachmentUrl", () => {
+    const result = updateDeliverableSchema.safeParse({
+      attachmentUrl: "https://storage.example.com/file.docx",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid attachmentUrl when provided", () => {
+    const result = updateDeliverableSchema.safeParse({ attachmentUrl: "bad-url" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts null acceptedBy", () => {
+    const result = updateDeliverableSchema.safeParse({ acceptedBy: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts null acceptedAt", () => {
+    const result = updateDeliverableSchema.safeParse({ acceptedAt: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid datetime string for acceptedAt", () => {
+    const result = updateDeliverableSchema.safeParse({
+      acceptedAt: "2024-06-15T10:00:00.000Z",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid datetime string for acceptedAt", () => {
+    const result = updateDeliverableSchema.safeParse({ acceptedAt: "not-a-date" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("listDeliverablesSchema", () => {
+  test("accepts empty query (all filters optional)", () => {
+    const result = listDeliverablesSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid taskId filter", () => {
+    const result = listDeliverablesSchema.safeParse({ taskId: "task-abc" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid kpiId filter", () => {
+    const result = listDeliverablesSchema.safeParse({ kpiId: "kpi-xyz" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid annualPlanId filter", () => {
+    const result = listDeliverablesSchema.safeParse({ annualPlanId: "plan-1" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid monthlyGoalId filter", () => {
+    const result = listDeliverablesSchema.safeParse({ monthlyGoalId: "goal-1" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts valid status filter", () => {
+    for (const status of ["NOT_STARTED", "IN_PROGRESS", "DELIVERED", "ACCEPTED"]) {
+      const result = listDeliverablesSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("accepts valid type filter", () => {
+    for (const type of ["DOCUMENT", "SYSTEM", "REPORT", "APPROVAL"]) {
+      const result = listDeliverablesSchema.safeParse({ type });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects invalid status filter", () => {
+    const result = listDeliverablesSchema.safeParse({ status: "INVALID" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid type filter", () => {
+    const result = listDeliverablesSchema.safeParse({ type: "INVALID_TYPE" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts combined filters", () => {
+    const result = listDeliverablesSchema.safeParse({
+      annualPlanId: "plan-1",
+      status: "IN_PROGRESS",
+      type: "DOCUMENT",
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GET /api/reports/delay-change` — returns delay/scope-change counts by date range with per-day breakdown (`byDate[]`)
- Add `PATCH /api/notifications/read-all` — marks all unread notifications as read for the authenticated user, returns `updatedCount`
- Add `GET /api/users/[id]/workload` — returns `taskCount`, `totalHours`, `loadPct`; members can only view own, managers can view any user
- Add **從上年複製** button on plans page with inline form calling `POST /api/plans/copy-template`
- Add `deliverable-validators` tests (34 cases: `createDeliverableSchema`, `updateDeliverableSchema`, `listDeliverablesSchema`)
- Fix pre-existing `data`-unwrap bug in reports/notifications/plans tests (responses are `{ok, data}` not flat)

## Test plan

- [x] `npx jest --testPathPatterns="reports.test.ts$|notifications.test.ts$|users-workload|plans.test.ts$|deliverable-validators"` → 91/91 pass
- [x] New route files follow existing `withAuth` / `withManager` middleware patterns
- [x] `read-all` only updates `isRead: false` records for the session user (verified by `updateMany` call assertion)
- [x] `workload` enforces 403 if a MEMBER requests another user's data
- [x] Plans page copy-template form resets state and refreshes plan list on success; shows error message on failure

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>