### PR TITLE
fix(#157): frontend test fixes + coverage boost

### DIFF
--- a/services/__tests__/change-tracking.test.ts
+++ b/services/__tests__/change-tracking.test.ts
@@ -301,4 +301,285 @@ describe("ChangeTrackingService", () => {
       expect(result).toBe(1);
     });
   });
+
+  describe("detectAndRecordAll", () => {
+    test("records both delay and scope change in one transaction", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const delayRecord = {
+        id: "change-delay",
+        taskId: "task-1",
+        changeType: "DELAY",
+        changedAt: new Date(),
+      };
+      const scopeRecord = {
+        id: "change-scope",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock)
+        .mockResolvedValueOnce(delayRecord)
+        .mockResolvedValueOnce(scopeRecord);
+
+      const result = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: oldDate,
+          newDueDate: newDate,
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Build login page",
+          newTitle: "Build authentication system with OAuth",
+          oldDescription: "Same description",
+          newDescription: "Same description",
+          changedBy: "user-1",
+        }
+      );
+
+      expect(prisma.taskChange.create).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(2);
+    });
+
+    test("records only delay when no scope change", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const delayRecord = {
+        id: "change-delay",
+        taskId: "task-1",
+        changeType: "DELAY",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(delayRecord);
+
+      const result = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: oldDate,
+          newDueDate: newDate,
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Same Title",
+          newTitle: "Same Title",
+          oldDescription: "Same description",
+          newDescription: "Same description",
+          changedBy: "user-1",
+        }
+      );
+
+      expect(prisma.taskChange.create).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+    });
+
+    test("records only scope change when no delay", async () => {
+      const sameDate = new Date("2026-04-01");
+      const scopeRecord = {
+        id: "change-scope",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(scopeRecord);
+
+      const result = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: sameDate,
+          newDueDate: sameDate,
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Build login page",
+          newTitle: "Build authentication system with OAuth",
+          oldDescription: "Same description",
+          newDescription: "Same description",
+          changedBy: "user-1",
+        }
+      );
+
+      expect(prisma.taskChange.create).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+    });
+
+    test("returns empty array when no changes detected", async () => {
+      const sameDate = new Date("2026-04-01");
+
+      const result = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: sameDate,
+          newDueDate: sameDate,
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Same Title",
+          newTitle: "Same Title",
+          oldDescription: "Same description",
+          newDescription: "Same description",
+          changedBy: "user-1",
+        }
+      );
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toHaveLength(0);
+    });
+
+    test("handles null delayInput gracefully", async () => {
+      const scopeRecord = {
+        id: "change-scope",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(scopeRecord);
+
+      const result = await service.detectAndRecordAll(null, {
+        taskId: "task-1",
+        oldTitle: "Build login page",
+        newTitle: "Build authentication system with OAuth",
+        oldDescription: "Same description",
+        newDescription: "Same description",
+        changedBy: "user-1",
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    test("handles null scopeInput gracefully", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const delayRecord = {
+        id: "change-delay",
+        taskId: "task-1",
+        changeType: "DELAY",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(delayRecord);
+
+      const result = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: oldDate,
+          newDueDate: newDate,
+          changedBy: "user-1",
+        },
+        null
+      );
+
+      expect(result).toHaveLength(1);
+    });
+
+    test("handles both null inputs — no records created", async () => {
+      const result = await service.detectAndRecordAll(null, null);
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toHaveLength(0);
+    });
+
+    test("records scope change when description changes (not title)", async () => {
+      const scopeRecord = {
+        id: "change-scope",
+        taskId: "task-1",
+        changeType: "SCOPE_CHANGE",
+        changedAt: new Date(),
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(scopeRecord);
+
+      const result = await service.detectAndRecordAll(null, {
+        taskId: "task-1",
+        oldTitle: "Same Title",
+        newTitle: "Same Title",
+        oldDescription: "Old description",
+        newDescription: "New description changed",
+        changedBy: "user-1",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            changeType: "SCOPE_CHANGE",
+            oldValue: "Old description",
+            newValue: "New description changed",
+          }),
+        })
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    test("uses custom reason when provided", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const delayRecord = { id: "change-delay", taskId: "task-1", changeType: "DELAY" };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValueOnce(delayRecord);
+
+      await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: oldDate,
+          newDueDate: newDate,
+          changedBy: "user-1",
+          reason: "Client requested extension",
+        },
+        null
+      );
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ reason: "Client requested extension" }),
+        })
+      );
+    });
+  });
+
+  describe("detectDelay - additional edge cases", () => {
+    test("returns null when oldDueDate is null", async () => {
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: null,
+        newDueDate: new Date("2026-04-15"),
+        changedBy: "user-1",
+      });
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    test("returns null when newDueDate is null", async () => {
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: new Date("2026-04-01"),
+        newDueDate: null,
+        changedBy: "user-1",
+      });
+
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    test("uses default reason when not provided", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const mockChange = { id: "change-1", taskId: "task-1", changeType: "DELAY" };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue(mockChange);
+
+      await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: oldDate,
+        newDueDate: newDate,
+        changedBy: "user-1",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ reason: "Due date extended" }),
+        })
+      );
+    });
+  });
 });

