### PR TITLE
docs: 補齊 6 項文件與實作不同步的缺口

### DIFF
--- a/DOCKER_COMPOSE_README.md
+++ b/DOCKER_COMPOSE_README.md
@@ -53,6 +53,56 @@ docker-compose down
 docker run -d -p 5000:5000 --name registry -v registry-data:/var/lib/registry registry:2
 ```
 
+## TITAN Next.js 應用容器（Issue #185）
+
+### 容器規格
+
+| 項目 | 說明 |
+|------|------|
+| Dockerfile | 多階段建置（deps → builder → runner） |
+| 基底映像 | `node:20-alpine` |
+| 建置產出 | Next.js standalone output（`server.js`） |
+| 執行使用者 | `nextjs`（UID 1001，非 root） |
+| 暴露埠號 | 3100（容器內部），透過 Nginx 反向代理對外 |
+| 健康檢查 | `GET /api/auth/csrf`（30s 間隔） |
+| 資源限制 | CPU 2 核 / 記憶體 1024MB |
+
+### 必要環境變數
+
+| 變數 | 說明 | 範例 |
+|------|------|------|
+| `DATABASE_URL` | PostgreSQL 連線字串 | `postgresql://titan:password@postgres:5432/titan` |
+| `REDIS_URL` | Redis 連線字串 | `redis://:password@redis:6379` |
+| `NEXTAUTH_URL` | 應用對外 URL（含路徑） | `https://titan.bank.local/titan` |
+| `NEXTAUTH_SECRET` | NextAuth 加密金鑰（必填） | `openssl rand -hex 32` 產生 |
+| `NODE_ENV` | 執行環境 | `production` |
+
+### 部署方式
+
+```bash
+# 生產環境（與其他服務一起啟動）
+docker compose up -d titan-app
+
+# 單獨重建（程式碼更新後）
+docker compose build titan-app
+docker compose up -d titan-app
+
+# 查看日誌
+docker logs -f titan-app
+
+# 健康狀態
+docker inspect --format='{{.State.Health.Status}}' titan-app
+```
+
+### 網路拓撲
+
+```
+外部使用者 → Nginx（:443）→ titan-app（:3100）→ postgres / redis
+                                          ↑ titan-internal 網路
+```
+
+`titan-app` 不直接暴露端口至主機，所有外部存取透過 Nginx 反向代理。
+
 ## 依賴
 - T06: 需先完成基礎設施規劃
 

--- a/config/monitoring/alertmanager/alertmanager.yml
+++ b/config/monitoring/alertmanager/alertmanager.yml
@@ -60,6 +60,45 @@ receivers:
         send_resolved: true
         max_alerts: 20
 
+  # ══════════════════════════════════════════════════════════════
+  # Slack 通知範例（取消註解並填入實際 Webhook URL 即可啟用）
+  # 申請 Slack Incoming Webhook：
+  #   https://api.slack.com/messaging/webhooks
+  # ══════════════════════════════════════════════════════════════
+  # - name: critical-slack
+  #   slack_configs:
+  #     - api_url: '${SLACK_WEBHOOK_URL}'
+  #       channel: '#titan-alerts'
+  #       title: '[TITAN 緊急] {{ .GroupLabels.alertname }}'
+  #       text: |
+  #         *狀態*: {{ .Status | toUpper }}
+  #         *告警*: {{ .GroupLabels.alertname }}
+  #         *實例*: {{ .GroupLabels.instance }}
+  #         *摘要*: {{ range .Alerts }}{{ .Annotations.summary }}{{ end }}
+  #       color: '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}'
+  #       send_resolved: true
+  #
+  # - name: warning-slack
+  #   slack_configs:
+  #     - api_url: '${SLACK_WEBHOOK_URL}'
+  #       channel: '#titan-alerts'
+  #       title: '[TITAN 警告] {{ .GroupLabels.alertname }}'
+  #       text: |
+  #         *狀態*: {{ .Status | toUpper }}
+  #         *告警*: {{ .GroupLabels.alertname }}
+  #         *摘要*: {{ range .Alerts }}{{ .Annotations.summary }}{{ end }}
+  #       send_resolved: true
+  #
+  # ══════════════════════════════════════════════════════════════
+  # LINE Notify 範例（台灣銀行常用，取消註解即可啟用）
+  # 申請 LINE Notify Token：https://notify-bot.line.me/
+  # ══════════════════════════════════════════════════════════════
+  # - name: critical-line
+  #   webhook_configs:
+  #     - url: 'http://host.docker.internal:8089/line-notify'
+  #       send_resolved: true
+  #       # 需搭配 LINE Notify proxy 服務將 Alertmanager payload 轉為 LINE 格式
+
 inhibit_rules:
   - source_matchers:
       - severity = "critical"

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -63,8 +63,17 @@ titan/
 │   ├── account-integration.md   # 帳號整合說明
 │   ├── version-manifest.md      # 版本清單
 │   │
