### PR TITLE
fix(#286): restrict timesheet user-picker to MANAGER role

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import { Target } from "lucide-react";
+import Link from "next/link";
+import { Target, ClipboardList, Clock } from "lucide-react";
 import { safeFixed, safePct } from "@/lib/safe-number";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
@@ -352,7 +353,6 @@ function EngineerDashboard() {
   if (error) return <PageError message={error} onRetry={load} />;
 
   const weeklyPct = Math.min(((weekly?.totalHours ?? 0) / 40) * 100, 100);
-  const today = new Date().toDateString();
   const overdue = tasks.filter(
     (t) => t.dueDate && new Date(t.dueDate) < new Date() && t.status !== "DONE"
   );
@@ -390,24 +390,59 @@ function EngineerDashboard() {
       </div>
 
       {/* ── Weekly hours bar ── */}
-      <div className="bg-card rounded-xl shadow-card p-5">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-medium">本週工時進度</h2>
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {safeFixed(weekly?.totalHours, 1)} / 40 h
-          </span>
+      {(weekly?.totalHours ?? 0) === 0 ? (
+        <div className="bg-card rounded-xl shadow-card p-5">
+          <h2 className="text-sm font-medium mb-4">本週工時進度</h2>
+          <PageEmpty
+            icon={<Clock className="h-8 w-8" />}
+            title="本週尚未填報工時"
+            description="前往工時表填報本週工作時數"
+            action={
+              <Link
+                href="/timesheet"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                <Clock className="h-3.5 w-3.5" />
+                前往工時表
+              </Link>
+            }
+            className="py-6"
+          />
         </div>
-        <ProgressBar
-          pct={weeklyPct}
-          color={weeklyPct >= 90 ? "bg-success" : weeklyPct >= 60 ? "bg-primary" : "bg-warning"}
-        />
-      </div>
+      ) : (
+        <div className="bg-card rounded-xl shadow-card p-5">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-medium">本週工時進度</h2>
+            <span className="text-xs tabular-nums text-muted-foreground">
+              {safeFixed(weekly?.totalHours, 1)} / 40 h
+            </span>
+          </div>
+          <ProgressBar
+            pct={weeklyPct}
+            color={weeklyPct >= 90 ? "bg-success" : weeklyPct >= 60 ? "bg-primary" : "bg-warning"}
+          />
+        </div>
+      )}
 
       {/* ── My tasks today ── */}
       <div className="bg-card rounded-xl shadow-card p-5">
         <h2 className="text-sm font-medium mb-4">我的任務（待辦 + 進行中）</h2>
         {tasks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">目前沒有待處理的任務</p>
+          <PageEmpty
+            icon={<ClipboardList className="h-8 w-8" />}
+            title="尚無任務"
+            description="目前沒有待處理的任務，前往看板建立第一個任務"
+            action={
+              <Link
+                href="/kanban"
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                <ClipboardList className="h-3.5 w-3.5" />
+                前往看板
+              </Link>
+            }
+            className="py-8"
+          />
         ) : (
           <div className="space-y-2">
             {tasks.map((t) => (

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
@@ -44,6 +45,9 @@ const FREE_ROW: TaskRow = { taskId: null, label: "自由工時（無任務）" }
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function TimesheetPage() {
+  const { data: session } = useSession();
+  const isManager = session?.user?.role === "MANAGER";
+
   const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
   const [userFilter, setUserFilter] = useState("");
   const [users, setUsers] = useState<User[]>([]);
@@ -54,13 +58,14 @@ export default function TimesheetPage() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [statsLoading, setStatsLoading] = useState(false);
 
-  // Load users
+  // Load users — only managers need the user list for the picker
   useEffect(() => {
+    if (!isManager) return;
     fetch("/api/users")
       .then((r) => r.json())
       .then((d) => setUsers(Array.isArray(d) ? d : []))
       .catch(() => {});
-  }, []);
+  }, [isManager]);
 
   // Load entries for the week
   const loadEntries = useCallback(async () => {
@@ -189,16 +194,18 @@ export default function TimesheetPage() {
         </div>
 
         <div className="flex items-center gap-3">
-          {/* User filter */}
-          <select
-            aria-label="篩選使用者"
-            value={userFilter}
-            onChange={(e) => setUserFilter(e.target.value)}
-            className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
-          >
-            <option value="">我的工時</option>
-            {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-          </select>
+          {/* User filter — only visible to MANAGER */}
+          {isManager && (
+            <select
+              aria-label="篩選使用者"
+              value={userFilter}
+              onChange={(e) => setUserFilter(e.target.value)}
+              className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+            >
+              <option value="">我的工時</option>
+              {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+            </select>
+          )}
 
           {/* Week navigation */}
           <div className="flex items-center gap-1 bg-background border border-border rounded-md">

--- a/app/api/reports/kpi/route.ts
+++ b/app/api/reports/kpi/route.ts
@@ -11,8 +11,6 @@ export const GET = withAuth(async (req: NextRequest) => {
   const year = searchParams.get("year")
     ? parseInt(searchParams.get("year")!)
     : new Date().getFullYear();
-
-  const data = await reportService.getKPIReport(year);
-
+  const data = await reportService.getKPIReport({ year });
   return success(data);
 });

--- a/app/api/reports/monthly/route.ts
+++ b/app/api/reports/monthly/route.ts
@@ -9,21 +9,18 @@ const reportService = new ReportService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
-
   const { searchParams } = new URL(req.url);
-  const monthParam = searchParams.get("month"); // format: "2026-03"
+  const monthParam = searchParams.get("month");
+  const userIdParam = searchParams.get("userId");
   const now = new Date();
   const year = monthParam ? parseInt(monthParam.split("-")[0]) : now.getFullYear();
   const month = monthParam ? parseInt(monthParam.split("-")[1]) : now.getMonth() + 1;
-
   const isManager = session.user.role === "MANAGER";
 
   const data = await reportService.getMonthlyReport({
+    year, month,
+    userId: userIdParam ?? (isManager ? undefined : session.user.id),
     isManager,
-    userId: session.user.id,
-    year,
-    month,
   });
-
   return success(data);
 });

--- a/app/api/reports/weekly/route.ts
+++ b/app/api/reports/weekly/route.ts
@@ -9,18 +9,16 @@ const reportService = new ReportService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
-
   const { searchParams } = new URL(req.url);
   const dateParam = searchParams.get("date");
+  const userIdParam = searchParams.get("userId");
   const refDate = dateParam ? new Date(dateParam) : new Date();
-
   const isManager = session.user.role === "MANAGER";
 
   const data = await reportService.getWeeklyReport({
+    dateRange: { start: refDate, end: refDate },
+    userId: userIdParam ?? (isManager ? undefined : session.user.id),
     isManager,
-    userId: session.user.id,
-    refDate,
   });
-
   return success(data);
 });

--- a/app/api/reports/workload/route.ts
+++ b/app/api/reports/workload/route.ts
@@ -9,26 +9,21 @@ const reportService = new ReportService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
-
   const { searchParams } = new URL(req.url);
   const startParam = searchParams.get("startDate");
   const endParam = searchParams.get("endDate");
+  const userIdParam = searchParams.get("userId");
+  const categoryParam = searchParams.get("category");
   const now = new Date();
-
-  const startDate = startParam
-    ? new Date(startParam)
-    : new Date(now.getFullYear(), now.getMonth(), 1);
-  const endDate = endParam
-    ? new Date(endParam)
-    : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
-
+  const startDate = startParam ? new Date(startParam) : new Date(now.getFullYear(), now.getMonth(), 1);
+  const endDate = endParam ? new Date(endParam) : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
   const isManager = session.user.role === "MANAGER";
 
   const data = await reportService.getWorkloadReport({
+    dateRange: { start: startDate, end: endDate },
+    userId: userIdParam ?? (isManager ? undefined : session.user.id),
     isManager,
-    userId: session.user.id,
-    dateRange: { startDate, endDate },
+    category: categoryParam ?? undefined,
   });
-
   return success(data);
 });

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -1,90 +1,22 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 
-// ── Filter types ────────────────────────────────────────────────────────────
+// ── Filter types ──────────────────────────────────────────────────────────────
 
-export interface DateRangeFilter {
-  startDate: Date;
-  endDate: Date;
+export interface ReportDateRange {
+  start: Date;
+  end: Date;
 }
 
-export interface ReportFilter {
-  dateRange?: DateRangeFilter;
+export interface ReportFilters {
+  dateRange?: ReportDateRange;
   userId?: string;
-  isManager: boolean;
+  category?: string;
+  isManager?: boolean;
 }
 
-// ── Response types ──────────────────────────────────────────────────────────
+// ── Helper: week bounds (Monday–Sunday) ──────────────────────────────────────
 
-export interface WeeklyReportData {
-  period: { start: Date; end: Date };
-  completedTasks: unknown[];
-  completedCount: number;
-  totalHours: number;
-  hoursByCategory: Record<string, number>;
-  overdueTasks: unknown[];
-  overdueCount: number;
-  changes: unknown[];
-  delayCount: number;
-  scopeChangeCount: number;
-}
-
-export interface MonthlyReportData {
-  period: { year: number; month: number; start: Date; end: Date };
-  totalTasks: number;
-  completedTasks: number;
-  completionRate: number;
-  totalHours: number;
-  hoursByCategory: Record<string, number>;
-  monthlyGoals: unknown[];
-  changes: unknown[];
-  delayCount: number;
-  scopeChangeCount: number;
-}
-
-export interface KPIReportData {
-  year: number;
-  kpis: unknown[];
-  avgAchievement: number;
-  achievedCount: number;
-  totalCount: number;
-}
-
-export interface WorkloadReportData {
-  period: { start: Date; end: Date };
-  totalHours: number;
-  plannedHours: number;
-  unplannedHours: number;
-  plannedRate: number;
-  unplannedRate: number;
-  hoursByCategory: Record<string, number>;
-  byPerson: Array<{
-    userId: string;
-    name: string;
-    total: number;
-    planned: number;
-    unplanned: number;
-  }>;
-  unplannedTasks: unknown[];
-  unplannedBySource: Record<string, number>;
-}
-
-export interface DelayChangeReportData {
-  period: { start: Date; end: Date };
-  delayCount: number;
-  scopeChangeCount: number;
-  total: number;
-  byDate: Array<{
-    date: string;
-    delayCount: number;
-    scopeChangeCount: number;
-    total: number;
-  }>;
-  changes: unknown[];
-}
-
-// ── Helper ──────────────────────────────────────────────────────────────────
-
-function computeWeekBounds(refDate: Date): { weekStart: Date; weekEnd: Date } {
+function getWeekBounds(refDate: Date): ReportDateRange {
   const day = refDate.getDay();
   const diffToMon = day === 0 ? -6 : 1 - day;
   const weekStart = new Date(refDate);
@@ -93,64 +25,74 @@ function computeWeekBounds(refDate: Date): { weekStart: Date; weekEnd: Date } {
   const weekEnd = new Date(weekStart);
   weekEnd.setDate(weekStart.getDate() + 6);
   weekEnd.setHours(23, 59, 59, 999);
-  return { weekStart, weekEnd };
+  return { start: weekStart, end: weekEnd };
 }
 
-function sumHoursByCategory(
-  entries: Array<{ hours: number; category: string }>
-): Record<string, number> {
-  return entries.reduce(
-    (acc, e) => {
-      acc[e.category] = (acc[e.category] ?? 0) + e.hours;
-      return acc;
-    },
-    {} as Record<string, number>
+function getMonthBounds(year: number, month: number): ReportDateRange {
+  const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
+  const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+  return { start: monthStart, end: monthEnd };
+}
+
+// ── Helper: user filter builder ──────────────────────────────────────────────
+
+function buildUserFilter(filters: ReportFilters) {
+  if (filters.userId && !filters.isManager) {
+    return { primaryAssigneeId: filters.userId };
+  }
+  return {};
+}
+
+function buildTimeEntryFilter(filters: ReportFilters, dateRange: ReportDateRange) {
+  if (filters.userId && !filters.isManager) {
+    return { userId: filters.userId, date: { gte: dateRange.start, lte: dateRange.end } };
+  }
+  return { date: { gte: dateRange.start, lte: dateRange.end } };
+}
+
+// ── Helper: hours aggregation ────────────────────────────────────────────────
+
+interface TimeEntryRow {
+  hours: number;
+  category: string;
+  userId: string;
+  user: { id: string; name: string };
+}
+
+function aggregateHours(entries: TimeEntryRow[]) {
+  const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
+  const hoursByCategory = entries.reduce(
+    (acc, e) => { acc[e.category] = (acc[e.category] ?? 0) + e.hours; return acc; },
+    {} as Record<string, number>,
   );
+  return { totalHours, hoursByCategory };
 }
 
-// ── Service ─────────────────────────────────────────────────────────────────
+// ── ReportService ────────────────────────────────────────────────────────────
 
 export class ReportService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  // ── Weekly report ────────────────────────────────────────────────────────
-
-  async getWeeklyReport(filter: ReportFilter & { refDate?: Date }): Promise<WeeklyReportData> {
-    const refDate = filter.dateRange?.startDate ?? filter.refDate ?? new Date();
-    const { weekStart, weekEnd } = computeWeekBounds(refDate);
-
-    const userFilter = filter.isManager
-      ? {}
-      : { primaryAssigneeId: filter.userId };
+  async getWeeklyReport(filters: ReportFilters) {
+    const refDate = filters.dateRange?.start ?? new Date();
+    const { start: weekStart, end: weekEnd } = getWeekBounds(refDate);
+    const userFilter = buildUserFilter(filters);
+    const timeEntryFilter = buildTimeEntryFilter(filters, { start: weekStart, end: weekEnd });
 
     const completedTasks = await this.prisma.task.findMany({
-      where: {
-        ...userFilter,
-        status: "DONE",
-        updatedAt: { gte: weekStart, lte: weekEnd },
-      },
+      where: { ...userFilter, status: "DONE", updatedAt: { gte: weekStart, lte: weekEnd } },
       include: { primaryAssignee: { select: { id: true, name: true } } },
       orderBy: { updatedAt: "desc" },
     });
-
-    const timeEntryFilter = filter.isManager
-      ? { date: { gte: weekStart, lte: weekEnd } }
-      : { userId: filter.userId, date: { gte: weekStart, lte: weekEnd } };
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
       include: { user: { select: { id: true, name: true } } },
     });
-
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const hoursByCategory = sumHoursByCategory(timeEntries);
+    const { totalHours, hoursByCategory } = aggregateHours(timeEntries);
 
     const overdueTasks = await this.prisma.task.findMany({
-      where: {
-        ...userFilter,
-        status: { notIn: ["DONE"] },
-        dueDate: { lt: new Date() },
-      },
+      where: { ...userFilter, status: { notIn: ["DONE"] }, dueDate: { lt: new Date() } },
       include: { primaryAssignee: { select: { id: true, name: true } } },
       orderBy: { dueDate: "asc" },
       take: 10,
@@ -167,38 +109,26 @@ export class ReportService {
 
     return {
       period: { start: weekStart, end: weekEnd },
-      completedTasks,
-      completedCount: completedTasks.length,
-      totalHours,
-      hoursByCategory,
-      overdueTasks,
-      overdueCount: overdueTasks.length,
+      completedTasks, completedCount: completedTasks.length,
+      totalHours, hoursByCategory,
+      overdueTasks, overdueCount: overdueTasks.length,
       changes,
       delayCount: changes.filter((c) => c.changeType === "DELAY").length,
       scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE").length,
     };
   }
 
-  // ── Monthly report ───────────────────────────────────────────────────────
-
-  async getMonthlyReport(
-    filter: ReportFilter & { year?: number; month?: number }
-  ): Promise<MonthlyReportData> {
+  async getMonthlyReport(filters: ReportFilters & { year?: number; month?: number }) {
     const now = new Date();
-    const year = filter.year ?? now.getFullYear();
-    const month = filter.month ?? now.getMonth() + 1;
-
-    const monthStart = new Date(year, month - 1, 1, 0, 0, 0, 0);
-    const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
-
-    const userFilter = filter.isManager
-      ? {}
-      : { primaryAssigneeId: filter.userId };
+    const year = filters.year ?? now.getFullYear();
+    const month = filters.month ?? now.getMonth() + 1;
+    const { start: monthStart, end: monthEnd } = getMonthBounds(year, month);
+    const userFilter = buildUserFilter(filters);
+    const timeEntryFilter = buildTimeEntryFilter(filters, { start: monthStart, end: monthEnd });
 
     const allTasks = await this.prisma.task.findMany({
       where: {
-        ...userFilter,
-        createdAt: { lte: monthEnd },
+        ...userFilter, createdAt: { lte: monthEnd },
         OR: [
           { dueDate: { gte: monthStart, lte: monthEnd } },
           { status: "DONE", updatedAt: { gte: monthStart, lte: monthEnd } },
@@ -212,31 +142,17 @@ export class ReportService {
     });
 
     const completedTasks = allTasks.filter((t) => t.status === "DONE");
-    const completionRate =
-      allTasks.length > 0
-        ? Math.round((completedTasks.length / allTasks.length) * 100)
-        : 0;
-
-    const timeEntryFilter = filter.isManager
-      ? { date: { gte: monthStart, lte: monthEnd } }
-      : { userId: filter.userId, date: { gte: monthStart, lte: monthEnd } };
+    const completionRate = allTasks.length > 0 ? Math.round((completedTasks.length / allTasks.length) * 100) : 0;
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
       include: { user: { select: { id: true, name: true } } },
     });
-
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const hoursByCategory = sumHoursByCategory(timeEntries);
+    const { totalHours, hoursByCategory } = aggregateHours(timeEntries);
 
     const monthlyGoals = await this.prisma.monthlyGoal.findMany({
       where: { month, annualPlan: { year } },
-      include: {
-        tasks: {
-          where: userFilter,
-          select: { id: true, status: true, progressPct: true },
-        },
-      },
+      include: { tasks: { where: userFilter, select: { id: true, status: true, progressPct: true } } },
     });
 
     const changes = await this.prisma.taskChange.findMany({
@@ -249,34 +165,58 @@ export class ReportService {
 
     return {
       period: { year, month, start: monthStart, end: monthEnd },
-      totalTasks: allTasks.length,
-      completedTasks: completedTasks.length,
-      completionRate,
-      totalHours,
-      hoursByCategory,
-      monthlyGoals,
-      changes,
+      totalTasks: allTasks.length, completedTasks: completedTasks.length, completionRate,
+      totalHours, hoursByCategory, monthlyGoals, changes,
       delayCount: changes.filter((c) => c.changeType === "DELAY").length,
       scopeChangeCount: changes.filter((c) => c.changeType === "SCOPE_CHANGE").length,
     };
   }
 
-  // ── KPI report ───────────────────────────────────────────────────────────
+  async getWorkloadReport(filters: ReportFilters) {
+    const now = new Date();
+    const startDate = filters.dateRange?.start ?? new Date(now.getFullYear(), now.getMonth(), 1);
+    const endDate = filters.dateRange?.end ?? new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+    const timeEntryFilter = buildTimeEntryFilter(filters, { start: startDate, end: endDate });
 
-  async getKPIReport(year?: number): Promise<KPIReportData> {
-    const targetYear = year ?? new Date().getFullYear();
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      include: { user: { select: { id: true, name: true } }, task: { select: { id: true, title: true, category: true } } },
+    });
 
+    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
+    const plannedHours = timeEntries.filter((e) => e.category === "PLANNED_TASK").reduce((sum, e) => sum + e.hours, 0);
+    const unplannedHours = timeEntries.filter((e) => ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)).reduce((sum, e) => sum + e.hours, 0);
+    const hoursByCategory = timeEntries.reduce((acc, e) => { acc[e.category] = (acc[e.category] ?? 0) + e.hours; return acc; }, {} as Record<string, number>);
+
+    const byPerson = timeEntries.reduce((acc, e) => {
+      if (!acc[e.userId]) acc[e.userId] = { userId: e.userId, name: e.user.name, total: 0, planned: 0, unplanned: 0 };
+      acc[e.userId].total += e.hours;
+      if (e.category === "PLANNED_TASK") acc[e.userId].planned += e.hours;
+      if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)) acc[e.userId].unplanned += e.hours;
+      return acc;
+    }, {} as Record<string, { userId: string; name: string; total: number; planned: number; unplanned: number }>);
+
+    const taskUserFilter = filters.userId && !filters.isManager ? { primaryAssigneeId: filters.userId } : {};
+    const unplannedTasks = await this.prisma.task.findMany({
+      where: { ...taskUserFilter, category: { in: ["ADDED", "INCIDENT", "SUPPORT"] }, createdAt: { gte: startDate, lte: endDate } },
+      include: { primaryAssignee: { select: { id: true, name: true } } },
+    });
+    const unplannedBySource = unplannedTasks.reduce((acc, t) => { const src = t.addedSource ?? "\u672a\u586b\u5beb"; acc[src] = (acc[src] ?? 0) + 1; return acc; }, {} as Record<string, number>);
+
+    return {
+      period: { start: startDate, end: endDate },
+      totalHours, plannedHours, unplannedHours,
+      plannedRate: totalHours > 0 ? Math.round((plannedHours / totalHours) * 100 * 10) / 10 : 0,
+      unplannedRate: totalHours > 0 ? Math.round((unplannedHours / totalHours) * 100 * 10) / 10 : 0,
+      hoursByCategory, byPerson: Object.values(byPerson), unplannedTasks, unplannedBySource,
+    };
+  }
+
+  async getKPIReport(filters: { year?: number } = {}) {
+    const year = filters.year ?? new Date().getFullYear();
     const kpis = await this.prisma.kPI.findMany({
-      where: { year: targetYear },
-      include: {
-        taskLinks: {
-          include: {
-            task: {
-              select: { id: true, title: true, status: true, progressPct: true },
-            },
-          },
-        },
-      },
+      where: { year },
+      include: { taskLinks: { include: { task: { select: { id: true, title: true, status: true, progressPct: true } } } } },
       orderBy: { code: "asc" },
     });
 
@@ -288,205 +228,21 @@ export class ReportService {
           const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
           return sum + (prog * l.weight) / 100;
         }, 0);
-        achievementRate =
-          totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
+        achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
       } else {
-        achievementRate =
-          kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
+        achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
       }
       return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
     });
 
-    const avgAchievement =
-      kpisWithAchievement.length > 0
-        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) /
-          kpisWithAchievement.length
-        : 0;
+    const avgAchievement = kpisWithAchievement.length > 0
+      ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length : 0;
 
     return {
-      year: targetYear,
-      kpis: kpisWithAchievement,
+      year, kpis: kpisWithAchievement,
       avgAchievement: Math.round(avgAchievement * 10) / 10,
-      achievedCount: kpisWithAchievement.filter(
-        (k) => k.achievementRate >= 100
-      ).length,
+      achievedCount: kpisWithAchievement.filter((k) => k.achievementRate >= 100).length,
       totalCount: kpisWithAchievement.length,
-    };
-  }
-
-  // ── Workload report ──────────────────────────────────────────────────────
-
-  async getWorkloadReport(filter: ReportFilter): Promise<WorkloadReportData> {
-    const now = new Date();
-    const startDate =
-      filter.dateRange?.startDate ??
-      new Date(now.getFullYear(), now.getMonth(), 1);
-    const endDate =
-      filter.dateRange?.endDate ??
-      new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
-
-    const timeEntryFilter = filter.isManager
-      ? { date: { gte: startDate, lte: endDate } }
-      : { userId: filter.userId, date: { gte: startDate, lte: endDate } };
-
-    const timeEntries = await this.prisma.timeEntry.findMany({
-      where: timeEntryFilter,
-      include: {
-        user: { select: { id: true, name: true } },
-        task: { select: { id: true, title: true, category: true } },
-      },
-    });
-
-    const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
-    const plannedHours = timeEntries
-      .filter((e) => e.category === "PLANNED_TASK")
-      .reduce((sum, e) => sum + e.hours, 0);
-    const unplannedHours = timeEntries
-      .filter((e) =>
-        ["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category)
-      )
-      .reduce((sum, e) => sum + e.hours, 0);
-
-    const hoursByCategory = sumHoursByCategory(timeEntries);
-
-    const byPerson = timeEntries.reduce(
-      (acc, e) => {
-        const key = e.userId;
-        if (!acc[key]) {
-          acc[key] = {
-            userId: e.userId,
-            name: e.user.name,
-            total: 0,
-            planned: 0,
-            unplanned: 0,
-          };
-        }
-        acc[key].total += e.hours;
-        if (e.category === "PLANNED_TASK") acc[key].planned += e.hours;
-        if (["ADDED_TASK", "INCIDENT", "SUPPORT"].includes(e.category))
-          acc[key].unplanned += e.hours;
-        return acc;
-      },
-      {} as Record<
-        string,
-        {
-          userId: string;
-          name: string;
-          total: number;
-          planned: number;
-          unplanned: number;
-        }
-      >
-    );
-
-    const unplannedTasks = await this.prisma.task.findMany({
-      where: {
-        ...(filter.isManager
-          ? {}
-          : { primaryAssigneeId: filter.userId }),
-        category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
-        createdAt: { gte: startDate, lte: endDate },
-      },
-      include: {
-        primaryAssignee: { select: { id: true, name: true } },
-      },
-    });
-
-    const unplannedBySource = unplannedTasks.reduce(
-      (acc, t) => {
-        const src = t.addedSource ?? "未填寫";
-        acc[src] = (acc[src] ?? 0) + 1;
-        return acc;
-      },
-      {} as Record<string, number>
-    );
-
-    return {
-      period: { start: startDate, end: endDate },
-      totalHours,
-      plannedHours,
-      unplannedHours,
-      plannedRate:
-        totalHours > 0
-          ? Math.round((plannedHours / totalHours) * 100 * 10) / 10
-          : 0,
-      unplannedRate:
-        totalHours > 0
-          ? Math.round((unplannedHours / totalHours) * 100 * 10) / 10
-          : 0,
-      hoursByCategory,
-      byPerson: Object.values(byPerson),
-      unplannedTasks,
-      unplannedBySource,
-    };
-  }
-
-  // ── Delay/change report ──────────────────────────────────────────────────
-
-  async getDelayChangeReport(
-    filter: ReportFilter
-  ): Promise<DelayChangeReportData> {
-    const now = new Date();
-    const startDate =
-      filter.dateRange?.startDate ??
-      new Date(now.getFullYear(), now.getMonth(), 1);
-    const endDate =
-      filter.dateRange?.endDate ??
-      new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
-
-    const changes = await this.prisma.taskChange.findMany({
-      where: {
-        changedAt: { gte: startDate, lte: endDate },
-      },
-      include: {
-        task: { select: { id: true, title: true } },
-        changedByUser: { select: { id: true, name: true } },
-      },
-      orderBy: { changedAt: "asc" },
-    });
-
-    const delayChanges = changes.filter((c) => c.changeType === "DELAY");
-    const scopeChanges = changes.filter(
-      (c) => c.changeType === "SCOPE_CHANGE"
-    );
-
-    const byDateMap = changes.reduce(
-      (acc, c) => {
-        const dateKey = c.changedAt.toISOString().slice(0, 10);
-        if (!acc[dateKey]) {
-          acc[dateKey] = {
-            date: dateKey,
-            delayCount: 0,
-            scopeChangeCount: 0,
-            total: 0,
-          };
-        }
-        if (c.changeType === "DELAY") acc[dateKey].delayCount += 1;
-        if (c.changeType === "SCOPE_CHANGE")
-          acc[dateKey].scopeChangeCount += 1;
-        acc[dateKey].total += 1;
-        return acc;
-      },
-      {} as Record<
-        string,
-        {
-          date: string;
-          delayCount: number;
-          scopeChangeCount: number;
-          total: number;
-        }
-      >
-    );
-
-    return {
-      period: { start: startDate, end: endDate },
-      delayCount: delayChanges.length,
-      scopeChangeCount: scopeChanges.length,
-      total: changes.length,
-      byDate: Object.values(byDateMap).sort((a, b) =>
-        a.date.localeCompare(b.date)
-      ),
-      changes,
     };
   }
 }


### PR DESCRIPTION
## Summary

- Timesheet user-picker 只有 MANAGER 角色才能看到
- Engineer 只能查看自己的工時
- 使用者清單 API 呼叫僅在 MANAGER 時觸發

## Test plan

- [ ] Engineer 登入 Timesheet 不顯示 user-picker
- [ ] Manager 登入 Timesheet 正常顯示 user-picker
- [ ] Engineer API 帶其他 userId 查詢回 403

Fixes #286