### PR TITLE
fix(test): resolve 21 failing Jest tests across 6 suites

### DIFF
--- a/__tests__/api/permissions.test.ts
+++ b/__tests__/api/permissions.test.ts
@@ -7,11 +7,22 @@
 import { createMockRequest } from "../utils/test-utils";
 
 const mockPermission = { findMany: jest.fn(), create: jest.fn(), updateMany: jest.fn() };
+const mockAuditLog = { create: jest.fn() };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { permission: mockPermission } }));
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    permission: mockPermission,
+    auditLog: mockAuditLog,
+  },
+}));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+
+// Mock logger to suppress output in tests
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
 
 const MEMBER = { user: { id: "u1", name: "Test", email: "t@e.com", role: "MEMBER" }, expires: "2099" };
 const MANAGER = { user: { id: "mgr", name: "Mgr", email: "m@e.com", role: "MANAGER" }, expires: "2099" };
@@ -70,6 +81,7 @@ describe("POST /api/permissions", () => {
     mockGetServerSession.mockResolvedValue(MANAGER);
     mockPermission.create.mockResolvedValue(MOCK_PERM);
     mockPermission.updateMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({ id: "audit-1" });
   });
 
   it("creates permission as manager", async () => {

--- a/__tests__/components/sidebar.test.tsx
+++ b/__tests__/components/sidebar.test.tsx
@@ -6,6 +6,21 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Sidebar } from "@/app/components/sidebar";
 
+// Mock window.matchMedia (not available in jsdom)
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: jest.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
 jest.mock("next/link", () => {
   const MockLink = ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) => (
     <a href={href} className={className}>{children}</a>
@@ -49,7 +64,7 @@ describe("Sidebar", () => {
   it("marks dashboard link as active when on dashboard path", () => {
     render(<Sidebar />);
     const dashboardLink = screen.getByText("儀表板").closest("a");
-    expect(dashboardLink?.className).toContain("bg-sidebar-accent");
+    expect(dashboardLink?.className).toContain("bg-[hsl(var(--sidebar-accent))]");
   });
 
   it("does not mark kanban as active when on dashboard", () => {
@@ -57,7 +72,7 @@ describe("Sidebar", () => {
     const dashboardLink = screen.getByText("儀表板").closest("a");
     const kanbanLink = screen.getByText("看板").closest("a");
     // Dashboard should be active, kanban should not have the active (non-hover) class as a standalone class
-    expect(dashboardLink?.className).toContain("bg-sidebar-accent");
+    expect(dashboardLink?.className).toContain("bg-[hsl(var(--sidebar-accent))]");
     // Kanban is not active — it should not contain the font-medium active indicator
     expect(kanbanLink?.className).not.toContain("font-medium");
   });
@@ -66,7 +81,7 @@ describe("Sidebar", () => {
     mockUsePathname.mockReturnValue("/kanban");
     render(<Sidebar />);
     const kanbanLink = screen.getByText("看板").closest("a");
-    expect(kanbanLink?.className).toContain("bg-sidebar-accent");
+    expect(kanbanLink?.className).toContain("bg-[hsl(var(--sidebar-accent))]");
   });
 
   it("renders navigation links with correct hrefs", () => {

--- a/__tests__/components/task-card.test.tsx
+++ b/__tests__/components/task-card.test.tsx
@@ -80,7 +80,7 @@ describe("TaskCard", () => {
     const task = { ...baseTask, priority: "P0" as const };
     const { container } = render(<TaskCard task={task} />);
     const card = container.firstChild as HTMLElement;
-    expect(card.className).toContain("border-l-red-500");
+    expect(card.className).toContain("border-l-danger");
   });
 
   it("shows primary assignee initial when no avatar", () => {

--- a/__tests__/components/topbar.test.tsx
+++ b/__tests__/components/topbar.test.tsx
@@ -5,6 +5,11 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/dashboard"),
+}));
+
 // Mock next-auth/react
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(() => ({

--- a/lib/__tests__/rbac-coverage.test.ts
+++ b/lib/__tests__/rbac-coverage.test.ts
@@ -57,6 +57,9 @@ jest.mock("@/lib/prisma", () => ({
       findMany: jest.fn(),
       count: jest.fn(),
     },
+    auditLog: {
+      create: jest.fn().mockResolvedValue({ id: "audit-1" }),
+    },
   },
 }));
 

--- a/services/__tests__/import-service.test.ts
+++ b/services/__tests__/import-service.test.ts
@@ -125,17 +125,28 @@ describe("ImportService", () => {
     ];
 
     test("importTasks creates tasks in batch", async () => {
-      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: "user-1" });
-      (prisma.task.create as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([
+        { id: "user-1", email: "a@b.com" },
+        { id: "user-2", email: "b@c.com" },
+      ]);
+      // $transaction receives a callback — invoke it with a mock tx that has task.createMany
+      (prisma.$transaction as jest.Mock).mockImplementation(async (cb: (tx: unknown) => unknown) => {
+        return cb({ task: { createMany: jest.fn().mockResolvedValue({ count: validRows.length }) } });
+      });
 
       await service.importTasks(validRows, "creator-1");
 
-      expect(prisma.task.create).toHaveBeenCalledTimes(validRows.length);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
     });
 
     test("importTasks returns count and errors", async () => {
-      (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: "user-1" });
-      (prisma.task.create as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([
+        { id: "user-1", email: "a@b.com" },
+        { id: "user-2", email: "b@c.com" },
+      ]);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (cb: (tx: unknown) => unknown) => {
+        return cb({ task: { createMany: jest.fn().mockResolvedValue({ count: 2 }) } });
+      });
 
       const result = await service.importTasks(validRows, "creator-1");
 
@@ -148,8 +159,10 @@ describe("ImportService", () => {
         { title: "", description: "", assigneeEmail: "", status: "TODO", priority: "P2", category: "PLANNED" }, // invalid: no title
       ];
 
-      (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
-      (prisma.task.create as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.$transaction as jest.Mock).mockImplementation(async (cb: (tx: unknown) => unknown) => {
+        return cb({ task: { createMany: jest.fn().mockResolvedValue({ count: 1 }) } });
+      });
 
       const result = await service.importTasks(mixedRows, "creator-1");
 


### PR DESCRIPTION
## Summary
- Fixed 21 failing tests across 6 test suites (sidebar, topbar, task-card, permissions, rbac-coverage, import-service)
- Root causes: missing jsdom mocks (matchMedia, usePathname), outdated CSS class assertions, incomplete Prisma mock for audit/transaction patterns

## Changes
- `sidebar.test.tsx`: Added `window.matchMedia` mock; updated active link class assertion to match `bg-[hsl(var(--sidebar-accent))]`
- `topbar.test.tsx`: Added `next/navigation` mock with `usePathname`
- `task-card.test.tsx`: Updated P0 border assertion from `border-l-red-500` to `border-l-danger`
- `permissions.test.ts`: Added `auditLog` and `logger` mocks for service-layer integration
- `rbac-coverage.test.ts`: Added `auditLog` mock for document DELETE route
- `import-service.test.ts`: Fixed `$transaction` mock to support callback pattern; switched to `user.findMany` for batch resolution

## Test plan
- [x] All 1023 tests pass (88 suites, 0 failures)
- [x] No source code changes — only test files modified

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)