### PR TITLE
feat(security): integrate AuditService into route handlers

### DIFF
--- a/__tests__/api/audit-integration.test.ts
+++ b/__tests__/api/audit-integration.test.ts
@@ -1,0 +1,390 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests: AuditService integration in route handlers — Issue #275
+ *
+ * Verifies that P0 security events produce audit log entries
+ * with correct fields (userId, action, resourceType, resourceId, ipAddress).
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+const mockAuditLog = { create: jest.fn() };
+const mockUser = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  findFirst: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  upsert: jest.fn(),
+  count: jest.fn(),
+  aggregate: jest.fn(),
+  deleteMany: jest.fn(),
+  updateMany: jest.fn(),
+  createMany: jest.fn(),
+};
+const mockTask = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  findFirst: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  upsert: jest.fn(),
+  count: jest.fn(),
+  aggregate: jest.fn(),
+  deleteMany: jest.fn(),
+  updateMany: jest.fn(),
+  createMany: jest.fn(),
+};
+const mockDocument = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  findFirst: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  upsert: jest.fn(),
+  count: jest.fn(),
+  aggregate: jest.fn(),
+  deleteMany: jest.fn(),
+  updateMany: jest.fn(),
+  createMany: jest.fn(),
+};
+const mockPermission = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  findFirst: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  upsert: jest.fn(),
+  count: jest.fn(),
+  aggregate: jest.fn(),
+  deleteMany: jest.fn(),
+  updateMany: jest.fn(),
+  createMany: jest.fn(),
+};
+const mockTaskChange = { create: jest.fn() };
+const mockTaskActivity = { create: jest.fn() };
+const mockTransaction = jest.fn();
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: mockUser,
+    task: mockTask,
+    document: mockDocument,
+    permission: mockPermission,
+    auditLog: mockAuditLog,
+    taskChange: mockTaskChange,
+    taskActivity: mockTaskActivity,
+    $transaction: mockTransaction,
+  },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
+// ── Session fixtures ─────────────────────────────────────────────────────
+const MANAGER_SESSION = {
+  user: { id: "manager-1", name: "Manager", email: "mgr@test.com", role: "MANAGER" },
+  expires: "2099-01-01",
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+function createRequestWithIp(
+  url: string,
+  options?: { method?: string; body?: unknown; searchParams?: Record<string, string> }
+) {
+  const req = createMockRequest(url, options);
+  // Add x-forwarded-for header
+  (req.headers as Headers).set("x-forwarded-for", "203.0.113.50");
+  return req;
+}
+
+// ── POST /api/users (CREATE_USER) ────────────────────────────────────────
+describe("POST /api/users — audit CREATE_USER", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-1" });
+  });
+
+  it("creates audit log entry after creating a user", async () => {
+    const newUser = { id: "user-new", name: "New User", email: "new@test.com", role: "ENGINEER" };
+    mockUser.findUnique.mockResolvedValue(null); // for duplicate check
+    mockUser.create.mockResolvedValue(newUser);
+
+    const { POST } = await import("@/app/api/users/route");
+    const req = createRequestWithIp("/api/users", {
+      method: "POST",
+      body: { name: "New User", email: "new@test.com", password: "SecureP@ss1!", role: "ENGINEER" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "CREATE_USER",
+          resourceType: "User",
+          resourceId: "user-new",
+          ipAddress: "203.0.113.50",
+        }),
+      })
+    );
+  });
+
+  it("does NOT log password in audit detail", async () => {
+    const newUser = { id: "user-new", name: "New User", email: "new@test.com", role: "ENGINEER" };
+    mockUser.findUnique.mockResolvedValue(null);
+    mockUser.create.mockResolvedValue(newUser);
+
+    const { POST } = await import("@/app/api/users/route");
+    const req = createRequestWithIp("/api/users", {
+      method: "POST",
+      body: { name: "New User", email: "new@test.com", password: "SecureP@ss1!", role: "ENGINEER" },
+    });
+    await POST(req);
+
+    const auditDetail = (mockAuditLog.create as jest.Mock).mock.calls[0]?.[0]?.data?.detail;
+    expect(auditDetail).not.toContain("SecureP@ss1!");
+    // The field name "password" may appear in change tracking with redacted values
+    // but the actual password value must never be logged
+    expect(auditDetail).not.toContain("NewSecret123!");
+  });
+});
+
+// ── PUT /api/users/[id] (UPDATE_USER) ────────────────────────────────────
+describe("PUT /api/users/[id] — audit UPDATE_USER", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-2" });
+  });
+
+  it("creates audit log entry after updating a user", async () => {
+    const updated = { id: "user-1", name: "Updated", email: "u@test.com", role: "ENGINEER" };
+    mockUser.findUnique.mockResolvedValue(updated);
+    mockUser.update.mockResolvedValue(updated);
+
+    const { PUT } = await import("@/app/api/users/[id]/route");
+    const req = createRequestWithIp("/api/users/user-1", {
+      method: "PUT",
+      body: { name: "Updated" },
+    });
+    const res = await PUT(req, { params: Promise.resolve({ id: "user-1" }) });
+
+    expect(res.status).toBe(200);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "UPDATE_USER",
+          resourceType: "User",
+          resourceId: "user-1",
+          ipAddress: "203.0.113.50",
+        }),
+      })
+    );
+  });
+
+  it("excludes password from audit detail on user update", async () => {
+    const updated = { id: "user-1", name: "U", email: "u@test.com", role: "ENGINEER" };
+    mockUser.findUnique.mockResolvedValue(updated);
+    mockUser.update.mockResolvedValue(updated);
+
+    const { PUT } = await import("@/app/api/users/[id]/route");
+    const req = createRequestWithIp("/api/users/user-1", {
+      method: "PUT",
+      body: { name: "U", password: "NewSecret123!" },
+    });
+    await PUT(req, { params: Promise.resolve({ id: "user-1" }) });
+
+    const auditDetail = (mockAuditLog.create as jest.Mock).mock.calls[0]?.[0]?.data?.detail;
+    expect(auditDetail).not.toContain("NewSecret123!");
+    // The field name "password" may appear in change tracking with redacted values
+    // but the actual password value must never be logged
+    expect(auditDetail).not.toContain("NewSecret123!");
+  });
+});
+
+// ── DELETE /api/users/[id] (SUSPEND_USER) ────────────────────────────────
+describe("DELETE /api/users/[id] — audit SUSPEND_USER", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-3" });
+  });
+
+  it("creates audit log for suspend", async () => {
+    mockUser.findUnique.mockResolvedValue({ id: "user-1", isSuspended: false });
+    mockUser.update.mockResolvedValue({ id: "user-1", isSuspended: true });
+
+    const { DELETE } = await import("@/app/api/users/[id]/route");
+    const req = createRequestWithIp("/api/users/user-1", { method: "DELETE" });
+    await DELETE(req, { params: Promise.resolve({ id: "user-1" }) });
+
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "SUSPEND_USER",
+          resourceType: "User",
+          resourceId: "user-1",
+        }),
+      })
+    );
+  });
+
+  it("creates audit log for unsuspend", async () => {
+    mockUser.findUnique.mockResolvedValue({ id: "user-1", isSuspended: true });
+    mockUser.update.mockResolvedValue({ id: "user-1", isSuspended: false });
+
+    const { DELETE } = await import("@/app/api/users/[id]/route");
+    const req = createRequestWithIp("/api/users/user-1?action=unsuspend", {
+      method: "DELETE",
+      searchParams: { action: "unsuspend" },
+    });
+    await DELETE(req, { params: Promise.resolve({ id: "user-1" }) });
+
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "UNSUSPEND_USER",
+          resourceType: "User",
+          resourceId: "user-1",
+        }),
+      })
+    );
+  });
+});
+
+// ── POST /api/permissions (GRANT_PERMISSION) ─────────────────────────────
+describe("POST /api/permissions — audit GRANT_PERMISSION", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-4" });
+  });
+
+  it("creates audit log after granting permission", async () => {
+    const perm = { id: "perm-1", granteeId: "user-2", permType: "VIEW_TEAM" };
+    mockPermission.create.mockResolvedValue(perm);
+
+    const { POST } = await import("@/app/api/permissions/route");
+    const req = createRequestWithIp("/api/permissions", {
+      method: "POST",
+      body: { granteeId: "user-2", permType: "VIEW_TEAM" },
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(201);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "GRANT_PERMISSION",
+          resourceType: "Permission",
+          resourceId: "perm-1",
+          ipAddress: "203.0.113.50",
+        }),
+      })
+    );
+  });
+});
+
+// ── DELETE /api/permissions (REVOKE_PERMISSION) ──────────────────────────
+describe("DELETE /api/permissions — audit REVOKE_PERMISSION", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-5" });
+  });
+
+  it("creates audit log after revoking permission", async () => {
+    mockPermission.updateMany.mockResolvedValue({ count: 1 });
+
+    const { DELETE } = await import("@/app/api/permissions/route");
+    const req = createRequestWithIp("/api/permissions", {
+      method: "DELETE",
+      body: { granteeId: "user-2", permType: "VIEW_TEAM" },
+    });
+    await DELETE(req);
+
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "REVOKE_PERMISSION",
+          resourceType: "Permission",
+        }),
+      })
+    );
+  });
+});
+
+// ── DELETE /api/tasks/[id] (DELETE_TASK) ─────────────────────────────────
+describe("DELETE /api/tasks/[id] — audit DELETE_TASK", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-6" });
+  });
+
+  it("creates audit log after deleting a task", async () => {
+    mockTask.findUnique.mockResolvedValue({ id: "task-1", title: "Test" });
+    mockTask.delete.mockResolvedValue({ id: "task-1" });
+
+    const { DELETE } = await import("@/app/api/tasks/[id]/route");
+    const req = createRequestWithIp("/api/tasks/task-1", { method: "DELETE" });
+    const res = await DELETE(req, { params: Promise.resolve({ id: "task-1" }) });
+
+    expect(res.status).toBe(200);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "DELETE_TASK",
+          resourceType: "Task",
+          resourceId: "task-1",
+          ipAddress: "203.0.113.50",
+        }),
+      })
+    );
+  });
+});
+
+// ── DELETE /api/documents/[id] (DELETE_DOCUMENT) ─────────────────────────
+describe("DELETE /api/documents/[id] — audit DELETE_DOCUMENT", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-7" });
+  });
+
+  it("creates audit log after deleting a document", async () => {
+    mockDocument.delete.mockResolvedValue({ id: "doc-1" });
+
+    const { DELETE } = await import("@/app/api/documents/[id]/route");
+    const req = createRequestWithIp("/api/documents/doc-1", { method: "DELETE" });
+    const res = await DELETE(req, { params: Promise.resolve({ id: "doc-1" }) });
+
+    expect(res.status).toBe(200);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "manager-1",
+          action: "DELETE_DOCUMENT",
+          resourceType: "Document",
+          resourceId: "doc-1",
+          ipAddress: "203.0.113.50",
+        }),
+      })
+    );
+  });
+});

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -13,6 +13,7 @@ import { success, error } from "@/lib/api-response";
 import { isPasswordValid, PASSWORD_POLICY_DESCRIPTION } from "@/lib/password-policy";
 import { AuditService } from "@/services/audit-service";
 import { logger } from "@/lib/logger";
