### PR TITLE
feat: P1 security improvements — 9/12 issues resolved

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ REDIS_PORT=6379
 # 格式：redis://:password@host:port
 REDIS_URL=redis://:changeme_redis_password_here@titan-redis:6379
 
+# ── TITAN Next.js App（Issue #185）──────────────────────────
+# 必填：NextAuth JWT 簽名密鑰（使用 openssl rand -hex 32 產生）
+NEXTAUTH_SECRET=changeme_nextauth_secret_here
+# TITAN 對外 URL（Nginx 反向代理後的完整 URL）
+TITAN_URL=https://titan.bank.local/titan
+
 # ── MinIO 物件儲存 ───────────────────────────────────────────
 # Root 帳號（等同 AWS Access Key）
 MINIO_ROOT_USER=minioadmin

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -8,6 +8,7 @@ import { logger } from "@/lib/logger";
 import { isPasswordExpired } from "@/lib/password-expiry";
 import { getRedisClient } from "@/lib/redis";
 import { AuditService } from "@/services/audit-service";
+import { registerSession } from "@/lib/session-limiter";
 
 /**
  * Singletons — created once at module load.
@@ -160,6 +161,10 @@ const handler = NextAuth({
         token.id = user.id;
         token.role = (user as { id: string; role: string }).role;
         token.mustChangePassword = (user as { mustChangePassword?: boolean }).mustChangePassword ?? false;
+        // Issue #184: generate session ID and register (invalidates previous session)
+        const sessionId = crypto.randomUUID();
+        token.sessionId = sessionId;
+        registerSession(user.id!, sessionId).catch(() => {});
       }
       return token;
     },

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -7,6 +7,7 @@ import { AccountLockService } from "@/lib/account-lock";
 import { logger } from "@/lib/logger";
 import { isPasswordExpired } from "@/lib/password-expiry";
 import { getRedisClient } from "@/lib/redis";
+import { AuditService } from "@/services/audit-service";
 
 /**
  * Singletons — created once at module load.
@@ -22,6 +23,7 @@ const accountLockService = new AccountLockService({
   lockDurationSeconds: 900,
   redisClient: redis,
 });
+const auditService = new AuditService(prisma);
 
 const handler = NextAuth({
   cookies: {
@@ -88,8 +90,16 @@ const handler = NextAuth({
         });
 
         if (!user || !user.isActive) {
-          // Count as a failure for lockout tracking
           await accountLockService.recordFailure(lockKey);
+          // Issue #187: persist login failure to AuditLog DB
+          auditService.log({
+            userId: null,
+            action: "LOGIN_FAILURE",
+            resourceType: "Auth",
+            resourceId: null,
+            detail: JSON.stringify({ username: credentials.username, reason: !user ? "user_not_found" : "account_inactive" }),
+            ipAddress: ip,
+          }).catch(() => {}); // fire-and-forget, never block auth
           return null;
         }
 
@@ -100,12 +110,31 @@ const handler = NextAuth({
             { username: credentials.username, ip },
             "[auth] Failed login attempt"
           );
+          // Issue #187: persist login failure to AuditLog DB
+          auditService.log({
+            userId: user.id,
+            action: "LOGIN_FAILURE",
+            resourceType: "Auth",
+            resourceId: user.id,
+            detail: JSON.stringify({ username: credentials.username, reason: "invalid_password" }),
+            ipAddress: ip,
+          }).catch(() => {});
           return null;
         }
 
         // 4. Successful login — clear failure counter
         await accountLockService.resetFailures(lockKey);
         logger.info({ userId: user.id, ip }, "[auth] Successful login");
+
+        // Issue #187: persist login success to AuditLog DB
+        auditService.log({
+          userId: user.id,
+          action: "LOGIN_SUCCESS",
+          resourceType: "Auth",
+          resourceId: user.id,
+          detail: JSON.stringify({ username: credentials.username }),
+          ipAddress: ip,
+        }).catch(() => {});
 
         // Issue #182: check if password change is required
         const needsPasswordChange =

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
 import {
   LayoutDashboard,
   KanbanSquare,
@@ -11,6 +12,8 @@ import {
   BarChart2,
   Target,
   Crosshair,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -27,18 +30,40 @@ const navItems = [
 
 export function Sidebar() {
   const pathname = usePathname();
+  const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <aside className="w-60 flex-shrink-0 bg-sidebar border-r border-sidebar-border flex flex-col h-screen sticky top-0">
-      {/* Logo */}
-      <div className="h-14 flex items-center px-5 border-b border-sidebar-border">
-        <span className="text-lg font-medium tracking-[-0.04em] text-foreground">
-          TITAN
-        </span>
+    <aside
+      role="navigation"
+      aria-label="主選單"
+      className={cn(
+        "flex-shrink-0 bg-sidebar border-r border-sidebar-border flex flex-col h-screen sticky top-0 transition-[width] duration-200",
+        collapsed ? "w-16" : "w-60"
+      )}
+    >
+      {/* Logo + collapse toggle */}
+      <div className="h-14 flex items-center justify-between px-3 border-b border-sidebar-border">
+        {!collapsed && (
+          <span className="text-lg font-medium tracking-[-0.04em] text-foreground pl-2">
+            TITAN
+          </span>
+        )}
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="p-1.5 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-foreground transition-colors"
+          aria-label={collapsed ? "展開側邊欄" : "收合側邊欄"}
+          title={collapsed ? "展開側邊欄" : "收合側邊欄"}
+        >
+          {collapsed ? (
+            <PanelLeftOpen className="h-4 w-4" />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" />
+          )}
+        </button>
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 p-3 space-y-0.5 overflow-y-auto">
+      <nav className="flex-1 p-2 space-y-0.5 overflow-y-auto" aria-label="頁面導航">
         {navItems.map(({ href, label, icon: Icon }) => {
           const isActive =
             pathname === href || pathname.startsWith(href + "/");
@@ -46,26 +71,31 @@ export function Sidebar() {
             <Link
               key={href}
               href={href}
+              aria-current={isActive ? "page" : undefined}
+              title={collapsed ? label : undefined}
               className={cn(
-                "flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors",
+                "flex items-center gap-3 rounded-md text-sm transition-colors",
+                collapsed ? "justify-center px-2 py-2" : "px-3 py-2",
                 isActive
                   ? "bg-sidebar-accent text-sidebar-primary font-medium"
                   : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               )}
             >
-              <Icon className="h-4 w-4 flex-shrink-0" />
-              <span>{label}</span>
+              <Icon className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              {!collapsed && <span>{label}</span>}
             </Link>
           );
         })}
       </nav>
 
       {/* Version footer */}
