### PR TITLE
feat(monitoring): add Plane targets to Prometheus

### DIFF
--- a/config/monitoring/prometheus/prometheus.yml
+++ b/config/monitoring/prometheus/prometheus.yml
@@ -78,3 +78,41 @@ scrape_configs:
       - targets: ['outline:3000']
         labels:
           type: 'application'
+
+  # ── Plane 服務監控（Issue #262）─────────────────────────
+  # Plane API — Django REST API 主服務
+  - job_name: 'plane-api'
+    metrics_path: '/api/v1/health'
+    static_configs:
+      - targets: ['plane-api:8000']
+        labels:
+          type: 'application'
+          app: 'plane'
+          component: 'api'
+
+  # Plane Web — Next.js 前端
+  - job_name: 'plane-web'
+    static_configs:
+      - targets: ['plane-web:3000']
+        labels:
+          type: 'application'
+          app: 'plane'
+          component: 'web'
+
+  # Plane Worker — Celery 背景任務
+  - job_name: 'plane-worker'
+    static_configs:
+      - targets: ['plane-worker:8000']
+        labels:
+          type: 'application'
+          app: 'plane'
+          component: 'worker'
+
+  # Plane RabbitMQ — 訊息佇列（Management API 提供 Prometheus 指標）
+  - job_name: 'plane-rabbitmq'
+    static_configs:
+      - targets: ['plane-mq:15692']
+        labels:
+          type: 'message-queue'
+          app: 'plane'
+          component: 'rabbitmq'


### PR DESCRIPTION
## Summary
- Adds Plane service scrape targets to `config/monitoring/prometheus/prometheus.yml`
- Covers: plane-api, plane-web, plane-worker, plane-rabbitmq
- Each target includes `app: plane` and `component` labels for Grafana dashboard filtering

## Test plan
- [ ] Reload Prometheus: `curl -X POST http://localhost:9090/-/reload`
- [ ] Verify targets appear in Prometheus UI: `http://localhost:9090/targets`
- [ ] Confirm Plane API target shows UP when Plane stack is running

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)