### PR TITLE
fix(notifications): use batch read-all endpoint instead of N concurrent PATCHes

### DIFF
--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -80,8 +80,11 @@ export function NotificationBell() {
   }
 
   async function markAllRead() {
-    const unread = notifications.filter((n) => !n.isRead);
-    await Promise.all(unread.map((n) => markRead(n.id)));
+    const res = await fetch("/api/notifications/read-all", { method: "PATCH" });
+    if (res.ok) {
+      setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
+      setUnreadCount(0);
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Replace `Promise.all(unread.map(n => markRead(n.id)))` with a single PATCH to `/api/notifications/read-all`
- The backend endpoint already existed using `prisma.notification.updateMany` — frontend just wasn't using it
- Reduces N concurrent requests to 1 single request

## Test plan
- [ ] Click "mark all read" with multiple unread notifications — verify single network request
- [ ] Verify all notifications update to read state in UI
- [ ] Verify unread count resets to 0

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)