-      <div className="p-4 border-t border-sidebar-border">
-        <p className="font-mono text-[11px] text-muted-foreground tabular-nums">
-          v1.0.0 — Sprint 4
-        </p>
-      </div>
+      {!collapsed && (
+        <div className="p-4 border-t border-sidebar-border">
+          <p className="font-mono text-[11px] text-muted-foreground tabular-nums">
+            v1.0.0 — Sprint 4
+          </p>
+        </div>
+      )}
     </aside>
   );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,42 @@ services:
       retries: 3
       start_period: 60s
 
+  # ── TITAN Next.js App（Issue #185）────────────────────────
+  # IT 團隊工作管理系統主應用
+  titan-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: titan-app
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@titan-postgres:5432/${POSTGRES_DB:-titan}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@titan-redis:6379
+      NEXTAUTH_URL: ${TITAN_URL:-https://titan.bank.local/titan}
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
+      NODE_ENV: production
+    # 安全強化：移除外部端口，僅透過 Nginx 反向代理存取
+    # ports:
+    #   - "3000:3000"
+    networks:
+      - titan-internal
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 1024M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/auth/csrf || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   # ── 專案管理：Plane ──────────────────────────────────────
   # ⚠️  Plane 採用獨立 docker-compose 部署，請參閱下列文件：
   #     - 部署指南：docs/plane-setup.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,11 +340,13 @@ volumes:
 # 網路設定：強化隔離
 # ═══════════════════════════════════════════════════════════
 networks:
-  # 內部網路：僅允許服務間通訊，不對外開放
+  # 內部網路：僅允許服務間通訊，不對外開放（Issue #186）
+  # internal: true 阻止容器直接訪問外部網路
+  # DNS 解析由 Docker 內建 DNS (127.0.0.11) 提供，不需外部 DNS
   titan-internal:
     name: titan-internal
     driver: bridge
-    internal: false  #允許 DNS 解析
+    internal: true
   # 外部網路：允許對外服務（Homepage）
   titan-external:
     name: titan-external

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,42 @@ services:
 
   # ── 統一儀表板：Homepage ─────────────────────────────────
   # 集中呈現所有 TITAN 服務連結與狀態
+  # ── Docker Socket Proxy（Issue #183）──────────────────────
+  # 安全強化：Homepage 不再直接掛載 Docker socket
+  # 僅暴露容器狀態查詢（GET /containers），阻擋所有寫入操作
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2
+    container_name: titan-docker-proxy
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1     # allow GET /containers
+      SERVICES: 0
+      TASKS: 0
+      NETWORKS: 0
+      NODES: 0
+      POST: 0           # block all POST (no container create/start/stop)
+      BUILD: 0
+      COMMIT: 0
+      CONFIGS: 0
+      DISTRIBUTION: 0
+      EXEC: 0
+      IMAGES: 0
+      INFO: 1
+      PLUGINS: 0
+      SECRETS: 0
+      SWARM: 0
+      SYSTEM: 0
+      VOLUMES: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - titan-internal
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 64M
+
   homepage:
     image: gethomepage/homepage:v0.9.13
     container_name: titan-homepage
@@ -210,9 +246,10 @@ services:
       PUID: ${HOMEPAGE_PUID:-1000}
       PGID: ${HOMEPAGE_PGID:-1000}
       HOMEPAGE_ALLOWED_HOSTS: ${HOMEPAGE_ALLOWED_HOSTS:-localhost}
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
     volumes:
       - ./config/homepage:/app/config      # 服務設定檔
-      - /var/run/docker.sock:/var/run/docker.sock:ro  # Docker 狀態讀取（唯讀）
+      # Issue #183: Docker socket 不再直接掛載，改用 socket proxy
     # 安全強化：保留外部端口供外部存取
     ports:
       - "${HOMEPAGE_PORT:-3000}:3000"
@@ -222,6 +259,7 @@ services:
     depends_on:
       - outline
       - minio
+      - docker-socket-proxy
     # 安全強化：Resource limits
     deploy:
       resources:
@@ -245,9 +283,11 @@ services:
     image: louislam/uptime-kuma:1.23.13
     container_name: titan-uptime-kuma
     restart: unless-stopped
+    environment:
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
     volumes:
       - uptime-kuma-data:/app/data
-      - /var/run/docker.sock:/var/run/docker.sock:ro  # 監控 Docker 容器狀態（唯讀）
+      # Issue #183: Docker socket 移除，改用 socket proxy
     ports:
       - "${UPTIME_KUMA_PORT:-3002}:3001"
     networks:

--- a/docs/rollback-sop.md
+++ b/docs/rollback-sop.md
@@ -1,0 +1,155 @@
+# TITAN 版本回滾 SOP
+
+**文件編號**: TITAN-OPS-001
+**版本**: 1.0
+**適用**: TITAN 平台所有容器服務
+
+---
+
+## 1. 回滾決策矩陣
+
+| 嚴重度 | 症狀 | 動作 | 時限 |
+|--------|------|------|------|
+| P0 | 系統完全不可用 | 立即回滾 | 15 分鐘內 |
+| P1 | 核心功能異常（登入、任務管理） | 評估後回滾 | 30 分鐘內 |
+| P2 | 非核心功能異常（報表、知識庫） | 嘗試修復，修復失敗則回滾 | 2 小時內 |
+| P3 | UI 問題、效能下降 | 記錄 Issue，下次部署修復 | 不回滾 |
+
+## 2. 應用層回滾（TITAN Next.js App）
+
+### 2.1 Docker Image 回滾
+
+```bash
+# 1. 查看可用的歷史 image
+docker images titan-app --format "table {{.Tag}}\t{{.CreatedAt}}" | head -5
+
+# 2. 修改 docker-compose 指定舊版 image tag
+# 例：image: titan-app:v1.2.3
+
+# 3. 重新部署
+docker compose -f docker-compose.yml up -d titan-app
+
+# 4. 驗證
+curl -s http://localhost:3000/api/auth/csrf | jq .
+docker logs titan-app --tail 20
+```
+
+### 2.2 Git 版本回滾
+
+```bash
+# 1. 查看最近部署的 commit
+git log --oneline -10
+
+# 2. 回滾到指定 commit
+git checkout <commit-hash>
+
+# 3. 重建 image 並部署
+docker compose -f docker-compose.yml build titan-app
+docker compose -f docker-compose.yml up -d titan-app
+
+# 4. 驗證
+./scripts/sit-titan-test.sh http://localhost:3000
+```
+
+## 3. 資料庫回滾
+
+### 3.1 Prisma Schema 回滾
+
+```bash
+# ⚠️ 注意：schema 回滾可能造成資料遺失，必須先備份
+
+# 1. 備份目前資料庫
+docker exec titan-postgres pg_dump -U titan titan > /tmp/titan-backup-$(date +%Y%m%d_%H%M%S).sql
+
+# 2. 回滾到上一版 schema
+git checkout <previous-commit> -- prisma/schema.prisma
+
+# 3. 推送 schema 變更
+docker exec titan-app npx prisma db push --accept-data-loss
+
+# 4. 驗證
+docker exec titan-app npx prisma db pull
+```
+
+### 3.2 從備份還原
+
+```bash
+# 1. 停止應用
+docker compose stop titan-app
+
+# 2. 還原資料庫
+docker exec -i titan-postgres psql -U titan titan < /path/to/backup.sql
+
+# 3. 重啟應用
+docker compose start titan-app
+
+# 4. 驗證資料完整性
+docker exec titan-app npx prisma db pull
+```
+
+## 4. 基礎設施回滾
+
+### 4.1 docker-compose.yml 變更回滾
+
+```bash
+# 1. 回滾設定檔
+git checkout <previous-commit> -- docker-compose.yml
+
+# 2. 重新部署所有服務
+docker compose down
+docker compose up -d
+
+# 3. 驗證所有服務
+docker compose ps
+./scripts/sit-smoke-test.sh
+```
+
+### 4.2 Nginx 設定回滾
+
+```bash
+# 1. 回滾 Nginx 設定
+git checkout <previous-commit> -- config/nginx/nginx.conf
+
+# 2. 重新載入（不中斷服務）
+docker exec titan-nginx nginx -t && docker exec titan-nginx nginx -s reload
+
+# 3. 驗證
+curl -I https://titan.bank.local/health
+```
+
+## 5. 回滾後檢查清單
+
+- [ ] 所有容器 running（`docker compose ps`）
+- [ ] 健康檢查通過（`/health` 端點）
+- [ ] 登入功能正常
+- [ ] SIT smoke test 通過
+- [ ] 稽核日誌記錄回滾事件
+- [ ] 通知相關人員回滾完成
+- [ ] 建立 Post-mortem Issue
+
+## 6. 告警通知設定
+
+### Uptime Kuma 告警通知
+
+Uptime Kuma 支援以下通知管道（需在 Dashboard 設定）：
+
+| 管道 | 適用場景 | 設定路徑 |
+|------|----------|----------|
+| Email (SMTP) | 正式告警 | Settings → Notifications → Email |
+| Webhook | 自動化觸發 | Settings → Notifications → Webhook |
+| LINE Notify | 行動通知 | Settings → Notifications → LINE |
+| Telegram | 即時通知 | Settings → Notifications → Telegram |
+
+### 建議告警規則
+
+| 監控對象 | 檢查間隔 | 告警條件 | 通知管道 |
+|----------|----------|----------|----------|
+| TITAN App (/api/auth/csrf) | 60s | 連續 3 次失敗 | Email + LINE |
+| PostgreSQL (TCP 5432) | 30s | 連續 2 次失敗 | Email + LINE |
+| Redis (TCP 6379) | 30s | 連續 2 次失敗 | Email |
+| Nginx (/health) | 30s | 連續 2 次失敗 | Email + LINE |
+| SSL 憑證到期 | 每日 | < 30 天 | Email |
+
+---
+
+*回滾操作必須記錄於稽核日誌，並在 24 小時內完成 Post-mortem 報告。*

--- a/lib/session-limiter.ts
+++ b/lib/session-limiter.ts
@@ -1,0 +1,94 @@
+/**
+ * Concurrent session limiter — Issue #184
+ *
+ * Enforces single active session per user. When a user logs in,
+ * the new session token replaces the old one. The old session
+ * is effectively invalidated via the JWT blacklist.
+ *
+ * Uses Redis when available, falls back to in-memory Map.
+ */
+
+import { logger } from "@/lib/logger";
+import { getRedisClient } from "@/lib/redis";
+import { JwtBlacklist } from "@/lib/jwt-blacklist";
+
+const REDIS_PREFIX = "active_session:";
+const SESSION_TTL = 8 * 60 * 60; // 8 hours (matches JWT maxAge)
+
+/** In-memory fallback: userId → sessionId */
+const memStore = new Map<string, string>();
+
+/**
+ * Register a new session for a user, invalidating any previous session.
+ */
+export async function registerSession(
+  userId: string,
+  sessionId: string
+): Promise<void> {
+  const redis = getRedisClient();
+
+  // Get the old session ID
+  let oldSessionId: string | null = null;
+
+  if (redis) {
+    try {
+      oldSessionId = await redis.get(`${REDIS_PREFIX}${userId}`);
+      await redis.set(`${REDIS_PREFIX}${userId}`, sessionId, "EX", SESSION_TTL);
+    } catch (err) {
+      logger.error({ err }, "[session-limiter] Redis error, using memory fallback");
+      oldSessionId = memStore.get(userId) ?? null;
+      memStore.set(userId, sessionId);
+    }
+  } else {
+    oldSessionId = memStore.get(userId) ?? null;
+    memStore.set(userId, sessionId);
+  }
+
+  // Blacklist the old session if it exists and differs
+  if (oldSessionId && oldSessionId !== sessionId) {
+    JwtBlacklist.add(`session:${oldSessionId}`);
+    logger.info(
+      { userId },
+      "[session-limiter] Previous session invalidated (concurrent login)"
+    );
+  }
+}
+
+/**
+ * Check if a session is still the active one for its user.
+ */
+export async function isSessionActive(
+  userId: string,
+  sessionId: string
+): Promise<boolean> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const active = await redis.get(`${REDIS_PREFIX}${userId}`);
+      return active === sessionId;
+    } catch {
+      // fallback
+    }
+  }
+
+  return memStore.get(userId) === sessionId;
+}
+
+/**
+ * Clear a user's active session (on logout).
+ */
+export async function clearSession(userId: string): Promise<void> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      await redis.del(`${REDIS_PREFIX}${userId}`);
+      return;
+    } catch {
+      // fallback
+    }
+  }
+
+  memStore.delete(userId);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,34 @@
 import type { NextConfig } from "next";
 
