### PR TITLE
feat(#198): PostgreSQL primary-replica replication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,15 @@ HOMEPAGE_VAR_MINIO_CONSOLE_URL=http://localhost:9001
 HOMEPAGE_VAR_MINIO_ROOT_USER=minioadmin
 HOMEPAGE_VAR_MINIO_ROOT_PASSWORD=changeme_minio_password_here
 
+# ── PostgreSQL Replication（Issue #198，選用）──────────────
+# 僅在啟用 docker-compose.replication.yml 時需要設定
+# Replication 專用帳號（非 superuser，僅有 REPLICATION 權限）
+REPLICATION_USER=replicator
+# 必填（啟用 replication 時）：使用 openssl rand -hex 32 產生
+REPLICATION_PASSWORD=changeme_replication_password_here
+# Replication slot 名稱（用於追蹤 WAL 消費進度）
+REPLICATION_SLOT=titan_replica_slot
+
 # ── Plane 專案管理（T12 任務佔位符）────────────────────────
 # ⚠️  以下設定保留給 T12 實作，目前無效
 # PLANE_SECRET_KEY=

--- a/config/postgres/primary-init.sh
+++ b/config/postgres/primary-init.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════
+# TITAN — PostgreSQL Primary 初始化腳本
+# 啟用 WAL 歸檔 + 建立 Replication Slot
+# 此腳本在 primary 容器首次啟動時執行
+# ═══════════════════════════════════════════════════════════
+set -euo pipefail
+
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+REPL_USER="${REPLICATION_USER:-replicator}"
+REPL_PASSWORD="${REPLICATION_PASSWORD:?REPLICATION_PASSWORD is required}"
+REPL_SLOT="${REPLICATION_SLOT:-titan_replica_slot}"
+
+echo "[primary-init] Configuring PostgreSQL primary for streaming replication..."
+
+# ── 1. 建立 replication 使用者 ──────────────────────────────
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER:-titan}" --dbname "${POSTGRES_DB:-titan}" <<-EOSQL
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${REPL_USER}') THEN
+            CREATE ROLE ${REPL_USER} WITH REPLICATION LOGIN PASSWORD '${REPL_PASSWORD}';
+            RAISE NOTICE 'Created replication user: ${REPL_USER}';
+        ELSE
+            ALTER ROLE ${REPL_USER} WITH PASSWORD '${REPL_PASSWORD}';
+            RAISE NOTICE 'Updated password for replication user: ${REPL_USER}';
+        END IF;
+    END
+    \$\$;
+EOSQL
+
+# ── 2. 設定 WAL 參數（寫入 postgresql.conf）────────────────
+# 使用 ALTER SYSTEM 確保設定持久化
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER:-titan}" --dbname "${POSTGRES_DB:-titan}" <<-EOSQL
+    -- WAL 歸檔設定
+    ALTER SYSTEM SET wal_level = 'replica';
+    ALTER SYSTEM SET max_wal_senders = 5;
+    ALTER SYSTEM SET max_replication_slots = 5;
+    ALTER SYSTEM SET wal_keep_size = '256MB';
+    ALTER SYSTEM SET hot_standby = on;
+    -- WAL 歸檔（本地備份用）
+    ALTER SYSTEM SET archive_mode = on;
+    ALTER SYSTEM SET archive_command = 'test ! -f /var/lib/postgresql/wal_archive/%f && cp %p /var/lib/postgresql/wal_archive/%f';
+EOSQL
+
+# ── 3. 設定 pg_hba.conf 允許 replication 連線 ──────────────
+# 檢查是否已有 replication 規則，避免重複新增
+if ! grep -q "replication.*${REPL_USER}" "${PGDATA}/pg_hba.conf" 2>/dev/null; then
+    echo "" >> "${PGDATA}/pg_hba.conf"
+    echo "# ── TITAN Replication ──────────────────────────────" >> "${PGDATA}/pg_hba.conf"
+    echo "host    replication    ${REPL_USER}    0.0.0.0/0    scram-sha-256" >> "${PGDATA}/pg_hba.conf"
+    echo "[primary-init] Added replication entry to pg_hba.conf"
+fi
+
+# ── 4. 建立 WAL archive 目錄 ───────────────────────────────
+mkdir -p /var/lib/postgresql/wal_archive
+echo "[primary-init] WAL archive directory created"
+
+# ── 5. 建立 Replication Slot ───────────────────────────────
+psql -v ON_ERROR_STOP=1 --username "${POSTGRES_USER:-titan}" --dbname "${POSTGRES_DB:-titan}" <<-EOSQL
+    SELECT CASE
+        WHEN NOT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '${REPL_SLOT}')
+        THEN pg_create_physical_replication_slot('${REPL_SLOT}')
+    END;
+EOSQL
+
+echo "[primary-init] Replication slot '${REPL_SLOT}' ensured"
+
+# ── 6. Reload 設定（若 server 已運行）──────────────────────
+pg_ctl reload -D "${PGDATA}" 2>/dev/null || true
+
+echo "[primary-init] Primary configuration complete. Restart required for wal_level change."

