### PR TITLE
fix(security): integrate rate limiter into apiHandler for all API routes

### DIFF
--- a/lib/api-handler.ts
+++ b/lib/api-handler.ts
@@ -10,7 +10,14 @@ import type { ApiResponse } from "@/lib/api-response";
 import { logger } from "@/lib/logger";
 import { requestLogger } from "@/lib/request-logger";
 import { validateCsrf, CsrfError } from "@/lib/csrf";
-import { RateLimitError } from "@/lib/rate-limiter";
+import {
+  RateLimitError,
+  createApiRateLimiter,
+  checkRateLimit,
+} from "@/lib/rate-limiter";
+
+// ── Module-level API rate limiter (singleton, in-memory fallback) ──────────
+const apiLimiter = createApiRateLimiter({ useMemory: true });
 
 export type RouteContext = { params: Promise<Record<string, string>> };
 
@@ -42,13 +49,23 @@ export function apiHandler<T extends (...args: any[]) => Promise<NextResponse<Ap
     return requestLogger(req, async () => {
       try {
         validateCsrf(req);
+
+        // Rate limit by IP (or forwarded IP) — applies to ALL API routes
+        const rateLimitKey =
+          req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+          req.headers.get("x-real-ip") ||
+          "unknown";
+        await checkRateLimit(apiLimiter, rateLimitKey);
+
         return await fn(req, context);
       } catch (err) {
         if (err instanceof CsrfError) {
           return error("ForbiddenError", err.message, 403);
         }
         if (err instanceof RateLimitError) {
-          return error("RateLimitError", err.message, 429);
+          const res = error("RateLimitError", err.message, 429);
+          res.headers.set("Retry-After", String(err.retryAfter));
+          return res;
         }
         if (err instanceof ValidationError) {
           return error("ValidationError", err.message, 400);


### PR DESCRIPTION
## Summary
- `checkRateLimit()` existed in `lib/rate-limiter.ts` but was never called by `apiHandler` — no API route had rate limiting
- Wired `createApiRateLimiter` (100 req/60s per IP, in-memory singleton) into `apiHandler` so ALL routes get automatic protection
- Added `Retry-After` response header on 429 responses per RFC 6585
- Rate limit key uses `x-forwarded-for` or `x-real-ip` for correct IP behind reverse proxy

## Test plan
- [ ] Send 101 requests in <60s to any API endpoint, verify 101st returns 429 with `Retry-After` header
- [ ] Verify normal API usage (<100 req/min) is unaffected
- [ ] Check that rate limit key correctly uses forwarded IP, not always "unknown"

Fixes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)