### PR TITLE
feat(#223): PDF report export — print CSS + window.print()

### DIFF
--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -1,10 +1,23 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Download, RefreshCw, BarChart3 } from "lucide-react";
+import { Download, RefreshCw, BarChart3, Printer } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { safeFixed, safePct } from "@/lib/safe-number";
+
+function PrintButton() {
+  return (
+    <button
+      onClick={() => window.print()}
+      data-print-hide
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-foreground border border-border rounded-md hover:bg-accent transition-colors"
+    >
+      <Printer className="h-3.5 w-3.5" />
+      列印 PDF
+    </button>
+  );
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────
 

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -627,9 +627,18 @@ export default function ReportsPage() {
 
   return (
     <div className="max-w-3xl mx-auto">
-      <div className="mb-6">
-        <h1 className="text-xl font-semibold tracking-tight">報表</h1>
-        <p className="text-sm text-muted-foreground mt-1">週報、月報、KPI、計畫外負荷分析</p>
+      {/* Print header — only visible when printing */}
+      <div className="print-header hidden">
+        <h1>TITAN — {activeTab === "weekly" ? "週報" : activeTab === "monthly" ? "月報" : activeTab === "kpi" ? "KPI 報表" : "計畫外負荷"}</h1>
+        <p>列印日期：{new Date().toLocaleDateString("zh-TW")}</p>
+      </div>
+
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">報表</h1>
+          <p className="text-sm text-muted-foreground mt-1">週報、月報、KPI、計畫外負荷分析</p>
+        </div>
+        <PrintButton />
       </div>
 
       {/* Tabs */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,3 +84,22 @@
     html { font-size: 14px; }
   }
 }
+
+@media print {
+  aside, header, nav, [data-print-hide] { display: none !important; }
+  body { background: white !important; color: black !important; font-size: 12px; }
+  main { padding: 0 !important; overflow: visible !important; }
+  .flex.h-screen { display: block !important; }
+  .flex-1.flex.flex-col { display: block !important; }
+  .shadow-card, .shadow-lg, .shadow-xl, .shadow-2xl {
+    box-shadow: none !important; border: 1px solid #e5e5e5 !important;
+  }
+  .bg-card { break-inside: avoid; margin-bottom: 8px; }
+  h1, h2, h3 { break-after: avoid; }
+  .print-header { display: block !important; text-align: center; margin-bottom: 16px; }
+  .print-header h1 { font-size: 18px; font-weight: 600; }
+  .print-header p { font-size: 11px; color: #666; }
+  [class*="bg-primary"], [class*="bg-success"], [class*="bg-warning"], [class*="bg-danger"] {
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `@media print` CSS: hide sidebar/topbar, full-width content, proper page breaks
- Add `PrintButton` component with Printer icon + `window.print()`
- Add print header with report title + date (visible only when printing)
- `print-color-adjust: exact` for progress bar visibility
- Zero new dependencies — works in air-gapped bank environment

## Test plan
- [ ] Click "列印 PDF" button on reports page → browser print dialog opens
- [ ] Print preview: sidebar/topbar hidden, content full width
- [ ] Progress bars and colors visible in print preview
- [ ] Save as PDF works in Chrome/Edge

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)