### PR TITLE
fix(types): resolve TypeScript errors blocking CI

### DIFF
--- a/__tests__/api/documents.test.ts
+++ b/__tests__/api/documents.test.ts
@@ -38,7 +38,7 @@ describe("GET /api/documents", () => {
 
   it("returns document list when authenticated", async () => {
     const { GET } = await import("@/app/api/documents/route");
-    const res = await GET(createMockRequest("/api/documents"));
+    const res = await (GET as Function)(createMockRequest("/api/documents"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data[0].id).toBe("doc-1");
@@ -47,14 +47,14 @@ describe("GET /api/documents", () => {
   it("returns 401 when no session", async () => {
     mockGetServerSession.mockResolvedValue(null);
     const { GET } = await import("@/app/api/documents/route");
-    const res = await GET(createMockRequest("/api/documents"));
+    const res = await (GET as Function)(createMockRequest("/api/documents"));
     expect(res.status).toBe(401);
   });
 
   it("returns 500 on database error", async () => {
     mockDocument.findMany.mockRejectedValue(new Error("DB"));
     const { GET } = await import("@/app/api/documents/route");
-    const res = await GET(createMockRequest("/api/documents"));
+    const res = await (GET as Function)(createMockRequest("/api/documents"));
     expect(res.status).toBe(500);
   });
 });

--- a/__tests__/api/kpi.test.ts
+++ b/__tests__/api/kpi.test.ts
@@ -118,7 +118,7 @@ describe("GET /api/kpi/[id]", () => {
 
   it("returns kpi by id", async () => {
     const { GET } = await import("@/app/api/kpi/[id]/route");
-    const res = await GET(createMockRequest("/api/kpi/kpi-1"), { params: { id: "kpi-1" } });
+    const res = await GET(createMockRequest("/api/kpi/kpi-1"), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.id).toBe("kpi-1");
@@ -127,14 +127,14 @@ describe("GET /api/kpi/[id]", () => {
   it("returns 404 when not found", async () => {
     mockKPI.findUnique.mockResolvedValue(null);
     const { GET } = await import("@/app/api/kpi/[id]/route");
-    const res = await GET(createMockRequest("/api/kpi/x"), { params: { id: "x" } });
+    const res = await GET(createMockRequest("/api/kpi/x"), { params: Promise.resolve({ id: "x" }) });
     expect(res.status).toBe(404);
   });
 
   it("returns 401 when no session", async () => {
     mockGetServerSession.mockResolvedValue(null);
     const { GET } = await import("@/app/api/kpi/[id]/route");
-    const res = await GET(createMockRequest("/api/kpi/kpi-1"), { params: { id: "kpi-1" } });
+    const res = await GET(createMockRequest("/api/kpi/kpi-1"), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(401);
   });
 });
@@ -148,14 +148,14 @@ describe("PUT /api/kpi/[id]", () => {
 
   it("updates KPI as manager", async () => {
     const { PUT } = await import("@/app/api/kpi/[id]/route");
-    const res = await PUT(createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { actual: 90 } }), { params: { id: "kpi-1" } });
+    const res = await PUT(createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { actual: 90 } }), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(200);
   });
 
   it("returns 403 for non-manager", async () => {
     mockGetServerSession.mockResolvedValue(MEMBER);
     const { PUT } = await import("@/app/api/kpi/[id]/route");
-    const res = await PUT(createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { actual: 90 } }), { params: { id: "kpi-1" } });
+    const res = await PUT(createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { actual: 90 } }), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(403);
   });
 });

--- a/__tests__/api/notifications.test.ts
+++ b/__tests__/api/notifications.test.ts
@@ -82,7 +82,7 @@ describe("PATCH /api/notifications/[id]/read", () => {
 
   it("marks notification as read", async () => {
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
-    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: { id: "notif-1" } });
+    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: Promise.resolve({ id: "notif-1" }) });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.data.isRead).toBe(true);
@@ -91,21 +91,21 @@ describe("PATCH /api/notifications/[id]/read", () => {
   it("returns 404 when notification not found", async () => {
     mockNotification.findUnique.mockResolvedValue(null);
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
-    const res = await PATCH(createMockRequest("/api/notifications/x/read", { method: "PATCH" }), { params: { id: "x" } });
+    const res = await PATCH(createMockRequest("/api/notifications/x/read", { method: "PATCH" }), { params: Promise.resolve({ id: "x" }) });
     expect(res.status).toBe(404);
   });
 
   it("returns 404 when notification belongs to different user", async () => {
     mockNotification.findUnique.mockResolvedValue({ ...MOCK_NOTIF, userId: "other" });
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
-    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: { id: "notif-1" } });
+    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: Promise.resolve({ id: "notif-1" }) });
     expect(res.status).toBe(404);
   });
 
   it("returns 401 when no session", async () => {
     mockGetServerSession.mockResolvedValue(null);
     const { PATCH } = await import("@/app/api/notifications/[id]/read/route");
-    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: { id: "notif-1" } });
+    const res = await PATCH(createMockRequest("/api/notifications/notif-1/read", { method: "PATCH" }), { params: Promise.resolve({ id: "notif-1" }) });
     expect(res.status).toBe(401);
   });
 });

