### PR TITLE
fix(infra): pin nginx to 1.27-alpine and unify uptime-kuma version

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -204,7 +204,7 @@ services:
   # ── 服務可達性監控：Uptime Kuma ──────────────────────────
   # HTTP/TCP/Ping/DNS 等主動式健康檢查
   uptime-kuma:
-    image: louislam/uptime-kuma:1.23.12
+    image: louislam/uptime-kuma:1.23.13
     container_name: titan-uptime-kuma
     restart: unless-stopped
     environment:

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # Nginx 反向代理（含 TLS）
   # ═══════════════════════════════════════════════════════════
   nginx:
-    image: nginx:1.25-alpine
+    image: nginx:1.27-alpine
     container_name: titan-nginx
     restart: unless-stopped
     ports:

--- a/plane/docker-compose.yml
+++ b/plane/docker-compose.yml
@@ -293,7 +293,7 @@ services:
 
   # ── Plane Nginx Proxy ──────────────────────────────────────
   plane-proxy:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     container_name: titan-plane-proxy
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
## Summary
- `plane/docker-compose.yml`: `nginx:alpine` (unversioned) pinned to `nginx:1.27-alpine`
- `nginx/docker-compose.yml`: `nginx:1.25-alpine` (outdated) updated to `nginx:1.27-alpine`
- `docker-compose.monitoring.yml`: `uptime-kuma:1.23.12` unified to `1.23.13` (matching `docker-compose.yml`)

Prevents version drift in air-gapped environments where images are pre-loaded.

## Test plan
- [ ] `docker compose -f nginx/docker-compose.yml config` shows `nginx:1.27-alpine`
- [ ] `docker compose -f plane/docker-compose.yml config` shows `nginx:1.27-alpine`
- [ ] `docker compose -f docker-compose.monitoring.yml config` shows `uptime-kuma:1.23.13`
- [ ] Verify no other `nginx:latest` or unversioned nginx tags remain

Fixes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)