### PR TITLE
fix(notifications): filter out suspended users from notifications

### DIFF
--- a/services/__tests__/notification-service.test.ts
+++ b/services/__tests__/notification-service.test.ts
@@ -32,6 +32,7 @@ describe("NotificationService", () => {
       backupAssigneeId: null,
     };
     (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
 
     const existingKeys = new Set<string>();
     const result = await service.buildDueSoonTaskNotifications(NOW, existingKeys);
@@ -55,6 +56,10 @@ describe("NotificationService", () => {
       backupAssigneeId: "user-b",
     };
     (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { id: "user-a" },
+      { id: "user-b" },
+    ]);
 
     const result = await service.buildDueSoonTaskNotifications(NOW, new Set());
 
@@ -62,6 +67,26 @@ describe("NotificationService", () => {
     const userIds = result.map((n) => n.userId);
     expect(userIds).toContain("user-a");
     expect(userIds).toContain("user-b");
+  });
+
+  test("excludes suspended users from TASK_DUE_SOON notifications", async () => {
+    const task = {
+      id: "task-suspended-1",
+      title: "停權測試任務",
+      dueDate: DUE_IN_3_DAYS,
+      primaryAssigneeId: "user-active",
+      backupAssigneeId: "user-suspended",
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    // Only active user returned — suspended user filtered by isActive: true
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { id: "user-active" },
+    ]);
+
+    const result = await service.buildDueSoonTaskNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe("user-active");
   });
 
   // ── MILESTONE_DUE ─────────────────────────────────────────────────────────
@@ -100,6 +125,24 @@ describe("NotificationService", () => {
     expect(result).toHaveLength(0);
   });
 
+  test("excludes suspended users from MILESTONE_DUE notifications", async () => {
+    const milestone = {
+      id: "ms-suspended-1",
+      title: "停權里程碑測試",
+      plannedEnd: DUE_IN_3_DAYS,
+    };
+    (prisma.milestone.findMany as jest.Mock).mockResolvedValue([milestone]);
+    // Only active user returned — suspended user filtered by isActive: true query
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([
+      { id: "user-active" },
+    ]);
+
+    const result = await service.buildDueSoonMilestoneNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].userId).toBe("user-active");
+  });
+
   // ── TASK_OVERDUE ──────────────────────────────────────────────────────────
 
   test("generates TASK_OVERDUE for past-due tasks", async () => {
@@ -111,6 +154,7 @@ describe("NotificationService", () => {
       backupAssigneeId: null,
     };
     (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-c" }]);
 
     const existingKeys = new Set<string>();
     const result = await service.buildOverdueTaskNotifications(NOW, existingKeys);
@@ -134,6 +178,23 @@ describe("NotificationService", () => {
     expect(result).toHaveLength(0);
   });
 
+  test("excludes suspended users from TASK_OVERDUE notifications", async () => {
+    const task = {
+      id: "task-suspended-2",
+      title: "停權逾期任務",
+      dueDate: TWO_DAYS_AGO,
+      primaryAssigneeId: "user-suspended",
+      backupAssigneeId: null,
+    };
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    // Suspended user not returned by active-only query
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await service.buildOverdueTaskNotifications(NOW, new Set());
+
+    expect(result).toHaveLength(0);
+  });
+
   // ── Duplicate prevention ──────────────────────────────────────────────────
 
   test("does not duplicate existing unread notifications", async () => {
@@ -145,6 +206,7 @@ describe("NotificationService", () => {
       backupAssigneeId: null,
     };
     (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
 
     // Pre-seed existing key so duplicate check fires
     const existingKeys = new Set<string>(["user-a:TASK_DUE_SOON:task-4"]);
@@ -192,7 +254,11 @@ describe("NotificationService", () => {
       .mockResolvedValueOnce([overdueTask]); // overdue query
 
     (prisma.milestone.findMany as jest.Mock).mockResolvedValue([]);
-    (prisma.user.findMany as jest.Mock).mockResolvedValue([{ id: "user-a" }]);
+    // user.findMany is called multiple times: due-soon active check, milestone query, overdue active check
+    (prisma.user.findMany as jest.Mock)
+      .mockResolvedValueOnce([{ id: "user-a" }])  // due soon active users
+      .mockResolvedValueOnce([{ id: "user-a" }])  // milestone active users
+      .mockResolvedValueOnce([{ id: "user-b" }]); // overdue active users
     (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
 
     const result = await service.generateAll(NOW);

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -37,6 +37,7 @@ export class NotificationService {
 
   /**
    * Builds notification payloads for tasks due within DAYS_AHEAD days.
+   * Only notifies active (non-suspended) users.
    */
   async buildDueSoonTaskNotifications(
     now: Date,
@@ -58,10 +59,26 @@ export class NotificationService {
       },
     });
 
+    // Collect all candidate user IDs and filter to active users only
+    const candidateIds = new Set(
+      tasks
+        .flatMap((t) => [t.primaryAssigneeId, t.backupAssigneeId])
+        .filter(Boolean) as string[]
+    );
+    const activeUsers =
+      candidateIds.size > 0
+        ? await this.prisma.user.findMany({
+            where: { id: { in: [...candidateIds] }, isActive: true },
+            select: { id: true },
+          })
+        : [];
+    const activeUserIds = new Set(activeUsers.map((u) => u.id));
+
     const result: NotificationInput[] = [];
     for (const task of tasks) {
       const userIds = [task.primaryAssigneeId, task.backupAssigneeId].filter(
-        (id): id is string => id !== null && id !== undefined
+        (id): id is string =>
+          id !== null && id !== undefined && activeUserIds.has(id)
       );
       const dueLabel = task.dueDate
         ? new Date(task.dueDate).toLocaleDateString("zh-TW")
@@ -87,7 +104,7 @@ export class NotificationService {
 
   /**
    * Builds notification payloads for milestones due within DAYS_AHEAD days.
-   * Notifies all users in the system.
+   * Notifies all active (non-suspended) users in the system.
    */
   async buildDueSoonMilestoneNotifications(
     now: Date,
@@ -103,7 +120,10 @@ export class NotificationService {
         },
         select: { id: true, title: true, plannedEnd: true },
       }),
-      this.prisma.user.findMany({ select: { id: true } }),
+      this.prisma.user.findMany({
+        where: { isActive: true },
+        select: { id: true },
+      }),
     ]);
 
     const result: NotificationInput[] = [];
@@ -129,6 +149,7 @@ export class NotificationService {
 
   /**
    * Builds notification payloads for overdue tasks (past due date, not done).
+   * Only notifies active (non-suspended) users.
    */
   async buildOverdueTaskNotifications(
     now: Date,
@@ -148,10 +169,26 @@ export class NotificationService {
       },
     });
 
+    // Collect all candidate user IDs and filter to active users only
+    const candidateIds = new Set(
+      tasks
+        .flatMap((t) => [t.primaryAssigneeId, t.backupAssigneeId])
+        .filter(Boolean) as string[]
+    );
+    const activeUsers =
+      candidateIds.size > 0
+        ? await this.prisma.user.findMany({
+            where: { id: { in: [...candidateIds] }, isActive: true },
+            select: { id: true },
+          })
+        : [];
+    const activeUserIds = new Set(activeUsers.map((u) => u.id));
+
     const result: NotificationInput[] = [];
     for (const task of tasks) {
       const userIds = [task.primaryAssigneeId, task.backupAssigneeId].filter(
-        (id): id is string => id !== null && id !== undefined
+        (id): id is string =>
+          id !== null && id !== undefined && activeUserIds.has(id)
       );
       const dueLabel = task.dueDate
         ? new Date(task.dueDate).toLocaleDateString("zh-TW")
@@ -197,7 +234,9 @@ export class NotificationService {
 
     let created = 0;
     if (toCreate.length > 0) {
-      const result = await this.prisma.notification.createMany({ data: toCreate });
+      const result = await this.prisma.notification.createMany({
+        data: toCreate,
+      });
       created = result.count;
     }
 


### PR DESCRIPTION
## Summary
- Add `isActive: true` filter to all user queries in `NotificationService` so suspended users no longer receive notifications (CR-07)
- `buildDueSoonMilestoneNotifications`: filter milestone user query with `where: { isActive: true }`
- `buildDueSoonTaskNotifications` / `buildOverdueTaskNotifications`: lookup active users and filter assignees against that set
- Add 3 new tests verifying suspended users are excluded from each notification type

## Test plan
- [x] All 13 notification service tests pass (10 existing + 3 new)
- [ ] Verify no notifications are sent to suspended users in staging

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)