### PR TITLE
fix(a11y): add aria-label to filter selects (select-name)

### DIFF
--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -220,6 +220,7 @@ export default function GanttPage() {
         <div className="flex items-center gap-3">
           {/* Assignee filter */}
           <select
+            aria-label="篩選負責人"
             value={assigneeFilter}
             onChange={(e) => setAssigneeFilter(e.target.value)}
             className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -270,6 +270,7 @@ export default function PlansPage() {
           <p className="text-xs text-muted-foreground">選擇來源計畫，系統將複製其架構（月度目標與里程碑）到新年度。</p>
           <div className="flex gap-3 flex-wrap">
             <select
+              aria-label="來源計畫"
               value={copySourcePlanId}
               onChange={(e) => setCopySourcePlanId(e.target.value)}
               className={cn(selectCls, "flex-1 min-w-48")}
@@ -311,6 +312,7 @@ export default function PlansPage() {
           </div>
           <div className="flex gap-3 flex-wrap">
             <select
+              aria-label="年度計畫"
               value={newGoalPlanId}
               onChange={(e) => setNewGoalPlanId(e.target.value)}
               className={cn(selectCls, "flex-1 min-w-40")}
@@ -321,6 +323,7 @@ export default function PlansPage() {
               ))}
             </select>
             <select
+              aria-label="目標月份"
               value={newGoalMonth}
               onChange={(e) => setNewGoalMonth(e.target.value)}
               className={cn(selectCls, "w-24")}

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -191,6 +191,7 @@ export default function TimesheetPage() {
         <div className="flex items-center gap-3">
           {/* User filter */}
           <select
+            aria-label="篩選使用者"
             value={userFilter}
             onChange={(e) => setUserFilter(e.target.value)}
             className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"

--- a/app/components/deliverable-list.tsx
+++ b/app/components/deliverable-list.tsx
@@ -148,6 +148,7 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
             className="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
           />
           <select
+            aria-label="交付物類型"
             value={newType}
             onChange={(e) => setNewType(e.target.value as DeliverableType)}
             className="bg-background border border-border text-foreground text-xs rounded px-1.5 py-1 focus:outline-none"

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -61,6 +61,7 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
 
       {/* Assignee */}
       <select
+        aria-label="篩選負責人"
         value={filters.assignee}
         onChange={(e) => onChange({ ...filters, assignee: e.target.value })}
         className={selectCls}
@@ -75,6 +76,7 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
 
       {/* Priority */}
       <select
+        aria-label="篩選優先度"
         value={filters.priority}
         onChange={(e) => onChange({ ...filters, priority: e.target.value })}
         className={selectCls}
@@ -88,6 +90,7 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
 
       {/* Category */}
       <select
+        aria-label="篩選分類"
         value={filters.category}
         onChange={(e) => onChange({ ...filters, category: e.target.value })}
         className={selectCls}

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -8,14 +8,12 @@ import { MANAGER_STATE_FILE } from './helpers/auth';
  * Known existing violations (to be fixed as separate issues):
  * - scrollable-region-focusable: kanban/scroll areas in Dashboard
  * - color-contrast: dark theme muted text in Login page
- * - select-name: Kanban filter <select> missing accessible name label
  *
  * Tests FAIL only on newly introduced violations not in the known list.
  */
 const KNOWN_VIOLATIONS = new Set([
   'scrollable-region-focusable',
   'color-contrast',
-  'select-name',
 ]);
 
 /** Run axe scan and assert no NEW violations beyond the known list. */


### PR DESCRIPTION
## Summary
- 為所有缺少 accessible name 的 `<select>` 元素加上 `aria-label`
- 涵蓋：task-filters（3 個）、gantt、timesheet、plans（3 個）、deliverable-list
- 從 `KNOWN_VIOLATIONS` 移除 `select-name`

## Test plan
- [x] 所有 filter select 有 `aria-label`
- [ ] axe-core 不再報告 `select-name` violation

Partially addresses #177 (item #2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)