### PR TITLE
feat: 通知訂閱管理 + OTP 密碼重設工作流

### DIFF
--- a/app/(app)/admin/notifications/page.tsx
+++ b/app/(app)/admin/notifications/page.tsx
@@ -1,0 +1,154 @@
+/**
+ * Notification Preferences Page — Issue #267
+ *
+ * Allows users to manage their notification subscription preferences.
+ * Each notification type can be independently enabled/disabled.
+ */
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+
+interface NotificationPref {
+  type: string;
+  enabled: boolean;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  TASK_ASSIGNED: "任務指派通知",
+  TASK_DUE_SOON: "任務即將到期提醒",
+  TASK_OVERDUE: "任務逾期通知",
+  TASK_COMMENTED: "任務留言通知",
+  MILESTONE_DUE: "里程碑到期提醒",
+  BACKUP_ACTIVATED: "B 角啟用通知",
+  TASK_CHANGED: "任務變更通知",
+};
+
+export default function NotificationPreferencesPage() {
+  const { data: session } = useSession();
+  const [preferences, setPreferences] = useState<NotificationPref[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const userId = (session?.user as { id?: string } | undefined)?.id;
+
+  const fetchPreferences = useCallback(async () => {
+    if (!userId) return;
+    try {
+      const res = await fetch(`/api/users/${userId}/notification-preferences`);
+      const json = await res.json();
+      if (json.ok) {
+        setPreferences(json.data.preferences);
+      }
+    } catch {
+      setMessage("載入通知偏好失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchPreferences();
+  }, [fetchPreferences]);
+
+  const handleToggle = (type: string) => {
+    setPreferences((prev) =>
+      prev.map((p) => (p.type === type ? { ...p, enabled: !p.enabled } : p))
+    );
+  };
+
+  const handleSave = async () => {
+    if (!userId) return;
+    setSaving(true);
+    setMessage(null);
+
+    try {
+      const res = await fetch(`/api/users/${userId}/notification-preferences`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ preferences }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        setMessage("通知偏好已儲存");
+        setPreferences(json.data.preferences);
+      } else {
+        setMessage(json.message || "儲存失敗");
+      }
+    } catch {
+      setMessage("網路錯誤，請稍後再試");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <h1 className="text-2xl font-bold mb-4">通知偏好設定</h1>
+        <p className="text-muted-foreground">載入中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <h1 className="text-2xl font-bold mb-2">通知偏好設定</h1>
+      <p className="text-muted-foreground mb-6">
+        選擇您想接收的通知類型。關閉後將不再收到該類型的站內通知。
+      </p>
+
+      <div className="space-y-3">
+        {preferences.map((pref) => (
+          <label
+            key={pref.type}
+            className="flex items-center justify-between p-4 rounded-lg border bg-card hover:bg-accent/50 cursor-pointer"
+          >
+            <div>
+              <span className="font-medium">
+                {TYPE_LABELS[pref.type] || pref.type}
+              </span>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={pref.enabled}
+              onClick={() => handleToggle(pref.type)}
+              className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                pref.enabled ? "bg-primary" : "bg-muted"
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg transform transition-transform ${
+                  pref.enabled ? "translate-x-5" : "translate-x-0"
+                }`}
+              />
+            </button>
+          </label>
+        ))}
+      </div>
+
+      {message && (
+        <p className="mt-4 text-sm text-muted-foreground">{message}</p>
+      )}
+
+      <div className="mt-6 flex gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
+        >
+          {saving ? "儲存中..." : "儲存偏好"}
+        </button>
+        <button
+          onClick={fetchPreferences}
+          disabled={loading}
+          className="px-4 py-2 border rounded-md hover:bg-accent"
+        >
+          重設
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,169 @@
+/**
+ * Password Reset Page — Issue #267
+ *
+ * Self-service password reset using OTP (for air-gapped environments).
+ * Flow: User enters email + OTP (received from admin) + new password.
+ */
+"use client";
+
+import { useState, FormEvent } from "react";
+import Link from "next/link";
+
+export default function ResetPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [token, setToken] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+
+    if (newPassword !== confirmPassword) {
+      setMessage({ type: "error", text: "新密碼與確認密碼不一致" });
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setMessage({ type: "error", text: "密碼長度至少 8 個字元" });
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, token, newPassword }),
+      });
+
+      const json = await res.json();
+
+      if (json.ok) {
+        setMessage({ type: "success", text: "密碼已成功重設，請使用新密碼登入。" });
+        setEmail("");
+        setToken("");
+        setNewPassword("");
+        setConfirmPassword("");
+      } else {
+        setMessage({ type: "error", text: json.message || "重設失敗，請檢查重設碼是否正確" });
+      }
+    } catch {
+      setMessage({ type: "error", text: "網路錯誤，請稍後再試" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">重設密碼</h1>
+          <p className="text-muted-foreground mt-2">
+            請輸入您的 Email 與管理員提供的重設碼
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium mb-1">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md bg-background"
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="token" className="block text-sm font-medium mb-1">
+              重設碼（OTP）
+            </label>
+            <input
+              id="token"
+              type="text"
+              required
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md bg-background text-center text-2xl tracking-widest"
+              placeholder="000000"
+              maxLength={6}
+              pattern="[0-9]{6}"
+              inputMode="numeric"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="newPassword" className="block text-sm font-medium mb-1">
+              新密碼
+            </label>
+            <input
+              id="newPassword"
+              type="password"
+              required
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md bg-background"
+              minLength={8}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium mb-1">
+              確認新密碼
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 border rounded-md bg-background"
+              minLength={8}
+            />
+          </div>
+
+          {message && (
+            <div
+              className={`p-3 rounded-md text-sm ${
+                message.type === "success"
+                  ? "bg-green-50 text-green-800 border border-green-200"
+                  : "bg-red-50 text-red-800 border border-red-200"
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 disabled:opacity-50"
+          >
+            {loading ? "處理中..." : "重設密碼"}
+          </button>
+        </form>
+
+        <div className="text-center text-sm">
+          <Link href="/login" className="text-primary hover:underline">
+            返回登入頁面
+          </Link>
+        </div>
+
+        <div className="text-center text-xs text-muted-foreground">
+          <p>重設碼由管理員產生，有效期限 30 分鐘。</p>
+          <p>如未收到重設碼，請聯繫您的主管。</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/generate-reset-token/route.ts
+++ b/app/api/admin/generate-reset-token/route.ts
@@ -1,0 +1,104 @@
+/**
+ * POST /api/admin/generate-reset-token — Issue #267
+ *
+ * Manager generates a one-time password reset token (OTP) for a user.
+ * Designed for air-gapped environments where email delivery is unavailable.
+ *
+ * Flow:
+ *   1. Manager requests OTP for target user
+ *   2. Manager delivers OTP to user via secure channel (in-person, internal chat)
+ *   3. User enters OTP at /login/reset-password page
+ *
+ * Authorization: MANAGER only
+ */
+import { NextRequest } from "next/server";
+import { randomInt } from "crypto";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success, error } from "@/lib/api-response";
+import { AuditService } from "@/services/audit-service";
+import { logger } from "@/lib/logger";
+import { getClientIp } from "@/lib/get-client-ip";
+
+const TOKEN_EXPIRY_MINUTES = 30;
+const auditService = new AuditService(prisma);
+
+function generateOTP(): string {
+  // 6-digit numeric OTP
+  return String(randomInt(100000, 999999));
+}
+
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const adminId = (session.user as { id: string }).id;
+
+  let body: { userId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return error("ValidationError", "無效的請求格式", 400);
+  }
+
+  if (!body.userId) {
+    return error("ValidationError", "請提供 userId", 400);
+  }
+
+  // Verify target user exists
+  const targetUser = await prisma.user.findUnique({
+    where: { id: body.userId },
+    select: { id: true, name: true, email: true, isActive: true },
+  });
+
+  if (!targetUser) {
+    return error("NotFoundError", "找不到指定使用者", 404);
+  }
+
+  if (!targetUser.isActive) {
+    return error("ValidationError", "該使用者已停用", 400);
+  }
+
+  // Invalidate any existing unused tokens for this user
+  await prisma.passwordResetToken.updateMany({
+    where: { userId: body.userId, usedAt: null },
+    data: { usedAt: new Date() }, // mark as used to invalidate
+  });
+
+  // Generate new OTP
+  const token = generateOTP();
+  const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MINUTES * 60 * 1000);
+
+  await prisma.passwordResetToken.create({
+    data: {
+      userId: body.userId,
+      token,
+      expiresAt,
+      createdBy: adminId,
+    },
+  });
+
+  // Audit log
+  const ip = getClientIp(req);
+  await auditService.log({
+    action: "PASSWORD_RESET_TOKEN_GENERATED",
+    userId: adminId,
+    targetId: body.userId,
+    targetType: "User",
+    details: `管理員為 ${targetUser.name} 產生密碼重設 OTP`,
+    ipAddress: ip,
+  });
+
+  logger.info({
+    event: "password_reset_token_generated",
+    adminId,
+    targetUserId: body.userId,
+    expiresAt: expiresAt.toISOString(),
+  });
+
+  return success({
+    token,
+    expiresAt: expiresAt.toISOString(),
+    expiresInMinutes: TOKEN_EXPIRY_MINUTES,
+    userName: targetUser.name,
+  });
+});

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,0 +1,123 @@
+/**
+ * POST /api/auth/reset-password — Issue #267
+ *
+ * User submits OTP + new password to reset their password.
+ * Does NOT require an existing session (user may be locked out).
+ *
+ * Flow:
+ *   1. User enters email + OTP + new password
+ *   2. Server validates OTP, checks expiry
+ *   3. Password updated, OTP marked as used, mustChangePassword cleared
+ *
+ * Rate-limited by the global rate limiter in middleware.ts.
+ */
+import { NextRequest } from "next/server";
+import { hash } from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+import { success, error } from "@/lib/api-response";
+import { isPasswordValid, PASSWORD_POLICY_DESCRIPTION } from "@/lib/password-policy";
+import { AuditService } from "@/services/audit-service";
+import { logger } from "@/lib/logger";
+import { getClientIp } from "@/lib/get-client-ip";
+
+const auditService = new AuditService(prisma);
+
+export async function POST(req: NextRequest) {
+  let body: { email?: string; token?: string; newPassword?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return error("ValidationError", "無效的請求格式", 400);
+  }
+
+  const { email, token, newPassword } = body;
+
+  if (!email || !token || !newPassword) {
+    return error("ValidationError", "請填寫 email、重設碼與新密碼", 400);
+  }
+
+  // Find user by email
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, name: true, isActive: true },
+  });
+
+  if (!user) {
+    // Return generic error to prevent email enumeration
+    return error("InvalidTokenError", "重設碼無效或已過期", 400);
+  }
+
+  if (!user.isActive) {
+    return error("InvalidTokenError", "重設碼無效或已過期", 400);
+  }
+
+  // Find valid, unused token
+  const resetToken = await prisma.passwordResetToken.findFirst({
+    where: {
+      userId: user.id,
+      token,
+      usedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  });
+
+  if (!resetToken) {
+    logger.warn({
+      event: "password_reset_invalid_token",
+      email,
+      ip: getClientIp(req),
+    });
+    return error("InvalidTokenError", "重設碼無效或已過期", 400);
+  }
+
+  // Validate new password against policy
+  const passwordCheck = isPasswordValid(newPassword);
+  if (!passwordCheck) {
+    return error("ValidationError", PASSWORD_POLICY_DESCRIPTION, 400);
+  }
+
+  // Hash new password and update
+  const hashedPassword = await hash(newPassword, 12);
+
+  await prisma.$transaction([
+    // Update password
+    prisma.user.update({
+      where: { id: user.id },
+      data: {
+        password: hashedPassword,
+        mustChangePassword: false,
+        passwordChangedAt: new Date(),
+      },
+    }),
+    // Mark token as used
+    prisma.passwordResetToken.update({
+      where: { id: resetToken.id },
+      data: { usedAt: new Date() },
+    }),
+    // Add to password history
+    prisma.passwordHistory.create({
+      data: {
+        userId: user.id,
+        hashedPassword,
+      },
+    }),
+  ]);
+
+  // Audit log
+  const ip = getClientIp(req);
+  await auditService.log({
+    action: "PASSWORD_RESET_COMPLETED",
+    userId: user.id,
+    targetId: user.id,
+    targetType: "User",
+    details: `使用者 ${user.name} 透過 OTP 完成密碼重設`,
+    ipAddress: ip,
+  });
+
+  logger.info({
+    event: "password_reset_completed",
+    userId: user.id,
+  });
+
+  return success({ message: "密碼已成功重設，請使用新密碼登入" });
+}

--- a/app/api/users/[id]/notification-preferences/route.ts
+++ b/app/api/users/[id]/notification-preferences/route.ts
@@ -1,0 +1,92 @@
+/**
+ * GET/PUT /api/users/:id/notification-preferences — Issue #267
+ *
+ * GET: Returns the user's notification preferences (defaults to all enabled).
+ * PUT: Updates notification preferences for the user.
+ *
+ * Authorization: User can only manage their own preferences.
+ * Managers can view/update any user's preferences.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth, requireRole } from "@/lib/rbac";
+import { success, error } from "@/lib/api-response";
+import { RouteContext } from "@/lib/api-handler";
+import { NotificationType } from "@prisma/client";
+
+const ALL_TYPES = Object.values(NotificationType);
+
+export const GET = withAuth(async (req: NextRequest, context?: RouteContext) => {
+  const session = await requireAuth();
+  const { id } = await context!.params;
+
+  // Users can only view their own preferences; Managers can view anyone's
+  if (session.user.id !== id) {
+    await requireRole("MANAGER");
+  }
+
+  const prefs = await prisma.notificationPreference.findMany({
+    where: { userId: id },
+  });
+
+  // Build full preference map, defaulting to enabled for unset types
+  const prefMap = new Map(prefs.map((p) => [p.type, p.enabled]));
+  const preferences = ALL_TYPES.map((type) => ({
+    type,
+    enabled: prefMap.get(type) ?? true,
+  }));
+
+  return success({ preferences });
+});
+
+export const PUT = withAuth(async (req: NextRequest, context?: RouteContext) => {
+  const session = await requireAuth();
+  const { id } = await context!.params;
+
+  if (session.user.id !== id) {
+    await requireRole("MANAGER");
+  }
+
+  let body: { preferences?: Array<{ type: string; enabled: boolean }> };
+  try {
+    body = await req.json();
+  } catch {
+    return error("ValidationError", "無效的請求格式", 400);
+  }
+
+  if (!body.preferences || !Array.isArray(body.preferences)) {
+    return error("ValidationError", "請提供 preferences 陣列", 400);
+  }
+
+  // Validate all types
+  for (const pref of body.preferences) {
+    if (!ALL_TYPES.includes(pref.type as NotificationType)) {
+      return error("ValidationError", `無效的通知類型: ${pref.type}`, 400);
+    }
+  }
+
+  // Upsert each preference
+  const results = await Promise.all(
+    body.preferences.map((pref) =>
+      prisma.notificationPreference.upsert({
+        where: {
+          userId_type: { userId: id, type: pref.type as NotificationType },
+        },
+        update: { enabled: pref.enabled },
+        create: {
+          userId: id,
+          type: pref.type as NotificationType,
+          enabled: pref.enabled,
+        },
+      })
+    )
+  );
+
+  const preferences = results.map((r) => ({
+    type: r.type,
+    enabled: r.enabled,
+  }));
+
+  return success({ preferences });
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,8 @@ model User {
   deliverableAcceptances   Deliverable[]     @relation("DeliverableAcceptor")
   createdKPIs              KPI[]             @relation("KPICreator")
   passwordHistory          PasswordHistory[]
+  notificationPreferences  NotificationPreference[]
+  passwordResetTokens      PasswordResetToken[]
 
   @@map("users")
 }
@@ -475,6 +477,40 @@ model Notification {
 
   @@index([userId])
   @@map("notifications")
+}
+
+/// Notification preferences per user — Issue #267
+/// Each user can opt-in/out of specific notification types.
+model NotificationPreference {
+  id        String           @id @default(cuid())
+  userId    String
+  type      NotificationType
+  enabled   Boolean          @default(true)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@unique([userId, type])
+  @@map("notification_preferences")
+}
+
+/// Password reset tokens — Issue #267
+/// For air-gapped environments: admin generates OTP, user resets password.
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  userId    String
+  token     String   @unique          // 6-digit OTP or secure random token
+  expiresAt DateTime                  // default: 30 minutes from creation
+  usedAt    DateTime?                 // null = not yet used
+  createdBy String                    // admin userId who generated this token
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@index([token])
+  @@map("password_reset_tokens")
 }
 
 // ═══════════════════════════════════════


### PR DESCRIPTION
## Summary

- **通知訂閱管理（F6）**：新增 `NotificationPreference` model、API endpoint 與 UI，使用者可自訂接收的通知類型
- **密碼重設（F7）**：適用 air-gapped 環境的 OTP 方案 — Manager 產生 6 碼重設碼，使用者自助重設密碼
- Prisma schema 新增 `NotificationPreference` 與 `PasswordResetToken` model

### 新增檔案
- `app/api/users/[id]/notification-preferences/route.ts` — GET/PUT 通知偏好
- `app/api/admin/generate-reset-token/route.ts` — Manager 產生 OTP
- `app/api/auth/reset-password/route.ts` — 使用者以 OTP 重設密碼
- `app/(app)/admin/notifications/page.tsx` — 通知偏好設定 UI
- `app/(auth)/reset-password/page.tsx` — 密碼重設 UI

Fixes #267

## Test plan

- [ ] `npx prisma validate` 確認 schema 正確
- [ ] 通知偏好 API：GET 回傳所有類型預設 enabled，PUT 可更新
- [ ] OTP 產生：Manager 可為使用者產生 6 碼 OTP
- [ ] 密碼重設：使用正確 OTP 可重設密碼，過期/錯誤 OTP 被拒絕
- [ ] 審計日誌：OTP 產生與密碼重設均有 AuditLog 記錄

🤖 Generated with [Claude Code](https://claude.com/claude-code)