### PR TITLE
fix(infra): wire Alertmanager webhook receivers into routing tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,15 @@ SMTP_FROM_EMAIL=no-reply@titan.local
 # true = TLS（465 埠），false = STARTTLS（587 埠）
 SMTP_SECURE=false
 
+# ── Alertmanager 告警通知（必要）──────────────────────────────
+# SMTP 設定供 Alertmanager email receiver 使用（共用上方 SMTP_HOST/PORT）
+SMTP_FROM=titan-alerts@titan.local
+SMTP_USER=
+# 告警收件人（必填，否則 Alertmanager 啟動失敗）
+ALERT_EMAIL_TO=ops-team@example.com
+# Webhook 端點（Slack incoming webhook / n8n / custom alerting endpoint）
+ALERT_WEBHOOK_URL=http://host.docker.internal:8088/webhooks/alerts/default
+
 # ── Homepage 統一儀表板 ──────────────────────────────────────
 # 容器執行使用者 UID/GID（與 config/homepage 檔案擁有者一致）
 HOMEPAGE_PUID=1000

--- a/config/monitoring/alertmanager/alertmanager.yml
+++ b/config/monitoring/alertmanager/alertmanager.yml
@@ -20,10 +20,20 @@ route:
       repeat_interval: 30m
       continue: true
     - matchers:
+        - severity = "critical"
+      receiver: critical-webhook
+      repeat_interval: 30m
+      continue: false
+    - matchers:
         - severity = "warning"
       receiver: warning-email
       repeat_interval: 4h
       continue: true
+    - matchers:
+        - severity = "warning"
+      receiver: warning-webhook
+      repeat_interval: 4h
+      continue: false
 
 receivers:
   - name: default-email
@@ -47,7 +57,14 @@ receivers:
         headers:
           Subject: '[TITAN 警告] {{ .GroupLabels.alertname }}'
 
-  # Webhook backup (optional — configure if webhook receiver available)
+  # Webhook receivers — 確保告警即使 Email 故障也能透過 webhook 送達
+  # 設定 ALERT_WEBHOOK_URL 環境變數指向實際的 webhook 端點（Slack incoming webhook / n8n / custom）
+  - name: default-webhook
+    webhook_configs:
+      - url: '${ALERT_WEBHOOK_URL:-http://host.docker.internal:8088/webhooks/alerts/default}'
+        send_resolved: true
+        max_alerts: 20
+
   - name: critical-webhook
     webhook_configs:
       - url: 'http://host.docker.internal:8088/webhooks/alerts/critical'


### PR DESCRIPTION
## Summary
- Webhook receivers (`critical-webhook`, `warning-webhook`) were defined but never referenced in any route — alerts fired but nobody received notifications
- Added webhook routes for critical and warning severities as fallback after email routes
- Added `default-webhook` receiver with configurable `ALERT_WEBHOOK_URL` env var
- Documented `ALERT_EMAIL_TO` and `ALERT_WEBHOOK_URL` in `.env.example`

## Test plan
- [ ] POST test alert to `localhost:9093/api/v1/alerts` with `severity=critical`
- [ ] Confirm email AND webhook both receive the notification
- [ ] POST test alert with `severity=warning`, verify both channels fire
- [ ] Verify Alertmanager starts without errors: `docker logs titan-alertmanager`

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)