### PR TITLE
feat(P2-1): password history — prevent reuse of last 5 passwords

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -57,16 +57,36 @@ export async function POST(req: NextRequest) {
     return error("ValidationError", "目前密碼不正確", 400);
   }
 
-  // Update password
-  const newHash = await hash(newPassword, 10);
-  await prisma.user.update({
-    where: { id: userId },
-    data: {
-      password: newHash,
-      passwordChangedAt: new Date(),
-      mustChangePassword: false,
-    },
+  // Check password history — reject if new password matches any of the last 5 (Issue #201)
+  const PASSWORD_HISTORY_LIMIT = 5;
+  const recentHashes = await prisma.passwordHistory.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    take: PASSWORD_HISTORY_LIMIT,
+    select: { hash: true },
   });
+
+  for (const entry of recentHashes) {
+    if (await compare(newPassword, entry.hash)) {
+      return error("ValidationError", `新密碼不得與最近 ${PASSWORD_HISTORY_LIMIT} 組密碼相同`, 400);
+    }
+  }
+
+  // Update password and save old hash to history
+  const newHash = await hash(newPassword, 10);
+  await prisma.$transaction([
+    prisma.passwordHistory.create({
+      data: { userId, hash: user.password },
+    }),
+    prisma.user.update({
+      where: { id: userId },
+      data: {
+        password: newHash,
+        passwordChangedAt: new Date(),
+        mustChangePassword: false,
+      },
+    }),
+  ]);
 
   // Audit log
   await auditService.log({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,8 +49,22 @@ model User {
   grantedByPermissions     Permission[]      @relation("PermissionGranter")
   deliverableAcceptances   Deliverable[]     @relation("DeliverableAcceptor")
   createdKPIs              KPI[]             @relation("KPICreator")
+  passwordHistory          PasswordHistory[]
 
   @@map("users")
+}
+
+/// Stores hashed passwords to prevent reuse of recent N passwords (Issue #201).
+model PasswordHistory {
+  id        String   @id @default(cuid())
+  userId    String
+  hash      String   // bcrypt hash of the previous password
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, createdAt(sort: Desc)])
+  @@map("password_history")
 }
 
 model Permission {


### PR DESCRIPTION
## Summary
- 新增 `PasswordHistory` Prisma model（`password_history` table）
- 變更密碼時檢查新密碼是否與最近 5 組相同（bcrypt compare）
- 舊密碼 hash 在 transaction 中同步寫入 history
- Index: `(userId, createdAt DESC)` 確保查詢效率

## Test plan
- [ ] 變更密碼後，再次使用同一密碼應被拒絕
- [ ] 連續變更 6 次後，第 1 組密碼可重新使用
- [ ] `npx prisma db push` 成功建表
- [ ] AuditLog 仍正常記錄 `PASSWORD_CHANGE`

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)