### PR TITLE
feat(knowledge): integrate Outline wiki into TITAN UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,13 @@ OUTLINE_S3_BUCKET=outline
 # 日誌等級：error / warn / info / debug
 OUTLINE_LOG_LEVEL=info
 
+# ── Outline 與 TITAN UI 整合（Issue #258）──────────────────
+# TITAN 前端 iframe 嵌入 Outline 的 URL（公開環境變數）
+# 部署時設為 nginx 反向代理路徑（如 /outline）
+NEXT_PUBLIC_OUTLINE_URL=/outline
+# TITAN 後端存取 Outline 的內部 URL（Docker 內網通訊用）
+OUTLINE_INTERNAL_URL=/outline
+
 # ── Outline OIDC 單一登入（選用）────────────────────────────
 # 若使用公司 SSO（如 Keycloak、Azure AD），請填入以下設定
 # 若不使用 SSO，留空即可（使用 email + 密碼登入）

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Loader2, Save, Plus, BookOpen } from "lucide-react";
+import { Loader2, Save, Plus, BookOpen, ExternalLink, FileEdit, Globe } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DocumentTree, type DocNode } from "@/app/components/document-tree";
 import { MarkdownEditor } from "@/app/components/markdown-editor";
@@ -21,6 +21,10 @@ type DocDetail = {
   updatedAt: string;
 };
 
