### PR TITLE
ci: add GitHub Actions CI pipeline for PR testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: titan
+          POSTGRES_PASSWORD: titan_test
+          POSTGRES_DB: titan_test
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Unit + Integration tests
+        run: npx jest --forceExit --coverage
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000
+
+      - name: Build
+        run: npm run build
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000
+
+      - name: Security audit
+        run: npm audit --audit-level=high || true


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with automated CI pipeline triggered on pull requests to `main`
- Pipeline includes: PostgreSQL 16 service, npm cache, Prisma generate, TypeScript type check, Jest tests with coverage, Next.js build, and security audit
- Security audit step uses `|| true` to allow known advisory failures without blocking the pipeline

Fixes #290

## Test plan

- [ ] Verify CI triggers on new PRs to `main`
- [ ] Confirm PostgreSQL service starts and is healthy
- [ ] Confirm `npx prisma generate` succeeds
- [ ] Confirm `tsc --noEmit` type check passes
- [ ] Confirm Jest tests run with `--forceExit --coverage`
- [ ] Confirm `npm run build` succeeds
- [ ] Confirm `npm audit` runs (allowed to fail gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)