### PR TITLE
feat(api): add unplannedRatio/weeklyHours to workload endpoint

### DIFF
--- a/app/api/users/[id]/workload/route.ts
+++ b/app/api/users/[id]/workload/route.ts
@@ -37,40 +37,64 @@ export const GET = withAuth(async (
     ? new Date(endParam)
     : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
 
-  // Active tasks (exclude DONE) assigned to this user
-  const activeTasks = await prisma.task.findMany({
-    where: {
-      primaryAssigneeId: id,
-      status: { notIn: ["DONE"] },
-    },
-    select: {
-      id: true,
-      title: true,
-      status: true,
-      priority: true,
-      estimatedHours: true,
-      dueDate: true,
-    },
-  });
+  // Compute start of the current ISO week (Monday) for weeklyHours
+  const weekStart = new Date(now);
+  const dayOfWeek = weekStart.getDay(); // 0=Sun, 1=Mon, ...
+  const diffToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  weekStart.setDate(weekStart.getDate() - diffToMonday);
+  weekStart.setHours(0, 0, 0, 0);
 
-  // Time entries within the date range
-  const timeEntries = await prisma.timeEntry.findMany({
-    where: {
-      userId: id,
-      date: { gte: startDate, lte: endDate },
-    },
-    select: {
-      id: true,
-      hours: true,
-      category: true,
-      date: true,
-    },
-  });
+  // Active tasks (exclude DONE) assigned to this user
+  const [activeTasks, timeEntries, weeklyTimeAgg] = await Promise.all([
+    prisma.task.findMany({
+      where: {
+        primaryAssigneeId: id,
+        status: { notIn: ["DONE"] },
+      },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        category: true,
+        estimatedHours: true,
+        dueDate: true,
+      },
+    }),
+    // Time entries within the requested date range
+    prisma.timeEntry.findMany({
+      where: {
+        userId: id,
+        date: { gte: startDate, lte: endDate },
+      },
+      select: {
+        id: true,
+        hours: true,
+        category: true,
+        date: true,
+      },
+    }),
+    // Aggregate weekly hours for the current week
+    prisma.timeEntry.aggregate({
+      where: {
+        userId: id,
+        date: { gte: weekStart },
+      },
+      _sum: { hours: true },
+    }),
+  ]);
 
   const taskCount = activeTasks.length;
   const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
   const estimatedHours = activeTasks.reduce((sum, t) => sum + (t.estimatedHours ?? 0), 0);
   const loadPct = Math.round((totalHours / STANDARD_MONTHLY_HOURS) * 100 * 10) / 10;
+
+  // Spec-required fields: unplannedRatio and weeklyHours (Issue #287)
+  const unplannedCount = activeTasks.filter(
+    (t) => ["ADDED", "INCIDENT", "SUPPORT"].includes(t.category)
+  ).length;
+  const unplannedRatio = taskCount > 0 ? Math.round((unplannedCount / taskCount) * 100 * 10) / 10 : 0;
+  const weeklyHours = weeklyTimeAgg._sum.hours ?? 0;
 
   return success({
     userId: id,
@@ -80,6 +104,8 @@ export const GET = withAuth(async (
     totalHours,
     estimatedHours,
     loadPct,
+    unplannedRatio,
+    weeklyHours,
     activeTasks,
   });
 });


### PR DESCRIPTION
## Summary
- Add `unplannedRatio` (% of active tasks in ADDED/INCIDENT/SUPPORT categories) to workload response
- Add `weeklyHours` (aggregated time entries for current ISO week) to workload response
- Include `category` in activeTasks select for client-side filtering
- Use `Promise.all` for parallel DB queries (tasks + time entries + weekly aggregate)

## Test plan
- [ ] `GET /api/users/:id/workload` response now includes `unplannedRatio` and `weeklyHours` fields
- [ ] `unplannedRatio` is 0 when no unplanned tasks exist
- [ ] `weeklyHours` aggregates correctly from Monday to current day
- [ ] RBAC: engineer can only view own workload; manager can view any

Fixes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)