--- a/__tests__/pages/root.test.tsx
+++ b/__tests__/pages/root.test.tsx
@@ -33,7 +33,7 @@ describe("Root Page (app/page.tsx)", () => {
     const { default: RootPage } = await import("@/app/page");
     // Server Component — just call it directly to trigger redirect
     try {
-      RootPage({} as never);
+      RootPage();
     } catch {
       // redirect() may throw in some environments — that is expected
     }
@@ -45,7 +45,7 @@ describe("Root Page (app/page.tsx)", () => {
     // The component should not return renderable JSX
     let result: unknown;
     try {
-      result = RootPage({} as never);
+      result = RootPage();
     } catch {
       result = undefined;
     }
@@ -55,7 +55,7 @@ describe("Root Page (app/page.tsx)", () => {
 
   it("redirect target is exactly /dashboard (not /login or /home)", async () => {
     const { default: RootPage } = await import("@/app/page");
-    try { RootPage({} as never); } catch { /* expected */ }
+    try { RootPage(); } catch { /* expected */ }
     // Must redirect to /dashboard specifically
     expect(mockRedirect).not.toHaveBeenCalledWith("/login");
     expect(mockRedirect).not.toHaveBeenCalledWith("/home");
@@ -64,7 +64,7 @@ describe("Root Page (app/page.tsx)", () => {
 
   it("redirect is called exactly once per render", async () => {
     const { default: RootPage } = await import("@/app/page");
-    try { RootPage({} as never); } catch { /* expected */ }
+    try { RootPage(); } catch { /* expected */ }
     expect(mockRedirect).toHaveBeenCalledTimes(1);
   });
 });

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { MANAGER_STATE_FILE } from './helpers/auth';
 
@@ -15,7 +16,7 @@ const KNOWN_VIOLATIONS = new Set<string>([
 ]);
 
 /** Run axe scan and assert no NEW violations beyond the known list. */
-async function assertNoNewViolations(page: Parameters<typeof AxeBuilder>[0]['page'], label: string) {
+async function assertNoNewViolations(page: Page, label: string) {
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])
     .exclude('[aria-hidden="true"]')

--- a/lib/__tests__/api-handler.test.ts
+++ b/lib/__tests__/api-handler.test.ts
@@ -54,7 +54,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 200 with data on success", async () => {
-    const handler = apiHandler(async () => success({ id: 1 }));
+    const handler = apiHandler(async (_req: NextRequest) => success({ id: 1 }));
     const res = await handler(req);
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -63,7 +63,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 400 with details on ValidationError", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new ValidationError("invalid input");
     });
     const res = await handler(req);
@@ -75,7 +75,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 401 on UnauthorizedError", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new UnauthorizedError();
     });
     const res = await handler(req);
@@ -86,7 +86,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 403 on ForbiddenError", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new ForbiddenError();
     });
     const res = await handler(req);
@@ -97,7 +97,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 404 on NotFoundError", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new NotFoundError("resource not found");
     });
     const res = await handler(req);
@@ -109,7 +109,7 @@ describe("apiHandler", () => {
   });
 
   test("returns 500 on unexpected error", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new Error("something broke");
     });
     const res = await handler(req);
@@ -120,7 +120,7 @@ describe("apiHandler", () => {
   });
 
   test("response format is { ok, data, error, message }", async () => {
-    const handler = apiHandler(async () => success({ value: 42 }));
+    const handler = apiHandler(async (_req: NextRequest) => success({ value: 42 }));
     const res = await handler(req);
     const body = await res.json();
     expect(body).toHaveProperty("ok");
@@ -133,7 +133,7 @@ describe("apiHandler", () => {
   test("logs error details for 500 errors", async () => {
     // apiHandler now uses pino logger.error instead of console.error
     const loggerSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new Error("db crash");
     });
     await handler(req);
@@ -147,7 +147,7 @@ describe("apiHandler", () => {
   });
 
   test("does not expose stack trace in response", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       throw new Error("internal");
     });
     const res = await handler(req);
@@ -157,7 +157,7 @@ describe("apiHandler", () => {
   });
 
   test("handles async handler correctly", async () => {
-    const handler = apiHandler(async () => {
+    const handler = apiHandler(async (_req: NextRequest) => {
       await Promise.resolve();
       return success({ async: true });
     });

--- a/services/__tests__/export-service.test.ts
+++ b/services/__tests__/export-service.test.ts
@@ -42,7 +42,7 @@ describe("ExportService", () => {
 
     // Parse with exceljs to verify content
     const workbook = new ExcelJS.Workbook();
-    await workbook.xlsx.load(buffer);
+    await workbook.xlsx.load(buffer as Buffer);
     const worksheet = workbook.worksheets[0];
 
     // First row should be headers


### PR DESCRIPTION
## Summary
- Fixes all `npx tsc --noEmit` errors that were blocking all CI pipelines
- 7 files updated across e2e tests, unit tests, and service code
- Root causes: type inference mismatch in `apiHandler` generics, Next.js 15 async `params` in RouteContext, Buffer generic incompatibility with ExcelJS, and incorrect AxeBuilder type extraction

## Changes
- **e2e/accessibility.spec.ts**: Use explicit `Page` type import instead of broken `Parameters<typeof AxeBuilder>` extraction
- **lib/__tests__/api-handler.test.ts**: Add `_req: NextRequest` parameter to inner functions so `apiHandler<T>` infers a callable signature
- **__tests__/api/documents.test.ts**: Cast `GET` as `Function` for 0-arg handler wrappers
- **__tests__/api/kpi.test.ts**: Wrap route params with `Promise.resolve()` per Next.js 15 `RouteContext` type
- **__tests__/api/notifications.test.ts**: Same `Promise.resolve` params fix
- **__tests__/pages/root.test.tsx**: Remove arguments from 0-param `RootPage()` calls
- **services/__tests__/export-service.test.ts**: Cast `Buffer` for ExcelJS type compatibility

## Test plan
- [x] `npx tsc --noEmit` passes with exit code 0
- [ ] CI pipeline completes successfully

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)