### PR TITLE
feat(P2-9): projector viewport optimization (1024x768)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -235,7 +235,7 @@ function ManagerDashboard() {
   return (
     <div className="space-y-6">
       {/* ── Stats cards ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <StatCard label="本週完成任務" value={weekly?.completedCount ?? "—"} />
         <StatCard label="本週總工時 (h)" value={safeFixed(weekly?.totalHours, 1, "—")} />
         <StatCard
@@ -303,7 +303,7 @@ function ManagerDashboard() {
       </div>
 
       {/* ── This month ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <StatCard label="本週延遲次數" value={weekly?.delayCount ?? "—"} accent={(weekly?.delayCount ?? 0) > 0} />
         <StatCard label="本週範疇變更" value={weekly?.scopeChangeCount ?? "—"} />
         <StatCard
@@ -379,7 +379,7 @@ function EngineerDashboard() {
   return (
     <div className="space-y-6">
       {/* ── Summary cards ── */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
         <StatCard label="進行中任務" value={tasks.length} />
         <StatCard label="逾期任務" value={overdue.length} accent={overdue.length > 0} />
         <StatCard

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   LayoutDashboard, KanbanSquare, GanttChartSquare, BookOpen,
   Clock, BarChart2, Target, Crosshair, PanelLeftClose, PanelLeftOpen,
@@ -38,6 +38,15 @@ const navGroups = [
 export function Sidebar() {
   const pathname = usePathname();
   const [collapsed, setCollapsed] = useState(false);
+
+  // Auto-collapse on projector/small viewports (≤1024px) — Issue #197
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 1024px)");
+    setCollapsed(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setCollapsed(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
 
   return (
     <aside

--- a/app/globals.css
+++ b/app/globals.css
@@ -78,4 +78,9 @@
   ::-webkit-scrollbar-track { background: transparent; }
   ::-webkit-scrollbar-thumb { background: hsl(var(--border)); border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: hsl(var(--muted-foreground)); }
+
+  /* Projector viewport optimization (1024x768) — Issue #197 */
+  @media (max-width: 1024px) and (max-height: 768px) {
+    html { font-size: 14px; }
+  }
 }


### PR DESCRIPTION
## Summary
- Sidebar 在 ≤1024px viewport 自動 collapse（matchMedia 監聽）
- Dashboard stat card grid 從 `sm:grid-cols-4` 改為 `md:grid-cols-4`
- 1024x768 場景下 base font-size 調為 14px

## Test plan
- [ ] 1024x768 viewport：sidebar 自動收合
- [ ] stat cards 在 768-1024px 區間維持 2 columns
- [ ] 放大視窗後 sidebar 可手動展開

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)