### PR TITLE
fix(documents): only create version snapshot when content changes

### DIFF
--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -41,20 +41,25 @@ export const PUT = withAuth(async (
   const existing = await prisma.document.findUnique({ where: { id } });
   if (!existing) throw new NotFoundError("文件不存在");
 
-  const newVersion = existing.version + 1;
+  const contentChanged = content !== undefined && content !== existing.content;
 
-  await prisma.documentVersion.create({
-    data: {
-      documentId: id,
-      content: existing.content,
-      version: existing.version,
-      createdBy: session.user.id,
-    },
-  });
+  if (contentChanged) {
+    await prisma.documentVersion.create({
+      data: {
+        documentId: id,
+        content: existing.content,
+        version: existing.version,
+        createdBy: session.user.id,
+      },
+    });
+  }
 
-  const updates: Record<string, unknown> = { updatedBy: session.user.id, version: newVersion };
+  const updates: Record<string, unknown> = { updatedBy: session.user.id };
   if (title !== undefined) updates.title = title;
-  if (content !== undefined) updates.content = content;
+  if (contentChanged) {
+    updates.content = content;
+    updates.version = existing.version + 1;
+  }
   if (parentId !== undefined) updates.parentId = parentId || null;
 
   const doc = await prisma.document.update({


### PR DESCRIPTION
## Summary
- Document PUT endpoint now compares incoming content with existing content before creating a DocumentVersion snapshot
- Version number only increments when content actually changes
- Title-only or parentId-only updates no longer create spurious version snapshots

## Test plan
- [ ] PUT a document with identical content — verify no new DocumentVersion is created
- [ ] PUT a document with changed content — verify DocumentVersion snapshot is created
- [ ] PUT a document with only title change — verify version number stays the same

Fixes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)