### PR TITLE
fix(#250,#251,#253): P0 security + monitoring fixes

### DIFF
--- a/config/monitoring/alertmanager/alertmanager.yml
+++ b/config/monitoring/alertmanager/alertmanager.yml
@@ -1,8 +1,14 @@
 global:
   resolve_timeout: 5m
+  # Email SMTP — configure in .env: SMTP_HOST, SMTP_FROM, ALERT_EMAIL_TO
+  smtp_smarthost: '${SMTP_HOST:?需設定 SMTP_HOST}:${SMTP_PORT:-587}'
+  smtp_from: '${SMTP_FROM:-titan-alerts@titan.local}'
+  smtp_auth_username: '${SMTP_USER:-}'
+  smtp_auth_password: '${SMTP_PASSWORD:-}'
+  smtp_require_tls: false
 
 route:
-  receiver: default-log
+  receiver: default-email
   group_by: ['alertname', 'job', 'instance']
   group_wait: 30s
   group_interval: 5m
@@ -10,16 +16,38 @@ route:
   routes:
     - matchers:
         - severity = "critical"
-      receiver: critical-webhook
+      receiver: critical-email
+      repeat_interval: 30m
       continue: true
     - matchers:
         - severity = "warning"
-      receiver: warning-webhook
+      receiver: warning-email
+      repeat_interval: 4h
       continue: true
 
 receivers:
-  - name: default-log
+  - name: default-email
+    email_configs:
+      - to: '${ALERT_EMAIL_TO:?需設定 ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[TITAN] {{ .Status | toUpper }} - {{ .GroupLabels.alertname }}'
 
+  - name: critical-email
+    email_configs:
+      - to: '${ALERT_EMAIL_TO:?需設定 ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[TITAN 緊急] {{ .GroupLabels.alertname }} - {{ .GroupLabels.instance }}'
+
+  - name: warning-email
+    email_configs:
+      - to: '${ALERT_EMAIL_TO:?需設定 ALERT_EMAIL_TO}'
+        send_resolved: true
+        headers:
+          Subject: '[TITAN 警告] {{ .GroupLabels.alertname }}'
+
+  # Webhook backup (optional — configure if webhook receiver available)
   - name: critical-webhook
     webhook_configs:
       - url: 'http://host.docker.internal:8088/webhooks/alerts/critical'

--- a/middleware.ts
+++ b/middleware.ts
@@ -6,7 +6,7 @@
  *   - Uses NEXTAUTH_SECRET to verify the JWT signature and expiry
  *   - Blocks unauthenticated, expired, or tampered tokens with HTTP 401
  *   - Logs every blocked request via the structured logger
- *   - 生成每請求唯一 nonce，寫入 Content-Security-Policy 與 x-nonce header
+ *   - 生成每請求唯一 nonce，寫入 Content-Security-Policy 與 x-csp-nonce header
  *
  * Layer 2 (route handlers, Node.js runtime): full DB session check.
  *   - withAuth / withManager wrappers are kept on ALL route handlers (not removed)
@@ -15,7 +15,7 @@
  * Neither layer alone is sufficient — both must pass for a request to succeed.
  *
  * CSP Nonce 使用方式（Issue #190）：
- *   - Server Components 可透過 headers() 讀取 'x-nonce'
+ *   - Server Components 可透過 headers() 讀取 'x-csp-nonce'
  *   - 將 nonce 傳給 <Script nonce={nonce}> 或自訂 inline script 元素
  *   - next.config.ts 的靜態 CSP 作為未進入此 middleware 路由的 fallback
  */
@@ -55,7 +55,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   if (pathname.startsWith("/api/auth/")) {
     const res = NextResponse.next();
     res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-    res.headers.set("x-nonce", nonce);
+    res.headers.set("x-csp-nonce", nonce);
     res.headers.set("x-request-id", requestId);
     return res;
   }
@@ -64,7 +64,7 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   if (pathname === "/change-password") {
     const res = NextResponse.next();
     res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-    res.headers.set("x-nonce", nonce);
+    res.headers.set("x-csp-nonce", nonce);
     res.headers.set("x-request-id", requestId);
     return res;
   }
@@ -84,15 +84,15 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
     return jwtResult; // 401 response for API routes — blocked at Edge before hitting Node.js
   }
 
-  // 所有通過驗證的請求：注入 nonce-based CSP、x-nonce、x-request-id
+  // 所有通過驗證的請求：注入 nonce-based CSP、x-csp-nonce、x-request-id
   // Route handlers 可透過 headers() 讀取 'x-request-id' 做跨層追蹤
   const requestHeaders = new Headers(req.headers);
-  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("x-csp-nonce", nonce);
   requestHeaders.set("x-request-id", requestId);
 
   const res = NextResponse.next({ request: { headers: requestHeaders } });
   res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-  res.headers.set("x-nonce", nonce);
+  res.headers.set("x-csp-nonce", nonce);
   res.headers.set("x-request-id", requestId);
   return res;
 }

--- a/scripts/backup/restore.sh
+++ b/scripts/backup/restore.sh
@@ -228,6 +228,11 @@ if [ -n "${RESTORE_MINIO}" ]; then
     for BUCKET_DIR in "${TEMP_DIR}"/*; do
         if [ -d "${BUCKET_DIR}" ]; then
             BUCKET_NAME=$(basename "${BUCKET_DIR}")
+            # Validate bucket name: only allow safe characters
+            if ! [[ "${BUCKET_NAME}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                log_warn "跳過不安全的 bucket 名稱: ${BUCKET_NAME}"
+                continue
+            fi
             log_info "還原 bucket: ${BUCKET_NAME}"
             mc mirror --preserve --overwrite "${BUCKET_DIR}" "titanrestore/${BUCKET_NAME}"
         fi
@@ -273,6 +278,11 @@ if [ -n "${RESTORE_CONFIG}" ]; then
     for ITEM in "${TEMP_DIR}"/*; do
         if [ -e "${ITEM}" ]; then
             ITEM_NAME=$(basename "${ITEM}")
+            # Validate item name: only allow safe characters
+            if ! [[ "${ITEM_NAME}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+                log_warn "跳過不安全的檔案名稱: ${ITEM_NAME}"
+                continue
+            fi
             log_info "還原: ${ITEM_NAME}"
             cp -rp "${ITEM}" "${TITAN_ROOT}/"
         fi


### PR DESCRIPTION
Closes #250, Closes #251, Closes #253

- #250: unify CSP nonce header x-nonce → x-csp-nonce
- #251: Alertmanager email receivers (SMTP)
- #253: restore.sh bucket name regex validation

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>