### PR TITLE
feat(P2-7): Error Boundary + error reporting to AuditLog

### DIFF
--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * App-level Error Boundary (Issue #196).
+ * Catches errors in any page within the (app) route group.
+ * Reports to /api/error-report for AuditLog persistence.
+ */
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    fetch("/api/error-report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: error.message,
+        digest: error.digest,
+        source: "app-error",
+        url: window.location.pathname,
+      }),
+    }).catch(() => {});
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="max-w-md text-center space-y-4">
+        <h2 className="text-xl font-semibold">此頁面發生錯誤</h2>
+        <p className="text-muted-foreground">
+          很抱歉，載入此頁面時發生問題。錯誤已自動回報。
+        </p>
+        <button
+          onClick={reset}
+          className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+        >
+          重試
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/api/error-report/route.ts
+++ b/app/api/error-report/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+
+/**
+ * POST /api/error-report — Client-side error reporting (Issue #196).
+ * Persists frontend errors to AuditLog for tracking and investigation.
+ * No auth required — errors may occur before/during auth flows.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { message, digest, source, url } = body as {
+      message?: string;
+      digest?: string;
+      source?: string;
+      url?: string;
+    };
+
+    if (!message) {
+      return NextResponse.json({ error: "message required" }, { status: 400 });
+    }
+
+    const detail = JSON.stringify({
+      message: String(message).slice(0, 2000),
+      digest: digest ?? null,
+      source: source ?? "unknown",
+      url: url ?? null,
+      userAgent: req.headers.get("user-agent")?.slice(0, 500) ?? null,
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        userId: null,
+        action: "FRONTEND_ERROR",
+        resourceType: "error",
+        resourceId: digest ?? null,
+        detail,
+        ipAddress: req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+      },
+    });
+
+    logger.warn({ source, url, digest }, `Frontend error: ${String(message).slice(0, 200)}`);
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    logger.error({ err }, "Failed to persist error report");
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+/**
+ * Root-level Error Boundary (Issue #196).
+ * Catches errors in the root layout itself. Must include <html> and <body> tags.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  // Fire-and-forget error report to AuditLog
+  if (typeof window !== "undefined") {
+    fetch("/api/error-report", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: error.message,
+        digest: error.digest,
+        source: "global-error",
+      }),
+    }).catch(() => {});
+  }
+
+  return (
+    <html lang="zh-TW">
+      <body style={{ fontFamily: "system-ui, sans-serif", padding: "2rem" }}>
+        <div style={{ maxWidth: 480, margin: "4rem auto", textAlign: "center" }}>
+          <h1 style={{ fontSize: "1.5rem", marginBottom: "1rem" }}>
+            系統發生錯誤
+          </h1>
+          <p style={{ color: "#666", marginBottom: "1.5rem" }}>
+            很抱歉，系統遇到了非預期的問題。錯誤已自動回報，技術團隊會盡快處理。
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: "0.5rem 1.5rem",
+              borderRadius: "0.375rem",
+              border: "1px solid #d1d5db",
+              background: "#fff",
+              cursor: "pointer",
+            }}
+          >
+            重試
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- `app/global-error.tsx` — 根層級 Error Boundary，捕獲 layout 層錯誤
- `app/(app)/error.tsx` — 應用層 Error Boundary，捕獲所有頁面錯誤
- `app/api/error-report/route.ts` — 前端錯誤回報 API，將錯誤寫入 AuditLog
- 錯誤自動回報：包含 message、digest、source、URL、user agent
- 無需 auth（錯誤可能發生在認證流程中）

## Test plan
- [ ] 手動觸發頁面錯誤，確認 Error Boundary 顯示友善訊息
- [ ] 確認 AuditLog 有 `FRONTEND_ERROR` action 記錄
- [ ] 確認「重試」按鈕可恢復頁面

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)