--- a/config/postgres/replica-init.sh
+++ b/config/postgres/replica-init.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════
+# TITAN — PostgreSQL Replica 初始化腳本
+# 從 Primary 執行 pg_basebackup 並設定 Standby 模式
+# 此腳本作為 replica 容器的 entrypoint wrapper 執行
+# ═══════════════════════════════════════════════════════════
+set -euo pipefail
+
+PGDATA="${PGDATA:-/var/lib/postgresql/data}"
+PRIMARY_HOST="${PRIMARY_HOST:-titan-postgres}"
+PRIMARY_PORT="${PRIMARY_PORT:-5432}"
+REPL_USER="${REPLICATION_USER:-replicator}"
+REPL_PASSWORD="${REPLICATION_PASSWORD:?REPLICATION_PASSWORD is required}"
+REPL_SLOT="${REPLICATION_SLOT:-titan_replica_slot}"
+
+echo "[replica-init] Starting replica initialization..."
+
+# ── 1. 等待 Primary 就緒 ───────────────────────────────────
+echo "[replica-init] Waiting for primary at ${PRIMARY_HOST}:${PRIMARY_PORT}..."
+until PGPASSWORD="${REPL_PASSWORD}" pg_isready -h "${PRIMARY_HOST}" -p "${PRIMARY_PORT}" -U "${REPL_USER}" 2>/dev/null; do
+    echo "[replica-init] Primary not ready, waiting 3s..."
+    sleep 3
+done
+echo "[replica-init] Primary is ready"
+
+# ── 2. 檢查是否已初始化 ────────────────────────────────────
+if [ -f "${PGDATA}/PG_VERSION" ] && [ -f "${PGDATA}/standby.signal" ]; then
+    echo "[replica-init] Data directory already initialized as standby, starting PostgreSQL..."
+    exec docker-entrypoint.sh postgres
+fi
+
+# ── 3. 清空 PGDATA 並執行 base backup ─────────────────────
+echo "[replica-init] Performing pg_basebackup from primary..."
+rm -rf "${PGDATA}"/*
+
+PGPASSWORD="${REPL_PASSWORD}" pg_basebackup \
+    -h "${PRIMARY_HOST}" \
+    -p "${PRIMARY_PORT}" \
+    -U "${REPL_USER}" \
+    -D "${PGDATA}" \
+    -Fp -Xs -P -R \
+    --slot="${REPL_SLOT}" \
+    --checkpoint=fast
+
+echo "[replica-init] Base backup completed"
+
+# ── 4. 確認 standby.signal 存在（pg_basebackup -R 會建立）─
+if [ ! -f "${PGDATA}/standby.signal" ]; then
+    touch "${PGDATA}/standby.signal"
+    echo "[replica-init] Created standby.signal"
+fi
+
+# ── 5. 設定 primary_conninfo（若尚未由 -R 自動寫入）───────
+if ! grep -q "primary_conninfo" "${PGDATA}/postgresql.auto.conf" 2>/dev/null; then
+    cat >> "${PGDATA}/postgresql.auto.conf" <<EOF
+
+# TITAN Replication — Standby Configuration
+primary_conninfo = 'host=${PRIMARY_HOST} port=${PRIMARY_PORT} user=${REPL_USER} password=${REPL_PASSWORD} application_name=titan-replica'
+primary_slot_name = '${REPL_SLOT}'
+EOF
+    echo "[replica-init] Wrote primary_conninfo to postgresql.auto.conf"
+fi
+
+# ── 6. 設定唯讀模式 ────────────────────────────────────────
+cat >> "${PGDATA}/postgresql.auto.conf" <<EOF
+
+# Standby tuning
+hot_standby = on
+hot_standby_feedback = on
+max_standby_streaming_delay = 30s
+max_standby_archive_delay = 60s
+EOF
+
+# ── 7. 修正權限 ────────────────────────────────────────────
+chmod 0700 "${PGDATA}"
+
+echo "[replica-init] Replica initialization complete, starting PostgreSQL in standby mode..."
+
+# ── 8. 啟動 PostgreSQL ─────────────────────────────────────
+exec docker-entrypoint.sh postgres

--- a/docker-compose.replication.yml
+++ b/docker-compose.replication.yml
@@ -1,0 +1,93 @@
+# ═══════════════════════════════════════════════════════════
+# TITAN — PostgreSQL Primary-Replica Streaming Replication
+# Issue #198: 讀寫分離，提升可用性與讀取效能
+#
+# 使用方式（與基礎 compose 合併啟動）：
+#   docker compose -f docker-compose.yml \
+#     -f docker-compose.replication.yml up -d
+#
+# 前置條件：
+#   1. .env 中設定 REPLICATION_PASSWORD
+#   2. Primary 需重啟以套用 wal_level=replica
+#
+# 架構：
+#   titan-postgres (primary, RW) ──WAL──→ titan-postgres-replica (standby, RO)
+#   應用程式寫入連 primary:5432，讀取連 replica:5432
+# ═══════════════════════════════════════════════════════════
+
+version: '3.8'
+
+services:
+
+  # ── 覆寫 Primary：掛載初始化腳本 + WAL archive volume ────
+  postgres:
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - postgres-wal-archive:/var/lib/postgresql/wal_archive
+      - ./scripts/init:/docker-entrypoint-initdb.d:ro
+      - ./config/postgres/primary-init.sh:/docker-entrypoint-initdb.d/99-replication-init.sh:ro
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-titan}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-titan}
+      REPLICATION_USER: ${REPLICATION_USER:-replicator}
+      REPLICATION_PASSWORD: ${REPLICATION_PASSWORD:?REPLICATION_PASSWORD is required}
+      REPLICATION_SLOT: ${REPLICATION_SLOT:-titan_replica_slot}
+
+  # ── Replica：Streaming Standby（唯讀）──────────────────
+  postgres-replica:
+    image: postgres:16-alpine
+    container_name: titan-postgres-replica
+    restart: unless-stopped
+    user: postgres
+    entrypoint: ["/bin/bash", "/opt/titan/replica-init.sh"]
+    environment:
+      PGDATA: /var/lib/postgresql/data
+      PRIMARY_HOST: titan-postgres
+      PRIMARY_PORT: "5432"
+      REPLICATION_USER: ${REPLICATION_USER:-replicator}
+      REPLICATION_PASSWORD: ${REPLICATION_PASSWORD:?REPLICATION_PASSWORD is required}
+      REPLICATION_SLOT: ${REPLICATION_SLOT:-titan_replica_slot}
+      # Replica 不需要這些，但 docker-entrypoint.sh 可能用到
+      POSTGRES_USER: ${POSTGRES_USER:-titan}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-titan}
+    volumes:
+      - postgres-replica-data:/var/lib/postgresql/data
+      - ./config/postgres/replica-init.sh:/opt/titan/replica-init.sh:ro
+    networks:
+      - titan-internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - |
+          pg_isready -U ${POSTGRES_USER:-titan} -d ${POSTGRES_DB:-titan} &&
+          psql -U ${POSTGRES_USER:-titan} -d ${POSTGRES_DB:-titan} -tAc "SELECT pg_is_in_recovery();" | grep -q 't'
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  postgres-data:
+    name: titan-postgres-data
+  postgres-replica-data:
+    name: titan-postgres-replica-data
+  postgres-wal-archive:
+    name: titan-postgres-wal-archive
+
+networks:
+  titan-internal:
+    name: titan-internal
+    external: true

--- a/docs/pg-replication.md
+++ b/docs/pg-replication.md
@@ -1,0 +1,147 @@
+# PostgreSQL Primary-Replica Replication
+
+> Issue #198 — 讀寫分離，提升可用性與讀取效能
+
+## 架構
+
+```
+                        WAL Streaming
+titan-postgres ─────────────────────────→ titan-postgres-replica
+ (Primary, RW)          replication slot     (Standby, RO)
+   :5432                                        :5432
+```
+
+- **Primary** (`titan-postgres`)：處理所有寫入操作，與現有基礎設施完全相容
+- **Replica** (`titan-postgres-replica`)：接收 WAL 串流，提供唯讀查詢
+- 使用 Physical Replication Slot 確保 WAL 不會在 replica 消費前被回收
+
+## 前置條件
+
+1. 在 `.env` 中新增 replication 相關變數：
+
+```bash
+# PostgreSQL Replication（僅在啟用 replication 時需要）
+REPLICATION_USER=replicator
+REPLICATION_PASSWORD=<使用 openssl rand -hex 32 產生>
+REPLICATION_SLOT=titan_replica_slot
+```
+
+2. 如果 primary 已在運行，首次啟用需要重啟（`wal_level` 變更需要重啟）
+
+## 啟動方式
+
+```bash
+# 與基礎 compose 合併啟動
+docker compose -f docker-compose.yml \
+  -f docker-compose.replication.yml up -d
+```
+
+首次啟動流程：
+1. Primary 啟動 → 執行 `primary-init.sh`（建立 replication user、設定 WAL、建立 slot）
+2. Primary 重啟（wal_level 變更生效）
+3. Replica 啟動 → 執行 `replica-init.sh`（等待 primary → pg_basebackup → standby 模式）
+
+## 驗證
+
+### 確認 Primary WAL 設定
+
+```bash
+docker exec titan-postgres psql -U titan -d titan -c "SHOW wal_level;"
+# 應顯示：replica
+
+docker exec titan-postgres psql -U titan -d titan -c "SELECT * FROM pg_replication_slots;"
+# 應顯示 titan_replica_slot
+```
+
+### 確認 Replica 狀態
+
+```bash
+# 確認 replica 處於 recovery 模式
+docker exec titan-postgres-replica psql -U titan -d titan -c "SELECT pg_is_in_recovery();"
+# 應顯示：t
+
+# 查看 replication 延遲
+docker exec titan-postgres psql -U titan -d titan -c \
+  "SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn,
+          now() - write_lag AS write_lag
+   FROM pg_stat_replication;"
+```
+
+### 確認讀取可用
+
+```bash
+# 在 replica 上執行唯讀查詢
+docker exec titan-postgres-replica psql -U titan -d titan -c "SELECT count(*) FROM pg_tables;"
+```
+
+## 應用程式整合
+
+### 讀寫分離連線字串
+
+| 用途 | 連線字串 |
+|------|---------|
+| 寫入 (Primary) | `postgresql://titan:PASSWORD@titan-postgres:5432/titan` |
+| 唯讀 (Replica) | `postgresql://titan:PASSWORD@titan-postgres-replica:5432/titan` |
+
+### Prisma 整合（未來）
+
+Prisma 目前不原生支援 read replica，但可透過以下方式實現：
+- 使用 `@prisma/extension-read-replicas` 擴充套件
+- 或在應用層透過連線池 (PgBouncer) 實現路由
+
+## 監控
+
+### 關鍵指標
+
+| 指標 | 查詢方式 | 告警閾值 |
+|------|---------|---------|
+| Replication Lag | `pg_stat_replication.write_lag` | > 30s |
+| Slot 活躍狀態 | `pg_replication_slots.active` | = false |
+| WAL Archive 積壓 | `pg_stat_archiver.last_archived_wal` | 停滯 > 10min |
+
+### 健康檢查
+
+Replica 的 healthcheck 同時驗證：
+1. PostgreSQL 服務可回應連線 (`pg_isready`)
+2. 確認處於 standby 模式 (`pg_is_in_recovery() = true`)
+
+## 故障處理
+
+### Replica 同步中斷
+
+```bash
+# 1. 檢查 replication 狀態
+docker exec titan-postgres psql -U titan -d titan -c "SELECT * FROM pg_stat_replication;"
+
+# 2. 如果 replica 完全脫離，重建 replica
+docker compose -f docker-compose.yml -f docker-compose.replication.yml \
+  stop postgres-replica
+docker volume rm titan-postgres-replica-data
+docker compose -f docker-compose.yml -f docker-compose.replication.yml \
+  up -d postgres-replica
+```
+
+### Primary 故障（手動 Failover）
+
+> 注意：此為手動流程。自動 failover 需額外工具（如 Patroni）。
+
+```bash
+# 1. 停止 primary
+docker compose -f docker-compose.yml -f docker-compose.replication.yml \
+  stop postgres
+
+# 2. 提升 replica 為 primary
+docker exec titan-postgres-replica pg_ctl promote -D /var/lib/postgresql/data
+
+# 3. 更新應用程式連線字串指向 replica
+# 4. 重建原 primary 為新的 replica
+```
+
+## 檔案清單
+
+| 檔案 | 用途 |
+|------|------|
+| `docker-compose.replication.yml` | Replication 附加 compose（覆寫 primary + 新增 replica） |
+| `config/postgres/primary-init.sh` | Primary 初始化（WAL + replication user + slot） |
+| `config/postgres/replica-init.sh` | Replica 初始化（pg_basebackup + standby 設定） |
+| `docs/pg-replication.md` | 本文件 |


### PR DESCRIPTION
## Summary
- Add `docker-compose.replication.yml` as an add-on compose file for PG 16 streaming replication
- Primary init script (`config/postgres/primary-init.sh`): creates replication user, enables WAL archiving, creates physical replication slot
- Replica init script (`config/postgres/replica-init.sh`): waits for primary, performs `pg_basebackup`, configures hot standby mode
- Replica healthcheck verifies both connectivity and standby status (`pg_is_in_recovery()`)
- No modifications to existing `docker-compose.yml` or application code

## Usage
```bash
docker compose -f docker-compose.yml \
  -f docker-compose.replication.yml up -d
```

## Test plan
- [ ] Validate compose config merges cleanly (`docker compose config`)
- [ ] Start primary + replica, confirm WAL streaming active via `pg_stat_replication`
- [ ] Confirm replica is read-only (`pg_is_in_recovery() = true`)
- [ ] Write to primary, verify data appears on replica
- [ ] Healthcheck passes on both primary and replica containers

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)