### PR TITLE
fix(#252): PostgreSQL auto-failover setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,15 @@ REPLICATION_PASSWORD=changeme_replication_password_here
 # Replication slot 名稱（用於追蹤 WAL 消費進度）
 REPLICATION_SLOT=titan_replica_slot
 
+# ── PostgreSQL Failover（Issue #252，選用）──────────────────
+# 僅在啟用 docker-compose.failover.yml 時需要設定
+# 健康檢查間隔（秒），預設 10
+FAILOVER_CHECK_INTERVAL=10
+# 連續失敗幾次觸發自動 failover，預設 3
+FAILOVER_FAILURE_THRESHOLD=3
+# 單次健康檢查超時（秒），預設 5
+FAILOVER_CHECK_TIMEOUT=5
+
 # ── Plane 專案管理（T12 任務佔位符）────────────────────────
 # ⚠️  以下設定保留給 T12 實作，目前無效
 # PLANE_SECRET_KEY=

--- a/docker-compose.failover.yml
+++ b/docker-compose.failover.yml
@@ -1,0 +1,85 @@
+# ═══════════════════════════════════════════════════════════
+# TITAN — PostgreSQL Automatic Failover
+# Issue #252: PostgreSQL 單點故障 — 無自動 failover
+#
+# 使用方式（與基礎 compose + replication 合併啟動）：
+#   docker compose -f docker-compose.yml \
+#     -f docker-compose.replication.yml \
+#     -f docker-compose.failover.yml up -d
+#
+# 前置條件：
+#   1. docker-compose.replication.yml 已正常運行
+#   2. Primary + Replica streaming replication 正常
+#   3. .env 中 REPLICATION_PASSWORD 已設定
+#
+# 架構：
+#   titan-pg-monitor 持續檢查 Primary 健康狀態
+#   → 連續 3 次失敗 → 自動 promote Replica 為新 Primary
+#   → RTO 目標：≤ 10 分鐘
+#
+# 注意：
+#   此為單次 failover 設計（Primary → Replica promote）。
+#   Failover 後需人工重建原 Primary 為新 Replica。
+#   適合 5 人 IT 團隊的銀行離線環境。
+# ═══════════════════════════════════════════════════════════
+
+version: '3.8'
+
+services:
+
+  # ── Failover Monitor：持續監控 Primary 健康 ──────────────
+  pg-monitor:
+    image: postgres:16-alpine
+    container_name: titan-pg-monitor
+    restart: unless-stopped
+    user: postgres
+    entrypoint: ["/bin/bash", "/opt/titan/pg-failover.sh", "--auto"]
+    environment:
+      PRIMARY_HOST: titan-postgres
+      REPLICA_HOST: titan-postgres-replica
+      PG_PORT: "5432"
+      POSTGRES_USER: ${POSTGRES_USER:-titan}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:-titan}
+      # Failover 參數
+      FAILOVER_CHECK_INTERVAL: ${FAILOVER_CHECK_INTERVAL:-10}
+      FAILOVER_FAILURE_THRESHOLD: ${FAILOVER_FAILURE_THRESHOLD:-3}
+      FAILOVER_CHECK_TIMEOUT: ${FAILOVER_CHECK_TIMEOUT:-5}
+    volumes:
+      - ./scripts/pg-failover.sh:/opt/titan/pg-failover.sh:ro
+      - pg-monitor-logs:/var/log/titan
+    networks:
+      - titan-internal
+    depends_on:
+      postgres:
+        condition: service_healthy
+      postgres-replica:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 64M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - |
+          # Monitor 健康 = 程序存活且能連到至少一個 PG 節點
+          pg_isready -h titan-postgres -U ${POSTGRES_USER:-titan} -d ${POSTGRES_DB:-titan} 2>/dev/null ||
+          pg_isready -h titan-postgres-replica -U ${POSTGRES_USER:-titan} -d ${POSTGRES_DB:-titan} 2>/dev/null
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+volumes:
+  pg-monitor-logs:
+    name: titan-pg-monitor-logs
+
+networks:
+  titan-internal:
+    name: titan-internal
+    external: true

