### PR TITLE
fix: final 4 issues for 10/10 — unsuspend blacklist, server-side session, session cache, security enforcement

### DIFF
--- a/__tests__/api/security-controls.test.ts
+++ b/__tests__/api/security-controls.test.ts
@@ -45,6 +45,7 @@ import {
   withSessionTimeout,
   withJwtBlacklist,
   setApiRateLimiter,
+  sessionLastActivity,
 } from "@/lib/security-middleware";
 import { JwtBlacklist } from "@/lib/jwt-blacklist";
 import { UserService } from "@/services/user-service";
@@ -88,6 +89,7 @@ function errorHandler(): ReturnType<typeof withRateLimit> {
 beforeEach(() => {
   jest.clearAllMocks();
   JwtBlacklist.clear();
+  sessionLastActivity.clear(); // reset server-side session tracking between tests
   setApiRateLimiter(null); // reset singleton between tests
 });
 
@@ -189,42 +191,68 @@ describe("withAuditLog", () => {
 });
 
 // ── 3. withSessionTimeout ────────────────────────────────────────────────────
+//
+// Updated for Issue #165: server-side Map tracking replaces client header trust.
 
 describe("withSessionTimeout", () => {
-  test("allows request when session last-activity is within 30 minutes", async () => {
-    const recentActivity = Date.now() - 5 * 60 * 1000; // 5 minutes ago
+  test("allows request when server-side last-activity is within 30 minutes", async () => {
+    const userId = "user-active-sc";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // Pre-record activity 5 minutes ago
+    sessionLastActivity.set(userId, Date.now() - 5 * 60 * 1000);
 
     const wrapped = withSessionTimeout(okHandler());
-    const res = await wrapped(
-      makeReq("GET", "/api/tasks", {
-        "x-session-last-activity": String(recentActivity),
-      })
-    );
+    const res = await wrapped(makeReq("GET", "/api/tasks", { "x-user-id": userId }));
 
     expect(res.status).toBe(200);
   });
 
-  test("rejects with 401 when session has been idle for more than 30 minutes", async () => {
-    const staleActivity = Date.now() - 31 * 60 * 1000; // 31 minutes ago
+  test("rejects with 401 when server-side last-activity exceeds 30 minutes", async () => {
+    const userId = "user-stale-sc";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // Pre-record stale activity 31 minutes ago
+    sessionLastActivity.set(userId, Date.now() - 31 * 60 * 1000);
 
     const wrapped = withSessionTimeout(okHandler());
-    const res = await wrapped(
-      makeReq("GET", "/api/tasks", {
-        "x-session-last-activity": String(staleActivity),
-      })
-    );
+    const res = await wrapped(makeReq("GET", "/api/tasks", { "x-user-id": userId }));
 
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.error).toMatch(/UnauthorizedError/);
   });
 
-  test("allows request when no X-Session-Last-Activity header is present", async () => {
-    // When no header is present the middleware defers to the inner handler
+  test("ignores X-Session-Last-Activity header — client cannot bypass timeout", async () => {
+    const userId = "user-bypass-sc";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // Server records stale activity
+    sessionLastActivity.set(userId, Date.now() - 31 * 60 * 1000);
+
+    // Client sends a fresh fake timestamp in the header — must be ignored
     const wrapped = withSessionTimeout(okHandler());
-    const res = await wrapped(makeReq("GET", "/api/tasks"));
+    const res = await wrapped(
+      makeReq("GET", "/api/tasks", {
+        "x-user-id": userId,
+        "x-session-last-activity": String(Date.now()), // fake fresh timestamp
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  test("allows request when no server-side activity recorded yet (first request)", async () => {
+    const userId = "user-new-sc";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // No entry in the Map — first request for this user
+    const wrapped = withSessionTimeout(okHandler());
+    const res = await wrapped(makeReq("GET", "/api/tasks", { "x-user-id": userId }));
 
     expect(res.status).toBe(200);
+    // Activity must now be recorded
+    expect(sessionLastActivity.has(userId)).toBe(true);
   });
 });
 

--- a/lib/__tests__/security-middleware.test.ts
+++ b/lib/__tests__/security-middleware.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Tests written FIRST (RED) before implementation.
+ *
+ * Issue #165: Session timeout uses server-side tracking, not client header
+ * Issue #166: getCachedSession calls getServerSession only once per request
+ */
+
+// ── Mock next/server ──────────────────────────────────────────────────────
+jest.mock("next/server", () => {
+  const actual = jest.requireActual("next/server");
+  return {
+    ...actual,
+    NextResponse: {
+      json: jest.fn((body: unknown, init?: { status?: number }) => ({
+        status: init?.status ?? 200,
+        _body: body,
+        json: async () => body,
+      })),
+    },
+  };
+});
+
+// ── Mock next-auth ─────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+// ── Mock @/lib/prisma to avoid real DB connection ─────────────────────────
+jest.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+// ── Mock @/services/audit-service ─────────────────────────────────────────
+jest.mock("@/services/audit-service", () => ({
+  AuditService: jest.fn().mockImplementation(() => ({
+    log: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// ── Mock @/lib/rate-limiter ────────────────────────────────────────────────
+jest.mock("@/lib/rate-limiter", () => ({
+  createApiRateLimiter: jest.fn(() => ({})),
+  checkRateLimit: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Imports after mocks ────────────────────────────────────────────────────
+import { NextRequest } from "next/server";
+import {
+  withSessionTimeout,
+  sessionLastActivity,
+} from "@/lib/security-middleware";
+import { getCachedSession, clearCachedSession } from "@/lib/session-cache";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+function makeFakeRequest(
+  url = "http://localhost/api/test",
+  headers: Record<string, string> = {}
+): NextRequest {
+  return {
+    url,
+    method: "GET",
+    headers: new Headers(headers),
+    json: jest.fn(),
+  } as unknown as NextRequest;
+}
+
+const noopHandler = jest.fn().mockResolvedValue({ status: 200 });
+
+// ── Tests: withSessionTimeout (Issue #165) ─────────────────────────────────
+
+describe("withSessionTimeout — server-side tracking", () => {
+  beforeEach(() => {
+    sessionLastActivity.clear();
+    mockGetServerSession.mockReset();
+    noopHandler.mockClear();
+  });
+
+  test("session timeout uses server-side tracking, not client header", async () => {
+    const userId = "user-timeout-test";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    const req = makeFakeRequest("http://localhost/api/test");
+    const handler = withSessionTimeout(noopHandler);
+
+    // First request — records activity
+    await handler(req);
+    expect(sessionLastActivity.has(userId)).toBe(true);
+
+    // Simulate 31 minutes of idle by backdating the stored timestamp
+    const thirtyOneMinAgo = Date.now() - 31 * 60 * 1000;
+    sessionLastActivity.set(userId, thirtyOneMinAgo);
+
+    // Second request — should be rejected
+    const req2 = makeFakeRequest("http://localhost/api/test");
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+    const response = await handler(req2);
+
+    expect(response.status).toBe(401);
+    expect(noopHandler).toHaveBeenCalledTimes(1); // only first call went through
+  });
+
+  test("cannot bypass timeout by sending fake header", async () => {
+    const userId = "user-bypass-test";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // Pre-set a stale timestamp (31 minutes ago)
+    const thirtyOneMinAgo = Date.now() - 31 * 60 * 1000;
+    sessionLastActivity.set(userId, thirtyOneMinAgo);
+
+    // Attacker sends a fresh timestamp in the (now-ignored) client header
+    const req = makeFakeRequest("http://localhost/api/test", {
+      "x-session-last-activity": String(Date.now()),
+    });
+
+    const handler = withSessionTimeout(noopHandler);
+    const response = await handler(req);
+
+    // Must still be rejected — server-side state takes precedence
+    expect(response.status).toBe(401);
+    expect(noopHandler).not.toHaveBeenCalled();
+  });
+
+  test("active session is allowed through and timestamp is refreshed", async () => {
+    const userId = "user-active-test";
+    mockGetServerSession.mockResolvedValue({ user: { id: userId } });
+
+    // Set last activity 5 minutes ago (well within 30-min window)
+    const fiveMinAgo = Date.now() - 5 * 60 * 1000;
+    sessionLastActivity.set(userId, fiveMinAgo);
+
+    const req = makeFakeRequest("http://localhost/api/test");
+    const handler = withSessionTimeout(noopHandler);
+    const response = await handler(req);
+
+    expect(response.status).toBe(200);
+    expect(noopHandler).toHaveBeenCalled();
+
+    // Timestamp must have been updated to now
+    const updatedTs = sessionLastActivity.get(userId)!;
+    expect(updatedTs).toBeGreaterThan(fiveMinAgo);
+  });
+});
+
+// ── Tests: getCachedSession (Issue #166) ───────────────────────────────────
+
+describe("getCachedSession — request-level cache", () => {
+  beforeEach(() => {
+    mockGetServerSession.mockReset();
+  });
+
+  test("getCachedSession calls getServerSession only once per request", async () => {
+    const fakeSession = { user: { id: "u-cache-test" } };
+    mockGetServerSession.mockResolvedValue(fakeSession);
+
+    const req = makeFakeRequest();
+
+    // Call three times for the same request object
+    const s1 = await getCachedSession(req);
+    const s2 = await getCachedSession(req);
+    const s3 = await getCachedSession(req);
+
+    expect(s1).toBe(fakeSession);
+    expect(s2).toBe(fakeSession);
+    expect(s3).toBe(fakeSession);
+
+    // getServerSession must have been called exactly once
+    expect(mockGetServerSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("different Request objects get independent cache entries", async () => {
+    const sessionA = { user: { id: "u-a" } };
+    const sessionB = { user: { id: "u-b" } };
+    mockGetServerSession
+      .mockResolvedValueOnce(sessionA)
+      .mockResolvedValueOnce(sessionB);
+
+    const reqA = makeFakeRequest();
+    const reqB = makeFakeRequest();
+
+    const sA = await getCachedSession(reqA);
+    const sB = await getCachedSession(reqB);
+
+    expect(sA).toBe(sessionA);
+    expect(sB).toBe(sessionB);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("clearCachedSession forces a fresh getServerSession call", async () => {
+    const first = { user: { id: "u-clear-1" } };
+    const second = { user: { id: "u-clear-2" } };
+    mockGetServerSession
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    const req = makeFakeRequest();
+
+    const s1 = await getCachedSession(req);
+    clearCachedSession(req);
+    const s2 = await getCachedSession(req);
+
+    expect(s1).toBe(first);
+    expect(s2).toBe(second);
+    expect(mockGetServerSession).toHaveBeenCalledTimes(2);
+  });
+});

--- a/lib/security-middleware.ts
+++ b/lib/security-middleware.ts
@@ -20,8 +20,8 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
 import type { ApiResponse } from "@/lib/api-response";
+import { getCachedSession } from "@/lib/session-cache";
 import { error } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import {
@@ -78,7 +78,7 @@ async function getSessionUserId(req: NextRequest): Promise<string | null> {
   const override = req.headers.get("x-user-id");
   if (override) return override;
 
-  const session = await getServerSession();
+  const session = await getCachedSession(req);
   return (session?.user as { id?: string } | undefined)?.id ?? null;
 }
 
@@ -182,32 +182,46 @@ export function withAuditLog<T extends AnyHandler>(fn: T): T {
 const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
- * Middleware wrapper: checks the X-Session-Last-Activity header (unix ms).
+ * Server-side last-activity store keyed by userId (unix ms timestamp).
+ *
+ * Process-local Map — acceptable for single-instance bank deployment.
+ * Exported so tests can inspect or reset it.
+ */
+export const sessionLastActivity = new Map<string, number>();
+
+/**
+ * Middleware wrapper: tracks last activity per userId on the server side.
  * Rejects with HTTP 401 if the session has been idle for more than 30 minutes.
  *
- * The header is expected to be set by the client or a reverse-proxy on each
- * API request. In production this can alternatively be read from a Redis
- * session store via the sessionId cookie.
+ * The previous implementation trusted the client-supplied
+ * X-Session-Last-Activity header, which allowed clients to bypass the timeout
+ * by sending a fake timestamp — Issue #165.  This version ignores that header
+ * entirely and relies on server-side state only.
  */
 export function withSessionTimeout<T extends AnyHandler>(fn: T): T {
   const wrapped = async (
     req: NextRequest,
     context?: RouteContext
   ): Promise<NextResponse<ApiResponse>> => {
-    const lastActivityHeader = req.headers.get("x-session-last-activity");
+    const userId = await getSessionUserId(req);
 
-    if (lastActivityHeader !== null) {
-      const lastActivity = parseInt(lastActivityHeader, 10);
-      if (!Number.isNaN(lastActivity)) {
-        const idleMs = Date.now() - lastActivity;
+    if (userId) {
+      const now = Date.now();
+      const lastActivity = sessionLastActivity.get(userId);
+
+      if (lastActivity !== undefined) {
+        const idleMs = now - lastActivity;
         if (idleMs > SESSION_IDLE_TIMEOUT_MS) {
           logger.warn(
-            { idleMs },
+            { idleMs, userId },
             "[withSessionTimeout] Session idle timeout exceeded"
           );
           return error("UnauthorizedError", "Session expired — please log in again", 401) as NextResponse<ApiResponse>;
         }
       }
+
+      // Update last-activity timestamp on every valid request.
+      sessionLastActivity.set(userId, now);
     }
 
     return fn(req, context);

--- a/lib/session-cache.ts
+++ b/lib/session-cache.ts
@@ -1,0 +1,44 @@
+/**
+ * Request-level session cache — Issue #166
+ *
+ * Prevents redundant getServerSession() calls when multiple security
+ * middleware wrappers (withRateLimit, withAuditLog, withSessionTimeout,
+ * withJwtBlacklist) all need the session for the same request.
+ *
+ * Uses a WeakMap so entries are automatically garbage-collected when
+ * the Request object is no longer referenced.
+ */
+
+import { getServerSession } from "next-auth";
+import type { NextRequest } from "next/server";
+
+// Session type returned by next-auth getServerSession.
+// We use `unknown` here to avoid importing next-auth internals; callers
+// can cast to their specific session shape.
+export type CachedSession = Awaited<ReturnType<typeof getServerSession>>;
+
+const _cache = new WeakMap<NextRequest, CachedSession>();
+
+/**
+ * Returns the session for this request, fetching it from next-auth only
+ * on the first call per request object.  Subsequent calls return the
+ * cached value without hitting the database again.
+ */
+export async function getCachedSession(req: NextRequest): Promise<CachedSession> {
+  if (_cache.has(req)) {
+    return _cache.get(req)!;
+  }
+  const session = await getServerSession();
+  _cache.set(req, session);
+  return session;
+}
+
+/** Exposed for testing — allows injecting a pre-built session into the cache. */
+export function setCachedSession(req: NextRequest, session: CachedSession): void {
+  _cache.set(req, session);
+}
+
+/** Exposed for testing — clears the cache entry for a specific request. */
+export function clearCachedSession(req: NextRequest): void {
+  _cache.delete(req);
+}

--- a/scripts/check-security-middleware.sh
+++ b/scripts/check-security-middleware.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-security-middleware.sh — CI scanner for missing security middleware
+# Issue #167: enforce withAuditLog and withRateLimit on all mutating route handlers
+#
+# Scans all app/api/**/route.ts files and exits 1 if any exported
+# POST/PUT/PATCH/DELETE handler is not wrapped by BOTH withAuditLog AND withRateLimit.
+#
+# Usage: bash scripts/check-security-middleware.sh [route-dir]
+#        Returns exit 0 if all routes are covered, exit 1 if gaps found.
+
+set -euo pipefail
+
+ROUTE_DIR="${1:-app/api}"
+ERRORS=0
+
+# Colour codes (suppressed when not a TTY)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  NC='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' NC=''
+fi
+
+echo "Scanning ${ROUTE_DIR} for handlers missing withAuditLog or withRateLimit..."
+echo ""
+
+while IFS= read -r -d '' file; do
+  relative="${file#./}"
+
+  # Check if the file exports any mutating HTTP handler
+  if ! grep -qE '^export const (POST|PUT|PATCH|DELETE)' "$file"; then
+    continue
+  fi
+
+  file_has_audit=$(grep -c 'withAuditLog' "$file" || true)
+  file_has_rate=$(grep -c 'withRateLimit' "$file" || true)
+
+  file_error=0
+
+  if [ "$file_has_audit" -eq 0 ]; then
+    echo -e "${RED}FAIL${NC} ${relative} — missing withAuditLog"
+    grep -nE '^export const (POST|PUT|PATCH|DELETE)' "$file" \
+      | while IFS= read -r match; do
+          echo "  ${YELLOW}→${NC} ${match}"
+        done
+    file_error=1
+  fi
+
+  if [ "$file_has_rate" -eq 0 ]; then
+    echo -e "${RED}FAIL${NC} ${relative} — missing withRateLimit"
+    grep -nE '^export const (POST|PUT|PATCH|DELETE)' "$file" \
+      | while IFS= read -r match; do
+          echo "  ${YELLOW}→${NC} ${match}"
+        done
+    file_error=1
+  fi
+
+  if [ "$file_error" -eq 1 ]; then
+    echo ""
+    ERRORS=$((ERRORS + 1))
+  fi
+done < <(find "${ROUTE_DIR}" -name "route.ts" -print0)
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo -e "${RED}Security middleware check FAILED: ${ERRORS} route file(s) are missing required wrappers.${NC}"
+  echo "Every POST/PUT/PATCH/DELETE handler must use withAuditLog and withRateLimit."
+  exit 1
+else
+  echo -e "${GREEN}Security middleware check PASSED: all mutating route handlers are properly wrapped.${NC}"
+  exit 0
+fi

--- a/services/__tests__/user-service.test.ts
+++ b/services/__tests__/user-service.test.ts
@@ -1,6 +1,7 @@
 import { UserService } from "../user-service";
 import { createMockPrisma } from "../../lib/test-utils";
 import { NotFoundError, ValidationError } from "../errors";
+import { JwtBlacklist } from "../../lib/jwt-blacklist";
 
 describe("UserService", () => {
   let service: UserService;
@@ -25,6 +26,25 @@ describe("UserService", () => {
     (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
 
     await expect(service.getUser("nonexistent")).rejects.toThrow(NotFoundError);
+  });
+
+  test("unsuspendUser removes user from JWT blacklist", async () => {
+    const mockUser = { id: "u1", name: "Alice", email: "alice@example.com", role: "ENGINEER", isActive: false };
+    const updatedUser = { ...mockUser, isActive: true };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    (prisma.user.update as jest.Mock).mockResolvedValue(updatedUser);
+
+    // Pre-populate the blacklist as suspendUser would do
+    JwtBlacklist.add("user:u1");
+    expect(JwtBlacklist.has("user:u1")).toBe(true);
+
+    await service.unsuspendUser("u1");
+
+    // After unsuspend, the blacklist entry must be removed
+    expect(JwtBlacklist.has("user:u1")).toBe(false);
+
+    // Cleanup
+    JwtBlacklist.clear();
   });
 
   test("updateUser validates email uniqueness", async () => {

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -208,7 +208,7 @@ export class UserService {
     const existing = await this.prisma.user.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`User not found: ${id}`);
 
-    return this.prisma.user.update({
+    const updated = await this.prisma.user.update({
       where: { id },
       data: { isActive: true },
       select: {
@@ -219,5 +219,11 @@ export class UserService {
         isActive: true,
       },
     });
+
+    // Remove the userId-based blacklist key so the user's tokens are
+    // accepted again by withJwtBlacklist middleware — Issue #164.
+    JwtBlacklist.remove(`user:${id}`);
+
+    return updated;
   }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Closes #164** — `unsuspendUser` now calls `JwtBlacklist.remove(\`user:${id}\`)` so previously suspended users can authenticate again after being unsuspended
- **Closes #165** — `withSessionTimeout` replaced client-header trust (`X-Session-Last-Activity`) with a server-side `Map<userId, timestamp>`; clients can no longer bypass the 30-min timeout by sending a fake header
- **Closes #166** — New `lib/session-cache.ts` provides `getCachedSession(req)` backed by a `WeakMap<NextRequest, Session>`; all four security middleware wrappers now call this instead of calling `getServerSession()` independently
- **Closes #167** — New `scripts/check-security-middleware.sh` scans all `app/api/**/route.ts` files and exits 1 if any POST/PUT/PATCH/DELETE handler is missing `withAuditLog` or `withRateLimit`

## Test plan

- [x] `npx jest --no-coverage` — **794 tests, 0 failures**
- [x] TDD: `unsuspendUser removes user from JWT blacklist` (services/__tests__/user-service.test.ts)
- [x] TDD: `session timeout uses server-side tracking, not client header` (lib/__tests__/security-middleware.test.ts)
- [x] TDD: `cannot bypass timeout by sending fake header` (lib/__tests__/security-middleware.test.ts)
- [x] TDD: `getCachedSession calls getServerSession only once per request` (lib/__tests__/security-middleware.test.ts)
- [x] Existing `withSessionTimeout` tests in `__tests__/api/security-controls.test.ts` updated to reflect server-side tracking behavior
- [x] `scripts/check-security-middleware.sh` manually verified executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)