### PR TITLE
fix: light theme + middleware redirect + defensive guards

### DIFF
--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -45,7 +45,7 @@ type AnnualPlan = {
 const MONTHS = ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
 
 const STATUS_BAR: Record<string, string> = {
-  BACKLOG: "bg-zinc-700",
+  BACKLOG: "bg-muted",
   TODO: "bg-blue-500/70",
   IN_PROGRESS: "bg-yellow-500/80",
   REVIEW: "bg-purple-500/80",
@@ -61,11 +61,11 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const MILESTONE_STATUS_COLOR: Record<string, string> = {
-  PENDING: "text-zinc-400",
-  IN_PROGRESS: "text-yellow-400",
-  COMPLETED: "text-emerald-400",
-  DELAYED: "text-red-400",
-  CANCELLED: "text-zinc-600",
+  PENDING: "text-muted-foreground",
+  IN_PROGRESS: "text-yellow-500",
+  COMPLETED: "text-emerald-500",
+  DELAYED: "text-red-500",
+  CANCELLED: "text-muted-foreground/50",
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ function GanttBar({ task, year, totalDays, onClick }: GanttBarProps) {
   if (!task.startDate && !task.dueDate) {
     return (
       <div className="h-5 flex items-center">
-        <span className="text-xs text-zinc-700 italic">無日期</span>
+        <span className="text-xs text-muted-foreground/50 italic">無日期</span>
       </div>
     );
   }
@@ -119,7 +119,7 @@ function GanttBar({ task, year, totalDays, onClick }: GanttBarProps) {
         title={`${task.title} — ${STATUS_LABEL[task.status] ?? task.status}`}
         className={cn(
           "absolute h-5 rounded-sm cursor-pointer transition-opacity hover:opacity-90 flex items-center px-1.5 overflow-hidden",
-          STATUS_BAR[task.status] ?? "bg-zinc-600"
+          STATUS_BAR[task.status] ?? "bg-muted"
         )}
         style={{ left: `${leftPct}%`, width: `${widthPct}%`, minWidth: "4px" }}
       >
@@ -160,11 +160,11 @@ function MilestoneMarker({ milestone, year, totalDays }: MilestoneMarkerProps) {
     >
       <div className="w-px h-full bg-amber-500/30" />
       <div
-        className={cn("absolute top-0 -translate-x-1/2 flex flex-col items-center gap-0.5", MILESTONE_STATUS_COLOR[milestone.status] ?? "text-zinc-400")}
+        className={cn("absolute top-0 -translate-x-1/2 flex flex-col items-center gap-0.5", MILESTONE_STATUS_COLOR[milestone.status] ?? "text-muted-foreground")}
         style={{ whiteSpace: "nowrap" }}
       >
         <Diamond className="h-3 w-3 fill-current" />
-        <span className="text-[9px] font-medium bg-zinc-950/80 px-1 rounded">{milestone.title}</span>
+        <span className="text-[9px] font-medium bg-background/80 px-1 rounded">{milestone.title}</span>
       </div>
     </div>
   );
@@ -212,7 +212,7 @@ export default function GanttPage() {
       <div className="flex items-center justify-between flex-shrink-0">
         <div>
           <h1 className="text-2xl font-medium tracking-[-0.04em]">甘特圖</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">
+          <p className="text-muted-foreground text-sm mt-0.5">
             {plan ? plan.title : `${year} 年度計畫`}
           </p>
         </div>
@@ -222,26 +222,26 @@ export default function GanttPage() {
           <select
             value={assigneeFilter}
             onChange={(e) => setAssigneeFilter(e.target.value)}
-            className="bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-600 cursor-pointer"
+            className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
           >
             <option value="">全部成員</option>
             {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
           </select>
 
           {/* Year picker */}
-          <div className="flex items-center gap-1 bg-zinc-800 border border-zinc-700 rounded-md">
+          <div className="flex items-center gap-1 bg-background border border-border rounded-md">
             <button
               onClick={() => setYear((y) => y - 1)}
-              className="p-1.5 hover:bg-zinc-700 rounded-l-md transition-colors"
+              className="p-1.5 hover:bg-accent rounded-l-md transition-colors"
             >
-              <ChevronLeft className="h-4 w-4 text-zinc-400" />
+              <ChevronLeft className="h-4 w-4 text-muted-foreground" />
             </button>
-            <span className="px-3 text-sm font-medium text-zinc-200 tabular-nums">{year}</span>
+            <span className="px-3 text-sm font-medium text-foreground tabular-nums">{year}</span>
             <button
               onClick={() => setYear((y) => y + 1)}
-              className="p-1.5 hover:bg-zinc-700 rounded-r-md transition-colors"
+              className="p-1.5 hover:bg-accent rounded-r-md transition-colors"
             >
-              <ChevronRight className="h-4 w-4 text-zinc-400" />
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
             </button>
           </div>
         </div>
@@ -273,13 +273,13 @@ export default function GanttPage() {
 
               {/* Right: month header */}
               <div className="flex-1 relative">
-                <div className="flex border-b border-zinc-800">
+                <div className="flex border-b border-border">
                   {MONTHS.map((m, i) => {
                     const widthPct = ((new Date(year, i + 1, 0).getDate()) / totalDays) * 100;
                     return (
                       <div
                         key={i}
-                        className="text-center text-xs text-zinc-500 py-2 border-r border-zinc-800/50 last:border-0"
+                        className="text-center text-xs text-muted-foreground py-2 border-r border-border/50 last:border-0"
                         style={{ width: `${widthPct}%` }}
                       >
                         {m}
@@ -292,7 +292,7 @@ export default function GanttPage() {
 
             {/* Milestones row */}
             {plan.milestones.length > 0 && (
-              <div className="flex border-b border-zinc-800/50">
+              <div className="flex border-b border-border/50">
                 <div className="w-56 flex-shrink-0 px-3 py-2 flex items-center gap-2">
                   <Diamond className="h-3 w-3 text-amber-500" />
                   <span className="text-xs font-semibold text-amber-400/80">里程碑</span>
@@ -304,7 +304,7 @@ export default function GanttPage() {
                     return (
                       <div
                         key={i}
-                        className="absolute top-0 bottom-0 w-px bg-zinc-800/50"
+                        className="absolute top-0 bottom-0 w-px bg-border/50"
                         style={{ left: `${leftPct}%` }}
                       />
                     );
@@ -320,9 +320,9 @@ export default function GanttPage() {
             {plan.monthlyGoals.map((goal) => (
               <div key={goal.id}>
                 {/* Goal row */}
-                <div className="flex border-b border-zinc-800/30 bg-zinc-900/30">
+                <div className="flex border-b border-border/30 bg-muted/20">
                   <div className="w-56 flex-shrink-0 px-3 py-2">
-                    <span className="text-xs font-semibold text-zinc-400">
+                    <span className="text-xs font-semibold text-muted-foreground">
                       {goal.month}月　{goal.title}
                     </span>
                   </div>
@@ -330,7 +330,7 @@ export default function GanttPage() {
                     {MONTHS.map((_, i) => (
                       <div
                         key={i}
-                        className="absolute top-0 bottom-0 w-px bg-zinc-800/30"
+                        className="absolute top-0 bottom-0 w-px bg-border/30"
                         style={{ left: `${(monthStartDay(i, year) / totalDays) * 100}%` }}
                       />
                     ))}
@@ -342,7 +342,7 @@ export default function GanttPage() {
                       const l = (start / totalDays) * 100;
                       return (
                         <div
-                          className="absolute top-1/2 -translate-y-1/2 h-1.5 rounded-full bg-zinc-700/50"
+                          className="absolute top-1/2 -translate-y-1/2 h-1.5 rounded-full bg-muted"
                           style={{ left: `${l}%`, width: `${w}%` }}
                         />
                       );
@@ -352,28 +352,28 @@ export default function GanttPage() {
 
                 {/* Task rows */}
                 {goal.tasks.length === 0 ? (
-                  <div className="flex border-b border-zinc-800/20">
+                  <div className="flex border-b border-border/20">
                     <div className="w-56 flex-shrink-0 px-5 py-2">
-                      <span className="text-xs text-zinc-700 italic">無任務</span>
+                      <span className="text-xs text-muted-foreground/50 italic">無任務</span>
                     </div>
                     <div className="flex-1 h-8" />
                   </div>
                 ) : (
                   goal.tasks.map((task) => (
-                    <div key={task.id} className="flex border-b border-zinc-800/20 hover:bg-zinc-900/20 transition-colors group">
+                    <div key={task.id} className="flex border-b border-border/20 hover:bg-accent/20 transition-colors group">
                       <div className="w-56 flex-shrink-0 px-5 py-1.5 flex items-center gap-2">
                         <div
-                          className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", STATUS_BAR[task.status] ?? "bg-zinc-600")}
+                          className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", STATUS_BAR[task.status] ?? "bg-muted")}
                         />
                         <span
-                          className="text-xs text-zinc-400 group-hover:text-zinc-200 cursor-pointer truncate transition-colors"
+                          className="text-xs text-muted-foreground group-hover:text-foreground cursor-pointer truncate transition-colors"
                           onClick={() => setSelectedTaskId(task.id)}
                           title={task.title}
                         >
                           {task.title}
                         </span>
                         {task.primaryAssignee && (
-                          <span className="ml-auto text-[10px] text-zinc-600 flex-shrink-0">
+                          <span className="ml-auto text-[10px] text-muted-foreground/60 flex-shrink-0">
                             {task.primaryAssignee.name.slice(0, 2)}
                           </span>
                         )}
@@ -382,7 +382,7 @@ export default function GanttPage() {
                         {MONTHS.map((_, i) => (
                           <div
                             key={i}
-                            className="absolute top-0 bottom-0 w-px bg-zinc-800/20"
+                            className="absolute top-0 bottom-0 w-px bg-border/20"
                             style={{ left: `${(monthStartDay(i, year) / totalDays) * 100}%` }}
                           />
                         ))}

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -11,7 +11,7 @@ import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states"
 type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
 
 const COLUMNS: { status: TaskStatus; label: string; color: string }[] = [
-  { status: "BACKLOG", label: "待辦清單", color: "text-zinc-400" },
+  { status: "BACKLOG", label: "待辦清單", color: "text-muted-foreground" },
   { status: "TODO", label: "待處理", color: "text-blue-400" },
   { status: "IN_PROGRESS", label: "進行中", color: "text-yellow-400" },
   { status: "REVIEW", label: "審核中", color: "text-purple-400" },
@@ -19,7 +19,7 @@ const COLUMNS: { status: TaskStatus; label: string; color: string }[] = [
 ];
 
 const columnBorder: Record<TaskStatus, string> = {
-  BACKLOG: "border-zinc-700/50",
+  BACKLOG: "border-border",
   TODO: "border-blue-500/20",
   IN_PROGRESS: "border-yellow-500/20",
   REVIEW: "border-purple-500/20",
@@ -27,7 +27,7 @@ const columnBorder: Record<TaskStatus, string> = {
 };
 
 const columnHeaderBg: Record<TaskStatus, string> = {
-  BACKLOG: "bg-zinc-800/60",
+  BACKLOG: "bg-muted/60",
   TODO: "bg-blue-500/10",
   IN_PROGRESS: "bg-yellow-500/10",
   REVIEW: "bg-purple-500/10",
@@ -121,7 +121,7 @@ export default function KanbanPage() {
           <h1 className="text-2xl font-medium tracking-[-0.04em]">看板</h1>
           <p className="text-muted-foreground text-sm mt-0.5">共 {tasks.length} 項任務</p>
         </div>
-        <button className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700">
+        <button className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border">
           <Plus className="h-3.5 w-3.5" />
           新增任務
         </button>
@@ -160,7 +160,7 @@ export default function KanbanPage() {
                 className={cn(
                   "flex flex-col w-72 flex-shrink-0 rounded-xl border transition-colors",
                   columnBorder[status],
-                  isOver && "ring-1 ring-zinc-500"
+                  isOver && "ring-1 ring-ring"
                 )}
                 onDragOver={(e) => handleDragOver(e, status)}
                 onDragLeave={() => setDragOver(null)}
@@ -172,7 +172,7 @@ export default function KanbanPage() {
                     <span className={cn("text-xs font-semibold uppercase tracking-wider", color)}>
                       {label}
                     </span>
-                    <span className="text-xs text-zinc-500 tabular-nums bg-zinc-800/60 px-1.5 py-0.5 rounded">
+                    <span className="text-xs text-muted-foreground tabular-nums bg-muted/60 px-1.5 py-0.5 rounded">
                       {colTasks.length}
                     </span>
                   </div>
@@ -198,7 +198,7 @@ export default function KanbanPage() {
                       />
                       {movingTask === task.id && (
                         <div className="flex justify-center py-1">
-                          <Loader2 className="h-3 w-3 animate-spin text-zinc-500" />
+                          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
                         </div>
                       )}
                     </div>
@@ -207,8 +207,8 @@ export default function KanbanPage() {
                   {colTasks.length === 0 && (
                     <div
                       className={cn(
-                        "flex items-center justify-center h-20 rounded-lg border border-dashed text-xs text-zinc-600 transition-colors",
-                        isOver ? "border-zinc-500 bg-zinc-800/30 text-zinc-400" : "border-zinc-800"
+                        "flex items-center justify-center h-20 rounded-lg border border-dashed text-xs text-muted-foreground transition-colors",
+                        isOver ? "border-ring bg-accent/30 text-foreground" : "border-border"
                       )}
                     >
                       {isOver ? "放置到此欄" : "尚無任務"}

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -40,7 +40,8 @@ export default function KnowledgePage() {
     try {
       const res = await fetch("/api/documents");
       if (!res.ok) throw new Error("文件載入失敗");
-      setDocs(await res.json());
+      const json = await res.json();
+      setDocs(Array.isArray(json) ? json : []);
     } catch (e) {
       setDocsError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -132,11 +133,11 @@ export default function KnowledgePage() {
       <div className="flex items-center justify-between pb-4 flex-shrink-0">
         <div>
           <h1 className="text-2xl font-medium tracking-[-0.04em]">知識庫</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">Markdown 文件管理</p>
+          <p className="text-muted-foreground text-sm mt-0.5">Markdown 文件管理</p>
         </div>
         <button
           onClick={() => createDoc(null)}
-          className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700"
+          className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
         >
           <Plus className="h-3.5 w-3.5" />
           新增文件
@@ -144,11 +145,11 @@ export default function KnowledgePage() {
       </div>
 
       {/* Main layout */}
-      <div className="flex flex-1 min-h-0 gap-0 border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="flex flex-1 min-h-0 gap-0 border border-border rounded-xl overflow-hidden">
         {/* Left sidebar */}
-        <div className="w-56 flex-shrink-0 border-r border-zinc-800 flex flex-col bg-zinc-950">
+        <div className="w-56 flex-shrink-0 border-r border-border flex flex-col bg-sidebar-background">
           {/* Search */}
-          <div className="p-2 border-b border-zinc-800">
+          <div className="p-2 border-b border-border">
             <DocumentSearch onSelect={setSelectedId} />
           </div>
 
@@ -184,32 +185,32 @@ export default function KnowledgePage() {
         </div>
 
         {/* Right panel */}
-        <div className="flex-1 flex flex-col min-w-0 bg-zinc-950">
+        <div className="flex-1 flex flex-col min-w-0 bg-card">
           {!selectedId ? (
             <div className="flex-1 flex items-center justify-center text-center">
               <div>
-                <p className="text-zinc-600 text-sm">從左側選擇文件</p>
-                <p className="text-zinc-700 text-xs mt-1">或點擊 + 新增文件</p>
+                <p className="text-muted-foreground text-sm">從左側選擇文件</p>
+                <p className="text-muted-foreground/60 text-xs mt-1">或點擊 + 新增文件</p>
               </div>
             </div>
           ) : loadingDetail ? (
             <div className="flex-1 flex items-center justify-center">
-              <Loader2 className="h-4 w-4 animate-spin text-zinc-600" />
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
           ) : docDetail ? (
             <>
               {/* Editor header */}
-              <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800 flex-shrink-0">
+              <div className="flex items-center gap-3 px-4 py-3 border-b border-border flex-shrink-0">
                 <input
                   type="text"
                   value={editTitle}
                   onChange={(e) => handleTitleChange(e.target.value)}
-                  className="flex-1 bg-transparent text-base font-semibold text-zinc-100 focus:outline-none placeholder:text-zinc-600 border-b border-transparent focus:border-zinc-700 pb-0.5 transition-colors"
+                  className="flex-1 bg-transparent text-base font-semibold text-foreground focus:outline-none placeholder:text-muted-foreground border-b border-transparent focus:border-border pb-0.5 transition-colors"
                   placeholder="文件標題..."
                 />
                 <div className="flex items-center gap-2 flex-shrink-0">
                   {dirty && (
-                    <span className="text-xs text-amber-400">未儲存</span>
+                    <span className="text-xs text-amber-500">未儲存</span>
                   )}
                   <button
                     onClick={save}
@@ -217,8 +218,8 @@ export default function KnowledgePage() {
                     className={cn(
                       "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
                       dirty
-                        ? "bg-zinc-700 hover:bg-zinc-600 text-zinc-200"
-                        : "bg-zinc-800 text-zinc-600 cursor-default"
+                        ? "bg-accent hover:bg-accent/80 text-accent-foreground"
+                        : "bg-muted text-muted-foreground cursor-default"
                     )}
                   >
                     {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
@@ -228,15 +229,15 @@ export default function KnowledgePage() {
               </div>
 
               {/* Meta */}
-              <div className="px-4 py-1.5 border-b border-zinc-800/50 flex items-center gap-4 flex-shrink-0">
-                <span className="text-xs text-zinc-600">
+              <div className="px-4 py-1.5 border-b border-border/50 flex items-center gap-4 flex-shrink-0">
+                <span className="text-xs text-muted-foreground">
                   建立：{docDetail.creator.name}
                 </span>
-                <span className="text-xs text-zinc-600">
+                <span className="text-xs text-muted-foreground">
                   最後更新：{docDetail.updater.name}
                   　{new Date(docDetail.updatedAt).toLocaleDateString("zh-TW")}
                 </span>
-                <span className="text-xs text-zinc-700 ml-auto">v{docDetail.version}</span>
+                <span className="text-xs text-muted-foreground/60 ml-auto">v{docDetail.version}</span>
               </div>
 
               {/* Markdown editor */}
@@ -258,7 +259,7 @@ export default function KnowledgePage() {
               </div>
             </>
           ) : (
-            <div className="flex-1 flex items-center justify-center text-zinc-600 text-sm">
+            <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
               文件不存在
             </div>
           )}

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -47,7 +47,7 @@ const statusLabels: Record<TaskStatus, string> = {
 };
 
 const statusColors: Record<TaskStatus, string> = {
-  BACKLOG: "text-zinc-400",
+  BACKLOG: "text-muted-foreground",
   TODO: "text-blue-400",
   IN_PROGRESS: "text-yellow-400",
   REVIEW: "text-purple-400",
@@ -172,18 +172,18 @@ export default function PlansPage() {
     }
   }
 
-  const inputCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors placeholder:text-zinc-600";
-  const selectCls = "bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 transition-colors cursor-pointer";
+  const inputCls = "bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring transition-colors placeholder:text-muted-foreground";
+  const selectCls = "bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring transition-colors cursor-pointer";
 
   return (
     <div className="flex flex-col gap-6 max-w-5xl">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-1.5 text-xs text-zinc-500">
-        <span className="text-zinc-300 font-medium">年度計畫</span>
+      <nav className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className="text-foreground font-medium">年度計畫</span>
         {selectedGoal && (
           <>
             <ChevronRight className="h-3 w-3" />
-            <span className="text-zinc-300 font-medium">
+            <span className="text-foreground font-medium">
               {monthNames[selectedGoal.month]} — {selectedGoal.title}
             </span>
           </>
@@ -199,21 +199,21 @@ export default function PlansPage() {
         <div className="flex items-center gap-2">
           <button
             onClick={() => setShowGoalForm(true)}
-            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700"
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
           >
             <Plus className="h-3.5 w-3.5" />
             新增月度目標
           </button>
           <button
             onClick={() => { setShowCopyForm((v) => !v); setShowPlanForm(false); setCopyError(""); }}
-            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 text-zinc-200 rounded-md transition-colors border border-zinc-700"
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
           >
             <Copy className="h-3.5 w-3.5" />
             從上年複製
           </button>
           <button
             onClick={() => setShowPlanForm(true)}
-            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 rounded-md transition-colors"
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground rounded-md transition-colors"
           >
             <Target className="h-3.5 w-3.5" />
             新增年度計畫
@@ -223,10 +223,10 @@ export default function PlansPage() {
 
       {/* Create plan form */}
       {showPlanForm && (
-        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+        <div className="bg-card border border-border rounded-xl p-4 space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-zinc-200">新增年度計畫</h3>
-            <button onClick={() => setShowPlanForm(false)} className="text-zinc-500 hover:text-zinc-200">
+            <h3 className="text-sm font-medium text-foreground">新增年度計畫</h3>
+            <button onClick={() => setShowPlanForm(false)} className="text-muted-foreground hover:text-foreground">
               <X className="h-4 w-4" />
             </button>
           </div>
@@ -250,7 +250,7 @@ export default function PlansPage() {
             <button
               onClick={createPlan}
               disabled={creatingPlan || !newPlanTitle.trim()}
-              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
             >
               {creatingPlan ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
             </button>
@@ -260,14 +260,14 @@ export default function PlansPage() {
 
       {/* Copy template form */}
       {showCopyForm && (
-        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+        <div className="bg-card border border-border rounded-xl p-4 space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-zinc-200">從上年複製計畫</h3>
-            <button onClick={() => setShowCopyForm(false)} className="text-zinc-500 hover:text-zinc-200">
+            <h3 className="text-sm font-medium text-foreground">從上年複製計畫</h3>
+            <button onClick={() => setShowCopyForm(false)} className="text-muted-foreground hover:text-foreground">
               <X className="h-4 w-4" />
             </button>
           </div>
-          <p className="text-xs text-zinc-500">選擇來源計畫，系統將複製其架構（月度目標與里程碑）到新年度。</p>
+          <p className="text-xs text-muted-foreground">選擇來源計畫，系統將複製其架構（月度目標與里程碑）到新年度。</p>
           <div className="flex gap-3 flex-wrap">
             <select
               value={copySourcePlanId}
@@ -289,7 +289,7 @@ export default function PlansPage() {
             <button
               onClick={copyTemplate}
               disabled={copyingTemplate || !copySourcePlanId || !copyTargetYear}
-              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
             >
               {copyingTemplate ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <><Copy className="h-3.5 w-3.5" />複製</>}
             </button>
@@ -302,10 +302,10 @@ export default function PlansPage() {
 
       {/* Create goal form */}
       {showGoalForm && (
-        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-4 space-y-3">
+        <div className="bg-card border border-border rounded-xl p-4 space-y-3">
           <div className="flex items-center justify-between">
-            <h3 className="text-sm font-medium text-zinc-200">新增月度目標</h3>
-            <button onClick={() => setShowGoalForm(false)} className="text-zinc-500 hover:text-zinc-200">
+            <h3 className="text-sm font-medium text-foreground">新增月度目標</h3>
+            <button onClick={() => setShowGoalForm(false)} className="text-muted-foreground hover:text-foreground">
               <X className="h-4 w-4" />
             </button>
           </div>
@@ -341,7 +341,7 @@ export default function PlansPage() {
             <button
               onClick={createGoal}
               disabled={creatingGoal || !newGoalTitle.trim() || !newGoalPlanId}
-              className="flex items-center gap-1.5 px-4 py-1.5 bg-zinc-200 hover:bg-white text-zinc-900 text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
+              className="flex items-center gap-1.5 px-4 py-1.5 bg-primary hover:bg-primary/90 text-primary-foreground text-sm font-medium rounded-md disabled:opacity-40 transition-colors"
             >
               {creatingGoal ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
             </button>
@@ -352,7 +352,7 @@ export default function PlansPage() {
       {/* Plan tree */}
       {loading ? (
         <div className="flex items-center justify-center py-16">
-          <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
         </div>
       ) : plans.length === 0 ? (
         <PageEmpty
@@ -361,6 +361,7 @@ export default function PlansPage() {
           description="目前沒有任何計畫，請點擊「新增年度計畫」建立"
         />
       ) : (
+
         <PlanTree
           plans={plans}
           onSelectGoal={(goalId) => loadGoal(goalId)}
@@ -370,19 +371,19 @@ export default function PlansPage() {
 
       {/* Goal detail panel */}
       {selectedGoal && (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl">
-          <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+        <div className="bg-card border border-border rounded-xl">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-border">
             <div>
-              <div className="text-xs text-zinc-500 mb-0.5">月度目標詳情</div>
-              <h2 className="text-sm font-medium text-zinc-200">
+              <div className="text-xs text-muted-foreground mb-0.5">月度目標詳情</div>
+              <h2 className="text-sm font-medium text-foreground">
                 {monthNames[selectedGoal.month]} — {selectedGoal.title}
               </h2>
             </div>
             <div className="flex items-center gap-3">
-              {goalLoading && <Loader2 className="h-4 w-4 animate-spin text-zinc-500" />}
+              {goalLoading && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
               <button
                 onClick={() => setSelectedGoal(null)}
-                className="text-zinc-500 hover:text-zinc-200 transition-colors"
+                className="text-muted-foreground hover:text-foreground transition-colors"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -393,26 +394,26 @@ export default function PlansPage() {
           <div className="p-4">
             {selectedGoal.tasks && selectedGoal.tasks.length > 0 ? (
               <div className="space-y-2">
-                <h3 className="text-xs font-medium text-zinc-400 mb-3">個人任務</h3>
+                <h3 className="text-xs font-medium text-muted-foreground mb-3">個人任務</h3>
                 {selectedGoal.tasks.map((task) => (
                   <div
                     key={task.id}
                     onClick={() => setSelectedTaskId(task.id)}
-                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-zinc-800/50 cursor-pointer transition-colors group"
+                    className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-accent/50 cursor-pointer transition-colors group"
                   >
                     <span className={cn("text-xs font-medium w-16 flex-shrink-0", statusColors[task.status])}>
                       {statusLabels[task.status]}
                     </span>
-                    <span className="flex-1 text-sm text-zinc-200 group-hover:text-white truncate transition-colors">
+                    <span className="flex-1 text-sm text-foreground group-hover:text-foreground/90 truncate transition-colors">
                       {task.title}
                     </span>
                     {task.primaryAssignee && (
-                      <div className="flex-shrink-0 h-5 w-5 rounded-full bg-zinc-700 flex items-center justify-center text-[10px] text-zinc-300">
+                      <div className="flex-shrink-0 h-5 w-5 rounded-full bg-muted flex items-center justify-center text-[10px] text-muted-foreground">
                         {task.primaryAssignee.name.charAt(0)}
                       </div>
                     )}
                     {task.dueDate && (
-                      <span className="text-[10px] text-zinc-500 flex-shrink-0">
+                      <span className="text-[10px] text-muted-foreground flex-shrink-0">
                         {new Date(task.dueDate).getMonth() + 1}/{new Date(task.dueDate).getDate()}
                       </span>
                     )}
@@ -420,7 +421,7 @@ export default function PlansPage() {
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-zinc-600 text-center py-6">此月度目標尚無任務</p>
+              <p className="text-sm text-muted-foreground text-center py-6">此月度目標尚無任務</p>
             )}
           </div>
         </div>

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -91,7 +91,7 @@ function WeeklyReport() {
 
   if (loading) return <PageLoading message="載入週報..." />;
   if (error) return <PageError message={error} onRetry={load} />;
-  if (!data) return <PageEmpty title="無週報資料" description="本週尚無相關數據" />;
+  if (!data || !data.period) return <PageEmpty title="無週報資料" description="本週尚無相關數據" />;
 
   const start = new Date(data.period.start).toLocaleDateString("zh-TW");
   const end = new Date(data.period.end).toLocaleDateString("zh-TW");
@@ -238,7 +238,7 @@ function MonthlyReport() {
         <PageLoading message="載入月報..." />
       ) : error ? (
         <PageError message={error} onRetry={load} />
-      ) : !data ? (
+      ) : !data || !data.period ? (
         <PageEmpty title="無月報資料" description="本月尚無相關數據" />
       ) : (
         <>
@@ -508,7 +508,7 @@ function WorkloadReport() {
         <PageLoading message="載入負荷報表..." />
       ) : error ? (
         <PageError message={error} onRetry={load} />
-      ) : !data ? (
+      ) : !data || !data.period ? (
         <PageEmpty title="無負荷報表資料" description="所選期間尚無工時數據" />
       ) : (
         <>

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -185,7 +185,7 @@ export default function TimesheetPage() {
       <div className="flex items-center justify-between flex-shrink-0">
         <div>
           <h1 className="text-2xl font-medium tracking-[-0.04em]">工時紀錄</h1>
-          <p className="text-zinc-500 text-sm mt-0.5">{formatWeekLabel(weekStart)}</p>
+          <p className="text-muted-foreground text-sm mt-0.5">{formatWeekLabel(weekStart)}</p>
         </div>
 
         <div className="flex items-center gap-3">
@@ -193,34 +193,34 @@ export default function TimesheetPage() {
           <select
             value={userFilter}
             onChange={(e) => setUserFilter(e.target.value)}
-            className="bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-600 cursor-pointer"
+            className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
           >
             <option value="">我的工時</option>
             {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
           </select>
 
           {/* Week navigation */}
-          <div className="flex items-center gap-1 bg-zinc-800 border border-zinc-700 rounded-md">
-            <button onClick={prevWeek} className="p-1.5 hover:bg-zinc-700 rounded-l-md transition-colors">
-              <ChevronLeft className="h-4 w-4 text-zinc-400" />
+          <div className="flex items-center gap-1 bg-background border border-border rounded-md">
+            <button onClick={prevWeek} className="p-1.5 hover:bg-accent rounded-l-md transition-colors">
+              <ChevronLeft className="h-4 w-4 text-muted-foreground" />
             </button>
             <button
               onClick={thisWeek}
-              className="px-3 py-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+              className="px-3 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
               本週
             </button>
-            <button onClick={nextWeek} className="p-1.5 hover:bg-zinc-700 rounded-r-md transition-colors">
-              <ChevronRight className="h-4 w-4 text-zinc-400" />
+            <button onClick={nextWeek} className="p-1.5 hover:bg-accent rounded-r-md transition-colors">
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
             </button>
           </div>
 
           <button
             onClick={loadEntries}
             disabled={loading}
-            className="p-1.5 rounded-md bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 transition-colors"
+            className="p-1.5 rounded-md bg-background border border-border hover:bg-accent transition-colors"
           >
-            <RefreshCw className={cn("h-4 w-4 text-zinc-400", loading && "animate-spin")} />
+            <RefreshCw className={cn("h-4 w-4 text-muted-foreground", loading && "animate-spin")} />
           </button>
         </div>
       </div>
@@ -229,7 +229,7 @@ export default function TimesheetPage() {
       <div className="flex-1 flex flex-col gap-4 min-h-0 overflow-auto">
         {/* Stats summary */}
         {statsLoading ? (
-          <div className="flex items-center gap-2 text-xs text-zinc-600">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <Loader2 className="h-3 w-3 animate-spin" />
             計算中...
           </div>
@@ -242,7 +242,7 @@ export default function TimesheetPage() {
         ) : null}
 
         {/* Grid */}
-        <div className="border border-zinc-800 rounded-xl overflow-hidden bg-zinc-950">
+        <div className="border border-border rounded-xl overflow-hidden bg-card">
           {loading ? (
             <PageLoading message="載入工時..." className="py-12" />
           ) : loadError ? (
@@ -266,7 +266,7 @@ export default function TimesheetPage() {
         </div>
 
         {/* Help */}
-        <div className="text-xs text-zinc-700 pb-2">
+        <div className="text-xs text-muted-foreground/60 pb-2">
           點擊格子可輸入工時與分類。綠色 = 正常，橘色 = 超時（&gt;8h）。
         </div>
       </div>

--- a/app/components/deliverable-list.tsx
+++ b/app/components/deliverable-list.tsx
@@ -23,7 +23,7 @@ const typeConfig: Record<DeliverableType, { label: string; icon: React.ElementTy
 };
 
 const statusConfig: Record<DeliverableStatus, { label: string; color: string }> = {
-  NOT_STARTED: { label: "未開始", color: "text-zinc-400 bg-zinc-800" },
+  NOT_STARTED: { label: "未開始", color: "text-muted-foreground bg-muted" },
   IN_PROGRESS: { label: "進行中", color: "text-blue-400 bg-blue-400/10" },
   DELIVERED: { label: "已交付", color: "text-orange-400 bg-orange-400/10" },
   ACCEPTED: { label: "已驗收", color: "text-emerald-400 bg-emerald-400/10" },
@@ -111,13 +111,13 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
           <div
             key={item.id}
             className={cn(
-              "flex items-center gap-2 group px-2 py-2 rounded-md hover:bg-zinc-800/50 transition-colors",
+              "flex items-center gap-2 group px-2 py-2 rounded-md hover:bg-accent/50 transition-colors",
               updating === item.id && "opacity-50"
             )}
           >
-            <Icon className="h-3.5 w-3.5 text-zinc-500 flex-shrink-0" />
-            <span className="flex-1 text-sm text-zinc-200 truncate">{item.title}</span>
-            <span className="text-[10px] text-zinc-500">{tConfig.label}</span>
+            <Icon className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            <span className="flex-1 text-sm text-foreground truncate">{item.title}</span>
+            <span className="text-[10px] text-muted-foreground">{tConfig.label}</span>
             <button
               onClick={() => cycleStatus(item)}
               disabled={updating === item.id}
@@ -128,7 +128,7 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
             <button
               onClick={() => deleteItem(item.id)}
               disabled={updating === item.id}
-              className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 transition-all"
+              className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-red-500 transition-all"
             >
               <Trash2 className="h-3.5 w-3.5" />
             </button>
@@ -137,7 +137,7 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
       })}
 
       {showForm ? (
-        <div className="flex items-center gap-2 mt-2 p-2 bg-zinc-800/50 rounded-md">
+        <div className="flex items-center gap-2 mt-2 p-2 bg-accent/50 rounded-md">
           <input
             type="text"
             value={newTitle}
@@ -145,12 +145,12 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
             onKeyDown={(e) => e.key === "Enter" && addDeliverable()}
             placeholder="交付項名稱..."
             autoFocus
-            className="flex-1 bg-transparent text-sm text-zinc-300 placeholder:text-zinc-600 outline-none"
+            className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
           />
           <select
             value={newType}
             onChange={(e) => setNewType(e.target.value as DeliverableType)}
-            className="bg-zinc-900 border border-zinc-700 text-zinc-300 text-xs rounded px-1.5 py-1 focus:outline-none"
+            className="bg-background border border-border text-foreground text-xs rounded px-1.5 py-1 focus:outline-none"
           >
             {Object.entries(typeConfig).map(([k, v]) => (
               <option key={k} value={k}>{v.label}</option>
@@ -165,7 +165,7 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
           </button>
           <button
             onClick={() => { setShowForm(false); setNewTitle(""); }}
-            className="text-zinc-500 hover:text-zinc-300 text-xs transition-colors"
+            className="text-muted-foreground hover:text-foreground text-xs transition-colors"
           >
             取消
           </button>
@@ -173,7 +173,7 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
       ) : (
         <button
           onClick={() => setShowForm(true)}
-          className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-zinc-300 transition-colors mt-1"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mt-1"
         >
           <Plus className="h-3.5 w-3.5" />
           新增交付項

--- a/app/components/document-search.tsx
+++ b/app/components/document-search.tsx
@@ -58,35 +58,35 @@ export function DocumentSearch({ onSelect }: DocumentSearchProps) {
 
   return (
     <div className="relative">
-      <div className="flex items-center gap-2 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2">
-        <Search className={cn("h-3.5 w-3.5 flex-shrink-0", loading ? "text-zinc-400 animate-pulse" : "text-zinc-500")} />
+      <div className="flex items-center gap-2 bg-background border border-border rounded-lg px-3 py-2">
+        <Search className={cn("h-3.5 w-3.5 flex-shrink-0", loading ? "text-muted-foreground animate-pulse" : "text-muted-foreground")} />
         <input
           type="text"
           value={query}
           onChange={handleChange}
           onFocus={() => results.length > 0 && setOpen(true)}
           placeholder="搜尋文件..."
-          className="flex-1 bg-transparent text-sm text-zinc-200 placeholder:text-zinc-600 focus:outline-none"
+          className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
         />
         {query && (
           <button onClick={() => { setQuery(""); setResults([]); setOpen(false); }}>
-            <X className="h-3.5 w-3.5 text-zinc-500 hover:text-zinc-300" />
+            <X className="h-3.5 w-3.5 text-muted-foreground hover:text-foreground" />
           </button>
         )}
       </div>
 
       {open && results.length > 0 && (
-        <div className="absolute top-full mt-1 left-0 right-0 z-50 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl overflow-hidden">
+        <div className="absolute top-full mt-1 left-0 right-0 z-50 bg-card border border-border rounded-lg shadow-xl overflow-hidden">
           {results.map((r) => (
             <button
               key={r.id}
               onClick={() => handleSelect(r.id)}
-              className="w-full flex items-start gap-3 px-4 py-3 hover:bg-zinc-800 transition-colors text-left"
+              className="w-full flex items-start gap-3 px-4 py-3 hover:bg-accent transition-colors text-left"
             >
-              <FileText className="h-4 w-4 text-zinc-500 flex-shrink-0 mt-0.5" />
+              <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0 mt-0.5" />
               <div className="min-w-0">
-                <div className="text-sm font-medium text-zinc-200 truncate">{r.title}</div>
-                <div className="text-xs text-zinc-500 mt-0.5 line-clamp-2">{r.snippet}</div>
+                <div className="text-sm font-medium text-foreground truncate">{r.title}</div>
+                <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">{r.snippet}</div>
               </div>
             </button>
           ))}
@@ -94,7 +94,7 @@ export function DocumentSearch({ onSelect }: DocumentSearchProps) {
       )}
 
       {open && results.length === 0 && !loading && query.trim() && (
-        <div className="absolute top-full mt-1 left-0 right-0 z-50 bg-zinc-900 border border-zinc-700 rounded-lg shadow-xl px-4 py-3 text-sm text-zinc-500">
+        <div className="absolute top-full mt-1 left-0 right-0 z-50 bg-card border border-border rounded-lg shadow-xl px-4 py-3 text-sm text-muted-foreground">
           找不到相關文件
         </div>
       )}

--- a/app/components/document-tree.tsx
+++ b/app/components/document-tree.tsx
@@ -15,6 +15,7 @@ export type DocNode = {
 };
 
 function buildTree(docs: DocNode[]): (DocNode & { children: (DocNode & { children: DocNode[] })[] })[] {
+  if (!Array.isArray(docs)) return [];
   const map = new Map<string, DocNode & { children: DocNode[] }>();
   for (const d of docs) map.set(d.id, { ...d, children: [] });
   const roots: (DocNode & { children: DocNode[] })[] = [];
@@ -48,8 +49,8 @@ function TreeNode({ node, depth, selectedId, onSelect, onNewChild, onDelete }: T
         className={cn(
           "group flex items-center gap-1 px-2 py-1 rounded-md cursor-pointer text-sm transition-colors",
           isSelected
-            ? "bg-zinc-700 text-zinc-100"
-            : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+            ? "bg-accent text-accent-foreground"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground"
         )}
         style={{ paddingLeft: `${8 + depth * 16}px` }}
         onClick={() => onSelect(node.id)}
@@ -72,7 +73,7 @@ function TreeNode({ node, depth, selectedId, onSelect, onNewChild, onDelete }: T
             ? expanded
               ? <FolderOpen className="h-3.5 w-3.5 text-yellow-500/70" />
               : <Folder className="h-3.5 w-3.5 text-yellow-500/70" />
-            : <FileText className="h-3.5 w-3.5 text-zinc-500" />}
+            : <FileText className="h-3.5 w-3.5 text-muted-foreground" />}
         </span>
 
         {/* Title */}
@@ -82,14 +83,14 @@ function TreeNode({ node, depth, selectedId, onSelect, onNewChild, onDelete }: T
         <span className="flex-shrink-0 opacity-0 group-hover:opacity-100 flex items-center gap-0.5">
           <button
             title="新增子文件"
-            className="p-0.5 rounded hover:bg-zinc-600 text-zinc-400 hover:text-zinc-200"
+            className="p-0.5 rounded hover:bg-accent text-muted-foreground hover:text-foreground"
             onClick={(e) => { e.stopPropagation(); onNewChild(node.id); }}
           >
             <Plus className="h-3 w-3" />
           </button>
           <button
             title="刪除"
-            className="p-0.5 rounded hover:bg-red-900/40 text-zinc-500 hover:text-red-400"
+            className="p-0.5 rounded hover:bg-red-100/40 text-muted-foreground hover:text-red-500"
             onClick={(e) => { e.stopPropagation(); onDelete(node.id); }}
           >
             <Trash2 className="h-3 w-3" />
@@ -129,12 +130,12 @@ export function DocumentTree({ docs, selectedId, onSelect, onNewDoc, onDelete }:
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-zinc-800">
-        <span className="text-xs font-semibold text-zinc-500 uppercase tracking-wider">文件</span>
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">文件</span>
         <button
           title="新增根文件"
           onClick={() => onNewDoc(null)}
-          className="p-1 rounded hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200 transition-colors"
+          className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
         >
           <Plus className="h-3.5 w-3.5" />
         </button>
@@ -142,7 +143,7 @@ export function DocumentTree({ docs, selectedId, onSelect, onNewDoc, onDelete }:
 
       <div className="flex-1 overflow-y-auto py-1">
         {tree.length === 0 ? (
-          <div className="px-4 py-6 text-center text-xs text-zinc-600">
+          <div className="px-4 py-6 text-center text-xs text-muted-foreground">
             尚無文件<br />點擊 + 新增
           </div>
         ) : (

--- a/app/components/markdown-editor.tsx
+++ b/app/components/markdown-editor.tsx
@@ -19,22 +19,22 @@ function renderMarkdown(md: string): string {
     .replace(/>/g, "&gt;")
     .replace(/```[\s\S]*?```/g, (m) => {
       const code = m.slice(3, -3).replace(/^\n/, "");
-      return `<pre class="bg-zinc-800 rounded p-3 text-xs overflow-x-auto my-2 text-zinc-200"><code>${code}</code></pre>`;
+      return `<pre class="bg-muted rounded p-3 text-xs overflow-x-auto my-2 text-foreground"><code>${code}</code></pre>`;
     })
-    .replace(/`([^`]+)`/g, '<code class="bg-zinc-800 px-1 py-0.5 rounded text-xs text-emerald-400">$1</code>')
-    .replace(/^### (.+)$/gm, '<h3 class="text-base font-semibold mt-4 mb-1 text-zinc-200">$1</h3>')
-    .replace(/^## (.+)$/gm, '<h2 class="text-lg font-semibold mt-5 mb-2 text-zinc-100">$1</h2>')
-    .replace(/^# (.+)$/gm, '<h1 class="text-xl font-bold mt-6 mb-2 text-white">$1</h1>')
+    .replace(/`([^`]+)`/g, '<code class="bg-muted px-1 py-0.5 rounded text-xs text-emerald-600">$1</code>')
+    .replace(/^### (.+)$/gm, '<h3 class="text-base font-semibold mt-4 mb-1 text-foreground">$1</h3>')
+    .replace(/^## (.+)$/gm, '<h2 class="text-lg font-semibold mt-5 mb-2 text-foreground">$1</h2>')
+    .replace(/^# (.+)$/gm, '<h1 class="text-xl font-bold mt-6 mb-2 text-foreground">$1</h1>')
     .replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>')
-    .replace(/\*\*(.+?)\*\*/g, '<strong class="text-zinc-100">$1</strong>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong class="text-foreground">$1</strong>')
     .replace(/\*(.+?)\*/g, '<em>$1</em>')
-    .replace(/^---$/gm, '<hr class="border-zinc-700 my-4" />')
-    .replace(/^[-*] (.+)$/gm, '<li class="ml-4 list-disc text-zinc-300">$1</li>')
-    .replace(/^\d+\. (.+)$/gm, '<li class="ml-4 list-decimal text-zinc-300">$1</li>')
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-blue-400 hover:underline">$1</a>')
-    .replace(/\n\n/g, '</p><p class="my-2 text-zinc-300 leading-relaxed">')
+    .replace(/^---$/gm, '<hr class="border-border my-4" />')
+    .replace(/^[-*] (.+)$/gm, '<li class="ml-4 list-disc text-foreground">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li class="ml-4 list-decimal text-foreground">$1</li>')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-primary hover:underline">$1</a>')
+    .replace(/\n\n/g, '</p><p class="my-2 text-foreground leading-relaxed">')
     .replace(/\n/g, "<br />");
-  return `<p class="my-2 text-zinc-300 leading-relaxed">${html}</p>`;
+  return `<p class="my-2 text-foreground leading-relaxed">${html}</p>`;
 }
 
 export function MarkdownEditor({ value, onChange, placeholder, minHeight = 400 }: MarkdownEditorProps) {
@@ -42,12 +42,12 @@ export function MarkdownEditor({ value, onChange, placeholder, minHeight = 400 }
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-1 px-3 py-1.5 border-b border-zinc-800 bg-zinc-900/50">
+      <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border bg-muted/30">
         <button
           onClick={() => setMode("edit")}
           className={cn(
             "flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors",
-            mode === "edit" ? "bg-zinc-700 text-zinc-100" : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+            mode === "edit" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent"
           )}
         >
           <Edit3 className="h-3 w-3" />
@@ -57,13 +57,13 @@ export function MarkdownEditor({ value, onChange, placeholder, minHeight = 400 }
           onClick={() => setMode("preview")}
           className={cn(
             "flex items-center gap-1.5 text-xs px-2.5 py-1 rounded transition-colors",
-            mode === "preview" ? "bg-zinc-700 text-zinc-100" : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+            mode === "preview" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent"
           )}
         >
           <Eye className="h-3 w-3" />
           預覽
         </button>
-        <span className="ml-auto text-xs text-zinc-600">Markdown</span>
+        <span className="ml-auto text-xs text-muted-foreground">Markdown</span>
       </div>
 
       {mode === "edit" ? (
@@ -71,7 +71,7 @@ export function MarkdownEditor({ value, onChange, placeholder, minHeight = 400 }
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder ?? "輸入 Markdown 內容..."}
-          className="flex-1 resize-none bg-transparent text-sm text-zinc-200 p-4 focus:outline-none font-mono leading-relaxed placeholder:text-zinc-600"
+          className="flex-1 resize-none bg-transparent text-sm text-foreground p-4 focus:outline-none font-mono leading-relaxed placeholder:text-muted-foreground"
           style={{ minHeight }}
         />
       ) : (

--- a/app/components/plan-tree.tsx
+++ b/app/components/plan-tree.tsx
@@ -25,10 +25,10 @@ type AnnualPlan = {
 };
 
 const goalStatusConfig: Record<GoalStatus, { icon: React.ElementType; color: string; label: string }> = {
-  NOT_STARTED: { icon: Circle, color: "text-zinc-500", label: "未開始" },
-  IN_PROGRESS: { icon: Clock, color: "text-blue-400", label: "進行中" },
-  COMPLETED: { icon: CheckCircle2, color: "text-emerald-400", label: "已完成" },
-  CANCELLED: { icon: XCircle, color: "text-zinc-600", label: "已取消" },
+  NOT_STARTED: { icon: Circle, color: "text-muted-foreground", label: "未開始" },
+  IN_PROGRESS: { icon: Clock, color: "text-blue-500", label: "進行中" },
+  COMPLETED: { icon: CheckCircle2, color: "text-emerald-500", label: "已完成" },
+  CANCELLED: { icon: XCircle, color: "text-muted-foreground/50", label: "已取消" },
 };
 
 const monthNames = ["", "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
@@ -53,7 +53,7 @@ export function PlanTree({ plans, onSelectGoal, onSelectPlan }: PlanTreeProps) {
 
   if (plans.length === 0) {
     return (
-      <div className="text-center py-12 text-zinc-500 text-sm">
+      <div className="text-center py-12 text-muted-foreground text-sm">
         尚無年度計畫，請先建立
       </div>
     );
@@ -64,47 +64,47 @@ export function PlanTree({ plans, onSelectGoal, onSelectPlan }: PlanTreeProps) {
       {plans.map((plan) => {
         const expanded = expandedPlans.has(plan.id);
         return (
-          <div key={plan.id} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+          <div key={plan.id} className="bg-card border border-border rounded-xl overflow-hidden">
             {/* Plan header */}
             <div className="flex items-center gap-3 px-4 py-3">
               <button
                 onClick={() => togglePlan(plan.id)}
-                className="text-zinc-400 hover:text-zinc-200 transition-colors flex-shrink-0"
+                className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
               >
                 {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
               </button>
               <Target className="h-4 w-4 text-blue-400 flex-shrink-0" />
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <span className="text-xs text-zinc-500 font-mono">{plan.year}</span>
+                  <span className="text-xs text-muted-foreground font-mono">{plan.year}</span>
                   <button
                     onClick={() => onSelectPlan?.(plan.id)}
-                    className="text-sm font-medium text-zinc-200 hover:text-white truncate transition-colors text-left"
+                    className="text-sm font-medium text-foreground hover:text-foreground/80 truncate transition-colors text-left"
                   >
                     {plan.title}
                   </button>
                 </div>
                 {/* Progress bar */}
                 <div className="flex items-center gap-2 mt-1.5">
-                  <div className="flex-1 h-1 bg-zinc-800 rounded-full overflow-hidden">
+                  <div className="flex-1 h-1 bg-muted rounded-full overflow-hidden">
                     <div
                       className="h-full bg-blue-500 rounded-full transition-all"
                       style={{ width: `${plan.progressPct}%` }}
                     />
                   </div>
-                  <span className="text-[10px] text-zinc-500 tabular-nums w-8 text-right">
+                  <span className="text-[10px] text-muted-foreground tabular-nums w-8 text-right">
                     {Math.round(plan.progressPct)}%
                   </span>
                 </div>
               </div>
-              <span className="text-xs text-zinc-500 flex-shrink-0">
+              <span className="text-xs text-muted-foreground flex-shrink-0">
                 {plan.monthlyGoals.length} 個月度目標
               </span>
             </div>
 
             {/* Monthly goals */}
             {expanded && plan.monthlyGoals.length > 0 && (
-              <div className="border-t border-zinc-800">
+              <div className="border-t border-border">
                 {plan.monthlyGoals.map((goal, idx) => {
                   const sConfig = goalStatusConfig[goal.status];
                   const StatusIcon = sConfig.icon;
@@ -112,33 +112,33 @@ export function PlanTree({ plans, onSelectGoal, onSelectPlan }: PlanTreeProps) {
                     <div
                       key={goal.id}
                       className={cn(
-                        "flex items-center gap-3 px-4 py-2.5 hover:bg-zinc-800/50 transition-colors cursor-pointer",
-                        idx < plan.monthlyGoals.length - 1 && "border-b border-zinc-800/50"
+                        "flex items-center gap-3 px-4 py-2.5 hover:bg-accent/50 transition-colors cursor-pointer",
+                        idx < plan.monthlyGoals.length - 1 && "border-b border-border/50"
                       )}
                       onClick={() => onSelectGoal?.(goal.id)}
                     >
                       {/* Indent */}
                       <div className="w-4 flex-shrink-0" />
-                      <Calendar className="h-3.5 w-3.5 text-zinc-600 flex-shrink-0" />
-                      <span className="text-xs text-zinc-500 w-7 flex-shrink-0 font-mono">
+                      <Calendar className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                      <span className="text-xs text-muted-foreground w-7 flex-shrink-0 font-mono">
                         {monthNames[goal.month]}
                       </span>
                       <StatusIcon className={cn("h-3.5 w-3.5 flex-shrink-0", sConfig.color)} />
-                      <span className="flex-1 text-sm text-zinc-300 truncate">{goal.title}</span>
+                      <span className="flex-1 text-sm text-foreground truncate">{goal.title}</span>
                       {/* Mini progress */}
                       <div className="flex items-center gap-1.5 flex-shrink-0">
-                        <div className="w-16 h-1 bg-zinc-800 rounded-full overflow-hidden">
+                        <div className="w-16 h-1 bg-muted rounded-full overflow-hidden">
                           <div
                             className="h-full bg-emerald-500 rounded-full"
                             style={{ width: `${goal.progressPct}%` }}
                           />
                         </div>
-                        <span className="text-[10px] text-zinc-500 tabular-nums w-6 text-right">
+                        <span className="text-[10px] text-muted-foreground tabular-nums w-6 text-right">
                           {Math.round(goal.progressPct)}%
                         </span>
                       </div>
                       {goal._count && (
-                        <span className="text-[10px] text-zinc-600 w-10 text-right flex-shrink-0">
+                        <span className="text-[10px] text-muted-foreground/60 w-10 text-right flex-shrink-0">
                           {goal._count.tasks} 項
                         </span>
                       )}
@@ -149,7 +149,7 @@ export function PlanTree({ plans, onSelectGoal, onSelectPlan }: PlanTreeProps) {
             )}
 
             {expanded && plan.monthlyGoals.length === 0 && (
-              <div className="border-t border-zinc-800 px-4 py-3 text-xs text-zinc-600">
+              <div className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
                 此計畫尚無月度目標
               </div>
             )}

--- a/app/components/subtask-list.tsx
+++ b/app/components/subtask-list.tsx
@@ -87,13 +87,13 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
       {/* Progress bar */}
       {total > 0 && (
         <div className="flex items-center gap-2 mb-3">
-          <div className="flex-1 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+          <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
             <div
               className="h-full bg-emerald-500 rounded-full transition-all duration-300"
               style={{ width: `${pct}%` }}
             />
           </div>
-          <span className="text-xs text-zinc-400 tabular-nums">
+          <span className="text-xs text-muted-foreground tabular-nums">
             {doneCount}/{total}
           </span>
         </div>
@@ -105,7 +105,7 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
           <div
             key={subtask.id}
             className={cn(
-              "flex items-center gap-2 group px-2 py-1.5 rounded-md hover:bg-zinc-800/50 transition-colors",
+              "flex items-center gap-2 group px-2 py-1.5 rounded-md hover:bg-accent/50 transition-colors",
               loading === subtask.id && "opacity-50"
             )}
           >
@@ -116,7 +116,7 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
                 "flex-shrink-0 h-4 w-4 rounded border transition-colors flex items-center justify-center",
                 subtask.done
                   ? "bg-emerald-500 border-emerald-500"
-                  : "border-zinc-600 hover:border-zinc-400"
+                  : "border-border hover:border-ring/50"
               )}
             >
               {subtask.done && <Check className="h-3 w-3 text-white" />}
@@ -124,7 +124,7 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
             <span
               className={cn(
                 "flex-1 text-sm",
-                subtask.done ? "line-through text-zinc-500" : "text-zinc-200"
+                subtask.done ? "line-through text-muted-foreground" : "text-foreground"
               )}
             >
               {subtask.title}
@@ -132,7 +132,7 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
             <button
               onClick={() => deleteSubtask(subtask.id)}
               disabled={loading === subtask.id}
-              className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 transition-all"
+              className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-red-500 transition-all"
             >
               <Trash2 className="h-3.5 w-3.5" />
             </button>
@@ -148,12 +148,12 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
           onChange={(e) => setNewTitle(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && addSubtask()}
           placeholder="新增子任務..."
-          className="flex-1 bg-transparent border-b border-zinc-700 focus:border-zinc-500 text-sm text-zinc-300 placeholder:text-zinc-600 outline-none py-1 transition-colors"
+          className="flex-1 bg-transparent border-b border-border focus:border-ring text-sm text-foreground placeholder:text-muted-foreground outline-none py-1 transition-colors"
         />
         <button
           onClick={addSubtask}
           disabled={adding || !newTitle.trim()}
-          className="text-zinc-500 hover:text-zinc-300 disabled:opacity-30 transition-colors"
+          className="text-muted-foreground hover:text-foreground disabled:opacity-30 transition-colors"
         >
           <Plus className="h-4 w-4" />
         </button>

--- a/app/components/task-card.tsx
+++ b/app/components/task-card.tsx
@@ -33,7 +33,7 @@ const priorityConfig = {
   P0: { label: "P0", icon: AlertCircle, color: "text-red-400 bg-red-400/10 border-red-400/20" },
   P1: { label: "P1", icon: ArrowUp, color: "text-orange-400 bg-orange-400/10 border-orange-400/20" },
   P2: { label: "P2", icon: Minus, color: "text-yellow-400 bg-yellow-400/10 border-yellow-400/20" },
-  P3: { label: "P3", icon: ArrowDown, color: "text-zinc-400 bg-zinc-400/10 border-zinc-400/20" },
+  P3: { label: "P3", icon: ArrowDown, color: "text-muted-foreground bg-muted border-border" },
 };
 
 const categoryConfig = {
@@ -41,13 +41,13 @@ const categoryConfig = {
   ADDED: { label: "追加", icon: CheckSquare, color: "text-purple-400" },
   INCIDENT: { label: "突發", icon: Zap, color: "text-red-400" },
   SUPPORT: { label: "支援", icon: Users, color: "text-green-400" },
-  ADMIN: { label: "行政", icon: BookOpen, color: "text-zinc-400" },
+  ADMIN: { label: "行政", icon: BookOpen, color: "text-muted-foreground" },
   LEARNING: { label: "學習", icon: BookOpen, color: "text-teal-400" },
 };
 
 function Avatar({ name, avatar }: { name: string; avatar?: string | null }) {
   return (
-    <div className="h-5 w-5 rounded-full bg-zinc-700 flex items-center justify-center text-[10px] font-medium text-zinc-300 overflow-hidden flex-shrink-0">
+    <div className="h-5 w-5 rounded-full bg-muted flex items-center justify-center text-[10px] font-medium text-muted-foreground overflow-hidden flex-shrink-0">
       {avatar ? (
         <img src={avatar} alt={name} className="h-full w-full object-cover" />
       ) : (
@@ -89,8 +89,8 @@ export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
     <div
       onClick={() => onClick?.(task)}
       className={cn(
-        "bg-zinc-900 border border-zinc-800 rounded-lg p-3 cursor-pointer select-none",
-        "hover:border-zinc-600 hover:bg-zinc-800/80 transition-all duration-150",
+        "bg-card border border-border rounded-lg p-3 cursor-pointer select-none",
+        "hover:border-border/60 hover:bg-accent/30 transition-all duration-150",
         isDragging && "opacity-50 rotate-1 scale-105 shadow-xl",
         task.priority === "P0" && "border-l-2 border-l-red-500"
       )}
@@ -113,7 +113,7 @@ export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
       </div>
 
       {/* Title */}
-      <p className="text-sm font-medium text-zinc-100 leading-snug line-clamp-2 mb-2">
+      <p className="text-sm font-medium text-foreground leading-snug line-clamp-2 mb-2">
         {task.title}
       </p>
 
@@ -138,7 +138,7 @@ export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
 
           {/* Subtask progress */}
           {totalSubtasks > 0 && (
-            <span className="text-[10px] text-zinc-500 flex items-center gap-0.5">
+            <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
               <CheckSquare className="h-2.5 w-2.5" />
               {doneSubtasks}/{totalSubtasks}
             </span>
@@ -146,7 +146,7 @@ export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
 
           {/* Estimated hours */}
           {task.estimatedHours && (
-            <span className="text-[10px] text-zinc-500 flex items-center gap-0.5">
+            <span className="text-[10px] text-muted-foreground flex items-center gap-0.5">
               <Clock className="h-2.5 w-2.5" />
               {task.estimatedHours}h
             </span>
@@ -158,7 +158,7 @@ export function TaskCard({ task, onClick, isDragging }: TaskCardProps) {
           <span
             className={cn(
               "text-[10px] flex items-center gap-0.5",
-              dueInfo.overdue ? "text-red-400 font-medium" : dueInfo.soon ? "text-orange-400" : "text-zinc-500"
+              dueInfo.overdue ? "text-red-500 font-medium" : dueInfo.soon ? "text-orange-500" : "text-muted-foreground"
             )}
           >
             <Calendar className="h-2.5 w-2.5" />

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -65,13 +65,13 @@ const categoryOptions = [
 ];
 
 const inputCls =
-  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-colors placeholder:text-zinc-600";
+  "w-full bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring transition-colors placeholder:text-muted-foreground";
 
 const selectCls =
-  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-colors cursor-pointer";
+  "w-full bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring transition-colors cursor-pointer";
 
 function Label({ children }: { children: React.ReactNode }) {
-  return <label className="block text-xs font-medium text-zinc-400 mb-1">{children}</label>;
+  return <label className="block text-xs font-medium text-muted-foreground mb-1">{children}</label>;
 }
 
 export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalProps) {
@@ -161,17 +161,17 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
       className="fixed inset-0 z-50 flex items-start justify-center bg-black/70 backdrop-blur-sm pt-12 pb-4 px-4"
       onClick={(e) => e.target === e.currentTarget && onClose()}
     >
-      <div className="bg-zinc-950 border border-zinc-800 rounded-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-2xl">
+      <div className="bg-card border border-border rounded-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-2xl">
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-zinc-800 sticky top-0 bg-zinc-950 z-10">
-          <h2 className="text-sm font-medium text-zinc-300 tracking-wide">任務詳情</h2>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-border sticky top-0 bg-card z-10">
+          <h2 className="text-sm font-medium text-foreground tracking-wide">任務詳情</h2>
           <div className="flex items-center gap-2">
             <button
               onClick={save}
               disabled={saving || loading}
               className={cn(
                 "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
-                "bg-zinc-800 hover:bg-zinc-700 text-zinc-200 disabled:opacity-40"
+                "bg-accent hover:bg-accent/80 text-accent-foreground disabled:opacity-40"
               )}
             >
               {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
@@ -179,7 +179,7 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
             </button>
             <button
               onClick={onClose}
-              className="text-zinc-500 hover:text-zinc-200 transition-colors"
+              className="text-muted-foreground hover:text-foreground transition-colors"
             >
               <X className="h-4 w-4" />
             </button>
@@ -188,7 +188,7 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
 
         {loading ? (
           <div className="flex items-center justify-center py-16">
-            <Loader2 className="h-5 w-5 animate-spin text-zinc-500" />
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
         ) : task ? (
           <div className="p-5 space-y-5">
@@ -298,8 +298,8 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
 
             {/* Subtasks */}
             <div>
-              <h3 className="text-xs font-medium text-zinc-400 mb-2">子任務清單</h3>
-              <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">
+              <h3 className="text-xs font-medium text-muted-foreground mb-2">子任務清單</h3>
+              <div className="bg-muted/30 border border-border rounded-lg p-3">
                 <SubTaskList
                   subtasks={task.subTasks}
                   taskId={taskId}
@@ -309,8 +309,8 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
 
             {/* Deliverables */}
             <div>
-              <h3 className="text-xs font-medium text-zinc-400 mb-2">交付項</h3>
-              <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3">
+              <h3 className="text-xs font-medium text-muted-foreground mb-2">交付項</h3>
+              <div className="bg-muted/30 border border-border rounded-lg p-3">
                 <DeliverableList
                   deliverables={task.deliverables}
                   taskId={taskId}
@@ -319,7 +319,7 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
             </div>
           </div>
         ) : (
-          <div className="py-16 text-center text-zinc-500 text-sm">任務不存在</div>
+          <div className="py-16 text-center text-muted-foreground text-sm">任務不存在</div>
         )}
       </div>
     </div>

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -50,11 +50,11 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
   const clearFilters = () => onChange({ assignee: "", priority: "", category: "" });
 
   const selectCls =
-    "bg-zinc-900 border border-zinc-700 text-zinc-300 text-sm rounded-md px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 cursor-pointer hover:border-zinc-600 transition-colors";
+    "bg-background border border-border text-foreground text-sm rounded-md px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring focus:border-ring cursor-pointer hover:border-ring/50 transition-colors";
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
-      <div className="flex items-center gap-1.5 text-zinc-400">
+      <div className="flex items-center gap-1.5 text-muted-foreground">
         <Filter className="h-3.5 w-3.5" />
         <span className="text-xs font-medium">篩選</span>
       </div>
@@ -104,8 +104,8 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
         <button
           onClick={clearFilters}
           className={cn(
-            "flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors",
-            "px-2 py-1.5 rounded-md border border-zinc-700 hover:border-zinc-600 bg-zinc-900"
+            "flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors",
+            "px-2 py-1.5 rounded-md border border-border hover:border-border/60 bg-background"
           )}
         >
           <X className="h-3 w-3" />

--- a/app/components/time-entry-cell.tsx
+++ b/app/components/time-entry-cell.tsx
@@ -17,12 +17,12 @@ const CATEGORIES = [
   { value: "ADDED_TASK", label: "追加任務", color: "bg-orange-500/20 text-orange-300 border-orange-500/30" },
   { value: "INCIDENT", label: "突發事件", color: "bg-red-500/20 text-red-300 border-red-500/30" },
   { value: "SUPPORT", label: "用戶支援", color: "bg-purple-500/20 text-purple-300 border-purple-500/30" },
-  { value: "ADMIN", label: "行政庶務", color: "bg-zinc-500/20 text-zinc-300 border-zinc-500/30" },
+  { value: "ADMIN", label: "行政庶務", color: "bg-slate-200/50 text-slate-600 border-slate-300/50" },
   { value: "LEARNING", label: "學習成長", color: "bg-emerald-500/20 text-emerald-300 border-emerald-500/30" },
 ];
 
 function getCatStyle(cat: string) {
-  return CATEGORIES.find((c) => c.value === cat)?.color ?? "bg-zinc-800 text-zinc-400 border-zinc-700";
+  return CATEGORIES.find((c) => c.value === cat)?.color ?? "bg-muted text-muted-foreground border-border";
 }
 
 type TimeEntryCellProps = {
@@ -92,7 +92,7 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
           "w-full min-h-[36px] rounded-md border text-xs transition-all",
           entry && entry.hours > 0
             ? cn("font-medium px-2 py-1", getCatStyle(entry.category))
-            : "border-dashed border-zinc-800 text-zinc-700 hover:border-zinc-600 hover:text-zinc-500 hover:bg-zinc-800/30"
+            : "border-dashed border-border text-muted-foreground/50 hover:border-ring/50 hover:text-muted-foreground hover:bg-accent/30"
         )}
       >
         {entry && entry.hours > 0 ? (
@@ -104,9 +104,9 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
 
       {/* Popover editor */}
       {open && (
-        <div className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 w-56 bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl p-3 space-y-2.5">
+        <div className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 w-56 bg-card border border-border rounded-xl shadow-2xl p-3 space-y-2.5">
           <div>
-            <label className="block text-xs text-zinc-500 mb-1">工時（小時）</label>
+            <label className="block text-xs text-muted-foreground mb-1">工時（小時）</label>
             <input
               type="number"
               min="0"
@@ -116,17 +116,17 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
               value={hours}
               onChange={(e) => setHours(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSave()}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-2.5 py-1.5 text-sm text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               placeholder="0"
             />
           </div>
 
           <div>
-            <label className="block text-xs text-zinc-500 mb-1">分類</label>
+            <label className="block text-xs text-muted-foreground mb-1">分類</label>
             <select
               value={category}
               onChange={(e) => setCategory(e.target.value)}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500 cursor-pointer"
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
             >
               {CATEGORIES.map((c) => (
                 <option key={c.value} value={c.value}>{c.label}</option>
@@ -135,13 +135,13 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
           </div>
 
           <div>
-            <label className="block text-xs text-zinc-500 mb-1">備註</label>
+            <label className="block text-xs text-muted-foreground mb-1">備註</label>
             <input
               type="text"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSave()}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-2.5 py-1.5 text-xs text-zinc-200 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               placeholder="可選備註..."
             />
           </div>
@@ -150,7 +150,7 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
             <button
               onClick={handleSave}
               disabled={saving}
-              className="flex-1 bg-zinc-700 hover:bg-zinc-600 text-zinc-200 text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+              className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
             >
               {saving ? "儲存中..." : "儲存"}
             </button>
@@ -165,7 +165,7 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
             )}
             <button
               onClick={() => setOpen(false)}
-              className="px-2.5 py-1.5 text-zinc-500 hover:text-zinc-300 text-xs rounded-md transition-colors"
+              className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
             >
               取消
             </button>

--- a/app/components/time-summary.tsx
+++ b/app/components/time-summary.tsx
@@ -20,23 +20,23 @@ const CAT_META: Record<string, { label: string; barClass: string; bgClass: strin
   ADDED_TASK:   { label: "追加任務", barClass: "bg-orange-500", bgClass: "bg-orange-500/10 border-orange-500/20" },
   INCIDENT:     { label: "突發事件", barClass: "bg-red-500", bgClass: "bg-red-500/10 border-red-500/20" },
   SUPPORT:      { label: "用戶支援", barClass: "bg-purple-500", bgClass: "bg-purple-500/10 border-purple-500/20" },
-  ADMIN:        { label: "行政庶務", barClass: "bg-zinc-500", bgClass: "bg-zinc-500/10 border-zinc-500/20" },
+  ADMIN:        { label: "行政庶務", barClass: "bg-slate-400", bgClass: "bg-slate-400/10 border-slate-400/20" },
   LEARNING:     { label: "學習成長", barClass: "bg-emerald-500", bgClass: "bg-emerald-500/10 border-emerald-500/20" },
 };
 
 export function TimeSummary({ totalHours, breakdown, taskInvestmentRate }: TimeSummaryProps) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4 space-y-4">
+    <div className="bg-card border border-border rounded-xl p-4 space-y-4">
       {/* Header totals */}
       <div className="flex items-center gap-6">
         <div>
-          <div className="text-2xl font-bold text-zinc-100 tabular-nums">{safeFixed(totalHours, 1)}</div>
-          <div className="text-xs text-zinc-500 mt-0.5">本週總工時</div>
+          <div className="text-2xl font-bold text-foreground tabular-nums">{safeFixed(totalHours, 1)}</div>
+          <div className="text-xs text-muted-foreground mt-0.5">本週總工時</div>
         </div>
-        <div className="h-10 w-px bg-zinc-800" />
+        <div className="h-10 w-px bg-border" />
         <div>
-          <div className="text-2xl font-bold text-emerald-400 tabular-nums">{taskInvestmentRate}%</div>
-          <div className="text-xs text-zinc-500 mt-0.5">任務投入率</div>
+          <div className="text-2xl font-bold text-emerald-500 tabular-nums">{taskInvestmentRate}%</div>
+          <div className="text-xs text-muted-foreground mt-0.5">任務投入率</div>
         </div>
       </div>
 
@@ -48,7 +48,7 @@ export function TimeSummary({ totalHours, breakdown, taskInvestmentRate }: TimeS
             .map((b) => (
               <div
                 key={b.category}
-                className={cn("h-full transition-all", CAT_META[b.category]?.barClass ?? "bg-zinc-500")}
+                className={cn("h-full transition-all", CAT_META[b.category]?.barClass ?? "bg-slate-400")}
                 style={{ width: `${b.pct}%` }}
                 title={`${CAT_META[b.category]?.label}: ${b.hours}h (${b.pct}%)`}
               />
@@ -65,20 +65,20 @@ export function TimeSummary({ totalHours, breakdown, taskInvestmentRate }: TimeS
             <div key={b.category} className="flex items-center gap-3">
               <div className={cn("flex items-center gap-2 flex-1 px-2.5 py-1.5 rounded-lg border text-xs", meta.bgClass)}>
                 <span className={cn("w-2 h-2 rounded-full flex-shrink-0", meta.barClass)} />
-                <span className="text-zinc-300 font-medium">{meta.label}</span>
+                <span className="text-foreground font-medium">{meta.label}</span>
               </div>
               <div className="text-right min-w-[48px]">
-                <span className={cn("text-xs font-semibold tabular-nums", b.hours > 0 ? "text-zinc-200" : "text-zinc-700")}>
+                <span className={cn("text-xs font-semibold tabular-nums", b.hours > 0 ? "text-foreground" : "text-muted-foreground/40")}>
                   {b.hours > 0 ? `${safeFixed(b.hours, 1)}h` : "—"}
                 </span>
               </div>
               <div className="w-8 text-right">
-                <span className="text-xs text-zinc-600 tabular-nums">
+                <span className="text-xs text-muted-foreground/60 tabular-nums">
                   {b.pct > 0 ? `${b.pct}%` : ""}
                 </span>
               </div>
               {/* Mini bar */}
-              <div className="w-20 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+              <div className="w-20 h-1.5 bg-muted rounded-full overflow-hidden">
                 <div
                   className={cn("h-full rounded-full transition-all", meta.barClass)}
                   style={{ width: `${b.pct}%` }}

--- a/app/components/timesheet-grid.tsx
+++ b/app/components/timesheet-grid.tsx
@@ -62,17 +62,17 @@ export function TimesheetGrid({ weekStart, taskRows, entries, onCellSave, onCell
     <div className="overflow-x-auto">
       <table className="w-full border-collapse text-sm">
         <thead>
-          <tr className="border-b border-zinc-800">
-            <th className="text-left px-3 py-2.5 text-xs font-medium text-zinc-500 w-48 sticky left-0 bg-zinc-950 z-10">
+          <tr className="border-b border-border">
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground w-48 sticky left-0 bg-card z-10">
               任務
             </th>
             {DAYS.map((day, i) => (
               <th key={i} className="px-2 py-2.5 text-center min-w-[100px]">
-                <div className="text-xs font-semibold text-zinc-400">週{day}</div>
-                <div className="text-xs text-zinc-600 mt-0.5">{formatDateLabel(weekStart, i)}</div>
+                <div className="text-xs font-semibold text-muted-foreground">週{day}</div>
+                <div className="text-xs text-muted-foreground/60 mt-0.5">{formatDateLabel(weekStart, i)}</div>
               </th>
             ))}
-            <th className="px-3 py-2.5 text-center text-xs font-medium text-zinc-500 min-w-[64px]">
+            <th className="px-3 py-2.5 text-center text-xs font-medium text-muted-foreground min-w-[64px]">
               合計
             </th>
           </tr>
@@ -80,9 +80,9 @@ export function TimesheetGrid({ weekStart, taskRows, entries, onCellSave, onCell
 
         <tbody>
           {taskRows.map((row, rowIdx) => (
-            <tr key={row.taskId ?? `free-${rowIdx}`} className="border-b border-zinc-800/50 hover:bg-zinc-900/30 transition-colors group">
-              <td className="px-3 py-2 sticky left-0 bg-zinc-950 group-hover:bg-zinc-900/30 z-10">
-                <span className="text-xs text-zinc-400 truncate block max-w-[176px]" title={row.label}>
+            <tr key={row.taskId ?? `free-${rowIdx}`} className="border-b border-border/50 hover:bg-accent/20 transition-colors group">
+              <td className="px-3 py-2 sticky left-0 bg-card group-hover:bg-accent/20 z-10">
+                <span className="text-xs text-muted-foreground truncate block max-w-[176px]" title={row.label}>
                   {row.label}
                 </span>
               </td>
@@ -102,7 +102,7 @@ export function TimesheetGrid({ weekStart, taskRows, entries, onCellSave, onCell
                 );
               })}
               <td className="px-3 py-2 text-center">
-                <span className={cn("text-xs font-medium tabular-nums", rowTotals[rowIdx] > 0 ? "text-zinc-300" : "text-zinc-700")}>
+                <span className={cn("text-xs font-medium tabular-nums", rowTotals[rowIdx] > 0 ? "text-foreground" : "text-muted-foreground/40")}>
                   {rowTotals[rowIdx] > 0 ? safeFixed(rowTotals[rowIdx], 1) : "—"}
                 </span>
               </td>
@@ -111,19 +111,19 @@ export function TimesheetGrid({ weekStart, taskRows, entries, onCellSave, onCell
         </tbody>
 
         <tfoot>
-          <tr className="border-t border-zinc-700 bg-zinc-900/50">
-            <td className="px-3 py-2.5 sticky left-0 bg-zinc-900 z-10">
-              <span className="text-xs font-semibold text-zinc-400">每日合計</span>
+          <tr className="border-t border-border bg-muted/30">
+            <td className="px-3 py-2.5 sticky left-0 bg-muted/30 z-10">
+              <span className="text-xs font-semibold text-muted-foreground">每日合計</span>
             </td>
             {dailyTotals.map((total, i) => (
               <td key={i} className="px-2 py-2.5 text-center">
-                <span className={cn("text-xs font-semibold tabular-nums", total > 8 ? "text-amber-400" : total > 0 ? "text-emerald-400" : "text-zinc-600")}>
+                <span className={cn("text-xs font-semibold tabular-nums", total > 8 ? "text-amber-500" : total > 0 ? "text-emerald-500" : "text-muted-foreground/40")}>
                   {total > 0 ? safeFixed(total, 1) : "—"}
                 </span>
               </td>
             ))}
             <td className="px-3 py-2.5 text-center">
-              <span className="text-xs font-bold text-zinc-200 tabular-nums">{safeFixed(grandTotal, 1)}</span>
+              <span className="text-xs font-bold text-foreground tabular-nums">{safeFixed(grandTotal, 1)}</span>
             </td>
           </tr>
         </tfoot>

--- a/app/components/version-history.tsx
+++ b/app/components/version-history.tsx
@@ -43,10 +43,10 @@ export function VersionHistory({ documentId, currentVersion, onRestore }: Versio
   }, [open, documentId]);
 
   return (
-    <div className="border-t border-zinc-800">
+    <div className="border-t border-border">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="w-full flex items-center gap-2 px-4 py-2.5 text-xs text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/50 transition-colors"
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-xs text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
       >
         <History className="h-3.5 w-3.5" />
         <span>版本歷史（v{currentVersion}）</span>
@@ -54,47 +54,47 @@ export function VersionHistory({ documentId, currentVersion, onRestore }: Versio
       </button>
 
       {open && (
-        <div className="border-t border-zinc-800 max-h-64 overflow-y-auto">
+        <div className="border-t border-border max-h-64 overflow-y-auto">
           {loading && (
-            <div className="px-4 py-3 text-xs text-zinc-600 text-center">載入中...</div>
+            <div className="px-4 py-3 text-xs text-muted-foreground text-center">載入中...</div>
           )}
           {!loading && versions.length === 0 && (
-            <div className="px-4 py-3 text-xs text-zinc-600 text-center">尚無歷史版本</div>
+            <div className="px-4 py-3 text-xs text-muted-foreground text-center">尚無歷史版本</div>
           )}
           {versions.map((v) => (
             <div
               key={v.id}
-              className="border-b border-zinc-800/50 last:border-0"
+              className="border-b border-border/50 last:border-0"
             >
               <div
-                className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-zinc-800/30 transition-colors"
+                className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-accent/30 transition-colors"
                 onClick={() => setExpandedId(expandedId === v.id ? null : v.id)}
               >
-                <Clock className="h-3 w-3 text-zinc-600 flex-shrink-0" />
+                <Clock className="h-3 w-3 text-muted-foreground flex-shrink-0" />
                 <div className="flex-1 min-w-0">
-                  <span className="text-xs font-medium text-zinc-300">v{v.version}</span>
-                  <span className="text-xs text-zinc-600 ml-2">{v.creator.name}</span>
+                  <span className="text-xs font-medium text-foreground">v{v.version}</span>
+                  <span className="text-xs text-muted-foreground ml-2">{v.creator.name}</span>
                 </div>
-                <span className="text-xs text-zinc-600 flex-shrink-0">
+                <span className="text-xs text-muted-foreground flex-shrink-0">
                   {new Date(v.createdAt).toLocaleDateString("zh-TW", {
                     month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit",
                   })}
                 </span>
                 {expandedId === v.id
-                  ? <ChevronUp className="h-3 w-3 text-zinc-600" />
-                  : <ChevronDown className="h-3 w-3 text-zinc-600" />}
+                  ? <ChevronUp className="h-3 w-3 text-muted-foreground" />
+                  : <ChevronDown className="h-3 w-3 text-muted-foreground" />}
               </div>
 
               {expandedId === v.id && (
                 <div className="px-4 pb-3">
-                  <pre className="bg-zinc-900 border border-zinc-800 rounded p-3 text-xs text-zinc-400 overflow-x-auto max-h-32 whitespace-pre-wrap">
+                  <pre className="bg-muted border border-border rounded p-3 text-xs text-muted-foreground overflow-x-auto max-h-32 whitespace-pre-wrap">
                     {v.content.slice(0, 500)}{v.content.length > 500 ? "..." : ""}
                   </pre>
                   <button
                     onClick={() => { onRestore(v.content); setOpen(false); }}
                     className={cn(
-                      "mt-2 text-xs px-3 py-1 rounded border border-zinc-700",
-                      "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+                      "mt-2 text-xs px-3 py-1 rounded border border-border",
+                      "text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
                     )}
                   >
                     還原此版本

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,46 +4,35 @@
 
 @layer base {
   :root {
-    /* Dark theme by default — TITAN is a product/admin app */
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-
-    --card: 240 10% 6%;
-    --card-foreground: 0 0% 98%;
-
-    --popover: 240 10% 6%;
-    --popover-foreground: 0 0% 98%;
-
-    --primary: 217 91% 60%;
+    /* Light theme — bright, clean, professional for bank IT */
+    --background: 0 0% 98%;
+    --foreground: 222 47% 11%;
+    --card: 0 0% 100%;
+    --card-foreground: 222 47% 11%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 221 83% 53%;
     --primary-foreground: 0 0% 100%;
-
-    --secondary: 240 4% 16%;
-    --secondary-foreground: 0 0% 98%;
-
-    --muted: 240 4% 16%;
-    --muted-foreground: 240 5% 64.9%;
-
-    --accent: 240 4% 16%;
-    --accent-foreground: 0 0% 98%;
-
-    --destructive: 0 62.8% 50%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 240 4% 16%;
-    --input: 240 4% 16%;
-    --ring: 217 91% 60%;
-
-    --radius: 0.5rem;
-
-    /* Sidebar */
-    --sidebar-background: 240 10% 5%;
-    --sidebar-foreground: 240 5% 75%;
-    --sidebar-primary: 217 91% 60%;
+    --secondary: 210 40% 96%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 210 40% 96%;
+    --muted-foreground: 215 16% 47%;
+    --accent: 210 40% 96%;
+    --accent-foreground: 222 47% 11%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 221 83% 53%;
+    --radius: 0.375rem;
+    --sidebar-background: 210 40% 98%;
+    --sidebar-foreground: 215 16% 47%;
+    --sidebar-primary: 221 83% 53%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 4% 12%;
-    --sidebar-accent-foreground: 0 0% 98%;
-    --sidebar-border: 240 4% 12%;
-    --sidebar-ring: 217 91% 60%;
+    --sidebar-accent: 214 32% 93%;
+    --sidebar-accent-foreground: 222 47% 11%;
+    --sidebar-border: 214 32% 91%;
+    --sidebar-ring: 221 83% 53%;
   }
 }
 
@@ -53,18 +42,18 @@
   }
 
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-background text-foreground font-sans antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 
-  /* Custom scrollbar for dark theme */
+  /* Custom scrollbar */
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
   }
 
   ::-webkit-scrollbar-track {
-    background: hsl(var(--background));
+    background: transparent;
   }
 
   ::-webkit-scrollbar-thumb {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   return (
     <html
       lang="zh-TW"
-      className={`${GeistSans.variable} ${GeistMono.variable} dark`}
+      className={`${GeistSans.variable} ${GeistMono.variable}`}
     >
       <body className={GeistSans.className}>{children}</body>
     </html>

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,10 +25,16 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     return NextResponse.next();
   }
 
-  // Perform Edge JWT check for all other /api/* routes
+  // Perform Edge JWT check
   const jwtResult = await checkEdgeJwt(req);
   if (jwtResult !== null) {
-    return jwtResult; // 401 response — blocked at Edge before hitting Node.js
+    // Page routes: redirect to /login instead of returning 401 JSON
+    if (!pathname.startsWith("/api/")) {
+      const loginUrl = new URL("/login", req.url);
+      loginUrl.searchParams.set("callbackUrl", pathname);
+      return NextResponse.redirect(loginUrl);
+    }
+    return jwtResult; // 401 response for API routes — blocked at Edge before hitting Node.js
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary

- **Light theme**: Replace dark CSS variables in `globals.css` with bright, professional light theme for bank IT; add `antialiased` to body; transparent scrollbar track
- **Remove dark class**: Remove `dark` class from `<html>` in `layout.tsx`
- **Middleware redirect**: Page routes (non-`/api/`) now redirect to `/login?callbackUrl=...` on JWT failure instead of returning 401 JSON
- **reports/page.tsx guards**: Add `!data.period` guard on WeeklyReport, MonthlyReport, and WorkloadReport to prevent runtime crashes on malformed API response
- **knowledge/page.tsx guard**: Use `Array.isArray` check before `setDocs` to handle non-array API responses
- **document-tree.tsx guard**: Add `if (!Array.isArray(docs)) return []` at the top of `buildTree`
- **Semantic colour tokens**: Replace all `zinc-*` hardcoded Tailwind classes across 18 files with semantic tokens (`bg-card`, `bg-muted`, `border-border`, `text-foreground`, `text-muted-foreground`, `hover:bg-accent`, `focus:ring-ring`, etc.)

Closes #206

## Test plan

- [ ] Verify light theme renders correctly across all pages (no dark backgrounds remain)
- [ ] Confirm unauthenticated page navigation redirects to `/login` with correct `callbackUrl`
- [ ] Confirm unauthenticated API calls still return 401 JSON (not redirect)
- [ ] Verify reports page does not crash when API returns data without `period`
- [ ] Verify knowledge page does not crash when `/api/documents` returns non-array
- [ ] Verify document tree renders empty gracefully when `docs` is not an array
- [ ] Visual check: all interactive elements (buttons, inputs, selects) are visible on light background

🤖 Generated with [Claude Code](https://claude.com/claude-code)