-│   └── auth/                    # 認證相關文件目錄
-│       └── security/            # 資安相關文件目錄
+│   ├── pg-replication.md        # PostgreSQL Primary-Replica 設定
+│   ├── pg-failover.md           # PostgreSQL 自動 Failover
+│   ├── key-rotation-policy.md   # 金鑰輪換政策
+│   │
+│   ├── auth/                    # 認證相關文件目錄
+│   │   └── keycloak-phase2-upgrade.md # Keycloak Phase 2 升級指引（新增）
+│   │
+│   └── security/                # 資安相關文件目錄
+│       ├── checklist.md         # 安全檢查清單
+│       ├── os-baseline.md       # OS 安全基線
+│       └── docker-socket-isolation.md # Docker Socket 隔離策略（新增）
 ```
 
 ---

--- a/docs/auth/keycloak-phase2-upgrade.md
+++ b/docs/auth/keycloak-phase2-upgrade.md
@@ -1,0 +1,133 @@
+# Keycloak Phase 2 認證整合升級指引
+
+> 從 Phase 1（本地帳號）升級至 Phase 2（Keycloak OIDC/SSO）
+
+**版本**: v1.0
+**最後更新**: 2026-03-25
+**前置文件**: `docs/auth-design.md`（§2. Phase 2）
+**相關 Issue**: #12, #220
+
+---
+
+## 1. 升級路徑概覽
+
+```
+Phase 1（目前）                    Phase 2（目標）
+┌─────────────────┐              ┌─────────────────┐
+│ TITAN Next.js   │              │ TITAN Next.js   │
+│ NextAuth local  │──升級──→     │ NextAuth OIDC   │
+│ bcrypt 密碼     │              │                 │
+├─────────────────┤              ├─────────────────┤
+│ Outline         │              │ Outline         │
+│ Email/Password  │──升級──→     │ OIDC Client     │
+├─────────────────┤              ├─────────────────┤
+│ Plane           │              │ Plane           │
+│ Local auth      │──升級──→     │ OIDC Client     │
+└─────────────────┘              └────────┬────────┘
+                                          │ OIDC
+                                          ▼
+                                 ┌─────────────────┐
+                                 │ Keycloak        │
+                                 │ (Identity Broker)│
+                                 │      ↓ LDAP     │
+                                 │ Bank AD/LDAP    │
+                                 └─────────────────┘
+```
+
+## 2. 前置條件
+
+- [ ] 行方 IT 部門提供 AD/LDAP 連線資訊（參考 `docs/auth-design.md` §2.2）
+- [ ] Keycloak 部署主機已備妥（建議同 TITAN 網段）
+- [ ] SSL 憑證已準備（Keycloak 需 HTTPS）
+- [ ] 維護窗口已排定（建議週六 09:00-17:00）
+- [ ] 完成 Phase 1 所有測試覆蓋率門檻
+
+## 3. 升級步驟
+
+### Step 1: 部署 Keycloak（1-2 小時）
+
+```bash
+# 加入 Keycloak 到 docker-compose
+# 建議使用獨立的 docker-compose.keycloak.yml
+docker compose -f docker-compose.yml -f docker-compose.keycloak.yml up -d keycloak
+
+# 等待 Keycloak 啟動（首次啟動較慢，需初始化資料庫）
+docker logs -f titan-keycloak
+# 看到 "Keycloak ... started in XXXs" 即可
+```
+
+### Step 2: 設定 Keycloak Realm（30 分鐘）
+
+1. 開啟 Keycloak Admin Console：`https://keycloak.internal.bank.com/admin`
+2. 建立 Realm：`titan`
+3. 匯入預設設定：`config/auth/keycloak-realm-export.json`
+4. 設定 LDAP User Federation（參考 `docs/auth-design.md` §2.2）
+5. 建立 Client：`titan-app`、`outline`、`plane`
+6. 設定群組對映（參考 `docs/auth-design.md` §2.5）
+
+### Step 3: 設定 TITAN Next.js OIDC（1 小時）
+
+```bash
+# 更新 .env
+NEXTAUTH_PROVIDER=oidc
+OIDC_CLIENT_ID=titan-app
+OIDC_CLIENT_SECRET=<Keycloak 產生的 client secret>
+OIDC_ISSUER=https://keycloak.internal.bank.com/realms/titan
+
+# NextAuth 設定檔已支援 OIDC provider（見 app/api/auth/[...nextauth]/route.ts）
+# AUTH_MODE 設為 hybrid 可同時保留本地帳號作為緊急 fallback
+AUTH_MODE=hybrid
+```
+
+### Step 4: 設定 Outline OIDC（30 分鐘）
+
+參考 `docs/auth-design.md` §2.3 設定 Outline 的 OIDC 環境變數。
+
+### Step 5: 設定 Plane OIDC（30 分鐘）
+
+參考 `docs/auth-design.md` §2.4 設定 Plane 的 OIDC 環境變數。
+
+### Step 6: 帳號遷移（1-2 小時）
+
+```bash
+# 確保 AD 使用者同步至 Keycloak
+# Keycloak Admin → User Federation → Synchronize all users
+
+# 驗證 Keycloak 使用者列表
+# Keycloak Admin → Users → 確認 AD 使用者已出現
+
+# Phase 1 本地帳號停用排程：
+# 1. 通知所有使用者改用 SSO 登入
+# 2. 觀察期 2 週，確認所有人已切換
+# 3. 停用 Phase 1 本地帳號（保留管理員緊急帳號）
+```
+
+### Step 7: 驗證（1 小時）
+
+- [ ] 使用 AD 帳號登入 TITAN Next.js
+- [ ] 使用 AD 帳號登入 Outline
+- [ ] 使用 AD 帳號登入 Plane
+- [ ] 確認角色對映正確（AD 群組 → 應用角色）
+- [ ] 確認管理員本地帳號仍可登入（fallback）
+- [ ] 確認 Session 正常過期與續期
+
+## 4. 回滾方案
+
+如升級過程發生問題：
+
+```bash
+# 還原 .env 為 Phase 1 設定
+AUTH_MODE=local
+
+# 重啟服務
+docker compose restart app outline
+
+# Phase 1 本地帳號立即可用
+```
+
+## 5. 參考
+
+- `docs/auth-design.md` — 完整認證設計文件
+- `docs/account-integration.md` — 帳號整合說明
+- Issue #12 — 認證模組實作
+- Issue #220 — LDAP/AD 整合規劃

