### PR TITLE
fix(infra): use service_name instead of container_name for DB/Redis URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,8 +313,8 @@ services:
       redis:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@titan-postgres:5432/${POSTGRES_DB:-titan}
-      REDIS_URL: redis://:${REDIS_PASSWORD}@titan-redis:6379
+      DATABASE_URL: postgresql://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       NEXTAUTH_URL: ${TITAN_URL:-https://titan.bank.local/titan}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}
       NODE_ENV: production


### PR DESCRIPTION
## Summary
- titan-app 的 DATABASE_URL 和 REDIS_URL 改用 service name (`postgres`, `redis`) 取代 container name (`titan-postgres`, `titan-redis`)
- 與同 compose 的 Outline 服務保持一致
- Docker Compose DNS 以 service name 為標準，container_name 在 scale/replica 場景不可靠

## Test plan
- [ ] `docker compose config` 驗證語法正確
- [ ] titan-app 可透過 `postgres:5432` 連接資料庫
- [ ] titan-app 可透過 `redis:6379` 連接 Redis

Fixes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)