### PR TITLE
fix(security): remove hardcoded NEXTAUTH_SECRET (CR-14)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,7 +53,7 @@ services:
       DATABASE_URL: postgresql://titan:titan_dev_password@titan-db:5432/titan_dev
       REDIS_URL: redis://titan-redis:6379
       NEXTAUTH_URL: http://mac-mini.tailde842d.ts.net:3100
-      NEXTAUTH_SECRET: dev_secret_change_in_production
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?請在 .env 設定 NEXTAUTH_SECRET（openssl rand -hex 32）}
       NODE_ENV: development
       PRISMA_QUERY_ENGINE_LIBRARY: /app/node_modules/.prisma/client/libquery_engine-linux-musl-arm64-openssl-3.0.x.so.node
     ports:


### PR DESCRIPTION
## Summary
- Replace hardcoded `dev_secret_change_in_production` in `docker-compose.dev.yml` with `${NEXTAUTH_SECRET:?...}` env var reference
- Compose now fails fast with a clear error message if `NEXTAUTH_SECRET` is not set in `.env`
- `.env.example` already documents the generation command (`openssl rand -hex 32`)

## Test plan
- [ ] `docker compose -f docker-compose.dev.yml config` fails without `.env` NEXTAUTH_SECRET set
- [ ] After setting NEXTAUTH_SECRET in `.env`, `docker compose -f docker-compose.dev.yml config` renders correctly

Fixes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)