+/**
+ * TITAN Next.js Configuration — Issue #192
+ *
+ * - output: standalone — required for Docker production builds
+ * - poweredByHeader: false — hide X-Powered-By (security)
+ * - Security headers — defense-in-depth (supplements Nginx headers)
+ */
 const nextConfig: NextConfig = {
+  output: "standalone",
+  poweredByHeader: false,
   turbopack: {},
+
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          { key: "X-XSS-Protection", value: "1; mode=block" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -342,13 +342,32 @@ backup_configs() {
     log_warn "  docker-compose.yml 不存在"
   fi
 
-  # 備份 .env（敏感資料，加密儲存）
+  # 備份 .env（敏感資料，Issue #194: 加密儲存）
   if [[ -f "${PROJECT_DIR}/.env" ]]; then
-    cp "${PROJECT_DIR}/.env" "${configs_dir}/.env"
-    gzip -9 "${configs_dir}/.env"
-    # 限制讀取權限
-    chmod 600 "${configs_dir}/.env.gz"
-    log_info "  .env 備份完成（權限已設為 600）"
+    local env_backup="${configs_dir}/.env"
+
+    if command -v age &>/dev/null && [[ -f "${PROJECT_DIR}/.backup-key.pub" ]]; then
+      # age 加密：使用預先產生的公鑰加密
+      # 解密方式：age -d -i backup-key.txt .env.age > .env
+      age -r "$(cat "${PROJECT_DIR}/.backup-key.pub")" \
+        -o "${env_backup}.age" "${PROJECT_DIR}/.env"
+      chmod 600 "${env_backup}.age"
+      log_info "  .env 備份完成（age 加密）"
+    elif command -v gpg &>/dev/null && [[ -n "${BACKUP_GPG_RECIPIENT:-}" ]]; then
+      # GPG 加密（備用方案）
+      gpg --batch --yes --recipient "${BACKUP_GPG_RECIPIENT}" \
+        --output "${env_backup}.gpg" --encrypt "${PROJECT_DIR}/.env"
+      chmod 600 "${env_backup}.gpg"
+      log_info "  .env 備份完成（GPG 加密）"
+    else
+      # 無加密工具 — gzip + 權限限制（降級警告）
+      cp "${PROJECT_DIR}/.env" "${env_backup}"
+      gzip -9 "${env_backup}"
+      chmod 600 "${env_backup}.gz"
+      log_warn "  .env 備份完成（未加密！請安裝 age 或設定 GPG）"
+      log_warn "  安裝 age: brew install age 或 apt install age"
+      log_warn "  產生金鑰: age-keygen -o backup-key.txt && cat backup-key.txt | grep 'public' > .backup-key.pub"
+    fi
   else
     log_warn "  .env 不存在，請確認環境變數設定"
   fi

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -156,26 +156,34 @@ export class UserService {
       },
     });
 
-    // Emit audit log for role change
-    if (input.role !== undefined && input.role !== existing.role) {
-      await this.auditor.log({
-        userId: input.updatedBy ?? null,
-        action: "ROLE_CHANGE",
-        resourceType: "User",
-        resourceId: id,
-        detail: JSON.stringify({ from: existing.role, to: input.role }),
-        ipAddress: input.ipAddress ?? null,
-      });
-    }
+    // Issue #191: record before/after diff for all changes (ISO 27001 A.12.4.1)
+    const changes: Record<string, { from: unknown; to: unknown }> = {};
+    if (input.name !== undefined && input.name !== existing.name)
+      changes.name = { from: existing.name, to: input.name };
+    if (input.email !== undefined && input.email !== existing.email)
+      changes.email = { from: existing.email, to: input.email };
+    if (input.role !== undefined && input.role !== existing.role)
+      changes.role = { from: existing.role, to: input.role };
+    if (input.isActive !== undefined && input.isActive !== existing.isActive)
+      changes.isActive = { from: existing.isActive, to: input.isActive };
+    if (input.password !== undefined)
+      changes.password = { from: "[redacted]", to: "[changed]" };
+    if (input.avatar !== undefined && input.avatar !== existing.avatar)
+      changes.avatar = { from: existing.avatar ? "[had avatar]" : null, to: input.avatar ? "[new avatar]" : null };
 
-    // Emit audit log for password change
-    if (input.password !== undefined) {
+    if (Object.keys(changes).length > 0) {
+      const action = input.role !== undefined && input.role !== existing.role
+        ? "ROLE_CHANGE"
+        : input.password !== undefined
+        ? "PASSWORD_CHANGE"
+        : "USER_UPDATE";
+
       await this.auditor.log({
         userId: input.updatedBy ?? null,
-        action: "PASSWORD_CHANGE",
+        action,
         resourceType: "User",
         resourceId: id,
-        detail: "Password changed",
+        detail: JSON.stringify({ changes }),
         ipAddress: input.ipAddress ?? null,
       });
     }


### PR DESCRIPTION
## Summary

P1 security and infrastructure improvements (9 of 12 issues):

### Compliance & Audit (#187, #191)
- Login success/failure events now persist to AuditLog DB (not just stdout)
- User updates record before/after JSON diff in AuditLog detail field

### Security (#184, #194, #183, #186)
- Single concurrent session per user (new login invalidates previous)
- .env backup encrypted with age/GPG (falls back to gzip with warning)
- Docker socket proxy replaces direct socket mount on Homepage/Uptime Kuma
- titan-internal network set to `internal: true` (no external internet)

### Infrastructure (#185, #192)
- TITAN app added to production docker-compose with resource limits
- next.config.ts: `output: standalone`, `poweredByHeader: false`, security headers

### Operations (#188)
- Rollback SOP document with decision matrix, step-by-step procedures
- Uptime Kuma alert notification recommendations

### UX (#189)
- Sidebar: collapsible icon-only mode + ARIA attributes (a11y)

### Remaining P1 (3 items, next batch)
- #190 — CSP nonce-based (remove unsafe-inline)
- #193 — Services test coverage 80%+
- #177 — Testing follow-up (P3)

## Test plan

- [x] Existing 30 security middleware tests pass
- [x] Existing 11 user service tests pass
- [x] SIT smoke test 22/22 passing
- [x] No breaking changes to existing functionality

Closes #183, Closes #184, Closes #185, Closes #186, Closes #187, Closes #188, Closes #189, Closes #191, Closes #192, Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)