### PR TITLE
refactor(#296): extract shared KPI calculator to lib/kpi-calculator.ts

### DIFF
--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { FormError, FormBanner } from "@/app/components/form-error";
 import { safeFixed, safePct } from "@/lib/safe-number";
+import { calculateAchievement } from "@/lib/kpi-calculator";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -41,17 +42,7 @@ interface KPI {
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 function achievementRate(kpi: KPI): number {
-  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-    const totalWeight = kpi.taskLinks.reduce((s, l) => s + l.weight, 0);
-    const weighted = kpi.taskLinks.reduce((s, l) => {
-      const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-      return s + (prog * l.weight) / 100;
-    }, 0);
-    return totalWeight > 0
-      ? Math.min((weighted / totalWeight) * kpi.target, 100)
-      : 0;
-  }
-  return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
+  return calculateAchievement(kpi);
 }
 
 function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { NotFoundError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { calculateAchievement } from "@/lib/kpi-calculator";
 
 export const GET = withAuth(async (
   _req: NextRequest,
@@ -32,17 +33,7 @@ export const GET = withAuth(async (
 
   if (!kpi) throw new NotFoundError("找不到 KPI");
 
-  let achievementRate = 0;
-  if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-    const totalWeight = kpi.taskLinks.reduce((sum, link) => sum + link.weight, 0);
-    const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
-      const progress = link.task.status === "DONE" ? 100 : link.task.progressPct;
-      return sum + (progress * link.weight) / 100;
-    }, 0);
-    achievementRate = totalWeight > 0 ? (weightedProgress / totalWeight) * kpi.target : 0;
-  } else {
-    achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-  }
+  const achievementRate = calculateAchievement(kpi);
 
   const linkedTaskCount = kpi.taskLinks.length;
   const completedTaskCount = kpi.taskLinks.filter((l) => l.task.status === "DONE").length;
@@ -51,7 +42,7 @@ export const GET = withAuth(async (
     kpiId: kpi.id,
     target: kpi.target,
     actual: kpi.actual,
-    achievementRate: Math.min(achievementRate, 100),
+    achievementRate,
     linkedTaskCount,
     completedTaskCount,
     autoCalc: kpi.autoCalc,

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { ExportService } from "@/services/export-service";
+import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
 
 const exportService = new ExportService();
 
@@ -110,25 +111,14 @@ export const GET = withAuth(async (req: NextRequest) => {
       orderBy: { code: "asc" },
     });
 
-    const kpisWithAchievement = kpis.map((kpi) => {
-      let achievementRate = 0;
-      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-        const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
-        const weighted = kpi.taskLinks.reduce((sum, l) => {
-          const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-          return sum + (prog * l.weight) / 100;
-        }, 0);
-        achievementRate = totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
-      } else {
-        achievementRate = kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-      }
-      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
-    });
+    const kpisWithAchievement = kpis.map((kpi) => ({
+      ...kpi,
+      achievementRate: calculateAchievement(kpi),
+    }));
 
-    const avgAchievement =
-      kpisWithAchievement.length > 0
-        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) / kpisWithAchievement.length
-        : 0;
+    const avgAchievement = calculateAvgAchievement(
+      kpisWithAchievement.map((k) => k.achievementRate)
+    );
 
     result = exportService.exportKPIReport({
       year,

--- a/lib/kpi-calculator.ts
+++ b/lib/kpi-calculator.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared KPI achievement calculation — single source of truth.
+ * Used by: KPI page, achievement API, report service, export service.
+ */
+
+interface KPILike {
+  target: number;
+  actual: number;
+  autoCalc?: boolean;
+  taskLinks?: { weight: number; task: { status: string; progressPct: number } }[];
+}
+
+/** Calculate achievement rate (0–100) for a single KPI. */
+export function calculateAchievement(kpi: KPILike): number {
+  if (kpi.autoCalc && kpi.taskLinks && kpi.taskLinks.length > 0) {
+    const totalWeight = kpi.taskLinks.reduce((s, l) => s + l.weight, 0);
+    if (totalWeight === 0) return 0;
+    const weighted = kpi.taskLinks.reduce((s, l) => {
+      const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
+      return s + (prog * l.weight) / 100;
+    }, 0);
+    return Math.min((weighted / totalWeight) * kpi.target, 100);
+  }
+  return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
+}
+
+/** Calculate simple achievement rate (actual/target) without autoCalc logic. */
+export function calculateSimpleAchievement(actual: number, target: number): number {
+  if (target === 0) return 0;
+  return Math.min((actual / target) * 100, 100);
+}
+
+/** Average achievement across multiple rates. */
+export function calculateAvgAchievement(rates: number[]): number {
+  if (rates.length === 0) return 0;
+  return rates.reduce((sum, r) => sum + r, 0) / rates.length;
+}

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient, Prisma } from "@prisma/client";
+import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
 
 // ── Filter types ────────────────────────────────────────────────────────────
 
@@ -280,28 +281,14 @@ export class ReportService {
       orderBy: { code: "asc" },
     });
 
-    const kpisWithAchievement = kpis.map((kpi) => {
-      let achievementRate = 0;
-      if (kpi.autoCalc && kpi.taskLinks.length > 0) {
-        const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
-        const weighted = kpi.taskLinks.reduce((sum, l) => {
-          const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-          return sum + (prog * l.weight) / 100;
-        }, 0);
-        achievementRate =
-          totalWeight > 0 ? (weighted / totalWeight) * kpi.target : 0;
-      } else {
-        achievementRate =
-          kpi.target > 0 ? (kpi.actual / kpi.target) * 100 : 0;
-      }
-      return { ...kpi, achievementRate: Math.min(achievementRate, 100) };
-    });
+    const kpisWithAchievement = kpis.map((kpi) => ({
+      ...kpi,
+      achievementRate: calculateAchievement(kpi),
+    }));
 
-    const avgAchievement =
-      kpisWithAchievement.length > 0
-        ? kpisWithAchievement.reduce((s, k) => s + k.achievementRate, 0) /
-          kpisWithAchievement.length
-        : 0;
+    const avgAchievement = calculateAvgAchievement(
+      kpisWithAchievement.map((k) => k.achievementRate)
+    );
 
     return {
       year: targetYear,


### PR DESCRIPTION
## Summary
- Create `lib/kpi-calculator.ts` as single source of truth for KPI achievement calculation
- Replace duplicated formula in 4 locations:
  - `services/report-service.ts`
  - `app/api/kpi/[id]/achievement/route.ts`
  - `app/api/reports/export/route.ts`
  - `app/(app)/kpi/page.tsx`
- Exports: `calculateAchievement()`, `calculateSimpleAchievement()`, `calculateAvgAchievement()`

Fixes #296