--- a/docs/pg-failover.md
+++ b/docs/pg-failover.md
@@ -1,0 +1,208 @@
+# PostgreSQL 自動 Failover
+
+Issue: #252 — PostgreSQL 單點故障 — 無自動 failover
+
+## 概述
+
+TITAN 使用 shell-based failover monitor 實現 PostgreSQL 自動故障轉移。設計目標：
+
+| 項目 | 規格 |
+|------|------|
+| RTO（Recovery Time Objective） | ≤ 10 分鐘 |
+| 適用規模 | 5 人 IT 團隊 |
+| 環境 | 銀行離線（air-gapped）網路 |
+| 架構 | 單次 failover（Primary → Replica promote） |
+
+## 架構
+
+```
+┌──────────────────┐       ┌──────────────────────┐
+│  titan-postgres  │──WAL──│ titan-postgres-replica│
+│   (Primary, RW)  │       │   (Standby, RO)      │
+└────────┬─────────┘       └──────────┬───────────┘
+         │                            │
+         └──────────┬─────────────────┘
+                    │
+           ┌────────┴────────┐
+           │ titan-pg-monitor │
+           │ (健康檢查 loop)  │
+           └─────────────────┘
+                    │
+         每 10 秒檢查 Primary
+         連續 3 次失敗 → promote Replica
+```
+
+## 啟動方式
+
+```bash
+# 完整啟動（base + replication + failover）
+docker compose -f docker-compose.yml \
+  -f docker-compose.replication.yml \
+  -f docker-compose.failover.yml up -d
+```
+
+## 環境變數
+
+在 `.env` 中設定（皆有預設值，可不改）：
+
+| 變數 | 預設值 | 說明 |
+|------|--------|------|
+| `FAILOVER_CHECK_INTERVAL` | `10` | 健康檢查間隔（秒） |
+| `FAILOVER_FAILURE_THRESHOLD` | `3` | 連續失敗幾次觸發 failover |
+| `FAILOVER_CHECK_TIMEOUT` | `5` | 單次檢查超時（秒） |
+
+偵測到故障的時間 = `CHECK_INTERVAL × FAILURE_THRESHOLD` = 預設 30 秒。
+
+## Failover 流程
+
+### 自動 Failover（預設行為）
+
+1. `titan-pg-monitor` 每 10 秒向 Primary 發送 `pg_isready` + `pg_is_in_recovery()` 查詢
+2. 連續 3 次檢查失敗（共 ~30 秒）
+3. 確認 Replica 可連線且處於 standby 模式
+4. 檢查 Replica 的 replication lag
+5. 執行 `pg_promote(true, 60)` 將 Replica 提升為新 Primary
+6. 驗證提升成功（`pg_is_in_recovery()` 回傳 `f`）
+7. 記錄 failover 事件至 `/var/log/titan/pg-failover.log`
+8. Monitor 進入觀察模式
+
+### 手動 Failover
+
+```bash
+# 進入 monitor 容器執行
+docker exec -it titan-pg-monitor \
+  /opt/titan/pg-failover.sh --manual
+```
+
+如果 Primary 仍在運行，會要求輸入 `YES` 確認。
+
+## 狀態檢查
+
+```bash
+# 從 monitor 容器檢查狀態
+docker exec -it titan-pg-monitor \
+  /opt/titan/pg-failover.sh --status
+
+# 查看 monitor 日誌
+docker logs titan-pg-monitor --tail 50
+
+# 查看 failover 日誌檔
+docker exec -it titan-pg-monitor \
+  cat /var/log/titan/pg-failover.log
+```
+
+### 判斷目前 Primary 是誰
+
+```bash
+# 檢查原 Primary
+docker exec titan-postgres \
+  psql -U titan -d titan -tAc "SELECT pg_is_in_recovery();"
+# f = Primary, t = Standby
+
+# 檢查原 Replica
+docker exec titan-postgres-replica \
+  psql -U titan -d titan -tAc "SELECT pg_is_in_recovery();"
+# f = 已被提升為 Primary, t = 仍為 Standby
+```
+
+## Failover 後恢復
+
+Failover 完成後，舊 Primary 需要人工處理。以下為恢復步驟：
+
+### 步驟 1：確認 Failover 狀態
+
+```bash
+docker exec titan-pg-monitor /opt/titan/pg-failover.sh --status
+```
+
+### 步驟 2：停止舊 Primary
+
+```bash
+docker compose -f docker-compose.yml \
+  -f docker-compose.replication.yml \
+  -f docker-compose.failover.yml \
+  stop postgres
+```
+
+### 步驟 3：將舊 Primary 重建為新 Replica
+
+```bash
+# 1. 清除舊 Primary 資料
+docker volume rm titan-postgres-data
+
+# 2. 重新建立（此時需要交換角色設定）
+#    修改 .env 或 docker-compose.override.yml 使：
+#    - titan-postgres-replica 為 Primary（已被 promote）
+#    - titan-postgres 為新 Replica
+
+# 3. 或者更簡單：從新 Primary 重新做 pg_basebackup
+docker exec titan-postgres bash -c "
+  rm -rf /var/lib/postgresql/data/*
+  PGPASSWORD=\$REPLICATION_PASSWORD pg_basebackup \
+    -h titan-postgres-replica -p 5432 \
+    -U \$REPLICATION_USER \
+    -D /var/lib/postgresql/data \
+    -Fp -Xs -P -R \
+    --checkpoint=fast
+  touch /var/lib/postgresql/data/standby.signal
+  chmod 0700 /var/lib/postgresql/data
+"
+
+# 4. 重啟服務
+docker compose -f docker-compose.yml \
+  -f docker-compose.replication.yml \
+  -f docker-compose.failover.yml \
+  restart postgres
+```
+
+### 步驟 4：驗證恢復
+
+```bash
+# 確認新的 replication 正常
+docker exec titan-postgres-replica \
+  psql -U titan -d titan -tAc \
+  "SELECT client_addr, state, sent_lsn, replay_lsn FROM pg_stat_replication;"
+```
+
+## 限制與注意事項
+
+1. **單次 failover**：此設計為單向 promote。Failover 後 Monitor 不會再自動 failback。需人工恢復。
+2. **應用程式連線**：Failover 後，應用程式的 `DATABASE_URL` 仍指向 `titan-postgres`。若 Primary 被 promote 的是 Replica，需要：
+   - 將舊 Primary 容器重建為 proxy/redirect，或
+   - 更新應用程式 `DATABASE_URL` 指向 `titan-postgres-replica`，或
+   - 使用上方恢復步驟重建角色
+3. **資料遺失**：若 Primary 突然故障，可能遺失尚未同步到 Replica 的 WAL（asynchronous replication）。對 5 人團隊而言，風險極低。
+4. **不適用於**：多節點叢集、自動 failback、讀寫分離路由。如有需要，請評估 Patroni 或 pg_auto_failover。
+
+## 疑難排解
+
+### Monitor 無法連線到 Primary
+
+```bash
+# 確認網路連通
+docker exec titan-pg-monitor pg_isready -h titan-postgres -U titan
+
+# 確認 Primary 容器運行中
+docker ps | grep titan-postgres
+```
+
+### Failover 未觸發
+
+```bash
+# 檢查 Monitor 是否運行
+docker logs titan-pg-monitor --tail 20
+
+# 確認失敗閾值設定
+docker exec titan-pg-monitor env | grep FAILOVER
+```
+
+### Promote 失敗
+
+```bash
+# 手動 promote
+docker exec titan-postgres-replica \
+  psql -U titan -d titan -c "SELECT pg_promote(true, 60);"
+
+# 或使用 pg_ctl
+docker exec titan-postgres-replica pg_ctl promote -D /var/lib/postgresql/data
+```