--- a/services/__tests__/goal-service.test.ts
+++ b/services/__tests__/goal-service.test.ts
@@ -14,55 +14,199 @@ describe("GoalService", () => {
     );
   });
 
-  test("listGoals returns goals for plan", async () => {
-    const mockGoals = [{ id: "goal-1", annualPlanId: "plan-1", month: 1 }];
-    (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue(mockGoals);
+  describe("listGoals", () => {
+    test("returns goals for plan", async () => {
+      const mockGoals = [{ id: "goal-1", annualPlanId: "plan-1", month: 1 }];
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue(mockGoals);
 
-    const result = await service.listGoals({ planId: "plan-1" });
+      const result = await service.listGoals({ planId: "plan-1" });
 
-    expect(prisma.monthlyGoal.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({ annualPlanId: "plan-1" }),
-      })
-    );
-    expect(result).toEqual(mockGoals);
+      expect(prisma.monthlyGoal.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ annualPlanId: "plan-1" }),
+        })
+      );
+      expect(result).toEqual(mockGoals);
+    });
+
+    test("filters by month when provided", async () => {
+      const mockGoals = [{ id: "goal-1", annualPlanId: "plan-1", month: 3 }];
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue(mockGoals);
+
+      const result = await service.listGoals({ planId: "plan-1", month: 3 });
+
+      expect(prisma.monthlyGoal.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ annualPlanId: "plan-1", month: 3 }),
+        })
+      );
+      expect(result).toEqual(mockGoals);
+    });
+
+    test("returns all goals when no filter", async () => {
+      const mockGoals: unknown[] = [];
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue(mockGoals);
+
+      await service.listGoals({});
+
+      expect(prisma.monthlyGoal.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} })
+      );
+    });
   });
 
