### PR TITLE
fix(api): sanitize Zod validation errors to prevent internal leak

### DIFF
--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -18,7 +18,10 @@ export const GET = withAuth(async (req: NextRequest) => {
   });
 
   if (!query.success) {
-    throw new ValidationError(query.error.issues.map((e) => e.message).join(", "));
+    const flat = query.error.flatten();
+    throw new ValidationError(
+      JSON.stringify({ error: "輸入驗證失敗", fields: flat.fieldErrors })
+    );
   }
 
   const service = new DeliverableService(prisma);
@@ -31,7 +34,10 @@ export const POST = withManager(async (req: NextRequest) => {
   const parsed = createDeliverableSchema.safeParse(body);
 
   if (!parsed.success) {
-    throw new ValidationError(parsed.error.issues.map((e) => e.message).join(", "));
+    const flat = parsed.error.flatten();
+    throw new ValidationError(
+      JSON.stringify({ error: "輸入驗證失敗", fields: flat.fieldErrors })
+    );
   }
 
   const service = new DeliverableService(prisma);

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -8,8 +8,13 @@ import { ValidationError } from "@/services/errors";
 export function validateBody<T>(schema: ZodSchema<T>, body: unknown): T {
   const result = schema.safeParse(body);
   if (!result.success) {
-    const formatted = (result.error as ZodError).format();
-    throw new ValidationError(JSON.stringify(formatted));
+    const flat = (result.error as ZodError).flatten();
+    throw new ValidationError(
+      JSON.stringify({
+        error: "輸入驗證失敗",
+        fields: flat.fieldErrors,
+      })
+    );
   }
   return result.data;
 }


### PR DESCRIPTION
## Summary
- Replace raw Zod `.format()` tree in `lib/validate.ts` with flattened `{ error: "輸入驗證失敗", fields: fieldErrors }` 
- Replace raw `.issues` array in `app/api/deliverables/route.ts` with same sanitized format
- Prevents internal schema structure from leaking to API consumers

## Test plan
- [ ] Send invalid payload to any validated endpoint — verify response shows `fields` with field-level errors only
- [ ] Verify no Zod internal paths (`_errors`, nested format tree) appear in responses

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)