### PR TITLE
fix(security): fix change-password error display to show validation messages

### DIFF
--- a/app/(auth)/change-password/page.tsx
+++ b/app/(auth)/change-password/page.tsx
@@ -33,7 +33,7 @@ export default function ChangePasswordPage() {
       const data = await res.json();
 
       if (!res.ok) {
-        setError(data.error || "密碼變更失敗");
+        setError(data.message || data.error || "密碼變更失敗");
         setLoading(false);
         return;
       }


### PR DESCRIPTION
## Summary
- 修正密碼變更頁面的錯誤訊息顯示：前端 error handler 原本讀取 `data.error`（錯誤類型名稱如 "ValidationError"），改為優先讀取 `data.message`（人類可讀的訊息如「目前密碼不正確」）
- API 端的 `currentPassword` bcrypt 驗證已存在且正確運作，問題出在前端無法正確顯示驗證失敗的原因

## Root Cause
`lib/api-response.ts` 的 error 回傳格式為 `{ ok: false, error: "ValidationError", message: "目前密碼不正確" }`，但前端使用 `data.error` 取得訊息，導致使用者只看到 "ValidationError" 而非中文錯誤說明。

## Test plan
- [ ] 登入後進入 /change-password，輸入錯誤的目前密碼，確認顯示「目前密碼不正確」
- [ ] 輸入不符合密碼政策的新密碼，確認顯示密碼政策說明
- [ ] 輸入與目前密碼相同的新密碼，確認顯示「新密碼不得與目前密碼相同」

Fixes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)