### PR TITLE
refactor(kpi): extract shared KPI calculator to deduplicate formula

### DIFF
--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { FormError, FormBanner } from "@/app/components/form-error";
 import { safeFixed, safePct } from "@/lib/safe-number";
+import { calculateAchievement } from "@/lib/kpi-calculator";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -41,17 +42,7 @@ interface KPI {
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 function achievementRate(kpi: KPI): number {
-  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-    const totalWeight = kpi.taskLinks.reduce((s, l) => s + l.weight, 0);
-    const weighted = kpi.taskLinks.reduce((s, l) => {
-      const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-      return s + (prog * l.weight) / 100;
-    }, 0);
-    return totalWeight > 0
-      ? Math.min((weighted / totalWeight) * kpi.target, 100)
-      : 0;
-  }
-  return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
+  return calculateAchievement(kpi);
 }
 
 function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { NotFoundError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { calculateAchievement } from "@/lib/kpi-calculator";
 
 export const GET = withAuth(async (
   _req: NextRequest,
@@ -32,17 +33,7 @@ export const GET = withAuth(async (
 
   if (!kpi) throw new NotFoundError("找不到 KPI");
 
-  let achievementRate = 0;
-  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-    const totalWeight = kpi.taskLinks.reduce((sum, link) => sum + link.weight, 0);
-    const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
-      const progress = link.task.status === "DONE" ? 100 : link.task.progressPct;
-      return sum + (progress * link.weight) / 100;
-    }, 0);
-    achievementRate = totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
-  } else {
-    achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-  }
+  const achievementRate = calculateAchievement(kpi);
 
   const linkedTaskCount = kpi.taskLinks.length;
   const completedTaskCount = kpi.taskLinks.filter((l) => l.task.status === "DONE").length;
@@ -51,7 +42,7 @@ export const GET = withAuth(async (
     kpiId: kpi.id,
     target: kpi.target,
     actual: kpi.actual,
-    achievementRate: Math.min(achievementRate, 100),
+    achievementRate,
     linkedTaskCount,
     completedTaskCount,
     autoCalc: kpi.autoCalc,

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { ExportService } from "@/services/export-service";
+import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
 
 const exportService = new ExportService();
 
@@ -110,29 +111,17 @@ export const GET = withAuth(async (req: NextRequest) => {
       orderBy: { code: "asc" },
     });
 
-    const kpisWithAchievement = kpis.map((kpi) => {
-      let achievementRate = 0;
-      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-        const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
-        const weighted = kpi.taskLinks.reduce((sum, l) => {
-          const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-          return sum + (prog * l.weight) / 100;
-        }, 0);
-        achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
-      } else {
-        achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-      }
-      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
-    });
+    const kpisWithAchievement = kpis.map((kpi) => ({
+      ...kpi,
+      achievementRate: calculateAchievement(kpi),
+    }));
 
-    const avgAchievement =
-      kpisWithAchievement.length > 0
-        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length
-        : 0;
+    const rates = kpisWithAchievement.map((k) => k.achievementRate);
+    const avgAchievement = calculateAvgAchievement(rates);
 
     result = exportService.exportKPIReport({
       year,
-      avgAchievement: Math.round(avgAchievement * 10) / 10,
+      avgAchievement,
       achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100).length,
       totalCount: kpisWithAchievement.length,
       kpis: kpisWithAchievement.map((k) => ({

--- a/app/api/reports/kpi/route.ts
+++ b/app/api/reports/kpi/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { success } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
+import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
 
 export const GET = withAuth(async (req: NextRequest) => {
 
@@ -24,30 +25,18 @@ export const GET = withAuth(async (req: NextRequest) => {
     orderBy: { code: "asc" },
   });
 
-  const kpisWithAchievement = kpis.map((kpi) => {
-    let achievementRate = 0;
-    if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-      const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
-      const weighted = kpi.taskLinks.reduce((sum, l) => {
-        const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-        return sum + (prog * l.weight) / 100;
-      }, 0);
-      achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
-    } else {
-      achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-    }
-    return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
-  });
+  const kpisWithAchievement = kpis.map((kpi) => ({
+    ...kpi,
+    achievementRate: calculateAchievement(kpi),
+  }));
 
-  const avgAchievement =
-    kpisWithAchievement.length > 0
-      ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length
-      : 0;
+  const rates = kpisWithAchievement.map((k) => k.achievementRate);
+  const avgAchievement = calculateAvgAchievement(rates);
 
   return success({
     year,
     kpis: kpisWithAchievement,
-    avgAchievement: Math.round(avgAchievement * 10) / 10,
+    avgAchievement,
     achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100).length,
     totalCount: kpisWithAchievement.length,
   });

--- a/lib/kpi-calculator.ts
+++ b/lib/kpi-calculator.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared KPI achievement calculation functions.
+ *
+ * These pure functions centralise the KPI math that was previously
+ * duplicated across route handlers and client components.
+ */
+
+export interface TaskLinkForCalc {
+  weight: number;
+  task: {
+    status: string;
+    progressPct: number;
+  };
+}
+
+export interface KpiForCalc {
+  target: number;
+  actual: number;
+  autoCalc: boolean;
+  taskLinks: TaskLinkForCalc[];
+}
+
+/**
+ * Calculate the achievement rate (0–100) for a single KPI.
+ *
+ * - autoCalc KPIs: weighted average of linked task progress, scaled by target
+ * - Manual KPIs: actual / target * 100
+ * - Capped at 100
+ */
+export function calculateAchievement(kpi: KpiForCalc): number {
+  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
+    const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
+    const weightedProgress = kpi.taskLinks.reduce((sum, l) => {
+      const progress = l.task.status === "DONE" ? 100 : l.task.progressPct;
+      return sum + (progress * l.weight) / 100;
+    }, 0);
+    const rate = totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
+    return Math.min(rate, 100);
+  }
+  const rate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+  return Math.min(rate, 100);
+}
+
+/**
+ * Calculate the average achievement rate across an array of KPIs.
+ * Returns 0 if the array is empty. Rounded to 1 decimal place.
+ */
+export function calculateAvgAchievement(rates: number[]): number {
+  if (rates.length === 0) return 0;
+  const avg = rates.reduce((s, r) => s + r, 0) / rates.length;
+  return Math.round(avg * 10) / 10;
+}


### PR DESCRIPTION
## Summary
- Create `lib/kpi-calculator.ts` with `calculateAchievement()` and `calculateAvgAchievement()` pure functions
- Replace duplicated KPI achievement math in 4 locations:
  - `app/api/kpi/[id]/achievement/route.ts`
  - `app/api/reports/kpi/route.ts`
  - `app/api/reports/export/route.ts`
  - `app/(app)/kpi/page.tsx`
- All use the same shared module, ensuring consistent calculation logic

## Test plan
- [ ] KPI achievement route returns correct rates for autoCalc and manual KPIs
- [ ] Reports KPI endpoint returns correct avgAchievement
- [ ] Export KPI report has correct achievement rates
- [ ] KPI page displays correct achievement percentages
- [ ] Existing KPI-related tests still pass

Fixes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)