+import { getClientIp } from "@/lib/get-client-ip";
 
 const auditService = new AuditService(prisma);
 
@@ -88,13 +89,14 @@ export async function POST(req: NextRequest) {
     }),
   ]);
 
-  // Audit log
+  // Audit log — never log password values
   await auditService.log({
     userId,
     action: "PASSWORD_CHANGE",
     resourceType: "User",
     resourceId: userId,
     detail: "Password changed by user (policy compliance)",
+    ipAddress: getClientIp(req),
   });
 
   logger.info({ userId }, "[auth] Password changed successfully");

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { NotFoundError } from "@/services/errors";
+import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { updateDocumentSchema } from "@/validators/document-validators";
 import { withAuth, withManager } from "@/lib/auth-middleware";
-import { requireAuth } from "@/lib/rbac";
+import { requireAuth, requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { getClientIp } from "@/lib/get-client-ip";
+
+const auditService = new AuditService(prisma);
 
 export const GET = withAuth(async (
   _req: NextRequest,
@@ -70,10 +74,21 @@ export const PUT = withAuth(async (
 });
 
 export const DELETE = withManager(async (
-  _req: NextRequest,
+  req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
+  const session = await requireRole("MANAGER");
   const { id } = await context.params;
   await prisma.document.delete({ where: { id } });
+
+  await auditService.log({
+    userId: session.user.id,
+    action: "DELETE_DOCUMENT",
+    resourceType: "Document",
+    resourceId: id,
+    detail: null,
+    ipAddress: getClientIp(req),
+  });
+
   return success({ success: true });
 });

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest } from "next/server";
 import { ValidationError } from "@/services/errors";
 import { withManager } from "@/lib/auth-middleware";
-import { requireAuth } from "@/lib/rbac";
+import { requireAuth, requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
 import { PermissionService } from "@/services/permission-service";
+import { AuditService } from "@/services/audit-service";
 import { prisma } from "@/lib/prisma";
+import { getClientIp } from "@/lib/get-client-ip";
 
 const permissionService = new PermissionService(prisma);
+const auditService = new AuditService(prisma);
 
 /** GET /api/permissions — list all permissions (MANAGER only) */
 export const GET = withManager(async (req: NextRequest) => {
@@ -45,11 +48,21 @@ export const POST = withManager(async (req: NextRequest) => {
     expiresAt: expiresAt ? new Date(expiresAt) : null,
   });
 
+  await auditService.log({
+    userId: session.user.id,
+    action: "GRANT_PERMISSION",
+    resourceType: "Permission",
+    resourceId: permission.id,
+    detail: JSON.stringify({ granteeId, permType, targetId: targetId ?? null }),
+    ipAddress: getClientIp(req),
+  });
+
   return success(permission, 201);
 });
 
 /** DELETE /api/permissions — revoke a permission (MANAGER only) */
 export const DELETE = withManager(async (req: NextRequest) => {
+  const session = await requireRole("MANAGER");
   const body = await req.json();
   const { granteeId, permType, targetId } = body;
 
@@ -61,6 +74,15 @@ export const DELETE = withManager(async (req: NextRequest) => {
     granteeId,
     permType,
     targetId: targetId ?? null,
+  });
+
+  await auditService.log({
+    userId: session.user.id,
+    action: "REVOKE_PERMISSION",
+    resourceType: "Permission",
+    resourceId: null,
+    detail: JSON.stringify({ granteeId, permType, targetId: targetId ?? null }),
+    ipAddress: getClientIp(req),
   });
 
   return success({ message: "已撤銷授權" });

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,13 +1,16 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { TaskService } from "@/services/task-service";
+import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { updateTaskSchema, updateTaskStatusSchema } from "@/validators/task-validators";
 import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
-import { requireAuth } from "@/lib/rbac";
+import { requireAuth, requireRole } from "@/lib/rbac";
+import { getClientIp } from "@/lib/get-client-ip";
 
 const taskService = new TaskService(prisma);
+const auditService = new AuditService(prisma);
 
 export const GET = withAuth(async (
   req: NextRequest,
@@ -33,8 +36,19 @@ export const DELETE = withManager(async (
   req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
+  const session = await requireRole("MANAGER");
   const { id } = await context.params;
   await taskService.deleteTask(id);
+
+  await auditService.log({
+    userId: session.user.id,
+    action: "DELETE_TASK",
+    resourceType: "Task",
+    resourceId: id,
+    detail: null,
+    ipAddress: getClientIp(req),
+  });
+
   return success({ success: true });
 });
 

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { UserService } from "@/services/user-service";
+import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { updateUserSchema } from "@/validators/user-validators";
 import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { getClientIp } from "@/lib/get-client-ip";
 
 const userService = new UserService(prisma);
+const auditService = new AuditService(prisma);
 
 export const GET = withAuth(async (
   req: NextRequest,
@@ -21,10 +25,23 @@ export const PUT = withManager(async (
   req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
+  const session = await requireRole("MANAGER");
   const { id } = await context.params;
   const raw = await req.json();
   const body = validateBody(updateUserSchema, raw);
   const user = await userService.updateUser(id, body);
+
+  // Exclude sensitive fields from audit detail
+  const { password: _pw, ...safeBody } = body as Record<string, unknown>;
+  await auditService.log({
+    userId: session.user.id,
+    action: "UPDATE_USER",
+    resourceType: "User",
+    resourceId: id,
+    detail: JSON.stringify(safeBody),
+    ipAddress: getClientIp(req),
+  });
+
   return success(user);
 });
 
@@ -32,16 +49,33 @@ export const DELETE = withManager(async (
   req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
+  const session = await requireRole("MANAGER");
   const { id } = await context.params;
   const { searchParams } = new URL(req.url);
   const action = searchParams.get("action");
 
   if (action === "unsuspend") {
     const user = await userService.unsuspendUser(id);
+    await auditService.log({
+      userId: session.user.id,
+      action: "UNSUSPEND_USER",
+      resourceType: "User",
+      resourceId: id,
+      detail: JSON.stringify({ action: "unsuspend" }),
+      ipAddress: getClientIp(req),
+    });
     return success(user);
   }
 
   // Default DELETE action = suspend
   const user = await userService.suspendUser(id);
+  await auditService.log({
+    userId: session.user.id,
+    action: "SUSPEND_USER",
+    resourceType: "User",
+    resourceId: id,
+    detail: JSON.stringify({ action: "suspend" }),
+    ipAddress: getClientIp(req),
+  });
   return success(user);
 });

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { UserService } from "@/services/user-service";
+import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { createUserSchema } from "@/validators/user-validators";
 import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { getClientIp } from "@/lib/get-client-ip";
 
 const userService = new UserService(prisma);
+const auditService = new AuditService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
@@ -17,8 +21,19 @@ export const GET = withAuth(async (req: NextRequest) => {
 });
 
 export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireRole("MANAGER");
   const raw = await req.json();
   const body = validateBody(createUserSchema, raw);
   const user = await userService.createUser(body);
+
+  await auditService.log({
+    userId: session.user.id,
+    action: "CREATE_USER",
+    resourceType: "User",
+    resourceId: user.id,
+    detail: JSON.stringify({ name: user.name, email: user.email, role: user.role }),
+    ipAddress: getClientIp(req),
+  });
+
   return success(user, 201);
 });

--- a/lib/__tests__/get-client-ip.test.ts
+++ b/lib/__tests__/get-client-ip.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment node
+ */
+import { getClientIp } from "../get-client-ip";
+import { NextRequest } from "next/server";
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers);
+  return { headers: h } as unknown as NextRequest;
+}
+
+describe("getClientIp", () => {
+  it("returns first IP from x-forwarded-for", () => {
+    expect(getClientIp(makeReq({ "x-forwarded-for": "203.0.113.50, 10.0.0.1" }))).toBe("203.0.113.50");
+  });
+
+  it("returns x-real-ip when x-forwarded-for is absent", () => {
+    expect(getClientIp(makeReq({ "x-real-ip": "198.51.100.1" }))).toBe("198.51.100.1");
+  });
+
+  it("prefers x-forwarded-for over x-real-ip", () => {
+    expect(
+      getClientIp(makeReq({ "x-forwarded-for": "203.0.113.50", "x-real-ip": "198.51.100.1" }))
+    ).toBe("203.0.113.50");
+  });
+
+  it("returns null when no IP headers present", () => {
+    expect(getClientIp(makeReq())).toBeNull();
+  });
+
+  it("trims whitespace from IP", () => {
+    expect(getClientIp(makeReq({ "x-forwarded-for": "  203.0.113.50  " }))).toBe("203.0.113.50");
+  });
+});

--- a/lib/get-client-ip.ts
+++ b/lib/get-client-ip.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+
+/**
+ * Extracts the client IP address from a Next.js request.
+ * Checks x-forwarded-for first (proxy/load balancer), then x-real-ip.
+ * Returns null if neither header is present.
+ */
+export function getClientIp(req: NextRequest): string | null {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip")?.trim() ??
+    null
+  );
+}


### PR DESCRIPTION
## Summary

- Integrates `AuditService.log()` into all P0 security event route handlers, resolving the compliance gap where audit logs were implemented but never called
- Adds audit logging for: User CRUD (`CREATE_USER`, `UPDATE_USER`, `SUSPEND_USER`, `UNSUSPEND_USER`), Permission changes (`GRANT_PERMISSION`, `REVOKE_PERMISSION`), Task deletion (`DELETE_TASK`), Document deletion (`DELETE_DOCUMENT`)
- Adds `ipAddress` to the existing password change audit log (was missing)
- Creates `lib/get-client-ip.ts` utility for consistent IP extraction across all routes
- Sensitive fields (password values) are excluded from audit detail

## Test plan

- [x] 5 unit tests for `getClientIp` utility — all pass
- [x] 10 integration tests verifying audit log creation for each P0 event — all pass
- [x] Existing task, document, permission, and audit-service tests — no regressions
- [ ] Manual verification: trigger each operation and confirm audit_logs table entries

Fixes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)