### PR TITLE
feat(P2-6): application metrics endpoint for Prometheus

### DIFF
--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { serializeMetrics } from "@/lib/metrics";
+
+/**
+ * GET /api/metrics — Prometheus-compatible metrics endpoint (Issue #195).
+ * Returns application metrics in text exposition format.
+ */
+export async function GET() {
+  return new NextResponse(serializeMetrics(), {
+    headers: { "Content-Type": "text/plain; version=0.0.4; charset=utf-8" },
+  });
+}

--- a/config/monitoring/prometheus/prometheus.yml
+++ b/config/monitoring/prometheus/prometheus.yml
@@ -63,6 +63,15 @@ scrape_configs:
         labels:
           type: 'storage'
 
+  # ── TITAN App 監控（Issue #195）──────────────────────────
+  - job_name: 'titan-app'
+    metrics_path: '/api/metrics'
+    static_configs:
+      - targets: ['titan-app:3000']
+        labels:
+          type: 'application'
+          app: 'titan'
+
   # ── Outline 服務監控 ────────────────────────────────────
   - job_name: 'outline'
     static_configs:

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,0 +1,86 @@
+/**
+ * Lightweight application metrics for Prometheus scraping (Issue #195).
+ * No external dependencies — outputs Prometheus text format directly.
+ *
+ * Counters persist in-memory per Node.js worker; resets on deploy.
+ * For durable metrics, use a proper time-series DB.
+ */
+
+interface Metrics {
+  httpRequestsTotal: Record<string, number>;
+  httpErrorsTotal: Record<string, number>;
+  httpDurationSum: Record<string, number>;
+  httpDurationCount: Record<string, number>;
+}
+
+const metrics: Metrics = {
+  httpRequestsTotal: {},
+  httpErrorsTotal: {},
+  httpDurationSum: {},
+  httpDurationCount: {},
+};
+
+/** Record a completed HTTP request. */
+export function recordRequest(method: string, path: string, status: number, durationMs: number) {
+  const route = normalizeRoute(path);
+  const key = `${method}|${route}|${status}`;
+
+  metrics.httpRequestsTotal[key] = (metrics.httpRequestsTotal[key] ?? 0) + 1;
+
+  if (status >= 400) {
+    metrics.httpErrorsTotal[key] = (metrics.httpErrorsTotal[key] ?? 0) + 1;
+  }
+
+  const durKey = `${method}|${route}`;
+  metrics.httpDurationSum[durKey] = (metrics.httpDurationSum[durKey] ?? 0) + durationMs;
+  metrics.httpDurationCount[durKey] = (metrics.httpDurationCount[durKey] ?? 0) + 1;
+}
+
+/** Normalize dynamic route segments to reduce cardinality. */
+function normalizeRoute(path: string): string {
+  return path
+    .replace(/\/[a-z0-9]{20,}/gi, "/:id") // cuid/uuid segments
+    .replace(/\/\d+/g, "/:id");            // numeric IDs
+}
+
+/** Serialize all metrics in Prometheus text exposition format. */
+export function serializeMetrics(): string {
+  const lines: string[] = [];
+
+  // http_requests_total
+  lines.push("# HELP titan_http_requests_total Total HTTP requests");
+  lines.push("# TYPE titan_http_requests_total counter");
+  for (const [key, count] of Object.entries(metrics.httpRequestsTotal)) {
+    const [method, route, status] = key.split("|");
+    lines.push(`titan_http_requests_total{method="${method}",route="${route}",status="${status}"} ${count}`);
+  }
+
+  // http_errors_total
+  lines.push("# HELP titan_http_errors_total Total HTTP errors (4xx/5xx)");
+  lines.push("# TYPE titan_http_errors_total counter");
+  for (const [key, count] of Object.entries(metrics.httpErrorsTotal)) {
+    const [method, route, status] = key.split("|");
+    lines.push(`titan_http_errors_total{method="${method}",route="${route}",status="${status}"} ${count}`);
+  }
+
+  // http_request_duration_ms (sum + count for computing average)
+  lines.push("# HELP titan_http_request_duration_ms_sum Sum of HTTP request durations in ms");
+  lines.push("# TYPE titan_http_request_duration_ms_sum counter");
+  for (const [key, sum] of Object.entries(metrics.httpDurationSum)) {
+    const [method, route] = key.split("|");
+    lines.push(`titan_http_request_duration_ms_sum{method="${method}",route="${route}"} ${sum.toFixed(2)}`);
+  }
+  lines.push("# HELP titan_http_request_duration_ms_count Count of HTTP requests for duration");
+  lines.push("# TYPE titan_http_request_duration_ms_count counter");
+  for (const [key, count] of Object.entries(metrics.httpDurationCount)) {
+    const [method, route] = key.split("|");
+    lines.push(`titan_http_request_duration_ms_count{method="${method}",route="${route}"} ${count}`);
+  }
+
+  // uptime
+  lines.push("# HELP titan_uptime_seconds Process uptime in seconds");
+  lines.push("# TYPE titan_uptime_seconds gauge");
+  lines.push(`titan_uptime_seconds ${(process.uptime?.() ?? 0).toFixed(0)}`);
+
+  return lines.join("\n") + "\n";
+}


### PR DESCRIPTION
## Summary
- `lib/metrics.ts` — 輕量級 in-memory metrics（request count、error count、duration、uptime）
- `GET /api/metrics` — Prometheus text exposition format endpoint
- Prometheus config 新增 `titan-app` scrape target（`/api/metrics`）
- 零外部依賴，純 TypeScript 實作

## Metrics exposed
- `titan_http_requests_total{method, route, status}`
- `titan_http_errors_total{method, route, status}`
- `titan_http_request_duration_ms_sum{method, route}`
- `titan_http_request_duration_ms_count{method, route}`
- `titan_uptime_seconds`

## Test plan
- [ ] `curl /api/metrics` 回傳 Prometheus 格式文字
- [ ] Prometheus 可成功 scrape titan-app target
- [ ] Grafana 可查詢 `titan_http_requests_total`

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)