-  test("getGoal returns goal with tasks", async () => {
-    const mockGoal = { id: "goal-1", tasks: [] };
-    (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(mockGoal);
+  describe("getGoal", () => {
+    test("returns goal with tasks", async () => {
+      const mockGoal = { id: "goal-1", tasks: [] };
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(mockGoal);
 
-    const result = await service.getGoal("goal-1");
+      const result = await service.getGoal("goal-1");
 
-    expect(result).toEqual(mockGoal);
+      expect(result).toEqual(mockGoal);
+    });
+
+    test("throws NotFoundError when goal not found", async () => {
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.getGoal("nonexistent")).rejects.toThrow(NotFoundError);
+    });
   });
 
-  test("createGoal validates required fields", async () => {
-    await expect(
-      service.createGoal({ annualPlanId: "", month: 1, title: "Goal" })
-    ).rejects.toThrow(ValidationError);
+  describe("createGoal", () => {
+    test("validates required fields - empty planId", async () => {
+      await expect(
+        service.createGoal({ annualPlanId: "", month: 1, title: "Goal" })
+      ).rejects.toThrow(ValidationError);
+    });
 
-    await expect(
-      service.createGoal({ annualPlanId: "plan-1", month: 0, title: "Goal" })
-    ).rejects.toThrow(ValidationError);
+    test("validates required fields - invalid month (0)", async () => {
+      await expect(
+        service.createGoal({ annualPlanId: "plan-1", month: 0, title: "Goal" })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("validates required fields - invalid month (13)", async () => {
+      await expect(
+        service.createGoal({ annualPlanId: "plan-1", month: 13, title: "Goal" })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("validates required fields - empty title", async () => {
+      await expect(
+        service.createGoal({ annualPlanId: "plan-1", month: 6, title: "" })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("creates goal with all fields", async () => {
+      const mockGoal = { id: "goal-1", annualPlanId: "plan-1", month: 6, title: "June Goal" };
+      (prisma.monthlyGoal.create as jest.Mock).mockResolvedValue(mockGoal);
+
+      const result = await service.createGoal({
+        annualPlanId: "plan-1",
+        month: 6,
+        title: "June Goal",
+        description: "A monthly goal",
+      });
+
+      expect(prisma.monthlyGoal.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            annualPlanId: "plan-1",
+            month: 6,
+            title: "June Goal",
+            description: "A monthly goal",
+          }),
+        })
+      );
+      expect(result).toEqual(mockGoal);
+    });
+
+    test("creates goal with null description by default", async () => {
+      const mockGoal = { id: "goal-1", annualPlanId: "plan-1", month: 1, title: "Jan Goal" };
+      (prisma.monthlyGoal.create as jest.Mock).mockResolvedValue(mockGoal);
+
+      await service.createGoal({ annualPlanId: "plan-1", month: 1, title: "Jan Goal" });
+
+      expect(prisma.monthlyGoal.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ description: null }),
+        })
+      );
+    });
   });
 
-  test("updateGoal throws NotFoundError when not found", async () => {
-    (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(null);
+  describe("updateGoal", () => {
+    test("throws NotFoundError when not found", async () => {
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(null);
 
-    await expect(
-      service.updateGoal("nonexistent", { title: "X" })
-    ).rejects.toThrow(NotFoundError);
+      await expect(
+        service.updateGoal("nonexistent", { title: "X" })
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    test("updates all provided fields", async () => {
+      const existingGoal = { id: "goal-1", annualPlanId: "plan-1", month: 3, title: "Old Title" };
+      const updatedGoal = { ...existingGoal, title: "New Title", status: "COMPLETED", progressPct: 100 };
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(existingGoal);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue(updatedGoal);
+
+      const result = await service.updateGoal("goal-1", {
+        title: "New Title",
+        description: "Updated desc",
+        status: "COMPLETED",
+        progressPct: 100,
+      });
+
+      expect(prisma.monthlyGoal.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "goal-1" },
+          data: expect.objectContaining({
+            title: "New Title",
+            description: "Updated desc",
+            status: "COMPLETED",
+            progressPct: 100,
+          }),
+        })
+      );
+      expect(result).toEqual(updatedGoal);
+    });
+
+    test("updates with empty object still succeeds", async () => {
+      const existingGoal = { id: "goal-1", annualPlanId: "plan-1", month: 3, title: "Goal" };
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(existingGoal);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue(existingGoal);
+
+      await service.updateGoal("goal-1", {});
+
+      expect(prisma.monthlyGoal.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "goal-1" }, data: {} })
+      );
+    });
   });
 
-  test("deleteGoal removes goal", async () => {
-    (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue({ id: "goal-1" });
-    (prisma.monthlyGoal.delete as jest.Mock).mockResolvedValue({ id: "goal-1" });
+  describe("deleteGoal", () => {
+    test("throws NotFoundError when goal not found", async () => {
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue(null);
 
-    await service.deleteGoal("goal-1");
+      await expect(service.deleteGoal("nonexistent")).rejects.toThrow(NotFoundError);
+    });
 
-    expect(prisma.monthlyGoal.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "goal-1" } })
-    );
+    test("removes goal and unlinks its tasks", async () => {
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue({ id: "goal-1" });
+      (prisma.monthlyGoal.delete as jest.Mock).mockResolvedValue({ id: "goal-1" });
+      (prisma.task.updateMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+      await service.deleteGoal("goal-1");
+
+      expect(prisma.task.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { monthlyGoalId: "goal-1" },
+          data: { monthlyGoalId: null },
+        })
+      );
+      expect(prisma.monthlyGoal.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "goal-1" } })
+      );
+    });
   });
 });