--- a/docs/backup-strategy.md
+++ b/docs/backup-strategy.md
@@ -35,13 +35,42 @@
 
 ### 安裝排程
 
+**方法 A：自動安裝（建議）**
+
 ```bash
-# 以具備 docker 權限的使用者安裝
+# 使用安裝腳本（自動檢查重複、設定權限）
+sudo /opt/titan/scripts/backup.sh --install-cron
+
+# 或手動安裝
 sudo crontab -l | cat - /opt/titan/config/cron/backup-cron | sudo crontab -
 
 # 確認安裝
 sudo crontab -l
 ```
+
+**方法 B：Docker 初次部署時自動安裝**
+
+首次執行 `docker compose up -d` 後，執行部署後腳本：
+
+```bash
+# 部署後設定（含 cron 安裝、權限設定、首次備份）
+/opt/titan/scripts/backup.sh --install-cron
+/opt/titan/scripts/backup.sh  # 立即執行首次備份
+```
+
+**驗證排程已安裝：**
+
+```bash
+# 檢查 crontab 中是否包含 backup.sh
+sudo crontab -l | grep backup
+# 預期輸出：0 2 * * * root /opt/titan/scripts/backup.sh ...
+
+# 檢查最近一次備份是否成功
+ls -lt /opt/titan/backups/daily/ | head -5
+```
+
+> **重要**：Cron 排程檔位於 `config/cron/backup-cron`。若修改備份時間或保留策略，
+> 需重新執行安裝指令。詳見 `docs/disaster-recovery.md` §3 備份策略。
 
 ---
 

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -405,12 +405,74 @@ docker-compose logs > /tmp/titan_incident_$(date +%Y%m%d_%H%M%S).log
 
 ---
 
