### PR TITLE
feat(infra): backup dashboard nav, image scanning, key rotation

### DIFF
--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import {
   LayoutDashboard, KanbanSquare, GanttChartSquare, BookOpen,
   Clock, BarChart2, Target, Crosshair, PanelLeftClose, PanelLeftOpen,
+  Shield,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -31,6 +32,12 @@ const navGroups = [
     items: [
       { href: "/timesheet", label: "工時紀錄", icon: Clock },
       { href: "/reports", label: "報表", icon: BarChart2 },
+    ],
+  },
+  {
+    label: "系統",
+    items: [
+      { href: "/admin", label: "系統管理", icon: Shield },
     ],
   },
 ];

--- a/docs/key-rotation-policy.md
+++ b/docs/key-rotation-policy.md
@@ -1,0 +1,54 @@
+# TITAN 密鑰輪換政策
+
+> Issue #269 — Key Rotation Policy
+
+## 密鑰清單
+
+| 密鑰 | 環境變數 | 用途 | 影響服務 |
+|------|---------|------|---------|
+| NextAuth Secret | NEXTAUTH_SECRET | JWT/session 加密 | titan-app |
+| DB 密碼 | POSTGRES_PASSWORD | 資料庫認證 | postgres, titan-app, outline |
+| Redis 密碼 | REDIS_PASSWORD | 快取認證 | redis, titan-app, outline |
+| MinIO 密碼 | MINIO_ROOT_PASSWORD | 物件儲存認證 | minio, outline |
+| Outline Secret | OUTLINE_SECRET_KEY | session 加密 | outline |
+| Outline Utils | OUTLINE_UTILS_SECRET | 工具加密 | outline |
+
+## 輪換週期
+
+- **P0（立即）**：發現洩漏時
+- **定期（90 天）**：所有主要密鑰
+- **依需求**：OIDC_CLIENT_SECRET, SMTP_PASSWORD
+
+## 輪換前準備
+
+1. 預排維護視窗（非工作時間）
+2. 全量備份：`./scripts/backup/backup-all.sh`
+3. 備份 .env：`cp .env .env.backup.$(date +%Y%m%d)`
+
+## 輪換指令
+
+```bash
+./scripts/rotate-secrets.sh --target nextauth-secret   # session 失效
+./scripts/rotate-secrets.sh --target db-password        # DB 短暫中斷
+./scripts/rotate-secrets.sh --target redis-password     # 快取清空
+./scripts/rotate-secrets.sh --target minio-password     # 附件短暫不可用
+./scripts/rotate-secrets.sh --target outline-secrets    # Outline session 失效
+./scripts/rotate-secrets.sh --target <name> --dry-run   # 模擬執行
+```
+
+## 驗證
+
+```bash
+docker compose ps && ./scripts/health-check.sh
+```
+
+## 回滾
+
+```bash
+cp .env.backup.YYYYMMDD .env && docker compose down && docker compose up -d
+```
+
+## 稽核
+
+- 輪換紀錄保存於 `.env-backups/`
+- 記錄日期、執行者、影響範圍

--- a/scripts/rotate-secrets.sh
+++ b/scripts/rotate-secrets.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# TITAN Secret Rotation Template — Issue #269
+# Usage: ./scripts/rotate-secrets.sh --target <name> [--dry-run]
+# See docs/key-rotation-policy.md for full documentation
+set -euo pipefail
+: "${TITAN_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+: "${ENV_FILE:=${TITAN_ROOT}/.env}"; : "${BACKUP_DIR:=${TITAN_ROOT}/.env-backups}"
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; NC='\033[0m'
+log_i(){ echo -e "${GREEN}[INFO]${NC} $1"; }; log_w(){ echo -e "${YELLOW}[WARN]${NC} $1"; }; log_e(){ echo -e "${RED}[ERR]${NC} $1"; }
+TGT=""; DRY=false
+while [[ $# -gt 0 ]]; do case "$1" in
+  --target) TGT="$2"; shift 2;; --dry-run) DRY=true; shift;;
+  -h|--help) echo "Usage: $0 --target <name> [--dry-run]"
+    echo "Targets: nextauth-secret db-password redis-password minio-password outline-secrets"; exit 0;;
+  *) log_e "Unknown: $1"; exit 1;; esac; done
+[[ -z "${TGT}" ]] && { log_e "必須指定 --target"; exit 1; }
+gen(){ openssl rand -base64 32 | tr -d '=/+' | head -c 48; }
+bak(){ mkdir -p "${BACKUP_DIR}"; cp "${ENV_FILE}" "${BACKUP_DIR}/.env.$(date +%Y%m%d_%H%M%S)"; log_i "已備份 .env"; }
+upd(){ local k="$1" v="$2"
+  [[ "${DRY}" == "true" ]] && { log_w "[DRY] ${k}=<hidden>"; return; }
+  if grep -q "^${k}=" "${ENV_FILE}"; then
+    [[ "$(uname)" == "Darwin" ]] && sed -i '' "s|^${k}=.*|${k}=${v}|" "${ENV_FILE}" || sed -i "s|^${k}=.*|${k}=${v}|" "${ENV_FILE}"
+  else echo "${k}=${v}" >> "${ENV_FILE}"; fi; log_i "Updated ${k}"; }
+rst(){ [[ "${DRY}" == "true" ]] && { log_w "[DRY] restart $*"; return; }
+  cd "${TITAN_ROOT}"; docker compose restart "$@" || log_w "重啟失敗"; }
+case "${TGT}" in
+  nextauth-secret) log_i "輪換 NEXTAUTH_SECRET (session 將失效)"
+    read -p "確認? (y/N) " -r; [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
+    bak; upd NEXTAUTH_SECRET "$(gen)"; rst titan-app;;
+  db-password) log_i "輪換 POSTGRES_PASSWORD (DB 短暫中斷)"
+    read -p "確認? (y/N) " -r; [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
+    bak; P=$(gen)
+    [[ "${DRY}" != "true" ]] && docker compose exec -T postgres psql -U "${POSTGRES_USER:-titan}" -c "ALTER USER ${POSTGRES_USER:-titan} PASSWORD '${P}';"
+    upd POSTGRES_PASSWORD "${P}"; rst postgres titan-app outline;;
+  redis-password) log_i "輪換 REDIS_PASSWORD"
+    read -p "確認? (y/N) " -r; [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
+    bak; upd REDIS_PASSWORD "$(gen)"; rst redis titan-app outline;;
+  minio-password) log_i "輪換 MINIO_ROOT_PASSWORD"
+    read -p "確認? (y/N) " -r; [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
+    bak; upd MINIO_ROOT_PASSWORD "$(gen)"; rst minio outline;;
+  outline-secrets) log_i "輪換 Outline secrets"
+    read -p "確認? (y/N) " -r; [[ ! $REPLY =~ ^[Yy]$ ]] && exit 0
+    bak; upd OUTLINE_SECRET_KEY "$(gen)"; upd OUTLINE_UTILS_SECRET "$(gen)"; rst outline;;
+  *) log_e "不支援: ${TGT}"; exit 1;; esac
+[[ "${DRY}" == "true" ]] && log_w "DRY RUN 完成"

