### PR TITLE
fix(T19): add PGPASSWORD to pg_restore in restore.sh

### DIFF
--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -154,7 +154,7 @@ if [ -n "${RESTORE_POSTGRES}" ]; then
     
     # 還原資料庫
     log_info "開始還原資料庫..."
-    pg_restore \
+    PGPASSWORD="${POSTGRES_PASSWORD:-}" pg_restore \
         -h "${POSTGRES_HOST}" \
         -p "${POSTGRES_PORT}" \
         -U "${POSTGRES_USER}" \


### PR DESCRIPTION
## Summary

- `restore.sh` called `pg_restore` without `PGPASSWORD`, causing authentication failure in any non-default password environment
- `backup-postgres.sh` already sets `PGPASSWORD` correctly — this aligns the restore path

**1-line fix**, no behavior change for default-password environments.

Closes #217

## Test plan

- [ ] Verify `pg_restore` receives password via `PGPASSWORD` env var
- [ ] Confirm backup → restore round-trip works with non-default password

🤖 Generated with [Claude Code](https://claude.com/claude-code)