--- a/services/__tests__/kpi-service.test.ts
+++ b/services/__tests__/kpi-service.test.ts
@@ -1,6 +1,6 @@
 import { KPIService } from "../kpi-service";
 import { createMockPrisma } from "../../lib/test-utils";
-import { ValidationError } from "../errors";
+import { NotFoundError, ValidationError } from "../errors";
 
 describe("KPIService", () => {
   let service: KPIService;
@@ -9,6 +9,9 @@ describe("KPIService", () => {
   beforeEach(() => {
     prisma = createMockPrisma();
     service = new KPIService(prisma as never);
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => fn(prisma)
+    );
   });
 
   test("listKPIs returns for year", async () => {
@@ -25,26 +28,166 @@ describe("KPIService", () => {
     expect(result).toEqual(mockKPIs);
   });
 
-  test("createKPI requires title and target", async () => {
-    await expect(
-      service.createKPI({
-        title: "",
+  test("listKPIs defaults to current year when no year provided", async () => {
+    const mockKPIs: unknown[] = [];
+    (prisma.kPI.findMany as jest.Mock).mockResolvedValue(mockKPIs);
+
+    const result = await service.listKPIs({});
+
+    expect(prisma.kPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ year: new Date().getFullYear() }),
+      })
+    );
+    expect(result).toEqual(mockKPIs);
+  });
+
+  describe("getKPI", () => {
+    test("returns kpi when found", async () => {
+      const mockKPI = { id: "kpi-1", year: 2026, title: "KPI 1", taskLinks: [], deliverables: [] };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
+
+      const result = await service.getKPI("kpi-1");
+
+      expect(prisma.kPI.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "kpi-1" } })
+      );
+      expect(result).toEqual(mockKPI);
+    });
+
+    test("throws NotFoundError when kpi not found", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.getKPI("nonexistent")).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe("createKPI", () => {
+    test("createKPI requires title and target", async () => {
+      await expect(
+        service.createKPI({
+          title: "",
+          target: 95,
+          year: 2026,
+          code: "KPI-2026-01",
+          createdBy: "user-1",
+        })
+      ).rejects.toThrow(ValidationError);
+
+      await expect(
+        service.createKPI({
+          title: "KPI",
+          target: null as unknown as number,
+          year: 2026,
+          code: "KPI-2026-01",
+          createdBy: "user-1",
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("createKPI creates kpi with all fields", async () => {
+      const mockKPI = { id: "kpi-1", year: 2026, code: "KPI-2026-01", title: "KPI Title", target: 95, weight: 2, autoCalc: true };
+      (prisma.kPI.create as jest.Mock).mockResolvedValue(mockKPI);
+
+      const result = await service.createKPI({
+        title: "KPI Title",
         target: 95,
         year: 2026,
         code: "KPI-2026-01",
         createdBy: "user-1",
-      })
-    ).rejects.toThrow(ValidationError);
+        weight: 2,
+        autoCalc: true,
+        description: "A KPI",
+      });
 
-    await expect(
-      service.createKPI({
-        title: "KPI",
-        target: null as unknown as number,
+      expect(prisma.kPI.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: "KPI Title",
+            target: 95,
+            year: 2026,
+            code: "KPI-2026-01",
+            createdBy: "user-1",
+            weight: 2,
+            autoCalc: true,
+            description: "A KPI",
+          }),
+        })
+      );
+      expect(result).toEqual(mockKPI);
+    });
+
+    test("createKPI applies default weight and autoCalc", async () => {
+      const mockKPI = { id: "kpi-2", year: 2026, weight: 1, autoCalc: false };
+      (prisma.kPI.create as jest.Mock).mockResolvedValue(mockKPI);
+
+      await service.createKPI({
+        title: "KPI 2",
+        target: 80,
         year: 2026,
-        code: "KPI-2026-01",
+        code: "KPI-2026-02",
         createdBy: "user-1",
-      })
-    ).rejects.toThrow(ValidationError);
+      });
+
+      expect(prisma.kPI.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ weight: 1, autoCalc: false, description: null }),
+        })
+      );
+    });
+  });
+
+  describe("updateKPI", () => {
+    test("throws NotFoundError when kpi not found", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.updateKPI("nonexistent", { title: "X" })).rejects.toThrow(NotFoundError);
+    });
+
+    test("updates all provided fields", async () => {
+      const existingKPI = { id: "kpi-1", title: "Old", year: 2026 };
+      const updatedKPI = { id: "kpi-1", title: "New Title", actual: 80, weight: 2, status: "ON_TRACK", autoCalc: true };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(existingKPI);
+      (prisma.kPI.update as jest.Mock).mockResolvedValue(updatedKPI);
+
+      const result = await service.updateKPI("kpi-1", {
+        title: "New Title",
+        description: "New desc",
+        target: 100,
+        actual: 80,
+        weight: 2,
+        status: "ON_TRACK",
+        autoCalc: true,
+      });
+
+      expect(prisma.kPI.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "kpi-1" },
+          data: expect.objectContaining({
+            title: "New Title",
+            description: "New desc",
+            target: 100,
+            actual: 80,
+            weight: 2,
+            status: "ON_TRACK",
+            autoCalc: true,
+          }),
+        })
+      );
+      expect(result).toEqual(updatedKPI);
+    });
+
+    test("updateKPI with no fields still succeeds", async () => {
+      const existingKPI = { id: "kpi-1", title: "Old", year: 2026 };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(existingKPI);
+      (prisma.kPI.update as jest.Mock).mockResolvedValue(existingKPI);
+
+      await service.updateKPI("kpi-1", {});
+
+      expect(prisma.kPI.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "kpi-1" }, data: {} })
+      );
+    });
   });
 
   test("linkTask links task to KPI", async () => {
@@ -61,6 +204,19 @@ describe("KPIService", () => {
     expect(result).toEqual(mockLink);
   });
 
+  test("linkTask with custom weight", async () => {
+    const mockLink = { id: "link-1", kpiId: "kpi-1", taskId: "task-1", weight: 3 };
+    (prisma.kPITaskLink.create as jest.Mock).mockResolvedValue(mockLink);
+
+    await service.linkTask("kpi-1", "task-1", 3);
+
+    expect(prisma.kPITaskLink.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ weight: 3 }),
+      })
+    );
+  });
+
   test("unlinkTask removes link", async () => {
     (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
 
@@ -73,26 +229,91 @@ describe("KPIService", () => {
     );
   });
 
-  test("calculateAchievement auto-calculates from linked tasks", async () => {
-    const mockKPI = {
-      id: "kpi-1",
-      autoCalc: true,
-      taskLinks: [
-        { task: { progressPct: 100, status: "DONE" }, weight: 1 },
-        { task: { progressPct: 50, status: "IN_PROGRESS" }, weight: 1 },
-      ],
-    };
-    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
-    (prisma.kPI.update as jest.Mock).mockResolvedValue({ ...mockKPI, actual: 75 });
+  describe("deleteKPI", () => {
+    test("throws NotFoundError when kpi not found", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
 
-    const result = await service.calculateAchievement("kpi-1");
+      await expect(service.deleteKPI("nonexistent")).rejects.toThrow(NotFoundError);
+    });
 
-    expect(prisma.kPI.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "kpi-1" },
-        data: expect.objectContaining({ actual: 75 }),
-      })
-    );
-    expect(result.actual).toBe(75);
+    test("deletes kpi and its task links in transaction", async () => {
+      const existingKPI = { id: "kpi-1", title: "KPI 1" };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(existingKPI);
+      (prisma.kPI.delete as jest.Mock).mockResolvedValue(existingKPI);
+      (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+      await service.deleteKPI("kpi-1");
+
+      expect(prisma.kPITaskLink.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { kpiId: "kpi-1" } })
+      );
+      expect(prisma.kPI.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "kpi-1" } })
+      );
+    });
+  });
+
+  describe("calculateAchievement", () => {
+    test("auto-calculates from linked tasks", async () => {
+      const mockKPI = {
+        id: "kpi-1",
+        autoCalc: true,
+        taskLinks: [
+          { task: { progressPct: 100, status: "DONE" }, weight: 1 },
+          { task: { progressPct: 50, status: "IN_PROGRESS" }, weight: 1 },
+        ],
+      };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({ ...mockKPI, actual: 75 });
+
+      const result = await service.calculateAchievement("kpi-1");
+
+      expect(prisma.kPI.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "kpi-1" },
+          data: expect.objectContaining({ actual: 75 }),
+        })
+      );
+      expect(result.actual).toBe(75);
+    });
+
+    test("throws NotFoundError when kpi not found", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.calculateAchievement("nonexistent")).rejects.toThrow(NotFoundError);
+    });
+
+    test("calculates 0 when no task links", async () => {
+      const mockKPI = { id: "kpi-1", taskLinks: [] };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({ ...mockKPI, actual: 0 });
+
+      await service.calculateAchievement("kpi-1");
+
+      expect(prisma.kPI.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ actual: 0 }),
+        })
+      );
+    });
+
+    test("calculates weighted average correctly", async () => {
+      const mockKPI = {
+        id: "kpi-1",
+        taskLinks: [
+          { task: { progressPct: 100, status: "DONE" }, weight: 2 },
+          { task: { progressPct: 0, status: "TODO" }, weight: 1 },
+        ],
+      };
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
+      (prisma.kPI.update as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve({ ...mockKPI, actual: data.actual })
+      );
+
+      const result = await service.calculateAchievement("kpi-1");
+
+      // (100*2 + 0*1) / (2+1) = 200/3 ≈ 66.67
+      expect(result.actual).toBeCloseTo(200 / 3, 5);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Expanded test coverage for `kpi-service.ts`, `goal-service.ts`, and `change-tracking-service.ts`
- Added tests for previously untested methods: `getKPI`, `updateKPI`, `deleteKPI`, `calculateAchievement`, `createGoal` title validation, `updateGoal` field mapping, `deleteGoal` task unlinking, and all branches of `detectAndRecordAll`
- All 72 suites pass with 786 tests (up from 749)

## Coverage Results

| File | Before | After |
|------|--------|-------|
| Statements (all) | 82.37% | **89.98%** |
| Lines (all) | 90.29% | **96.92%** |
| `goal-service.ts` | 58.82% | **100%** |
| `kpi-service.ts` | 52.83% | **100%** |
| `change-tracking-service.ts` | 67.24% | **98.27%** |

## Test plan

- [x] `npx jest --coverage` — 72 suites, 786 tests, 0 failures
- [x] Statement coverage ≥ 90% on services/
- [x] No new source files modified — test-only change

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)