--- a/scripts/pg-failover.sh
+++ b/scripts/pg-failover.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# ═══════════════════════════════════════════════════════════
+# TITAN — PostgreSQL Automatic Failover Script
+# Issue #252: PostgreSQL 單點故障 — 無自動 failover
+#
+# 功能：
+#   1. 偵測 Primary 不可用（連續 N 次健康檢查失敗）
+#   2. 將 Replica 提升為新 Primary（promote）
+#   3. 記錄 failover 事件（audit log）
+#
+# 使用方式：
+#   自動（由 titan-pg-monitor 容器執行）：
+#     /opt/titan/pg-failover.sh --auto
+#   手動（人工觸發 failover）：
+#     /opt/titan/pg-failover.sh --manual
+#   狀態檢查：
+#     /opt/titan/pg-failover.sh --status
+#
+# RTO 目標：≤ 10 分鐘（含偵測 + promote + 服務重連）
+# ═══════════════════════════════════════════════════════════
+set -euo pipefail
+
+# ── 設定 ──────────────────────────────────────────────────
+PRIMARY_HOST="${PRIMARY_HOST:-titan-postgres}"
+REPLICA_HOST="${REPLICA_HOST:-titan-postgres-replica}"
+PG_PORT="${PG_PORT:-5432}"
+PG_USER="${POSTGRES_USER:-titan}"
+PG_DB="${POSTGRES_DB:-titan}"
+PGPASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+export PGPASSWORD
+
+# 自動 failover 參數
+CHECK_INTERVAL="${FAILOVER_CHECK_INTERVAL:-10}"       # 每 N 秒檢查一次
+FAILURE_THRESHOLD="${FAILOVER_FAILURE_THRESHOLD:-3}"   # 連續 N 次失敗觸發 failover
+CHECK_TIMEOUT="${FAILOVER_CHECK_TIMEOUT:-5}"           # 單次檢查超時秒數
+
+# 日誌與狀態檔
+LOG_DIR="/var/log/titan"
+LOG_FILE="${LOG_DIR}/pg-failover.log"
+STATE_FILE="/tmp/pg-failover-state"
+
+# ── 工具函數 ──────────────────────────────────────────────
+log() {
+    local level="$1"; shift
+    local msg
+    msg="$(date '+%Y-%m-%d %H:%M:%S') [${level}] $*"
+    echo "$msg"
+    mkdir -p "$LOG_DIR" 2>/dev/null || true
+    echo "$msg" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+check_primary() {
+    # 嘗試連線 Primary 並確認不是 standby
+    if timeout "$CHECK_TIMEOUT" pg_isready -h "$PRIMARY_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
+        local is_recovery
+        is_recovery=$(timeout "$CHECK_TIMEOUT" psql -h "$PRIMARY_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc "SELECT pg_is_in_recovery();" 2>/dev/null || echo "error")
+        if [ "$is_recovery" = "f" ]; then
+            return 0  # Primary 正常（非 recovery 模式）
+        fi
+    fi
+    return 1  # Primary 不可用
+}
+
+check_replica() {
+    # 確認 Replica 可連線且處於 standby 模式
+    if timeout "$CHECK_TIMEOUT" pg_isready -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
+        local is_recovery
+        is_recovery=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc "SELECT pg_is_in_recovery();" 2>/dev/null || echo "error")
+        if [ "$is_recovery" = "t" ]; then
+            return 0  # Replica 正常（在 recovery/standby 模式）
+        fi
+    fi
+    return 1  # Replica 不可用或已非 standby
+}
+
+promote_replica() {
+    log "WARN" "=== FAILOVER 開始 ==="
+    log "WARN" "Primary ($PRIMARY_HOST) 不可用，準備提升 Replica ($REPLICA_HOST)..."
+
+    # 確認 Replica 仍可用
+    if ! check_replica; then
+        log "ERROR" "Replica ($REPLICA_HOST) 也不可用！無法執行 failover"
+        log "ERROR" "需要人工介入處理"
+        return 1
+    fi
+
+    # 檢查 Replica 的 replication lag
+    local lag
+    lag=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+        "SELECT CASE WHEN pg_last_wal_receive_lsn() IS NOT NULL
+                THEN extract(epoch FROM now() - pg_last_xact_replay_timestamp())::int
+                ELSE -1 END;" 2>/dev/null || echo "-1")
+    log "INFO" "Replica replication lag: ${lag}s"
+
+    # 執行 promote
+    log "WARN" "執行 pg_promote() on $REPLICA_HOST..."
+    local promote_result
+    promote_result=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+        "SELECT pg_promote(true, 60);" 2>&1)
+
+    if [ "$promote_result" = "t" ]; then
+        log "WARN" "pg_promote() 成功！"
+    else
+        log "ERROR" "pg_promote() 失敗: $promote_result"
+        return 1
+    fi
+
+    # 等待 Replica 完成提升
+    local max_wait=60
+    local waited=0
+    while [ $waited -lt $max_wait ]; do
+        local is_recovery
+        is_recovery=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc "SELECT pg_is_in_recovery();" 2>/dev/null || echo "error")
+        if [ "$is_recovery" = "f" ]; then
+            log "WARN" "=== FAILOVER 完成 ==="
+            log "WARN" "新 Primary: $REPLICA_HOST（原 Replica 已提升）"
+            log "WARN" "原 Primary ($PRIMARY_HOST) 需要人工處理（重建為 Replica 或修復）"
+            log "WARN" "請參閱 docs/pg-failover.md 了解恢復步驟"
+
+            # 寫入狀態檔
+            echo "FAILOVER_COMPLETED=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "$STATE_FILE"
+            echo "NEW_PRIMARY=$REPLICA_HOST" >> "$STATE_FILE"
+            echo "OLD_PRIMARY=$PRIMARY_HOST" >> "$STATE_FILE"
+            return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+
+    log "ERROR" "Replica 提升超時（${max_wait}s），需要人工介入"
+    return 1
+}
+
+show_status() {
+    echo "═══════════════════════════════════════════════════"
+    echo " TITAN PostgreSQL Failover 狀態"
+    echo "═══════════════════════════════════════════════════"
+    echo ""
+
+    # 檢查 Primary
+    echo -n "Primary ($PRIMARY_HOST): "
+    if check_primary; then
+        echo "✅ 正常運行"
+        local primary_uptime
+        primary_uptime=$(timeout "$CHECK_TIMEOUT" psql -h "$PRIMARY_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+            "SELECT now() - pg_postmaster_start_time();" 2>/dev/null || echo "N/A")
+        echo "  運行時間: $primary_uptime"
+    else
+        echo "❌ 不可用"
+    fi
+
+    # 檢查 Replica
+    echo -n "Replica ($REPLICA_HOST): "
+    if check_replica; then
+        echo "✅ 正常（Standby 模式）"
+        local lag
+        lag=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc \
+            "SELECT CASE WHEN pg_last_wal_receive_lsn() IS NOT NULL
+                    THEN extract(epoch FROM now() - pg_last_xact_replay_timestamp())::int || 's'
+                    ELSE 'N/A' END;" 2>/dev/null || echo "N/A")
+        echo "  Replication lag: $lag"
+    else
+        # 可能已被提升為 Primary
+        local is_recovery
+        is_recovery=$(timeout "$CHECK_TIMEOUT" psql -h "$REPLICA_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -tAc "SELECT pg_is_in_recovery();" 2>/dev/null || echo "error")
+        if [ "$is_recovery" = "f" ]; then
+            echo "⚠️  已提升為 Primary（非 Standby 模式）"
+        else
+            echo "❌ 不可用"
+        fi
+    fi
+
+    # 檢查 failover 狀態
+    echo ""
+    if [ -f "$STATE_FILE" ]; then
+        echo "⚠️  Failover 記錄存在："
+        cat "$STATE_FILE"
+    else
+        echo "ℹ️  尚未發生 failover"
+    fi
+    echo ""
+}
+
+run_monitor() {
+    log "INFO" "TITAN PostgreSQL Failover Monitor 啟動"
+    log "INFO" "Primary: $PRIMARY_HOST, Replica: $REPLICA_HOST"
+    log "INFO" "檢查間隔: ${CHECK_INTERVAL}s, 容錯次數: $FAILURE_THRESHOLD"
+
+    local consecutive_failures=0
+
+    while true; do
+        if check_primary; then
+            if [ $consecutive_failures -gt 0 ]; then
+                log "INFO" "Primary 恢復正常（前次連續失敗 ${consecutive_failures} 次）"
+            fi
+            consecutive_failures=0
+        else
+            consecutive_failures=$((consecutive_failures + 1))
+            log "WARN" "Primary 健康檢查失敗 (${consecutive_failures}/${FAILURE_THRESHOLD})"
+
+            if [ $consecutive_failures -ge "$FAILURE_THRESHOLD" ]; then
+                log "WARN" "連續 ${FAILURE_THRESHOLD} 次失敗，觸發自動 failover"
+                if promote_replica; then
+                    log "WARN" "自動 failover 完成，Monitor 進入觀察模式"
+                    # Failover 後持續監控新 Primary 但不再觸發 failover
+                    while true; do
+                        sleep "$CHECK_INTERVAL"
+                        log "INFO" "[觀察模式] 新 Primary ($REPLICA_HOST) 運行中"
+                    done
+                else
+                    log "ERROR" "自動 failover 失敗！需要人工介入"
+                    # 持續嘗試但增加間隔，避免風暴
+                    consecutive_failures=0
+                    sleep 60
+                fi
+            fi
+        fi
+
+        sleep "$CHECK_INTERVAL"
+    done
+}
+
+# ── 主程式 ────────────────────────────────────────────────
+case "${1:-}" in
+    --auto)
+        run_monitor
+        ;;
+    --manual)
+        log "WARN" "手動 failover 觸發"
+        if check_primary; then
+            echo "⚠️  Primary ($PRIMARY_HOST) 目前正常運作！"
+            echo "確定要強制 failover 嗎？（這會造成短暫服務中斷）"
+            read -r -p "輸入 'YES' 確認: " confirm
+            if [ "$confirm" != "YES" ]; then
+                echo "已取消"
+                exit 0
+            fi
+        fi
+        promote_replica
+        ;;
+    --status)
+        show_status
+        ;;
+    *)
+        echo "用法: $0 {--auto|--manual|--status}"
+        echo ""
+        echo "  --auto    啟動自動監控（由 titan-pg-monitor 容器使用）"
+        echo "  --manual  手動觸發 failover（需確認）"
+        echo "  --status  顯示目前 Primary/Replica 狀態"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- Add `docker-compose.failover.yml` with `titan-pg-monitor` sidecar that continuously checks Primary health
- Add `scripts/pg-failover.sh` supporting `--auto`, `--manual`, and `--status` modes
- Add `docs/pg-failover.md` with architecture, operations guide, and recovery procedures
- Update `.env.example` with failover tuning variables

## Design Decisions
- **Shell-based approach** over pg_auto_failover/Patroni: simpler, fewer dependencies, suitable for 5-user air-gapped environment
- **Single-direction failover**: Replica promote only, manual recovery afterward (appropriate for the team size)
- **RTO ≤ 10 minutes**: Detection ~30s (3 checks x 10s) + promote ~60s + app reconnect
- **No changes to existing docker-compose.yml**: separate compose file, opt-in activation

## Usage
```bash
docker compose -f docker-compose.yml \
  -f docker-compose.replication.yml \
  -f docker-compose.failover.yml up -d
```

## Test plan
- [ ] Verify `docker compose -f ... config` parses without errors
- [ ] Start full stack and confirm `titan-pg-monitor` healthcheck passes
- [ ] Simulate Primary failure (`docker stop titan-postgres`) and verify Replica is promoted within 30-40 seconds
- [ ] Verify `--status` command shows correct state after failover
- [ ] Follow recovery steps in docs to rebuild old Primary as new Replica

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)