### PR TITLE
feat: 部署 Loki + Promtail 日誌聚合

### DIFF
--- a/config/monitoring/grafana/datasources/loki.yml
+++ b/config/monitoring/grafana/datasources/loki.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+
+datasources:
+  - name: TITAN Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+    editable: false
+    jsonData:
+      maxLines: 1000
+      derivedFields:
+        # 從日誌中提取 traceID 並連結至 Prometheus（若有 trace 資訊）
+        - datasourceUid: prometheus
+          matcherRegex: '"traceId":"(\w+)"'
+          name: TraceID
+          url: '$${__value.raw}'

--- a/config/monitoring/loki/loki-config.yml
+++ b/config/monitoring/loki/loki-config.yml
@@ -1,0 +1,63 @@
+# ═══════════════════════════════════════════════════════════
+# Loki 配置 — TITAN 日誌聚合
+# Issue #265
+#
+# 設計考量：
+#   - 單節點部署（適合銀行內網小規模環境）
+#   - 本地 filesystem 儲存（無需外部 S3）
+#   - 保留 15 天日誌（與 Prometheus 指標保留期一致）
+#   - 適合 air-gapped 環境，無需外部連線
+# ═══════════════════════════════════════════════════════════
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+
+limits_config:
+  retention_period: 360h         # 15 天保留
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h  # 拒絕超過 7 天的舊日誌
+  max_query_series: 5000
+  max_query_parallelism: 2
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+
+analytics:
+  reporting_enabled: false       # air-gapped 環境不回報遙測

--- a/config/monitoring/promtail/promtail-config.yml
+++ b/config/monitoring/promtail/promtail-config.yml
@@ -1,0 +1,105 @@
+# ═══════════════════════════════════════════════════════════
+# Promtail 配置 — TITAN 日誌收集器
+# Issue #265
+#
+# 收集來源：
+#   1. Docker 容器日誌（/var/lib/docker/containers/）
+#   2. 系統日誌（/var/log/syslog）
+#
+# 標籤策略：
+#   - container_name：容器名稱（如 titan-app、titan-postgres）
+#   - job：依服務分組（titan-app、database、monitoring 等）
+#   - level：日誌等級（從 Pino JSON 或 syslog 解析）
+# ═══════════════════════════════════════════════════════════
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    tenant_id: titan
+    batchwait: 1s
+    batchsize: 1048576          # 1MB
+
+scrape_configs:
+
+  # ── Docker 容器日誌 ──────────────────────────────────────
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          __path__: /var/lib/docker/containers/*/*-json.log
+
+    pipeline_stages:
+      # Step 1: 解析 Docker JSON log 格式
+      - docker: {}
+
+      # Step 2: 從容器標籤提取 container_name
+      - regex:
+          expression: '/var/lib/docker/containers/(?P<container_id>[a-f0-9]+)/'
+          source: filename
+
+      # Step 3: 嘗試解析 Pino JSON 日誌（TITAN Next.js 使用 Pino）
+      - match:
+          selector: '{job="docker"}'
+          stages:
+            - json:
+                expressions:
+                  level: level
+                  msg: msg
+                  time: time
+            - labels:
+                level:
+
+      # Step 4: 靜態標籤 — 依容器名稱分組
+      - match:
+          selector: '{container_name=~"titan-app.*"}'
+          stages:
+            - static_labels:
+                service: titan-app
+      - match:
+          selector: '{container_name=~"titan-postgres.*"}'
+          stages:
+            - static_labels:
+                service: database
+      - match:
+          selector: '{container_name=~"titan-redis.*"}'
+          stages:
+            - static_labels:
+                service: cache
+      - match:
+          selector: '{container_name=~"titan-loki.*|titan-promtail.*|titan-prometheus.*|titan-grafana.*"}'
+          stages:
+            - static_labels:
+                service: monitoring
+      - match:
+          selector: '{container_name=~"titan-outline.*"}'
+          stages:
+            - static_labels:
+                service: outline
+      - match:
+          selector: '{container_name=~"titan-nginx.*"}'
+          stages:
+            - static_labels:
+                service: nginx
+
+  # ── 系統日誌（選用）──────────────────────────────────────
+  - job_name: syslog
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: syslog
+          __path__: /var/log/syslog
+    pipeline_stages:
+      - regex:
+          expression: '^(?P<timestamp>\S+ \S+ \S+) (?P<hostname>\S+) (?P<process>\S+): (?P<message>.*)'
+      - labels:
+          hostname:
+          process:

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,94 @@
+# ═══════════════════════════════════════════════════════════
+# TITAN — 日誌聚合配置：Loki + Promtail
+# Issue #265: 集中化日誌收集（輕量替代 ELK）
+#
+# 使用方式（與基礎 compose 合併啟動）：
+#   docker compose -f docker-compose.yml \
+#     -f docker-compose.monitoring.yml \
+#     -f docker-compose.logging.yml up -d
+#
+# 架構：
+#   容器日誌 → Promtail（收集）→ Loki（儲存）→ Grafana（查詢）
+#
+# 前置條件：
+#   1. docker-compose.monitoring.yml 已啟動（Grafana 已運行）
+#   2. titan-internal 網路已建立
+# ═══════════════════════════════════════════════════════════
+
+version: '3.8'
+
+services:
+
+  # ── 日誌儲存：Loki ──────────────────────────────────────────
+  # 輕量日誌聚合系統，類似 Prometheus 但用於日誌
+  # 儲存方式：本地 filesystem（小規模）或 MinIO S3（大規模）
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: titan-loki
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./config/monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    ports:
+      - "${LOKI_PORT:-3100}:3100"
+    networks:
+      - titan-internal
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  # ── 日誌收集：Promtail ──────────────────────────────────────
+  # 從 Docker 容器收集日誌並推送至 Loki
+  # 自動發現所有 Docker 容器並收集 stdout/stderr
+  promtail:
+    image: grafana/promtail:2.9.4
+    container_name: titan-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./config/monitoring/promtail/promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/log:/var/log:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - promtail-positions:/tmp/positions
+    networks:
+      - titan-internal
+    depends_on:
+      loki:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
+# ═══════════════════════════════════════════════════════════
+# 具名 Volume
+# ═══════════════════════════════════════════════════════════
+volumes:
+  loki-data:
+    name: titan-loki-data
+  promtail-positions:
+    name: titan-promtail-positions
+
+# ═══════════════════════════════════════════════════════════
+# 網路設定
+# ═══════════════════════════════════════════════════════════
+networks:
+  titan-internal:
+    name: titan-internal
+    external: true


### PR DESCRIPTION
## Summary

- 新增 `docker-compose.logging.yml`（Loki + Promtail 服務定義）
- Loki 配置：單節點 filesystem 儲存，15 天日誌保留，適合 air-gapped 環境
- Promtail 配置：自動收集所有 TITAN 容器日誌，支援 Pino JSON 解析、依服務分組
- Grafana Loki datasource 自動 provisioning

Fixes #265

## Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.monitoring.yml -f docker-compose.logging.yml config` 驗證語法
- [ ] 啟動後確認 Loki ready：`curl http://localhost:3100/ready`
- [ ] Grafana → Explore → 選擇 TITAN Loki datasource → 查詢 `{job="docker"}`
- [ ] 確認 titan-app 日誌的 Pino JSON level 被正確解析

🤖 Generated with [Claude Code](https://claude.com/claude-code)