### PR TITLE
fix(security): unify CSP nonce header across all middleware paths

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkEdgeJwt } from "@/lib/auth-depth";
 
+/** CSP nonce header 名稱 — middleware 設定與 Server Components 讀取必須一致 */
+const CSP_NONCE_HEADER = "x-csp-nonce";
+
 /** 建構帶有動態 nonce 的 CSP header 值 */
 function buildCspWithNonce(nonce: string): string {
   return [
@@ -53,18 +56,24 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
 
   // Skip auth routes — next-auth handles its own sign-in / callback / CSRF flows
   if (pathname.startsWith("/api/auth/")) {
-    const res = NextResponse.next();
+    const reqHeaders = new Headers(req.headers);
+    reqHeaders.set(CSP_NONCE_HEADER, nonce);
+    reqHeaders.set("x-request-id", requestId);
+    const res = NextResponse.next({ request: { headers: reqHeaders } });
     res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-    res.headers.set("x-csp-nonce", nonce);
+    res.headers.set(CSP_NONCE_HEADER, nonce);
     res.headers.set("x-request-id", requestId);
     return res;
   }
 
   // Skip the change-password page itself to avoid redirect loops
   if (pathname === "/change-password") {
-    const res = NextResponse.next();
+    const reqHeaders = new Headers(req.headers);
+    reqHeaders.set(CSP_NONCE_HEADER, nonce);
+    reqHeaders.set("x-request-id", requestId);
+    const res = NextResponse.next({ request: { headers: reqHeaders } });
     res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-    res.headers.set("x-csp-nonce", nonce);
+    res.headers.set(CSP_NONCE_HEADER, nonce);
     res.headers.set("x-request-id", requestId);
     return res;
   }
@@ -87,12 +96,12 @@ export async function middleware(req: NextRequest): Promise<NextResponse> {
   // 所有通過驗證的請求：注入 nonce-based CSP、x-csp-nonce、x-request-id
   // Route handlers 可透過 headers() 讀取 'x-request-id' 做跨層追蹤
   const requestHeaders = new Headers(req.headers);
-  requestHeaders.set("x-csp-nonce", nonce);
+  requestHeaders.set(CSP_NONCE_HEADER, nonce);
   requestHeaders.set("x-request-id", requestId);
 
   const res = NextResponse.next({ request: { headers: requestHeaders } });
   res.headers.set("Content-Security-Policy", buildCspWithNonce(nonce));
-  res.headers.set("x-csp-nonce", nonce);
+  res.headers.set(CSP_NONCE_HEADER, nonce);
   res.headers.set("x-request-id", requestId);
   return res;
 }


### PR DESCRIPTION
## Summary
- Auth routes (`/api/auth/*`) and `/change-password` only set CSP nonce on **response** headers but not **request** headers, so `layout.tsx` reading `headers().get("x-csp-nonce")` got `null`
- This caused `<script>` tags to render without a nonce while CSP required one — XSS protection silently failed
- Now all code paths forward nonce via both request and response headers
- Extracted header name into `CSP_NONCE_HEADER` constant to prevent future inconsistencies

## Test plan
- [ ] Verify `/api/auth/signin` response includes `x-csp-nonce` header and matching CSP nonce
- [ ] Verify `/change-password` page `<script>` tag has correct `nonce` attribute
- [ ] Verify authenticated pages still work with no CSP violations in DevTools Console
- [ ] Verify CSP header `nonce-{value}` matches `<script nonce="{value}">`

Fixes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)