### PR TITLE
fix(api): resolve assignee=me to actual session userId

### DIFF
--- a/__tests__/api/tasks.test.ts
+++ b/__tests__/api/tasks.test.ts
@@ -92,6 +92,20 @@ describe("GET /api/tasks", () => {
     );
   });
 
+  it("resolves assignee=me to session userId", async () => {
+    const { GET } = await import("@/app/api/tasks/route");
+    await GET(createMockRequest("/api/tasks", { searchParams: { assignee: "me" } }));
+    expect(mockTask.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            expect.objectContaining({ primaryAssigneeId: MEMBER_SESSION.user.id }),
+          ]),
+        }),
+      })
+    );
+  });
+
   it("passes status filter to prisma", async () => {
     const { GET } = await import("@/app/api/tasks/route");
     await GET(createMockRequest("/api/tasks", { searchParams: { status: "TODO" } }));

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -12,8 +12,16 @@ const taskService = new TaskService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
+
+  // Resolve "me" to the actual session userId (CR-19 / Issue #284)
+  let assignee = searchParams.get("assignee") ?? undefined;
+  if (assignee === "me") {
+    const session = await requireAuth();
+    assignee = session.user.id;
+  }
+
   const tasks = await taskService.listTasks({
-    assignee: searchParams.get("assignee") ?? undefined,
+    assignee,
     status: (searchParams.get("status") as TaskStatus) ?? undefined,
     priority: (searchParams.get("priority") as Priority) ?? undefined,
     category: (searchParams.get("category") as TaskCategory) ?? undefined,


### PR DESCRIPTION
## Summary

- **Bug**: Dashboard `EngineerDashboard` calls `/api/tasks?assignee=me` but the API route passed `"me"` literally to `taskService.listTasks`, which never matched any real user
- **Fix**: In `GET /api/tasks`, when `assignee === "me"`, call `requireAuth()` to get the session and substitute `session.user.id`
- **Test**: Added test case verifying `?assignee=me` resolves to the session user's actual ID before querying Prisma

Fixes #284

## Test plan

- [x] Existing 21 tests still pass
- [x] New test `resolves assignee=me to session userId` passes (22/22 total)
- [ ] Manual: Log in as ENGINEER, open Dashboard, verify tasks load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)