-## 8. DR 計畫維護
+## 8. HA 選項：PostgreSQL Primary-Replica
+
+> 參考 Issue #198、`docs/pg-replication.md`、`docker-compose.replication.yml`
+
+### 8.1 架構概述
+
+TITAN 支援 PostgreSQL Streaming Replication，提供讀寫分離與快速故障切換能力：
+
+```
+titan-postgres (Primary, RW)
+        │  WAL Streaming
+        ▼
+titan-postgres-replica (Standby, RO)
+```
+
+### 8.2 DR 效益
+
+| 指標 | 無 Replica | 啟用 Replica |
+|------|-----------|-------------|
+| RPO | 4 小時（依備份週期） | 近乎 0（WAL 即時串流） |
+| RTO | 30-90 分鐘（需還原備份） | 5-15 分鐘（Promote replica） |
+| 讀取負載 | 集中於 Primary | 分散至 Replica |
+
+### 8.3 故障切換步驟
+
+當 Primary 不可用時，將 Replica 提升為新 Primary：
+
+```bash
+# Step 1: 確認 Primary 確實不可用
+docker exec titan-postgres pg_isready || echo "Primary is DOWN"
+
+# Step 2: Promote Replica
+docker exec titan-postgres-replica pg_ctl promote -D /var/lib/postgresql/data
+
+# Step 3: 更新應用程式連線指向新 Primary
+# 修改 .env 中 DATABASE_URL 指向 replica 的 IP/hostname
+
+# Step 4: 重啟應用服務
+docker compose restart app
+
+# Step 5: 驗證
+docker exec titan-postgres-replica psql -U titan -d titan -c "SELECT pg_is_in_recovery();"
+# 預期回傳 false（已不再是 standby）
+```
+
+### 8.4 啟用方式
+
+詳見 `docs/pg-replication.md` 與 `docker-compose.replication.yml`。
+
+啟用指令：
+```bash
+docker compose -f docker-compose.yml -f docker-compose.replication.yml up -d
+```
+
+### 8.5 自動 Failover（docker-compose.failover.yml）
+
+進階方案使用 `docker-compose.failover.yml` 搭配 health check 自動偵測並切換，
+詳見 `docs/pg-failover.md`。
+
+---
+
+## 9. DR 計畫維護
 
 - **每半年複審**：IT 主管與相關工程師確認步驟仍然有效
 - **架構變更時**：任何影響備份或復原路徑的架構變更，必須同步更新本文件
 - **演練後**：若演練發現步驟有誤，立即更新並通知所有相關人員
 - **版本控制**：本文件納入 Git 管理，所有變更須有 commit 記錄
+- **Replica 啟用後**：更新 DR 演練步驟，納入 failover 切換練習
 
 ---
 

