### PR TITLE
feat(api): add pagination to tasks, notifications, documents endpoints

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -396,7 +396,9 @@ function EngineerDashboard() {
         fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => { if (!r.ok) throw new Error("任務載入失敗"); return r.json(); }),
         fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
       ]);
-      setTasks(Array.isArray(taskRes) ? taskRes : taskRes.tasks ?? []);
+      // Support paginated response { data: { items, pagination } } and legacy formats
+      const taskPayload = taskRes?.data ?? taskRes;
+      setTasks(Array.isArray(taskPayload) ? taskPayload : Array.isArray(taskPayload?.items) ? taskPayload.items : []);
       setWeekly(wr);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -54,8 +54,10 @@ export default function KanbanPage() {
       if (filters.category) params.set("category", filters.category);
       const res = await fetch(`/api/tasks?${params}`);
       if (!res.ok) throw new Error("任務載入失敗");
-      const data = await res.json();
-      setTasks(Array.isArray(data) ? data : []);
+      const json = await res.json();
+      // Support paginated response { data: { items, pagination } } and legacy array
+      const payload = json?.data ?? json;
+      setTasks(Array.isArray(payload) ? payload : Array.isArray(payload?.items) ? payload.items : []);
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -47,7 +47,9 @@ export default function KnowledgePage() {
       const res = await fetch("/api/documents");
       if (!res.ok) throw new Error("文件載入失敗");
       const json = await res.json();
-      setDocs(Array.isArray(json) ? json : []);
+      // Support paginated response { data: { items, pagination } } and legacy array
+      const payload = json?.data ?? json;
+      setDocs(Array.isArray(payload) ? payload : Array.isArray(payload?.items) ? payload.items : []);
     } catch (e) {
       setDocsError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -5,25 +5,36 @@ import { createDocumentSchema } from "@/validators/document-validators";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 
-export const GET = withAuth(async () => {
-  const docs = await prisma.document.findMany({
-    select: {
-      id: true,
-      parentId: true,
-      title: true,
-      slug: true,
-      version: true,
-      createdAt: true,
-      updatedAt: true,
-      creator: { select: { id: true, name: true } },
-      updater: { select: { id: true, name: true } },
-      _count: { select: { children: true } },
-    },
-    orderBy: [{ parentId: "asc" }, { title: "asc" }],
-  });
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  return success(docs);
+  const select = {
+    id: true,
+    parentId: true,
+    title: true,
+    slug: true,
+    version: true,
+    createdAt: true,
+    updatedAt: true,
+    creator: { select: { id: true, name: true } },
+    updater: { select: { id: true, name: true } },
+    _count: { select: { children: true } },
+  } as const;
+
+  const [docs, total] = await Promise.all([
+    prisma.document.findMany({
+      select,
+      orderBy: [{ parentId: "asc" }, { title: "asc" }],
+      skip,
+      take: limit,
+    }),
+    prisma.document.count(),
+  ]);
+
+  return success({ items: docs, pagination: buildPaginationMeta(total, { page, limit, skip }) });
 });
 
 export const POST = withAuth(async (req: NextRequest) => {

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -3,32 +3,42 @@ import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 
 export const GET = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
 
   const { searchParams } = new URL(req.url);
-  const limit = parseInt(searchParams.get("limit") ?? "20");
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  const notifications = await prisma.notification.findMany({
-    where: { userId: session.user.id },
-    select: {
-      id: true,
-      type: true,
-      title: true,
-      body: true,
-      isRead: true,
-      relatedId: true,
-      relatedType: true,
-      createdAt: true,
-    },
-    orderBy: { createdAt: "desc" },
-    take: limit,
+  const where = { userId: session.user.id };
+
+  const [notifications, total, unreadCount] = await Promise.all([
+    prisma.notification.findMany({
+      where,
+      select: {
+        id: true,
+        type: true,
+        title: true,
+        body: true,
+        isRead: true,
+        relatedId: true,
+        relatedType: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: limit,
+    }),
+    prisma.notification.count({ where }),
+    prisma.notification.count({
+      where: { userId: session.user.id, isRead: false },
+    }),
+  ]);
+
+  return success({
+    items: notifications,
+    unreadCount,
+    pagination: buildPaginationMeta(total, { page, limit, skip }),
   });
-
-  const unreadCount = await prisma.notification.count({
-    where: { userId: session.user.id, isRead: false },
-  });
-
-  return success({ notifications, unreadCount });
 });

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -7,6 +7,7 @@ import { createTaskSchema } from "@/validators/task-validators";
 import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 
 const taskService = new TaskService(prisma);
 
@@ -20,15 +21,19 @@ export const GET = withAuth(async (req: NextRequest) => {
     assignee = session.user.id;
   }
 
-  const tasks = await taskService.listTasks({
+  const { page, limit, skip } = parsePagination(searchParams);
+
+  const { tasks, total } = await taskService.listTasks({
     assignee,
     status: (searchParams.get("status") as TaskStatus) ?? undefined,
     priority: (searchParams.get("priority") as Priority) ?? undefined,
     category: (searchParams.get("category") as TaskCategory) ?? undefined,
     monthlyGoalId: searchParams.get("monthlyGoalId") ?? undefined,
+    skip,
+    take: limit,
   });
 
-  return success(tasks);
+  return success({ items: tasks, pagination: buildPaginationMeta(total, { page, limit, skip }) });
 });
 
 export const POST = withAuth(async (req: NextRequest) => {

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -61,9 +61,11 @@ export function NotificationBell() {
     try {
       const res = await fetch("/api/notifications?limit=15");
       if (res.ok) {
-        const data = await res.json();
-        setNotifications(data.notifications ?? []);
-        setUnreadCount(data.unreadCount ?? 0);
+        const json = await res.json();
+        // Support paginated response { data: { items, unreadCount, pagination } }
+        const payload = json?.data ?? json;
+        setNotifications(payload?.items ?? payload?.notifications ?? []);
+        setUnreadCount(payload?.unreadCount ?? 0);
       }
     } finally {
       setLoading(false);

--- a/lib/pagination.ts
+++ b/lib/pagination.ts
@@ -1,0 +1,51 @@
+/**
+ * Pagination utilities — Issue #397
+ *
+ * Provides helpers for parsing pagination query params
+ * and building standardised pagination response metadata.
+ */
+
+export interface PaginationParams {
+  page: number;
+  limit: number;
+  skip: number;
+}
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * Parse `page` and `limit` from URL search params.
+ * Clamps values to safe ranges.
+ */
+export function parsePagination(searchParams: URLSearchParams): PaginationParams {
+  const rawPage = parseInt(searchParams.get("page") ?? "", 10);
+  const rawLimit = parseInt(searchParams.get("limit") ?? "", 10);
+
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : DEFAULT_PAGE;
+  const limit = Number.isFinite(rawLimit) && rawLimit >= 1
+    ? Math.min(rawLimit, MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  return { page, limit, skip: (page - 1) * limit };
+}
+
+/**
+ * Build pagination metadata from total count and current params.
+ */
+export function buildPaginationMeta(total: number, params: PaginationParams): PaginationMeta {
+  return {
+    page: params.page,
+    limit: params.limit,
+    total,
+    totalPages: Math.ceil(total / params.limit),
+  };
+}

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -9,6 +9,8 @@ export interface ListTasksFilter {
   priority?: Priority | string;
   category?: TaskCategory | string;
   monthlyGoalId?: string;
+  skip?: number;
+  take?: number;
 }
 
 export interface CreateTaskInput {
@@ -72,19 +74,26 @@ export class TaskService {
     if (filter.category) where.category = filter.category;
     if (filter.monthlyGoalId) where.monthlyGoalId = filter.monthlyGoalId;
 
-    return this.prisma.task.findMany({
-      where,
-      include: {
-        primaryAssignee: { select: { id: true, name: true, avatar: true } },
-        backupAssignee: { select: { id: true, name: true, avatar: true } },
-        creator: { select: { id: true, name: true } },
-        monthlyGoal: { select: { id: true, title: true, month: true } },
-        subTasks: { orderBy: { order: "asc" } },
-        deliverables: true,
-        _count: { select: { subTasks: true, comments: true } },
-      },
-      orderBy: [{ priority: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
-    });
+    const [tasks, total] = await Promise.all([
+      this.prisma.task.findMany({
+        where,
+        include: {
+          primaryAssignee: { select: { id: true, name: true, avatar: true } },
+          backupAssignee: { select: { id: true, name: true, avatar: true } },
+          creator: { select: { id: true, name: true } },
+          monthlyGoal: { select: { id: true, title: true, month: true } },
+          subTasks: { orderBy: { order: "asc" } },
+          deliverables: true,
+          _count: { select: { subTasks: true, comments: true } },
+        },
+        orderBy: [{ priority: "asc" }, { dueDate: "asc" }, { createdAt: "desc" }],
+        ...(filter.skip !== undefined && { skip: filter.skip }),
+        ...(filter.take !== undefined && { take: filter.take }),
+      }),
+      this.prisma.task.count({ where }),
+    ]);
+
+    return { tasks, total };
   }
 
   async getTask(id: string) {


### PR DESCRIPTION
## Summary
- 新增 `lib/pagination.ts` 提供 `parsePagination()` 和 `buildPaginationMeta()` 工具函式
- `GET /api/tasks`、`GET /api/notifications`、`GET /api/documents` 支援 `?page=1&limit=20` 分頁參數
- 回應格式：`{ ok: true, data: { items: [...], pagination: { page, limit, total, totalPages } } }`
- 前端元件（kanban、dashboard、knowledge、notification-bell）已更新以相容新格式
- `TaskService.listTasks()` 改為回傳 `{ tasks, total }` 搭配 skip/take

## Test plan
- [ ] `GET /api/tasks?page=1&limit=5` 回傳正確的 5 筆資料與 pagination metadata
- [ ] `GET /api/notifications?page=2&limit=10` 回傳第二頁通知
- [ ] `GET /api/documents?page=1&limit=20` 回傳分頁文件清單
- [ ] 未帶 page/limit 參數時預設 page=1, limit=20
- [ ] Kanban 頁面正常載入任務卡片
- [ ] Dashboard 頁面正常顯示我的任務
- [ ] 通知鈴鐺正常載入通知列表

Fixes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)