--- a/scripts/scan-images.sh
+++ b/scripts/scan-images.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# TITAN Container Image Scanning — Issue #269
+set -euo pipefail
+: "${TITAN_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+COMPOSE_FILE="${TITAN_ROOT}/docker-compose.yml"
+REPORT_DIR="${TITAN_ROOT}/reports/image-scan"
+TS=$(date +%Y%m%d_%H%M%S); FMT="table"; SEV="HIGH,CRITICAL"
+while [[ $# -gt 0 ]]; do case "$1" in
+  --format) FMT="$2"; shift 2;; --severity) SEV="$2"; shift 2;;
+  -h|--help) echo "Usage: $0 [--format table|json] [--severity HIGH,CRITICAL]"; exit 0;;
+  *) echo "Unknown: $1"; exit 1;; esac; done
+RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; YELLOW='\033[0;33m'; NC='\033[0m'
+log_info(){ echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn(){ echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error(){ echo -e "${RED}[ERROR]${NC} $1"; }
+SCANNER=""
+if command -v trivy &>/dev/null; then SCANNER="trivy"
+elif command -v docker &>/dev/null && docker scout version &>/dev/null 2>&1; then SCANNER="docker-scout"
+else log_error "找不到掃描工具 (trivy/docker scout)"; exit 1; fi
+log_info "Scanner: ${SCANNER}"
+[[ ! -f "${COMPOSE_FILE}" ]] && { log_error "找不到 ${COMPOSE_FILE}"; exit 1; }
+IMAGES=$(grep -E '^\s+image:' "${COMPOSE_FILE}" | sed 's/.*image:\s*//' | sed 's/\s*$//' | sort -u)
+[[ -z "${IMAGES}" ]] && { log_warn "未找到映像"; exit 0; }
+mkdir -p "${REPORT_DIR}"
+TOTAL=0; FAILED=0; RPT="${REPORT_DIR}/scan_${TS}.txt"
+echo "TITAN Image Scan — $(date) — ${SCANNER} — ${SEV}" > "${RPT}"
+while IFS= read -r IMG; do
+  [[ -z "${IMG}" || "${IMG}" == *'\${'* ]] && continue
+  TOTAL=$((TOTAL+1)); log_info "掃描: ${IMG}"
+  if [[ "${SCANNER}" == "trivy" ]]; then
+    trivy image --severity "${SEV}" --format "${FMT}" --no-progress "${IMG}" 2>&1 | tee -a "${RPT}" || FAILED=$((FAILED+1))
+  else docker scout cves "${IMG}" 2>&1 | tee -a "${RPT}" || FAILED=$((FAILED+1)); fi
+done <<< "${IMAGES}"
+log_info "掃描: ${TOTAL}, 失敗: ${FAILED}, 報告: ${RPT}"
+exit ${FAILED}


### PR DESCRIPTION
## Summary

- Add "系統管理" navigation link in sidebar pointing to the existing `/admin` page (backup dashboard + audit log visualization from PR #323)
- Add `scripts/scan-images.sh` for container image vulnerability scanning using trivy or docker scout against all images in docker-compose.yml
- Add `scripts/rotate-secrets.sh` template for automated secret rotation with dry-run support, .env backup, and coordinated service restart
- Add `docs/key-rotation-policy.md` documenting all secrets inventory, 90-day rotation schedule, rotation procedures, verification steps, and rollback plan

Fixes #268, Fixes #269

## Test plan

- [ ] Verify sidebar shows "系統管理" link under "系統" group
- [ ] Verify clicking the link navigates to `/admin` page (MANAGER only)
- [ ] Verify `scripts/scan-images.sh --help` displays usage
- [ ] Verify `scripts/rotate-secrets.sh --help` displays usage
- [ ] Verify `scripts/rotate-secrets.sh --target nextauth-secret --dry-run` runs without errors
- [ ] Review `docs/key-rotation-policy.md` for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)