--- a/docs/security/docker-socket-isolation.md
+++ b/docs/security/docker-socket-isolation.md
@@ -1,0 +1,90 @@
+# Docker Socket 隔離策略
+
+> Issue #183 — 安全強化：移除 Docker socket 直接掛載
+
+**版本**: v1.0
+**最後更新**: 2026-03-25
+**適用範圍**: docker-compose.yml 中使用 Docker API 的服務
+
+---
+
+## 1. 背景
+
+Homepage 與 Uptime Kuma 需要讀取 Docker 容器狀態以顯示儀表板資訊。
+原方案直接掛載 `/var/run/docker.sock`，等同賦予容器完整的 Docker daemon 控制權，
+一旦容器被入侵，攻擊者可藉由 Docker API 執行任意容器、讀取 volume 資料甚至逃逸至主機。
+
+## 2. 解決方案：Docker Socket Proxy
+
+採用 [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy) 作為中介：
+
+```
+Homepage / Uptime Kuma
+        │
+        ▼  (TCP :2375, 僅允許 GET)
+docker-socket-proxy
+        │
+        ▼  (Unix socket)
+/var/run/docker.sock
+```
+
+### 2.1 服務定義（docker-compose.yml）
+
+```yaml
+docker-socket-proxy:
+  image: tecnativa/docker-socket-proxy:0.2
+  container_name: titan-docker-proxy
+  restart: unless-stopped
+  environment:
+    CONTAINERS: 1      # 允許查詢容器清單
+    IMAGES: 0          # 禁止映像操作
+    VOLUMES: 0         # 禁止 volume 操作
+    NETWORKS: 0        # 禁止網路操作
+    EXEC: 0            # 禁止 exec 操作
+    POST: 0            # 禁止所有寫入（POST/PUT/DELETE）
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+  networks:
+    - titan-internal
+```
+
+### 2.2 客戶端設定
+
+使用 Docker Socket Proxy 的服務需設定 `DOCKER_HOST`：
+
+```yaml
+homepage:
+  environment:
+    DOCKER_HOST: tcp://docker-socket-proxy:2375
+
+uptime-kuma:
+  environment:
+    DOCKER_HOST: tcp://docker-socket-proxy:2375
+```
+
+原先的 `/var/run/docker.sock` 掛載已移除。
+
+## 3. 安全效果
+
+| 項目 | 修復前 | 修復後 |
+|------|--------|--------|
+| Docker API 存取 | 完整讀寫 | 僅 GET /containers |
+| 容器逃逸風險 | 高（可建立特權容器） | 極低（無寫入能力） |
+| 最小權限原則 | 不符合 | 符合 |
+
+## 4. 驗證方式
+
+```bash
+# 確認 proxy 僅允許 GET
+docker exec titan-docker-proxy wget -qO- http://localhost:2375/containers/json | head
+# → 應回傳容器清單 JSON
+
+# 確認寫入被拒絕
+docker exec titan-docker-proxy wget -qO- --post-data='{}' http://localhost:2375/containers/create
+# → 應回傳 403 Forbidden
+```
+
+## 5. 參考
+
+- Issue #183
+- [OWASP Docker Security — Socket Exposure](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html)


### PR DESCRIPTION
## Summary

- 新增 Docker Socket Proxy 隔離策略文件（`docs/security/docker-socket-isolation.md`）
- 災難復原計畫新增 PostgreSQL HA Primary-Replica 章節
- 新增 Keycloak Phase 2 升級指引（`docs/auth/keycloak-phase2-upgrade.md`）
- 擴充備份策略文件的 Cron 自動安裝說明
- DOCKER_COMPOSE_README 新增 TITAN Next.js 容器部署規格與環境變數
- Alertmanager 設定新增 Slack、LINE Notify 通知範例（已註解）

Fixes #266

## Test plan

- [ ] 確認所有新增/修改文件的連結正確
- [ ] 確認 PROJECT.md 索引已同步更新
- [ ] 確認 alertmanager.yml 語法正確（`docker compose config` 驗證）

🤖 Generated with [Claude Code](https://claude.com/claude-code)