### PR TITLE
feat(infra): add /api/health endpoint for Docker healthcheck

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,68 @@
+/**
+ * GET /api/health — Issue #390
+ *
+ * Public health check endpoint (no auth required).
+ * Checks database and Redis connectivity.
+ * Returns 200 when all checks pass, 503 when any check fails.
+ */
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getRedisClient } from "@/lib/redis";
+
+interface HealthCheck {
+  status: "ok" | "error";
+  latency?: number;
+  error?: string;
+}
+
+export async function GET() {
+  const checks: Record<string, HealthCheck> = {};
+  let allOk = true;
+
+  // Database check — SELECT 1
+  const dbStart = Date.now();
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    checks.database = { status: "ok", latency: Date.now() - dbStart };
+  } catch (err) {
+    allOk = false;
+    checks.database = {
+      status: "error",
+      latency: Date.now() - dbStart,
+      error: err instanceof Error ? err.message : "Unknown database error",
+    };
+  }
+
+  // Redis check — PING
+  const redisStart = Date.now();
+  try {
+    const redis = getRedisClient();
+    if (redis) {
+      const pong = await redis.ping();
+      checks.redis = {
+        status: pong === "PONG" ? "ok" : "error",
+        latency: Date.now() - redisStart,
+      };
+      if (pong !== "PONG") allOk = false;
+    } else {
+      // Redis not configured — report as unavailable but not a hard failure
+      checks.redis = { status: "ok", latency: 0, error: "not configured" };
+    }
+  } catch (err) {
+    allOk = false;
+    checks.redis = {
+      status: "error",
+      latency: Date.now() - redisStart,
+      error: err instanceof Error ? err.message : "Unknown redis error",
+    };
+  }
+
+  const body = {
+    status: allOk ? "ok" : "degraded",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+    checks,
+  };
+
+  return NextResponse.json(body, { status: allOk ? 200 : 503 });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,7 +338,7 @@ services:
           cpus: '2'
           memory: 1024M
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/auth/csrf || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- 新增 `GET /api/health` 公開端點（無需認證）
- 檢查 PostgreSQL 連線（`SELECT 1`）和 Redis 連線（`PING`）
- 全部通過回傳 HTTP 200，任一失敗回傳 HTTP 503
- 回應包含：status、uptime、timestamp、各 check 的 latency 與錯誤資訊
- 更新 `docker-compose.yml` titan-app healthcheck 使用 `/api/health`

## Response format
```json
{
  "status": "ok",
  "uptime": 12345.67,
  "timestamp": "2026-03-25T10:00:00.000Z",
  "checks": {
    "database": { "status": "ok", "latency": 5 },
    "redis": { "status": "ok", "latency": 2 }
  }
}
```

## Test plan
- [ ] `curl http://localhost:3000/api/health` 回傳 200 + 正確 JSON
- [ ] 停止 PostgreSQL 後回傳 503 + database check error
- [ ] 停止 Redis 後回傳 503 + redis check error
- [ ] Docker Compose healthcheck 使用新端點正常運作
- [ ] 無需認證即可存取

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)