### PR TITLE
test: 新增 E2E negative test cases

### DIFF
--- a/e2e/auth-negative.spec.ts
+++ b/e2e/auth-negative.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Auth Negative E2E 測試 — Issue #289
+ *
+ * 驗證認證與授權的 negative paths：
+ * 1. 未登入存取受保護頁面 → redirect /login
+ * 2. 未登入呼叫 API → 401
+ * 3. Engineer 存取 Manager-only 功能 → 403
+ * 4. 無效 session cookie → redirect /login
+ *
+ * 注意：需要 Docker 環境（titan-app + titan-db）。
+ */
+
+import { test, expect } from '@playwright/test';
+import { ENGINEER_STATE_FILE } from './helpers/auth';
+
+// ═══════════════════════════════════════════════════════════
+// 未認證存取 — 受保護頁面
+// ═══════════════════════════════════════════════════════════
+
+test.describe('未認證存取 — 頁面 redirect', () => {
+  const protectedPages = [
+    '/dashboard',
+    '/kanban',
+    '/plans',
+    '/timesheet',
+    '/kpi',
+    '/reports',
+    '/admin',
+  ];
+
+  for (const path of protectedPages) {
+    test(`未登入訪問 ${path} → redirect to /login`, async ({ browser }) => {
+      // Fresh context with NO stored session
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      const response = await page.goto(path);
+      const url = page.url();
+      const status = response?.status() ?? 0;
+
+      // Either redirected to /login or received 401
+      const isBlocked = status === 401 || url.includes('/login');
+      expect(isBlocked).toBe(true);
+
+      await context.close();
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════
+// 未認證存取 — API endpoints → 401
+// ═══════════════════════════════════════════════════════════
+
+test.describe('未認證存取 — API 401', () => {
+  const apiEndpoints = [
+    { method: 'GET', path: '/api/tasks' },
+    { method: 'GET', path: '/api/users' },
+    { method: 'GET', path: '/api/notifications' },
+    { method: 'GET', path: '/api/kpi' },
+    { method: 'GET', path: '/api/plans' },
+  ];
+
+  for (const endpoint of apiEndpoints) {
+    test(`未登入 ${endpoint.method} ${endpoint.path} → 401`, async ({ request }) => {
+      const res = await request.get(endpoint.path);
+      expect(res.status()).toBe(401);
+
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+    });
+  }
+});
+
+// ═══════════════════════════════════════════════════════════
+// RBAC — Engineer 存取 Manager-only 功能 → 403
+// ═══════════════════════════════════════════════════════════
+
+test.describe('RBAC — Engineer 禁止存取 Manager-only API', () => {
+  test.use({ storageState: ENGINEER_STATE_FILE });
+
+  test('Engineer POST /api/users → 403', async ({ request }) => {
+    const res = await request.post('/api/users', {
+      data: {
+        name: 'test-rbac-user',
+        email: 'rbac-test@titan.local',
+        password: 'TestPassword123!',
+        role: 'ENGINEER',
+      },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('Engineer DELETE /api/users/:id → 403', async ({ request }) => {
+    const res = await request.delete('/api/users/nonexistent-id');
+    // Should get 403 (forbidden) not 404 (not found) — RBAC check first
+    expect(res.status()).toBe(403);
+  });
+
+  test('Engineer POST /api/admin/generate-reset-token → 403', async ({ request }) => {
+    const res = await request.post('/api/admin/generate-reset-token', {
+      data: { userId: 'some-user-id' },
+    });
+    expect(res.status()).toBe(403);
+  });
+
+  test('Engineer 存取 /admin 頁面 → 受限', async ({ page }) => {
+    await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+
+    // Admin page should either redirect or show access denied
+    const url = page.url();
+    const hasAccessDenied = await page.locator('text=權限不足').or(page.locator('text=無權限')).count();
+    const isRedirected = url.includes('/dashboard') || url.includes('/login');
+
+    expect(hasAccessDenied > 0 || isRedirected).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// 無效 Session — 偽造或過期的 cookie
+// ═══════════════════════════════════════════════════════════
+
+test.describe('無效 Session cookie', () => {
+  test('偽造 session cookie → redirect to /login', async ({ browser }) => {
+    const context = await browser.newContext();
+
+    // Set a fake session cookie
+    await context.addCookies([
+      {
+        name: 'next-auth.session-token',
+        value: 'fake-invalid-session-token-12345',
+        domain: 'localhost',
+        path: '/',
+      },
+    ]);
+
+    const page = await context.newPage();
+    const response = await page.goto('/dashboard');
+    const url = page.url();
+    const status = response?.status() ?? 0;
+
+    const isBlocked = status === 401 || url.includes('/login');
+    expect(isBlocked).toBe(true);
+
+    await context.close();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// 無效輸入 — API validation
+// ═══════════════════════════════════════════════════════════
+
+test.describe('API 輸入驗證', () => {
+  test.use({ storageState: ENGINEER_STATE_FILE });
+
+  test('GET /api/tasks?status=INVALID → 回傳空或錯誤', async ({ request }) => {
+    const res = await request.get('/api/tasks?status=INVALID_STATUS');
+    // Should either return empty results or 400, not crash
+    expect([200, 400]).toContain(res.status());
+  });
+
+  test('POST /api/auth/reset-password 空 body → 400', async ({ request }) => {
+    const res = await request.post('/api/auth/reset-password', {
+      data: {},
+    });
+    expect(res.status()).toBe(400);
+  });
+
+  test('POST /api/auth/reset-password 錯誤 OTP → 400', async ({ request }) => {
+    const res = await request.post('/api/auth/reset-password', {
+      data: {
+        email: 'admin@titan.local',
+        token: '000000',
+        newPassword: 'NewPassword123!',
+      },
+    });
+    expect(res.status()).toBe(400);
+  });
+});

--- a/e2e/negative-scenarios.spec.ts
+++ b/e2e/negative-scenarios.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Negative Scenario E2E 測試 — Issue #289
+ *
+ * 補充 auth-negative.spec.ts 以外的 negative test cases：
+ * 1. 不存在的頁面 → 404
+ * 2. 不存在的 API 資源 → 404
+ * 3. 空資料庫 — 更多頁面的 empty state 驗證
+ * 4. 並行操作與 edge cases
+ *
+ * 注意：需要 Docker 環境（titan-app + titan-db）。
+ */
+
+import { test, expect } from '@playwright/test';
+import { MANAGER_STATE_FILE, ENGINEER_STATE_FILE } from './helpers/auth';
+
+// ═══════════════════════════════════════════════════════════
+// 404 — 不存在的頁面
+// ═══════════════════════════════════════════════════════════
+
+test.describe('404 — 不存在的頁面', () => {
+  test.use({ storageState: MANAGER_STATE_FILE });
+
+  test('存取不存在的頁面 → 404 或錯誤頁', async ({ page }) => {
+    const response = await page.goto('/nonexistent-page-12345');
+    const status = response?.status() ?? 0;
+
+    // Should be 404 or a custom error page (not 500)
+    expect(status).toBeLessThan(500);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// 404 — 不存在的 API 資源
+// ═══════════════════════════════════════════════════════════
+
+test.describe('API — 不存在的資源 → 404', () => {
+  test.use({ storageState: MANAGER_STATE_FILE });
+
+  test('GET /api/tasks/nonexistent-id → 404', async ({ request }) => {
+    const res = await request.get('/api/tasks/nonexistent-id-12345');
+    expect(res.status()).toBe(404);
+  });
+
+  test('GET /api/users/nonexistent-id → 404', async ({ request }) => {
+    const res = await request.get('/api/users/nonexistent-id-12345');
+    expect(res.status()).toBe(404);
+  });
+
+  test('GET /api/plans/nonexistent-id → 404', async ({ request }) => {
+    const res = await request.get('/api/plans/nonexistent-id-12345');
+    expect(res.status()).toBe(404);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Empty State — 更多頁面驗證（補充 empty-state.spec.ts）
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Empty State — 額外頁面引導', () => {
+  test('Reports 頁面空資料時不白屏', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: MANAGER_STATE_FILE });
+    const page = await context.newPage();
+
+    await page.goto('/reports', { waitUntil: 'domcontentloaded' });
+
+    // Page should load without crash
+    await expect(page.locator('h1').first()).toBeVisible({ timeout: 15000 });
+
+    // Should show some content (not blank white screen)
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText?.length).toBeGreaterThan(10);
+
+    await context.close();
+  });
+
+  test('Gantt 頁面空資料時不白屏', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: MANAGER_STATE_FILE });
+    const page = await context.newPage();
+
+    await page.goto('/gantt', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('h1').first()).toBeVisible({ timeout: 15000 });
+
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText?.length).toBeGreaterThan(10);
+
+    await context.close();
+  });
+
+  test('KPI 頁面空資料時顯示引導', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: MANAGER_STATE_FILE });
+    const page = await context.newPage();
+
+    await page.goto('/kpi', { waitUntil: 'domcontentloaded' });
+
+    // Should show KPI heading
+    await expect(page.locator('h1').first()).toBeVisible({ timeout: 15000 });
+
+    // Should have some guidance text or empty state indicator
+    const bodyText = await page.locator('body').textContent();
+    expect(bodyText?.length).toBeGreaterThan(10);
+
+    await context.close();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════
+// Edge Cases — 重複操作與邊界輸入
+// ═══════════════════════════════════════════════════════════
+
+test.describe('Edge Cases — API 邊界輸入', () => {
+  test.use({ storageState: MANAGER_STATE_FILE });
+
+  test('GET /api/tasks?limit=-1 → 不崩潰', async ({ request }) => {
+    const res = await request.get('/api/tasks?limit=-1');
+    // Should not return 500
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('GET /api/tasks?limit=99999 → 不崩潰', async ({ request }) => {
+    const res = await request.get('/api/tasks?limit=99999');
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('GET /api/notifications?limit=0 → 不崩潰', async ({ request }) => {
+    const res = await request.get('/api/notifications?limit=0');
+    expect(res.status()).toBeLessThan(500);
+  });
+
+  test('PUT /api/tasks/nonexistent with valid body → 404', async ({ request }) => {
+    const res = await request.put('/api/tasks/nonexistent-id', {
+      data: { title: 'Updated title' },
+    });
+    expect(res.status()).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

新增 ~25 個 negative E2E test cases，補齊 happy path 以外的測試覆蓋：

- **`e2e/auth-negative.spec.ts`**：未認證 redirect、API 401、RBAC 403、無效 session、輸入驗證 400
- **`e2e/negative-scenarios.spec.ts`**：404 頁面/API、更多 empty state 驗證、API 邊界輸入

### 測試明細
| 類別 | 數量 | 說明 |
|------|------|------|
| 未登入 → redirect | 7 | 所有受保護頁面 |
| 未登入 → API 401 | 5 | tasks, users, notifications, kpi, plans |
| RBAC → 403 | 4 | Engineer → Manager-only 功能 |
| 無效 session | 1 | 偽造 cookie |
| API 驗證 → 400 | 3 | 空 body、錯誤 OTP |
| 404 頁面/資源 | 4 | 不存在的路徑與 ID |
| Empty state | 3 | Reports, Gantt, KPI |
| Edge cases | 4 | 負數 limit、超大值 |

Fixes #289

## Test plan

- [ ] `npx playwright test e2e/auth-negative.spec.ts` 通過
- [ ] `npx playwright test e2e/negative-scenarios.spec.ts` 通過
- [ ] 不影響既有 happy path 測試

🤖 Generated with [Claude Code](https://claude.com/claude-code)