### PR TITLE
fix(security): add Zod validation for subtask endpoints

### DIFF
--- a/app/api/subtasks/[id]/route.ts
+++ b/app/api/subtasks/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { ValidationError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { updateSubTaskSchema } from "@/validators/subtask-validators";
 
 export const PATCH = withAuth(async (
   req: NextRequest,
@@ -9,14 +11,24 @@ export const PATCH = withAuth(async (
 ) => {
   const { id } = await context.params;
   const body = await req.json();
+  const parsed = updateSubTaskSchema.safeParse(body);
+
+  if (!parsed.success) {
+    throw new ValidationError(
+      parsed.error.issues.map((i) => i.message).join("; "),
+    );
+  }
+
+  const { done, title, assigneeId, dueDate, order } = parsed.data;
 
   const subtask = await prisma.subTask.update({
     where: { id },
     data: {
-      ...(body.done !== undefined && { done: body.done }),
-      ...(body.title !== undefined && { title: body.title }),
-      ...(body.assigneeId !== undefined && { assigneeId: body.assigneeId || null }),
-      ...(body.dueDate !== undefined && { dueDate: body.dueDate ? new Date(body.dueDate) : null }),
+      ...(done !== undefined && { done }),
+      ...(title !== undefined && { title }),
+      ...(assigneeId !== undefined && { assigneeId: assigneeId ?? null }),
+      ...(dueDate !== undefined && { dueDate: dueDate ? new Date(dueDate) : null }),
+      ...(order !== undefined && { order }),
     },
   });
 

--- a/app/api/subtasks/route.ts
+++ b/app/api/subtasks/route.ts
@@ -3,23 +3,27 @@ import { prisma } from "@/lib/prisma";
 import { ValidationError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { createSubTaskSchema } from "@/validators/subtask-validators";
 
 export const POST = withAuth(async (req: NextRequest) => {
-
   const body = await req.json();
-  const { taskId, title, assigneeId, dueDate, order } = body;
+  const parsed = createSubTaskSchema.safeParse(body);
 
-  if (!taskId || !title) {
-    throw new ValidationError("taskId 和標題為必填");
+  if (!parsed.success) {
+    throw new ValidationError(
+      parsed.error.issues.map((i) => i.message).join("; "),
+    );
   }
+
+  const { taskId, title, assigneeId, dueDate, order } = parsed.data;
 
   const subtask = await prisma.subTask.create({
     data: {
       taskId,
       title,
-      assigneeId: assigneeId || null,
+      assigneeId: assigneeId ?? null,
       dueDate: dueDate ? new Date(dueDate) : null,
-      order: order ?? 0,
+      order,
     },
   });
 

--- a/validators/__tests__/subtask-validators.test.ts
+++ b/validators/__tests__/subtask-validators.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment node
+ */
+import {
+  createSubTaskSchema,
+  updateSubTaskSchema,
+} from "../subtask-validators";
+
+describe("createSubTaskSchema", () => {
+  const validInput = {
+    taskId: "task-id-123",
+    title: "Write unit tests",
+  };
+
+  test("accepts valid minimal input", () => {
+    const result = createSubTaskSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.order).toBe(0);
+    }
+  });
+
+  test("accepts valid input with all optional fields", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      assigneeId: "user-id-1",
+      dueDate: "2026-12-31T00:00:00.000Z",
+      order: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts null assigneeId", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      assigneeId: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts null dueDate", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      dueDate: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing taskId", () => {
+    const { taskId: _taskId, ...rest } = validInput;
+    const result = createSubTaskSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty taskId", () => {
+    const result = createSubTaskSchema.safeParse({ ...validInput, taskId: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing title", () => {
+    const { title: _title, ...rest } = validInput;
+    const result = createSubTaskSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty title", () => {
+    const result = createSubTaskSchema.safeParse({ ...validInput, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-datetime dueDate", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      dueDate: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative order", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      order: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-integer order", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      order: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("strips unknown fields", () => {
+    const result = createSubTaskSchema.safeParse({
+      ...validInput,
+      malicious: "<script>alert(1)</script>",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).malicious).toBeUndefined();
+    }
+  });
+});
+
+describe("updateSubTaskSchema", () => {
+  test("accepts partial update with only title", () => {
+    const result = updateSubTaskSchema.safeParse({ title: "New Title" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts partial update with only done", () => {
+    const result = updateSubTaskSchema.safeParse({ done: true });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty object (no fields)", () => {
+    const result = updateSubTaskSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts null assigneeId for unassign", () => {
+    const result = updateSubTaskSchema.safeParse({ assigneeId: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts null dueDate for clearing", () => {
+    const result = updateSubTaskSchema.safeParse({ dueDate: null });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty title", () => {
+    const result = updateSubTaskSchema.safeParse({ title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-boolean done", () => {
+    const result = updateSubTaskSchema.safeParse({ done: "yes" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects non-datetime dueDate string", () => {
+    const result = updateSubTaskSchema.safeParse({ dueDate: "tomorrow" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects negative order", () => {
+    const result = updateSubTaskSchema.safeParse({ order: -3 });
+    expect(result.success).toBe(false);
+  });
+});

--- a/validators/subtask-validators.ts
+++ b/validators/subtask-validators.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const createSubTaskSchema = z.object({
+  taskId: z.string().min(1),
+  title: z.string().min(1),
+  assigneeId: z.string().nullable().optional(),
+  dueDate: z.string().datetime().nullable().optional(),
+  order: z.number().int().nonnegative().optional().default(0),
+});
+
+export const updateSubTaskSchema = z.object({
+  title: z.string().min(1).optional(),
+  done: z.boolean().optional(),
+  assigneeId: z.string().nullable().optional(),
+  dueDate: z.string().datetime().nullable().optional(),
+  order: z.number().int().nonnegative().optional(),
+});
+
+export type CreateSubTaskInput = z.infer<typeof createSubTaskSchema>;
+export type UpdateSubTaskInput = z.infer<typeof updateSubTaskSchema>;


### PR DESCRIPTION
## Summary
- **新增** `validators/subtask-validators.ts`：定義 `createSubTaskSchema` 與 `updateSubTaskSchema`，驗證 subtask 輸入（類型、必填、範圍）
- **修改** `POST /api/subtasks` 與 `PATCH /api/subtasks/[id]`：將手動驗證替換為 Zod schema 解析，拒絕不合規 payload 並自動移除未知欄位
- **新增** 21 個單元測試覆蓋合法/非法輸入情境（空值、null、錯誤型別、負數、未知欄位等）

Fixes #283

## Test plan
- [x] `createSubTaskSchema` 接受最小合法輸入（taskId + title）
- [x] `createSubTaskSchema` 拒絕空 taskId、空 title、非 datetime 的 dueDate、負數 order
- [x] `updateSubTaskSchema` 接受部分更新（僅 title / 僅 done）
- [x] `updateSubTaskSchema` 拒絕非 boolean done、非 datetime dueDate
- [x] 未知欄位自動被 Zod strip 掉（防止注入額外資料）
- [x] 所有 21 個測試通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)