### PR TITLE
test(infra): add test suites for infra scripts

### DIFF
--- a/tests/test-auth-init.sh
+++ b/tests/test-auth-init.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN auth-init.sh 測試套件
+# Issue #257 — Test coverage gaps for infra scripts
+# =============================================================================
+# 測試策略：使用 stub 替換外部命令（curl, jq, docker），
+#           驗證腳本的前置檢查、DRY_RUN 模式與錯誤處理。
+#
+# 使用方式：bash tests/test-auth-init.sh
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${REPO_ROOT}/scripts/auth-init.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# ─── 測試框架 ──────────────────────────────────────────────────────────────────
+
+log() { printf '[test] %s\n' "$1"; }
+
+pass() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '[PASS] %s\n' "$1"
+}
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '[FAIL] %s\n' "$1" >&2
+}
+
+new_fixture() {
+  local name="$1"
+  local dir="${TMP_DIR}/${name}"
+  mkdir -p "${dir}/bin"
+  printf '%s\n' "${dir}"
+}
+
+# ─── Stub 工具 ─────────────────────────────────────────────────────────────────
+
+write_passing_stubs() {
+  local dir="$1"
+
+  cat > "${dir}/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+echo "curl $*" >> "${TEST_LOG}"
+# 模擬 Outline API 回傳成功
+echo '{"ok": true}'
+STUB
+
+  cat > "${dir}/bin/jq" <<'STUB'
+#!/usr/bin/env bash
+echo "jq $*" >> "${TEST_LOG}"
+# 根據輸入判斷回傳值
+if echo "$*" | grep -q "\.ok"; then
+  echo "true"
+elif echo "$*" | grep -q "\.error"; then
+  echo "null"
+else
+  cat  # passthrough
+fi
+STUB
+
+  cat > "${dir}/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "docker $*" >> "${TEST_LOG}"
+STUB
+
+  cat > "${dir}/bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+# 短路 sleep 以加速測試
+exit 0
+STUB
+
+  chmod +x "${dir}/bin/curl" "${dir}/bin/jq" "${dir}/bin/docker" "${dir}/bin/sleep"
+}
+
+write_curl_missing_stub() {
+  local dir="$1"
+  # 只建立 jq 和 docker，不建立 curl
+  cat > "${dir}/bin/jq" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > "${dir}/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${dir}/bin/jq" "${dir}/bin/docker"
+}
+
+# ─── 測試案例 ──────────────────────────────────────────────────────────────────
+
+# 1. 腳本存在且可讀
+test_script_exists() {
+  local name="auth-init: script exists"
+  if [[ -f "${SCRIPT_UNDER_TEST}" ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 2. 腳本使用 set -euo pipefail
+test_script_has_strict_mode() {
+  local name="auth-init: uses set -euo pipefail"
+  if grep -q 'set -euo pipefail' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 3. --help 應以 exit 0 結束
+test_help_exits_zero() {
+  local name="auth-init: --help exits 0"
+  local dir
+  dir="$(new_fixture help)"
+  write_passing_stubs "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    "${SCRIPT_UNDER_TEST}" --help >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -eq 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name} (exit code: ${status})"
+  fi
+}
+
+# 4. 缺少 OUTLINE_API_TOKEN 時應退出
+test_missing_api_token_exits_nonzero() {
+  local name="auth-init: exits non-zero when OUTLINE_API_TOKEN is missing"
+  local dir
+  dir="$(new_fixture missing-token)"
+  write_passing_stubs "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    OUTLINE_API_TOKEN="" \
+    SKIP_HEALTH_CHECK=true \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 5. 缺少 curl 時應報錯退出
+test_missing_curl_exits_nonzero() {
+  local name="auth-init: exits non-zero when curl is missing"
+  local dir
+  dir="$(new_fixture missing-curl)"
+  write_curl_missing_stub "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin" \
+    OUTLINE_API_TOKEN=test-token \
+    SKIP_HEALTH_CHECK=true \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 6. DRY_RUN 模式不應呼叫 API
+test_dry_run_does_not_call_api() {
+  local name="auth-init: DRY_RUN=true does not call Outline API"
+  local dir
+  dir="$(new_fixture dry-run)"
+  write_passing_stubs "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    TEST_LOG="${dir}/calls.log" \
+    OUTLINE_API_TOKEN=test-token \
+    SKIP_HEALTH_CHECK=true \
+    DRY_RUN=true \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  set -e
+
+  # 在 DRY_RUN 模式下，curl 不應被用於 users.invite
+  if [[ -f "${dir}/calls.log" ]] && grep -q "users.invite" "${dir}/calls.log"; then
+    fail "${name} (API was called in DRY_RUN mode)"
+  else
+    pass "${name}"
+  fi
+}
+
+# 7. 腳本包含 Outline admin 建立邏輯
+test_script_has_admin_creation() {
+  local name="auth-init: contains admin creation logic"
+  if grep -q 'create_outline_admin' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 8. 腳本包含 Collection 建立邏輯
+test_script_has_collection_creation() {
+  local name="auth-init: contains collection creation logic"
+  if grep -q 'create_outline_collections' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 9. 腳本包含 Plane admin 設定說明
+test_script_has_plane_admin_instructions() {
+  local name="auth-init: contains Plane admin setup instructions"
+  if grep -q 'setup_plane_admin\|plane.*superuser\|createsuperuser' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# ─── 主程式 ────────────────────────────────────────────────────────────────────
+
+main() {
+  log "=== auth-init.sh Test Suite ==="
+
+  test_script_exists
+  test_script_has_strict_mode
+  test_help_exits_zero
+  test_missing_api_token_exits_nonzero
+  test_missing_curl_exits_nonzero
+  test_dry_run_does_not_call_api
+  test_script_has_admin_creation
+  test_script_has_collection_creation
+  test_script_has_plane_admin_instructions
+
+  echo ""
+  log "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+
+  if [[ ${TESTS_FAILED} -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/tests/test-db-init.sh
+++ b/tests/test-db-init.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN db-init.sh 測試套件
+# Issue #257 — Test coverage gaps for infra scripts
+# =============================================================================
+# 測試策略：使用 stub 替換外部命令（psql, pg_isready, mc），
+#           驗證腳本的前置檢查、錯誤處理與流程邏輯。
+#
+# 使用方式：bash tests/test-db-init.sh
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${REPO_ROOT}/scripts/db-init.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# ─── 測試框架 ──────────────────────────────────────────────────────────────────
+
+log() { printf '[test] %s\n' "$1"; }
+
+pass() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '[PASS] %s\n' "$1"
+}
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '[FAIL] %s\n' "$1" >&2
+}
+
+new_fixture() {
+  local name="$1"
+  local dir="${TMP_DIR}/${name}"
+  mkdir -p "${dir}/bin"
+  printf '%s\n' "${dir}"
+}
+
+# ─── Stub 工具 ─────────────────────────────────────────────────────────────────
+
+write_passing_stubs() {
+  local dir="$1"
+
+  # psql stub — 紀錄呼叫並回傳成功
+  cat > "${dir}/bin/psql" <<'STUB'
+#!/usr/bin/env bash
+echo "psql $*" >> "${TEST_LOG}"
+# 模擬查詢回傳（資料庫不存在 → 空結果）
+echo ""
+STUB
+
+  # pg_isready stub — 回傳就緒
+  cat > "${dir}/bin/pg_isready" <<'STUB'
+#!/usr/bin/env bash
+echo "pg_isready $*" >> "${TEST_LOG}"
+exit 0
+STUB
+
+  # mc stub — 回傳成功
+  cat > "${dir}/bin/mc" <<'STUB'
+#!/usr/bin/env bash
+echo "mc $*" >> "${TEST_LOG}"
+# mc ls 回傳空（bucket 不存在）
+exit 0
+STUB
+
+  chmod +x "${dir}/bin/psql" "${dir}/bin/pg_isready" "${dir}/bin/mc"
+}
+
+write_psql_missing_stub() {
+  local dir="$1"
+  # 不建立 psql，讓 command -v 找不到
+  cat > "${dir}/bin/pg_isready" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  cat > "${dir}/bin/mc" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "${dir}/bin/pg_isready" "${dir}/bin/mc"
+}
+
+write_pg_not_ready_stub() {
+  local dir="$1"
+  write_passing_stubs "${dir}"
+
+  # 覆寫 pg_isready — 永遠回傳失敗
+  cat > "${dir}/bin/pg_isready" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "${dir}/bin/pg_isready"
+}
+
+# ─── 執行待測腳本的包裝器 ──────────────────────────────────────────────────────
+
+run_db_init() {
+  local dir="$1"
+  shift
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    TEST_LOG="${dir}/calls.log" \
+    POSTGRES_HOST=127.0.0.1 \
+    POSTGRES_PORT=5432 \
+    POSTGRES_USER=titan \
+    POSTGRES_PASSWORD=test-password \
+    OUTLINE_DB_PASSWORD=test-outline-pw \
+    PLANE_DB_PASSWORD=test-plane-pw \
+    MINIO_ROOT_USER=minioadmin \
+    MINIO_ROOT_PASSWORD=test-minio-pw \
+    MINIO_ENDPOINT=http://127.0.0.1:9000 \
+    "${SCRIPT_UNDER_TEST}" "$@" 2>&1
+}
+
+# ─── 測試案例 ──────────────────────────────────────────────────────────────────
+
+# 1. 腳本存在且可執行
+test_script_exists_and_executable() {
+  local name="db-init: script exists and is executable"
+  if [[ -f "${SCRIPT_UNDER_TEST}" && -x "${SCRIPT_UNDER_TEST}" || -r "${SCRIPT_UNDER_TEST}" ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 2. 腳本使用 set -euo pipefail
+test_script_has_strict_mode() {
+  local name="db-init: uses set -euo pipefail"
+  if grep -q 'set -euo pipefail' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 3. 缺少 psql 時應報錯退出
+test_missing_psql_exits_nonzero() {
+  local name="db-init: exits non-zero when psql is missing"
+  local dir
+  dir="$(new_fixture missing-psql)"
+  write_psql_missing_stub "${dir}"
+
+  set +e
+  # 使用限制的 PATH，確保找不到 psql
+  env \
+    PATH="${dir}/bin" \
+    POSTGRES_PASSWORD=test \
+    OUTLINE_DB_PASSWORD=test \
+    PLANE_DB_PASSWORD=test \
+    MINIO_ROOT_PASSWORD=test \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 4. 缺少必要環境變數時應報錯
+test_missing_env_var_exits_nonzero() {
+  local name="db-init: exits non-zero when POSTGRES_PASSWORD is missing"
+  local dir
+  dir="$(new_fixture missing-env)"
+  write_passing_stubs "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    POSTGRES_USER=titan \
+    OUTLINE_DB_PASSWORD=test \
+    PLANE_DB_PASSWORD=test \
+    MINIO_ROOT_PASSWORD=test \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 5. PostgreSQL 未就緒時應超時退出
+test_pg_not_ready_exits_nonzero() {
+  local name="db-init: exits non-zero when PostgreSQL is unreachable"
+  local dir
+  dir="$(new_fixture pg-not-ready)"
+  write_pg_not_ready_stub "${dir}"
+
+  set +e
+  # 縮短重試等待時間，避免測試過慢（透過短路 sleep）
+  cat > "${dir}/bin/sleep" <<'STUB'
+#!/usr/bin/env bash
+# 短路 sleep 以加速測試
+exit 0
+STUB
+  chmod +x "${dir}/bin/sleep"
+
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    TEST_LOG="${dir}/calls.log" \
+    POSTGRES_HOST=127.0.0.1 \
+    POSTGRES_PORT=59999 \
+    POSTGRES_USER=titan \
+    POSTGRES_PASSWORD=test \
+    OUTLINE_DB_PASSWORD=test \
+    PLANE_DB_PASSWORD=test \
+    MINIO_ROOT_PASSWORD=test \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 6. 正常執行時應呼叫 psql 建立資料庫
+test_normal_run_calls_psql() {
+  local name="db-init: calls psql to create databases on normal run"
+  local dir
+  dir="$(new_fixture normal-run)"
+  write_passing_stubs "${dir}"
+
+  set +e
+  run_db_init "${dir}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ -f "${dir}/calls.log" ]] && grep -q "psql" "${dir}/calls.log"; then
+    pass "${name}"
+  else
+    fail "${name} (psql not called or log missing)"
+  fi
+}
+
+# 7. 腳本包含建立 Outline 和 Plane 資料庫的邏輯
+test_script_creates_both_databases() {
+  local name="db-init: contains logic for both outline and plane databases"
+  local outline_found=false
+  local plane_found=false
+
+  if grep -q 'OUTLINE_DB' "${SCRIPT_UNDER_TEST}"; then
+    outline_found=true
+  fi
+  if grep -q 'PLANE_DB' "${SCRIPT_UNDER_TEST}"; then
+    plane_found=true
+  fi
+
+  if [[ "${outline_found}" == "true" && "${plane_found}" == "true" ]]; then
+    pass "${name}"
+  else
+    fail "${name} (outline=${outline_found}, plane=${plane_found})"
+  fi
+}
+
+# 8. 腳本包含最小權限使用者建立
+test_script_creates_least_privilege_users() {
+  local name="db-init: creates users with NOSUPERUSER"
+  if grep -q 'NOSUPERUSER' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# ─── 主程式 ────────────────────────────────────────────────────────────────────
+
+main() {
+  log "=== db-init.sh Test Suite ==="
+
+  test_script_exists_and_executable
+  test_script_has_strict_mode
+  test_missing_psql_exits_nonzero
+  test_missing_env_var_exits_nonzero
+  test_pg_not_ready_exits_nonzero
+  test_normal_run_calls_psql
+  test_script_creates_both_databases
+  test_script_creates_least_privilege_users
+
+  echo ""
+  log "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+
+  if [[ ${TESTS_FAILED} -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"

--- a/tests/test-generate-ssl-cert.sh
+++ b/tests/test-generate-ssl-cert.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# =============================================================================
+# TITAN generate-ssl-cert.sh 測試套件
+# Issue #257 — Test coverage gaps for infra scripts
+# =============================================================================
+# 測試策略：使用 stub 替換 openssl，驗證腳本流程、
+#           輸出檔案產生與權限設定。
+#
+# 使用方式：bash tests/test-generate-ssl-cert.sh
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="${REPO_ROOT}/scripts/generate-ssl-cert.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# ─── 測試框架 ──────────────────────────────────────────────────────────────────
+
+log() { printf '[test] %s\n' "$1"; }
+
+pass() {
+  TESTS_PASSED=$((TESTS_PASSED + 1))
+  printf '[PASS] %s\n' "$1"
+}
+
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1))
+  printf '[FAIL] %s\n' "$1" >&2
+}
+
+new_fixture() {
+  local name="$1"
+  local dir="${TMP_DIR}/${name}"
+  mkdir -p "${dir}/bin"
+  printf '%s\n' "${dir}"
+}
+
+# ─── Stub 工具 ─────────────────────────────────────────────────────────────────
+
+write_openssl_stub() {
+  local dir="$1"
+
+  # openssl stub — 模擬憑證產生
+  cat > "${dir}/bin/openssl" <<'STUB'
+#!/usr/bin/env bash
+echo "openssl $*" >> "${TEST_LOG:-/dev/null}"
+
+# 模擬 openssl version
+if [[ "$1" == "version" ]]; then
+  echo "OpenSSL 3.0.0 (stub)"
+  exit 0
+fi
+
+# 模擬 openssl req -x509 — 產生空的 cert 和 key 檔案
+if [[ "$1" == "req" ]]; then
+  # 找出 -keyout 和 -out 參數的值
+  local keyout="" certout=""
+  local args=("$@")
+  for ((i=0; i<${#args[@]}; i++)); do
+    case "${args[i]}" in
+      -keyout) keyout="${args[i+1]}" ;;
+      -out)    certout="${args[i+1]}" ;;
+    esac
+  done
+  [[ -n "${keyout}" ]] && echo "FAKE-KEY" > "${keyout}"
+  [[ -n "${certout}" ]] && echo "FAKE-CERT" > "${certout}"
+  exit 0
+fi
+
+# 模擬 openssl x509 驗證
+if [[ "$1" == "x509" ]]; then
+  if echo "$*" | grep -q "\-subject"; then
+    echo "subject=CN = titan.bank.local"
+  elif echo "$*" | grep -q "\-dates"; then
+    echo "notBefore=Jan  1 00:00:00 2026 GMT"
+    echo "notAfter=Jan  1 00:00:00 2036 GMT"
+  elif echo "$*" | grep -q "\-ext"; then
+    echo "DNS:titan.bank.local, DNS:localhost, IP:127.0.0.1"
+  fi
+  exit 0
+fi
+
+# 模擬 openssl rand
+if [[ "$1" == "rand" ]]; then
+  echo "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+  exit 0
+fi
+
+exit 0
+STUB
+
+  # read stub — 自動回答 y（覆寫既有憑證）
+  cat > "${dir}/bin/read_wrapper" <<'STUB'
+#!/usr/bin/env bash
+echo "y"
+STUB
+
+  chmod +x "${dir}/bin/openssl" "${dir}/bin/read_wrapper"
+}
+
+write_openssl_missing() {
+  local dir="$1"
+  # 不建立 openssl stub
+  mkdir -p "${dir}/bin"
+}
+
+# ─── 測試案例 ──────────────────────────────────────────────────────────────────
+
+# 1. 腳本存在且可讀
+test_script_exists() {
+  local name="generate-ssl-cert: script exists"
+  if [[ -f "${SCRIPT_UNDER_TEST}" ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 2. 腳本使用 set -euo pipefail
+test_script_has_strict_mode() {
+  local name="generate-ssl-cert: uses set -euo pipefail"
+  if grep -q 'set -euo pipefail' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 3. 缺少 openssl 時應報錯退出
+test_missing_openssl_exits_nonzero() {
+  local name="generate-ssl-cert: exits non-zero when openssl is missing"
+  local dir
+  dir="$(new_fixture missing-openssl)"
+  write_openssl_missing "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin" \
+    FORCE=1 \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ ${status} -ne 0 ]]; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 4. 正常執行時應呼叫 openssl
+test_normal_run_calls_openssl() {
+  local name="generate-ssl-cert: calls openssl on normal run"
+  local dir
+  dir="$(new_fixture normal-run)"
+  write_openssl_stub "${dir}"
+
+  set +e
+  env \
+    PATH="${dir}/bin:${PATH}" \
+    TEST_LOG="${dir}/calls.log" \
+    FORCE=1 \
+    "${SCRIPT_UNDER_TEST}" >/dev/null 2>&1
+  local status=$?
+  set -e
+
+  if [[ -f "${dir}/calls.log" ]] && grep -q "openssl req" "${dir}/calls.log"; then
+    pass "${name}"
+  else
+    fail "${name} (openssl req not called)"
+  fi
+}
+
+# 5. 腳本包含 SAN 配置（Subject Alternative Names）
+test_script_has_san_config() {
+  local name="generate-ssl-cert: includes SAN configuration"
+  if grep -q 'subjectAltName\|alt_names' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 6. 腳本設定安全的檔案權限
+test_script_sets_secure_permissions() {
+  local name="generate-ssl-cert: sets chmod 600 on private key"
+  if grep -q 'chmod 600.*KEY_FILE\|chmod 600.*key' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 7. 腳本包含既有憑證覆寫確認
+test_script_has_overwrite_confirmation() {
+  local name="generate-ssl-cert: asks for overwrite confirmation"
+  if grep -q 'FORCE\|confirm\|覆寫' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 8. 預設網域為 titan.bank.local
+test_default_domain() {
+  local name="generate-ssl-cert: default domain is titan.bank.local"
+  if grep -q 'titan.bank.local' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 9. 腳本包含憑證驗證步驟
+test_script_has_verification() {
+  local name="generate-ssl-cert: includes certificate verification"
+  if grep -q 'verify_certificate\|openssl x509.*-noout' "${SCRIPT_UNDER_TEST}"; then
+    pass "${name}"
+  else
+    fail "${name}"
+  fi
+}
+
+# 10. RSA 金鑰長度至少 2048 bit
+test_key_length_at_least_2048() {
+  local name="generate-ssl-cert: RSA key length >= 2048"
+  local key_bits
+  key_bits=$(grep -oE 'KEY_BITS=[0-9]+' "${SCRIPT_UNDER_TEST}" | head -1 | cut -d= -f2)
+
+  if [[ -n "${key_bits}" && ${key_bits} -ge 2048 ]]; then
+    pass "${name}"
+  else
+    fail "${name} (found KEY_BITS=${key_bits:-not set})"
+  fi
+}
+
+# ─── 主程式 ────────────────────────────────────────────────────────────────────
+
+main() {
+  log "=== generate-ssl-cert.sh Test Suite ==="
+
+  test_script_exists
+  test_script_has_strict_mode
+  test_missing_openssl_exits_nonzero
+  test_normal_run_calls_openssl
+  test_script_has_san_config
+  test_script_sets_secure_permissions
+  test_script_has_overwrite_confirmation
+  test_default_domain
+  test_script_has_verification
+  test_key_length_at_least_2048
+
+  echo ""
+  log "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+
+  if [[ ${TESTS_FAILED} -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds `tests/test-db-init.sh` (8 test cases) covering prerequisite checks, env var validation, PostgreSQL readiness, and least-privilege user creation
- Adds `tests/test-auth-init.sh` (9 test cases) covering dependency checks, API token validation, DRY_RUN mode, and Outline admin/collection creation
- Adds `tests/test-generate-ssl-cert.sh` (10 test cases) covering openssl availability, SAN config, secure file permissions, and RSA key length
- All tests use stub commands (no real Docker/DB required), following the existing `tests/infra-validation.sh` pattern

## Test plan
- [ ] Run `bash tests/test-db-init.sh` and verify all 8 cases pass
- [ ] Run `bash tests/test-auth-init.sh` and verify all 9 cases pass
- [ ] Run `bash tests/test-generate-ssl-cert.sh` and verify all 10 cases pass

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)