### PR TITLE
fix(#286): restrict timesheet user-picker to MANAGER role

### DIFF
--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
@@ -44,6 +45,8 @@ const FREE_ROW: TaskRow = { taskId: null, label: "自由工時（無任務）" }
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function TimesheetPage() {
+  const { data: session } = useSession();
+  const isManager = session?.user?.role === "MANAGER";
   const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
   const [userFilter, setUserFilter] = useState("");
   const [users, setUsers] = useState<User[]>([]);
@@ -189,16 +192,18 @@ export default function TimesheetPage() {
         </div>
 
         <div className="flex items-center gap-3">
-          {/* User filter */}
-          <select
-            aria-label="篩選使用者"
-            value={userFilter}
-            onChange={(e) => setUserFilter(e.target.value)}
-            className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
-          >
-            <option value="">我的工時</option>
-            {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-          </select>
+          {/* User filter — only visible to MANAGER */}
+          {isManager && (
+            <select
+              aria-label="篩選使用者"
+              value={userFilter}
+              onChange={(e) => setUserFilter(e.target.value)}
+              className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+            >
+              <option value="">我的工時</option>
+              {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+            </select>
+          )}
 
           {/* Week navigation */}
           <div className="flex items-center gap-1 bg-background border border-border rounded-md">


### PR DESCRIPTION
## Summary
- Only MANAGER role can see the user-picker dropdown on the timesheet page
- Engineers now only see their own time entries (no way to switch users via UI)
- Uses `useSession` to check role, consistent with other components (topbar.tsx)

Fixes #286

## Test plan
- [ ] Login as Engineer → no user-picker visible on /timesheet
- [ ] Login as Manager → user-picker visible, can switch users