### PR TITLE
fix(#177): safePct/safeLocaleString handle string input

### DIFF
--- a/lib/__tests__/safe-number.test.ts
+++ b/lib/__tests__/safe-number.test.ts
@@ -80,6 +80,19 @@ describe("safeLocaleString", () => {
     expect(safeLocaleString(NaN)).toBe("0");
   });
 
+  test("parses numeric string (consistent with safeFixed)", () => {
+    const result = safeLocaleString("1234567.89");
+    expect(result).toContain("1,234,567");
+  });
+
+  test("returns fallback for non-numeric string", () => {
+    expect(safeLocaleString("hello")).toBe("0");
+  });
+
+  test("returns fallback for whitespace-only string", () => {
+    expect(safeLocaleString("  ")).toBe("0");
+  });
+
   test("uses custom fallback", () => {
     expect(safeLocaleString(null, "zh-TW", undefined, "—")).toBe("—");
   });
@@ -140,6 +153,15 @@ describe("safePct", () => {
     expect(safePct(null)).toBe("0");
     expect(safePct(undefined)).toBe("0");
     expect(safePct(NaN)).toBe("0");
+  });
+
+  test("parses numeric string (consistent with safeFixed)", () => {
+    expect(safePct("75.5", 1)).toBe("75.5");
+    expect(safePct("150", 0)).toBe("100"); // clamped
+  });
+
+  test("returns fallback for non-numeric string", () => {
+    expect(safePct("hello")).toBe("0");
   });
 
   test("uses custom fallback", () => {

--- a/lib/safe-number.ts
+++ b/lib/safe-number.ts
@@ -35,6 +35,10 @@ export function safeLocaleString(
   if (typeof value === "number" && Number.isFinite(value)) {
     return value.toLocaleString(locale, options);
   }
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) return parsed.toLocaleString(locale, options);
+  }
   return fallback;
 }
 
@@ -64,8 +68,15 @@ export function safePct(
   fallback = "0",
   allowOverflow = false
 ): string {
+  let num: number | undefined;
   if (typeof value === "number" && Number.isFinite(value)) {
-    const clamped = allowOverflow ? value : Math.max(0, Math.min(100, value));
+    num = value;
+  } else if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) num = parsed;
+  }
+  if (num !== undefined) {
+    const clamped = allowOverflow ? num : Math.max(0, Math.min(100, num));
     return clamped.toFixed(digits);
   }
   return fallback;


### PR DESCRIPTION
## Summary
- `safePct` 和 `safeLocaleString` 新增 string input 解析（與 `safeFixed`/`safeNum` 一致）
- 傳入 numeric string（如 `"75.5"`）現在正確解析，不再回傳 fallback

## Test plan
- [x] `safePct("75.5", 1)` → `"75.5"`
- [x] `safePct("150", 0)` → `"100"`（clamp）
- [x] `safeLocaleString("1234567.89")` → 含千分位
- [x] Non-numeric strings 仍回傳 fallback
- [x] 59 tests passing

Partially addresses #177 (item #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)