### PR TITLE
chore(infra): upgrade Outline from 0.80.2 to 1.6.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
   # ── 知識庫：Outline ──────────────────────────────────────
   # 團隊知識庫與文件協作平台
   outline:
-    image: outlinewiki/outline:0.80.2
+    image: outlinewiki/outline:1.6.1
     container_name: titan-outline
     restart: unless-stopped
     # 安全強化：使用 non-root 使用者執行

--- a/docs/version-manifest.md
+++ b/docs/version-manifest.md
@@ -23,7 +23,7 @@
 
 | 映像名稱 | 版本 Tag | SHA256 摘要 | 壓縮大小 | 用途 |
 |---------|---------|------------|---------|------|
-| `outlinewiki/outline` | `0.80.2` | `sha256:（需從 Docker Hub 取得）` | ~350 MB | 知識管理 Wiki |
+| `outlinewiki/outline` | `1.6.1` | `sha256:（需從 Docker Hub 取得）` | ~350 MB | 知識管理 Wiki |
 | `gethomepage/homepage` | `v0.9.13` | `sha256:（需從 Docker Hub 取得）` | ~120 MB | 統一入口儀表板 |
 | `louislam/uptime-kuma` | `1.23.13` | `sha256:（需從 Docker Hub 取得）` | ~180 MB | 服務監控告警 |
 
@@ -53,7 +53,7 @@
 
 ```bash
 # Outline
-docker pull outlinewiki/outline:0.80.2
+docker pull outlinewiki/outline:1.6.1
 # Docker Hub: https://hub.docker.com/r/outlinewiki/outline/tags
 
 # Homepage
@@ -89,15 +89,15 @@ docker pull nginx:1.25-alpine
 
 ```bash
 # 拉取映像後取得摘要
-docker pull outlinewiki/outline:0.80.2
-docker inspect --format='{{index .RepoDigests 0}}' outlinewiki/outline:0.80.2
+docker pull outlinewiki/outline:1.6.1
+docker inspect --format='{{index .RepoDigests 0}}' outlinewiki/outline:1.6.1
 
 # 或使用 skopeo（推薦，不需拉取完整映像）
-skopeo inspect docker://outlinewiki/outline:0.80.2 | jq '.Digest'
+skopeo inspect docker://outlinewiki/outline:1.6.1 | jq '.Digest'
 
 # 批次取得所有映像摘要
 for image in \
-  "outlinewiki/outline:0.80.2" \
+  "outlinewiki/outline:1.6.1" \
   "gethomepage/homepage:v0.9.13" \
   "louislam/uptime-kuma:1.23.13" \
   "postgres:16-alpine" \
@@ -120,7 +120,7 @@ done
 # 步驟 1：在可連網的機器上拉取並儲存所有映像
 
 IMAGES=(
-  "outlinewiki/outline:0.80.2"
+  "outlinewiki/outline:1.6.1"
   "gethomepage/homepage:v0.9.13"
   "louislam/uptime-kuma:1.23.13"
   "postgres:16-alpine"
@@ -194,11 +194,11 @@ docker run -d -p 5000:5000 --restart=always \
   --name titan-registry registry:2
 
 # 推送映像至本地 Registry
-docker tag outlinewiki/outline:0.80.2 localhost:5000/outline:0.80.2
-docker push localhost:5000/outline:0.80.2
+docker tag outlinewiki/outline:1.6.1 localhost:5000/outline:1.6.1
+docker push localhost:5000/outline:1.6.1
 
 # 在 docker-compose.yml 中改用本地 Registry
-# image: localhost:5000/outline:0.80.2
+# image: localhost:5000/outline:1.6.1
 ```
 
 ---
@@ -228,11 +228,11 @@ docker push localhost:5000/outline:0.80.2
 
 ```bash
 # 使用 Trivy 掃描已知 CVE（在有網路的環境執行）
-trivy image outlinewiki/outline:0.80.2
+trivy image outlinewiki/outline:1.6.1
 trivy image postgres:16-alpine
 
 # 儲存掃描報告
-trivy image --format json --output outline-0.80.2-scan.json outlinewiki/outline:0.80.2
+trivy image --format json --output outline-1.6.1-scan.json outlinewiki/outline:1.6.1
 ```
 
 ---
@@ -242,6 +242,7 @@ trivy image --format json --output outline-0.80.2-scan.json outlinewiki/outline:
 | 版本 | 日期 | 變更內容 | 變更者 |
 |------|------|---------|-------|
 | v1.0 | 2026-03-23 | 初始版本建立，記錄 MVP 所有映像 | cct |
+| v1.1 | 2026-03-25 | Outline 從 0.80.2 升級至 1.6.1 (Issue #255) | claude |
 
 ---
 


### PR DESCRIPTION
## Summary
- Upgraded Outline wiki from `0.80.2` to `1.6.1` (latest stable)
- Updated `docker-compose.yml` image tag and all references in `docs/version-manifest.md`
- Outline 1.6.1 includes built-in MCP server, performance improvements, and security patches

## Files changed
- `docker-compose.yml`: Image tag update
- `docs/version-manifest.md`: All version references, download commands, scanning commands, and air-gapped transfer scripts

## Test plan
- [ ] Backup database before deploying
- [ ] Run `docker compose pull outline` to fetch new image
- [ ] Verify database migrations run on startup
- [ ] Confirm Outline UI loads and existing documents are accessible
- [ ] Verify OIDC/SSO login still works

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)