+type ViewMode = "editor" | "outline";
+
+const OUTLINE_URL = process.env.NEXT_PUBLIC_OUTLINE_URL || "/outline";
+
 export default function KnowledgePage() {
   const [docs, setDocs] = useState<DocNode[]>([]);
   const [loadingDocs, setLoadingDocs] = useState(true);
@@ -32,6 +36,7 @@ export default function KnowledgePage() {
   const [editContent, setEditContent] = useState("");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>("editor");
 
   // Load doc tree
   const loadDocs = useCallback(async () => {
@@ -133,138 +138,198 @@ export default function KnowledgePage() {
       <div className="flex items-center justify-between pb-4 flex-shrink-0">
         <div>
           <h1 className="text-xl font-semibold tracking-tight">知識庫</h1>
-          <p className="text-muted-foreground text-sm mt-0.5">Markdown 文件管理</p>
+          <p className="text-muted-foreground text-sm mt-0.5">
+            {viewMode === "editor" ? "Markdown 文件管理" : "Outline 協作知識庫"}
+          </p>
         </div>
-        <button
-          onClick={() => createDoc(null)}
-          className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          新增文件
-        </button>
-      </div>
-
-      {/* Main layout */}
-      <div className="flex flex-1 min-h-0 gap-0 border border-border rounded-xl overflow-hidden">
-        {/* Left sidebar */}
-        <div className="w-56 flex-shrink-0 border-r border-border flex flex-col bg-sidebar-background">
-          {/* Search */}
-          <div className="p-2 border-b border-border">
-            <DocumentSearch onSelect={setSelectedId} />
+        <div className="flex items-center gap-2">
+          {/* View mode toggle */}
+          <div className="flex items-center bg-muted rounded-lg p-0.5">
+            <button
+              onClick={() => setViewMode("editor")}
+              className={cn(
+                "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                viewMode === "editor"
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <FileEdit className="h-3.5 w-3.5" />
+              文件編輯器
+            </button>
+            <button
+              onClick={() => setViewMode("outline")}
+              className={cn(
+                "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                viewMode === "outline"
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              <Globe className="h-3.5 w-3.5" />
+              Outline Wiki
+            </button>
           </div>
 
-          {/* Tree */}
-          {loadingDocs ? (
-            <div className="flex-1 flex items-center justify-center">
-              <PageLoading message="載入文件..." className="py-6" />
-            </div>
-          ) : docsError ? (
-            <div className="flex-1 flex items-center justify-center p-2">
-              <PageError message={docsError} onRetry={loadDocs} className="py-4" />
-            </div>
-          ) : docs.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center p-2">
-              <PageEmpty
-                icon={<BookOpen className="h-7 w-7" />}
-                title="尚無文件"
-                description="點擊 + 新增文件"
-                className="py-4"
-              />
-            </div>
-          ) : (
-            <div className="flex-1 overflow-hidden">
-              <DocumentTree
-                docs={docs}
-                selectedId={selectedId}
-                onSelect={setSelectedId}
-                onNewDoc={createDoc}
-                onDelete={deleteDoc}
-              />
-            </div>
+          {viewMode === "editor" && (
+            <button
+              onClick={() => createDoc(null)}
+              className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              新增文件
+            </button>
           )}
-        </div>
 
-        {/* Right panel */}
-        <div className="flex-1 flex flex-col min-w-0 bg-card">
-          {!selectedId ? (
-            <div className="flex-1 flex items-center justify-center text-center">
-              <div>
-                <p className="text-muted-foreground text-sm">從左側選擇文件</p>
-                <p className="text-muted-foreground/60 text-xs mt-1">或點擊 + 新增文件</p>
-              </div>
-            </div>
-          ) : loadingDetail ? (
-            <div className="flex-1 flex items-center justify-center">
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-            </div>
-          ) : docDetail ? (
-            <>
-              {/* Editor header */}
-              <div className="flex items-center gap-3 px-4 py-3 border-b border-border flex-shrink-0">
-                <input
-                  type="text"
-                  value={editTitle}
-                  onChange={(e) => handleTitleChange(e.target.value)}
-                  className="flex-1 bg-transparent text-base font-semibold text-foreground focus:outline-none placeholder:text-muted-foreground border-b border-transparent focus:border-border pb-0.5 transition-colors"
-                  placeholder="文件標題..."
-                />
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {dirty && (
-                    <span className="text-xs text-amber-500">未儲存</span>
-                  )}
-                  <button
-                    onClick={save}
-                    disabled={!dirty || saving}
-                    className={cn(
-                      "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
-                      dirty
-                        ? "bg-accent hover:bg-accent/80 text-accent-foreground"
-                        : "bg-muted text-muted-foreground cursor-default"
-                    )}
-                  >
-                    {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
-                    儲存
-                  </button>
-                </div>
-              </div>
-
-              {/* Meta */}
-              <div className="px-4 py-1.5 border-b border-border/50 flex items-center gap-4 flex-shrink-0">
-                <span className="text-xs text-muted-foreground">
-                  建立：{docDetail.creator.name}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  最後更新：{docDetail.updater.name}
-                  　{new Date(docDetail.updatedAt).toLocaleDateString("zh-TW")}
-                </span>
-                <span className="text-xs text-muted-foreground/60 ml-auto">v{docDetail.version}</span>
-              </div>
-
-              {/* Markdown editor */}
-              <div className="flex-1 overflow-hidden">
-                <MarkdownEditor
-                  value={editContent}
-                  onChange={handleContentChange}
-                  placeholder="開始撰寫 Markdown..."
-                />
-              </div>
-
-              {/* Version history */}
-              <div className="flex-shrink-0">
-                <VersionHistory
-                  documentId={docDetail.id}
-                  currentVersion={docDetail.version}
-                  onRestore={handleRestore}
-                />
-              </div>
-            </>
-          ) : (
-            <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
-              文件不存在
-            </div>
+          {viewMode === "outline" && (
+            <a
+              href={OUTLINE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-card hover:bg-accent text-foreground rounded-md transition-colors border border-border"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              開啟完整 Outline
+            </a>
           )}
         </div>
       </div>
+
+      {/* Outline iframe view */}
+      {viewMode === "outline" && (
+        <div className="flex-1 min-h-0 border border-border rounded-xl overflow-hidden">
+          <iframe
+            src={OUTLINE_URL}
+            title="Outline 知識庫"
+            className="w-full h-full border-0"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+          />
+        </div>
+      )}
+
+      {/* Built-in editor view */}
+      {viewMode === "editor" && (
+        <div className="flex flex-1 min-h-0 gap-0 border border-border rounded-xl overflow-hidden">
+          {/* Left sidebar */}
+          <div className="w-56 flex-shrink-0 border-r border-border flex flex-col bg-sidebar-background">
+            {/* Search */}
+            <div className="p-2 border-b border-border">
+              <DocumentSearch onSelect={setSelectedId} />
+            </div>
+
+            {/* Tree */}
+            {loadingDocs ? (
+              <div className="flex-1 flex items-center justify-center">
+                <PageLoading message="載入文件..." className="py-6" />
+              </div>
+            ) : docsError ? (
+              <div className="flex-1 flex items-center justify-center p-2">
+                <PageError message={docsError} onRetry={loadDocs} className="py-4" />
+              </div>
+            ) : docs.length === 0 ? (
+              <div className="flex-1 flex items-center justify-center p-2">
+                <PageEmpty
+                  icon={<BookOpen className="h-7 w-7" />}
+                  title="尚無文件"
+                  description="點擊 + 新增文件"
+                  className="py-4"
+                />
+              </div>
+            ) : (
+              <div className="flex-1 overflow-hidden">
+                <DocumentTree
+                  docs={docs}
+                  selectedId={selectedId}
+                  onSelect={setSelectedId}
+                  onNewDoc={createDoc}
+                  onDelete={deleteDoc}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Right panel */}
+          <div className="flex-1 flex flex-col min-w-0 bg-card">
+            {!selectedId ? (
+              <div className="flex-1 flex items-center justify-center text-center">
+                <div>
+                  <p className="text-muted-foreground text-sm">從左側選擇文件</p>
+                  <p className="text-muted-foreground/60 text-xs mt-1">或點擊 + 新增文件</p>
+                </div>
+              </div>
+            ) : loadingDetail ? (
+              <div className="flex-1 flex items-center justify-center">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : docDetail ? (
+              <>
+                {/* Editor header */}
+                <div className="flex items-center gap-3 px-4 py-3 border-b border-border flex-shrink-0">
+                  <input
+                    type="text"
+                    value={editTitle}
+                    onChange={(e) => handleTitleChange(e.target.value)}
+                    className="flex-1 bg-transparent text-base font-semibold text-foreground focus:outline-none placeholder:text-muted-foreground border-b border-transparent focus:border-border pb-0.5 transition-colors"
+                    placeholder="文件標題..."
+                  />
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {dirty && (
+                      <span className="text-xs text-amber-500">未儲存</span>
+                    )}
+                    <button
+                      onClick={save}
+                      disabled={!dirty || saving}
+                      className={cn(
+                        "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                        dirty
+                          ? "bg-accent hover:bg-accent/80 text-accent-foreground"
+                          : "bg-muted text-muted-foreground cursor-default"
+                      )}
+                    >
+                      {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                      儲存
+                    </button>
+                  </div>
+                </div>
+
+                {/* Meta */}
+                <div className="px-4 py-1.5 border-b border-border/50 flex items-center gap-4 flex-shrink-0">
+                  <span className="text-xs text-muted-foreground">
+                    建立：{docDetail.creator.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    最後更新：{docDetail.updater.name}
+                    　{new Date(docDetail.updatedAt).toLocaleDateString("zh-TW")}
+                  </span>
+                  <span className="text-xs text-muted-foreground/60 ml-auto">v{docDetail.version}</span>
+                </div>
+
+                {/* Markdown editor */}
+                <div className="flex-1 overflow-hidden">
+                  <MarkdownEditor
+                    value={editContent}
+                    onChange={handleContentChange}
+                    placeholder="開始撰寫 Markdown..."
+                  />
+                </div>
+
+                {/* Version history */}
+                <div className="flex-shrink-0">
+                  <VersionHistory
+                    documentId={docDetail.id}
+                    currentVersion={docDetail.version}
+                    onRestore={handleRestore}
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+                文件不存在
+              </div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/api/outline/auth-redirect/route.ts
+++ b/app/api/outline/auth-redirect/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /api/outline/auth-redirect
+ *
+ * Verifies the TITAN session and redirects to Outline.
+ * This ensures users cannot access Outline without being authenticated
+ * in TITAN first. When OIDC (Keycloak) is configured in Phase 2,
+ * the shared session will eliminate the need for double login.
+ *
+ * For now, this acts as an authenticated gateway that:
+ * 1. Checks TITAN session (401 if not logged in)
+ * 2. Redirects to the Outline URL configured via OUTLINE_INTERNAL_URL
+ *
+ * Issue #258
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+
+const OUTLINE_URL = process.env.OUTLINE_INTERNAL_URL || "/outline";
+
+export const GET = withAuth(async (_req: NextRequest) => {
+  return NextResponse.redirect(new URL(OUTLINE_URL, _req.url));
+});


### PR DESCRIPTION
## Summary
- Added view mode toggle on knowledge page: built-in Markdown editor vs Outline wiki iframe
- Added `/api/outline/auth-redirect` route to enforce TITAN session before Outline access
- Added env vars `NEXT_PUBLIC_OUTLINE_URL` and `OUTLINE_INTERNAL_URL` for configuration
- Short-term solution per issue description; full OIDC SSO planned for Phase 2

## Changes
- `app/(app)/knowledge/page.tsx`: Added tab toggle between "editor" and "outline" views with iframe embed
- `app/api/outline/auth-redirect/route.ts`: New auth-gated redirect endpoint
- `.env.example`: Added Outline integration env vars

## Test plan
- [ ] Verify knowledge page loads in editor mode (default)
- [ ] Toggle to Outline Wiki tab and verify iframe loads Outline
- [ ] "Open full Outline" button opens in new tab
- [ ] Unauthenticated users cannot access `/api/outline/auth-redirect`
- [ ] Verify CSP `frame-ancestors 'self'` in nginx allows iframe embedding

Fixes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)