### PR TITLE
fix: P2 batch — issues #384 #385 #393 #394 #395 #401 #389 #388 #365

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ TITAN 是為銀行內部 IT 團隊（1 主管 + 4 工程師）打造的一體化
 
 | 層級 | 技術 |
 |------|------|
-| 前端 | Next.js 15 (App Router)、React 19、TypeScript |
+| 前端 | Next.js 15.5 (App Router)、React 19、TypeScript |
 | UI | Tailwind CSS、shadcn/ui、Geist 字體、明亮主題 |
 | 後端 | Next.js API Routes、Service Layer Pattern |
 | ORM | Prisma 5 (18 models、12 enums) |
 | 資料庫 | PostgreSQL 16 |
-| 認證 | NextAuth v4 (JWT/JWE)、RBAC (Manager/Engineer) |
-| 測試 | Jest (~930 tests)、Playwright E2E (~40 tests) |
+| 認證 | Auth.js v5 (JWT/JWE)、RBAC (Manager/Engineer) |
+| 測試 | Jest (~440 tests)、Playwright E2E (~180 tests)、600+ total |
 | 部署 | Docker Compose、Nginx 反向代理 |
 
 ## 安全架構

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { formatDateTime } from "@/lib/format";
 import {
   Database,
   Shield,
@@ -324,7 +325,7 @@ function AuditLogSection() {
                 {pagedLogs.map((log) => (
                   <tr key={log.id} className="hover:bg-accent/20 transition-colors">
                     <td className="px-4 py-2 text-xs tabular-nums text-muted-foreground whitespace-nowrap">
-                      {new Date(log.createdAt).toLocaleString("zh-TW")}
+                      {formatDateTime(log.createdAt)}
                     </td>
                     <td className="px-4 py-2">
                       <span className={cn(

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { Target, ClipboardList, Clock, BarChart3, Users } from "lucide-react";
 import { safeFixed, safePct } from "@/lib/safe-number";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { formatDate } from "@/lib/format";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -533,7 +534,7 @@ function EngineerDashboard() {
                         : "text-muted-foreground"
                     )}
                   >
-                    {new Date(t.dueDate).toLocaleDateString("zh-TW")}
+                    {formatDate(t.dueDate)}
                   </span>
                 )}
               </div>
@@ -551,7 +552,7 @@ function EngineerDashboard() {
               <div key={t.id} className="flex items-center justify-between text-sm">
                 <span className="text-foreground truncate">{t.title}</span>
                 <span className="text-danger tabular-nums text-xs flex-shrink-0 ml-2">
-                  {t.dueDate ? new Date(t.dueDate).toLocaleDateString("zh-TW") : ""}
+                  {t.dueDate ? formatDate(t.dueDate) : ""}
                 </span>
               </div>
             ))}

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -8,6 +8,7 @@ import { MarkdownEditor } from "@/app/components/markdown-editor";
 import { DocumentSearch } from "@/app/components/document-search";
 import { VersionHistory } from "@/app/components/version-history";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { formatDate } from "@/lib/format";
 
 type DocDetail = {
   id: string;
@@ -299,7 +300,7 @@ export default function KnowledgePage() {
                   </span>
                   <span className="text-xs text-muted-foreground">
                     最後更新：{docDetail.updater.name}
-                    　{new Date(docDetail.updatedAt).toLocaleDateString("zh-TW")}
+                    　{formatDate(docDetail.updatedAt)}
                   </span>
                   <span className="text-xs text-muted-foreground/60 ml-auto">v{docDetail.version}</span>
                 </div>

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -5,6 +5,7 @@ import { Download, RefreshCw, BarChart3, Printer } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { safeFixed, safePct } from "@/lib/safe-number";
+import { formatDate } from "@/lib/format";
 
 function PrintButton() {
   return (
@@ -107,8 +108,8 @@ function WeeklyReport() {
   if (error) return <PageError message={error} onRetry={load} />;
   if (!data || !data.period) return <PageEmpty title="無週報資料" description="本週尚無相關數據" />;
 
-  const start = new Date(data.period.start).toLocaleDateString("zh-TW");
-  const end = new Date(data.period.end).toLocaleDateString("zh-TW");
+  const start = formatDate(data.period.start);
+  const end = formatDate(data.period.end);
 
   return (
     <div className="space-y-6">
@@ -176,7 +177,7 @@ function WeeklyReport() {
               <div key={t.id} className="flex items-center justify-between text-sm">
                 <span className="text-foreground truncate">{t.title}</span>
                 <span className="text-xs text-danger flex-shrink-0 ml-2 tabular-nums">
-                  {new Date(t.dueDate).toLocaleDateString("zh-TW")}
+                  {formatDate(t.dueDate)}
                 </span>
               </div>
             ))}
@@ -788,7 +789,7 @@ export default function ReportsPage() {
       {/* Print header — only visible when printing */}
       <div className="print-header hidden">
         <h1>TITAN — {activeTab === "weekly" ? "週報" : activeTab === "monthly" ? "月報" : activeTab === "kpi" ? "KPI 報表" : "計畫外負荷"}</h1>
-        <p>列印日期：{new Date().toLocaleDateString("zh-TW")}</p>
+        <p>列印日期：{formatDate(new Date())}</p>
       </div>
 
       <div className="flex items-center justify-between mb-6">

--- a/app/api/documents/[id]/route.ts
+++ b/app/api/documents/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { NotFoundError } from "@/services/errors";
+import { DocumentService } from "@/services/document-service";
 import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { updateDocumentSchema } from "@/validators/document-validators";
@@ -9,6 +9,7 @@ import { requireAuth, requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
 import { getClientIp } from "@/lib/get-client-ip";
 
+const documentService = new DocumentService(prisma);
 const auditService = new AuditService(prisma);
 
 export const GET = withAuth(async (
@@ -16,19 +17,7 @@ export const GET = withAuth(async (
   context: { params: Promise<Record<string, string>> }
 ) => {
   const { id } = await context.params;
-  const doc = await prisma.document.findUnique({
-    where: { id },
-    include: {
-      creator: { select: { id: true, name: true } },
-      updater: { select: { id: true, name: true } },
-      children: {
-        select: { id: true, title: true, slug: true },
-        orderBy: { title: "asc" },
-      },
-    },
-  });
-
-  if (!doc) throw new NotFoundError("文件不存在");
+  const doc = await documentService.getDocument(id);
   return success(doc);
 });
 
@@ -42,37 +31,11 @@ export const PUT = withAuth(async (
   const raw = await req.json();
   const { title, content, parentId } = validateBody(updateDocumentSchema, raw);
 
-  const existing = await prisma.document.findUnique({ where: { id } });
-  if (!existing) throw new NotFoundError("文件不存在");
-
-  const contentChanged = content !== undefined && content !== existing.content;
-
-  if (contentChanged) {
-    await prisma.documentVersion.create({
-      data: {
-        documentId: id,
-        content: existing.content,
-        version: existing.version,
-        createdBy: session.user.id,
-      },
-    });
-  }
-
-  const updates: Record<string, unknown> = { updatedBy: session.user.id };
-  if (title !== undefined) updates.title = title;
-  if (contentChanged) {
-    updates.content = content;
-    updates.version = existing.version + 1;
-  }
-  if (parentId !== undefined) updates.parentId = parentId || null;
-
-  const doc = await prisma.document.update({
-    where: { id },
-    data: updates,
-    include: {
-      creator: { select: { id: true, name: true } },
-      updater: { select: { id: true, name: true } },
-    },
+  const doc = await documentService.updateDocument(id, {
+    title,
+    content,
+    parentId: parentId !== undefined ? (parentId || null) : undefined,
+    updatedBy: session.user.id,
   });
 
   return success(doc);
@@ -84,7 +47,7 @@ export const DELETE = withManager(async (
 ) => {
   const session = await requireRole("MANAGER");
   const { id } = await context.params;
-  await prisma.document.delete({ where: { id } });
+  await documentService.deleteDocument(id);
 
   await auditService.log({
     userId: session.user.id,

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -12,6 +12,16 @@ export const GET = withAuth(async (req: NextRequest) => {
 
   const notifications = await prisma.notification.findMany({
     where: { userId: session.user.id },
+    select: {
+      id: true,
+      type: true,
+      title: true,
+      body: true,
+      isRead: true,
+      relatedId: true,
+      relatedType: true,
+      createdAt: true,
+    },
     orderBy: { createdAt: "desc" },
     take: limit,
   });

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -35,7 +35,15 @@ export const GET = withAuth(async (req: NextRequest) => {
 
     const completedTasks = await prisma.task.findMany({
       where: { ...userFilter, status: "DONE", updatedAt: { gte: weekStart, lte: weekEnd } },
-      include: { primaryAssignee: { select: { id: true, name: true } } },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        category: true,
+        updatedAt: true,
+        primaryAssignee: { select: { id: true, name: true } },
+      },
       orderBy: { updatedAt: "desc" },
     });
 
@@ -43,7 +51,10 @@ export const GET = withAuth(async (req: NextRequest) => {
       ? { date: { gte: weekStart, lte: weekEnd } }
       : { userId: session.user.id, date: { gte: weekStart, lte: weekEnd } };
 
-    const timeEntries = await prisma.timeEntry.findMany({ where: timeEntryFilter });
+    const timeEntries = await prisma.timeEntry.findMany({
+      where: timeEntryFilter,
+      select: { hours: true, category: true },
+    });
     const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
     const hoursByCategory = timeEntries.reduce((acc, e) => {
       acc[e.category] = (acc[e.category] ?? 0) + e.hours;

--- a/app/api/time-entries/stats/route.ts
+++ b/app/api/time-entries/stats/route.ts
@@ -35,7 +35,10 @@ export const GET = withAuth(async (req: NextRequest) => {
     if (endDate) (where.date as Record<string, unknown>).lte = new Date(endDate);
   }
 
-  const entries = await prisma.timeEntry.findMany({ where });
+  const entries = await prisma.timeEntry.findMany({
+    where,
+    select: { hours: true, category: true },
+  });
 
   const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
 

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -13,6 +13,9 @@ interface Notification {
   createdAt: string;
 }
 
+/** Polling interval for notification refresh (ms). */
+const NOTIFICATION_POLL_INTERVAL_MS = 60_000;
+
 const TYPE_LABELS: Record<string, string> = {
   TASK_ASSIGNED: "任務指派",
   TASK_DUE_SOON: "即將到期",
@@ -89,7 +92,7 @@ export function NotificationBell() {
 
   useEffect(() => {
     fetchNotifications();
-    const interval = setInterval(fetchNotifications, 60000);
+    const interval = setInterval(fetchNotifications, NOTIFICATION_POLL_INTERVAL_MS);
     return () => clearInterval(interval);
   }, []);
 

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { X, Save, Loader2, Link2 } from "lucide-react";
+import { X, Save, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { SubTaskList } from "./subtask-list";
-import { DeliverableList } from "./deliverable-list";
+import { TaskFormFields, TaskSubtaskSection, TaskDeliverableSection, initialForm } from "./task-detail/index";
+import type { TaskForm } from "./task-detail/index";
 
 type User = { id: string; name: string; avatar?: string | null };
 type MonthlyGoal = { id: string; title: string; month: number };
@@ -40,74 +40,12 @@ interface TaskDetailModalProps {
   onUpdated?: () => void;
 }
 
-type TaskForm = {
-  title: string;
-  description: string;
-  status: string;
-  priority: string;
-  category: string;
-  primaryAssigneeId: string;
-  backupAssigneeId: string;
-  monthlyGoalId: string;
-  dueDate: string;
-  estimatedHours: string;
-};
-
-const initialForm: TaskForm = {
-  title: "",
-  description: "",
-  status: "",
-  priority: "",
-  category: "",
-  primaryAssigneeId: "",
-  backupAssigneeId: "",
-  monthlyGoalId: "",
-  dueDate: "",
-  estimatedHours: "",
-};
-
-const statusOptions = [
-  { value: "BACKLOG", label: "待辦清單" },
-  { value: "TODO", label: "待處理" },
-  { value: "IN_PROGRESS", label: "進行中" },
-  { value: "REVIEW", label: "審核中" },
-  { value: "DONE", label: "已完成" },
-];
-
-const priorityOptions = [
-  { value: "P0", label: "P0 緊急" },
-  { value: "P1", label: "P1 高" },
-  { value: "P2", label: "P2 中" },
-  { value: "P3", label: "P3 低" },
-];
-
-const categoryOptions = [
-  { value: "PLANNED", label: "原始規劃" },
-  { value: "ADDED", label: "追加任務" },
-  { value: "INCIDENT", label: "突發事件" },
-  { value: "SUPPORT", label: "用戶支援" },
-  { value: "ADMIN", label: "行政庶務" },
-  { value: "LEARNING", label: "學習成長" },
-];
-
-const inputCls =
-  "w-full h-10 bg-background border border-border rounded-lg px-3 text-sm text-foreground focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all placeholder:text-muted-foreground/60";
-
-const selectCls =
-  "w-full h-10 bg-background border border-border rounded-lg px-3 text-sm text-foreground focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all cursor-pointer";
-
-function Label({ children }: { children: React.ReactNode }) {
-  return <label className="block text-xs font-medium text-muted-foreground mb-1.5">{children}</label>;
-}
-
 export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalProps) {
   const [task, setTask] = useState<TaskDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   const [goals, setGoals] = useState<MonthlyGoal[]>([]);
-
-  // Consolidated form state
   const [form, setForm] = useState<TaskForm>(initialForm);
 
   const updateField = useCallback(
@@ -175,7 +113,7 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
     }
   }
 
-  // Close on backdrop click or Escape
+  // Close on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", handler);
@@ -218,131 +156,22 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
           </div>
         ) : task ? (
           <div className="p-5 space-y-5">
-            {/* Title */}
-            <div>
-              <Label>標題</Label>
-              <input
-                type="text"
-                value={form.title}
-                onChange={(e) => updateField("title", e.target.value)}
-                className={inputCls}
-              />
-            </div>
+            <TaskFormFields
+              form={form}
+              onFieldChange={updateField}
+              users={users}
+              goals={goals}
+            />
 
-            {/* Description */}
-            <div>
-              <Label>描述</Label>
-              <textarea
-                value={form.description}
-                onChange={(e) => updateField("description", e.target.value)}
-                rows={3}
-                placeholder="任務描述..."
-                className={cn(inputCls, "resize-none")}
-              />
-            </div>
+            <TaskSubtaskSection
+              subtasks={task.subTasks}
+              taskId={taskId}
+            />
 
-            {/* Status / Priority / Category */}
-            <div className="grid grid-cols-3 gap-3">
-              <div>
-                <Label>狀態</Label>
-                <select value={form.status} onChange={(e) => updateField("status", e.target.value)} className={selectCls}>
-                  {statusOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </div>
-              <div>
-                <Label>優先度</Label>
-                <select value={form.priority} onChange={(e) => updateField("priority", e.target.value)} className={selectCls}>
-                  {priorityOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </div>
-              <div>
-                <Label>分類</Label>
-                <select value={form.category} onChange={(e) => updateField("category", e.target.value)} className={selectCls}>
-                  {categoryOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </select>
-              </div>
-            </div>
-
-            {/* A角 / B角 */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <Label>A角（主要負責人）</Label>
-                <select value={form.primaryAssigneeId} onChange={(e) => updateField("primaryAssigneeId", e.target.value)} className={selectCls}>
-                  <option value="">未指派</option>
-                  {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-                </select>
-              </div>
-              <div>
-                <Label>B角（備援負責人）</Label>
-                <select value={form.backupAssigneeId} onChange={(e) => updateField("backupAssigneeId", e.target.value)} className={selectCls}>
-                  <option value="">未指派</option>
-                  {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-                </select>
-              </div>
-            </div>
-
-            {/* Due date / Estimated hours */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <Label>截止日期</Label>
-                <input
-                  type="date"
-                  value={form.dueDate}
-                  onChange={(e) => updateField("dueDate", e.target.value)}
-                  className={inputCls}
-                />
-              </div>
-              <div>
-                <Label>預估工時（小時）</Label>
-                <input
-                  type="number"
-                  min="0"
-                  step="0.5"
-                  value={form.estimatedHours}
-                  onChange={(e) => updateField("estimatedHours", e.target.value)}
-                  placeholder="0"
-                  className={inputCls}
-                />
-              </div>
-            </div>
-
-            {/* Monthly Goal link */}
-            <div>
-              <Label>
-                <span className="flex items-center gap-1">
-                  <Link2 className="h-3 w-3" />
-                  連結月度目標
-                </span>
-              </Label>
-              <select value={form.monthlyGoalId} onChange={(e) => updateField("monthlyGoalId", e.target.value)} className={selectCls}>
-                <option value="">不連結</option>
-                {goals.map((g) => (
-                  <option key={g.id} value={g.id}>{g.month}月 — {g.title}</option>
-                ))}
-              </select>
-            </div>
-
-            {/* Subtasks */}
-            <div>
-              <h3 className="text-xs font-medium text-muted-foreground mb-2">子任務清單</h3>
-              <div className="bg-muted/30 rounded-xl p-3">
-                <SubTaskList
-                  subtasks={task.subTasks}
-                  taskId={taskId}
-                />
-              </div>
-            </div>
-
-            {/* Deliverables */}
-            <div>
-              <h3 className="text-xs font-medium text-muted-foreground mb-2">交付項</h3>
-              <div className="bg-muted/30 rounded-xl p-3">
-                <DeliverableList
-                  deliverables={task.deliverables}
-                  taskId={taskId}
-                />
-              </div>
-            </div>
+            <TaskDeliverableSection
+              deliverables={task.deliverables}
+              taskId={taskId}
+            />
           </div>
         ) : (
           <div className="py-16 text-center text-muted-foreground text-sm">任務不存在</div>

--- a/app/components/task-detail/index.ts
+++ b/app/components/task-detail/index.ts
@@ -1,0 +1,4 @@
+export { TaskFormFields, initialForm } from "./task-form-fields";
+export type { TaskForm } from "./task-form-fields";
+export { TaskSubtaskSection } from "./task-subtask-section";
+export { TaskDeliverableSection } from "./task-deliverable-section";

--- a/app/components/task-detail/task-deliverable-section.tsx
+++ b/app/components/task-detail/task-deliverable-section.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { DeliverableList } from "../deliverable-list";
+
+interface TaskDeliverableSectionProps {
+  deliverables: {
+    id: string;
+    title: string;
+    type: "DOCUMENT" | "SYSTEM" | "REPORT" | "APPROVAL";
+    status: "NOT_STARTED" | "IN_PROGRESS" | "DELIVERED" | "ACCEPTED";
+    attachmentUrl?: string | null;
+  }[];
+  taskId: string;
+}
+
+export function TaskDeliverableSection({ deliverables, taskId }: TaskDeliverableSectionProps) {
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-muted-foreground mb-2">交付項</h3>
+      <div className="bg-muted/30 rounded-xl p-3">
+        <DeliverableList deliverables={deliverables} taskId={taskId} />
+      </div>
+    </div>
+  );
+}

--- a/app/components/task-detail/task-form-fields.tsx
+++ b/app/components/task-detail/task-form-fields.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback } from "react";
+import { Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type User = { id: string; name: string; avatar?: string | null };
+type MonthlyGoal = { id: string; title: string; month: number };
+
+export type TaskForm = {
+  title: string;
+  description: string;
+  status: string;
+  priority: string;
+  category: string;
+  primaryAssigneeId: string;
+  backupAssigneeId: string;
+  monthlyGoalId: string;
+  dueDate: string;
+  estimatedHours: string;
+};
+
+export const initialForm: TaskForm = {
+  title: "",
+  description: "",
+  status: "",
+  priority: "",
+  category: "",
+  primaryAssigneeId: "",
+  backupAssigneeId: "",
+  monthlyGoalId: "",
+  dueDate: "",
+  estimatedHours: "",
+};
+
+export const statusOptions = [
+  { value: "BACKLOG", label: "待辦清單" },
+  { value: "TODO", label: "待處理" },
+  { value: "IN_PROGRESS", label: "進行中" },
+  { value: "REVIEW", label: "審核中" },
+  { value: "DONE", label: "已完成" },
+];
+
+export const priorityOptions = [
+  { value: "P0", label: "P0 緊急" },
+  { value: "P1", label: "P1 高" },
+  { value: "P2", label: "P2 中" },
+  { value: "P3", label: "P3 低" },
+];
+
+export const categoryOptions = [
+  { value: "PLANNED", label: "原始規劃" },
+  { value: "ADDED", label: "追加任務" },
+  { value: "INCIDENT", label: "突發事件" },
+  { value: "SUPPORT", label: "用戶支援" },
+  { value: "ADMIN", label: "行政庶務" },
+  { value: "LEARNING", label: "學習成長" },
+];
+
+const inputCls =
+  "w-full h-10 bg-background border border-border rounded-lg px-3 text-sm text-foreground focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all placeholder:text-muted-foreground/60";
+
+const selectCls =
+  "w-full h-10 bg-background border border-border rounded-lg px-3 text-sm text-foreground focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all cursor-pointer";
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <label className="block text-xs font-medium text-muted-foreground mb-1.5">{children}</label>;
+}
+
+interface TaskFormFieldsProps {
+  form: TaskForm;
+  onFieldChange: <K extends keyof TaskForm>(field: K, value: TaskForm[K]) => void;
+  users: User[];
+  goals: MonthlyGoal[];
+}
+
+export function TaskFormFields({ form, onFieldChange, users, goals }: TaskFormFieldsProps) {
+  return (
+    <>
+      {/* Title */}
+      <div>
+        <Label>標題</Label>
+        <input
+          type="text"
+          value={form.title}
+          onChange={(e) => onFieldChange("title", e.target.value)}
+          className={inputCls}
+        />
+      </div>
+
+      {/* Description */}
+      <div>
+        <Label>描述</Label>
+        <textarea
+          value={form.description}
+          onChange={(e) => onFieldChange("description", e.target.value)}
+          rows={3}
+          placeholder="任務描述..."
+          className={cn(inputCls, "resize-none")}
+        />
+      </div>
+
+      {/* Status / Priority / Category */}
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <Label>狀態</Label>
+          <select value={form.status} onChange={(e) => onFieldChange("status", e.target.value)} className={selectCls}>
+            {statusOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </div>
+        <div>
+          <Label>優先度</Label>
+          <select value={form.priority} onChange={(e) => onFieldChange("priority", e.target.value)} className={selectCls}>
+            {priorityOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </div>
+        <div>
+          <Label>分類</Label>
+          <select value={form.category} onChange={(e) => onFieldChange("category", e.target.value)} className={selectCls}>
+            {categoryOptions.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {/* A角 / B角 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <Label>A角（主要負責人）</Label>
+          <select value={form.primaryAssigneeId} onChange={(e) => onFieldChange("primaryAssigneeId", e.target.value)} className={selectCls}>
+            <option value="">未指派</option>
+            {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+          </select>
+        </div>
+        <div>
+          <Label>B角（備援負責人）</Label>
+          <select value={form.backupAssigneeId} onChange={(e) => onFieldChange("backupAssigneeId", e.target.value)} className={selectCls}>
+            <option value="">未指派</option>
+            {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {/* Due date / Estimated hours */}
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <Label>截止日期</Label>
+          <input
+            type="date"
+            value={form.dueDate}
+            onChange={(e) => onFieldChange("dueDate", e.target.value)}
+            className={inputCls}
+          />
+        </div>
+        <div>
+          <Label>預估工時（小時）</Label>
+          <input
+            type="number"
+            min="0"
+            step="0.5"
+            value={form.estimatedHours}
+            onChange={(e) => onFieldChange("estimatedHours", e.target.value)}
+            placeholder="0"
+            className={inputCls}
+          />
+        </div>
+      </div>
+
+      {/* Monthly Goal link */}
+      <div>
+        <Label>
+          <span className="flex items-center gap-1">
+            <Link2 className="h-3 w-3" />
+            連結月度目標
+          </span>
+        </Label>
+        <select value={form.monthlyGoalId} onChange={(e) => onFieldChange("monthlyGoalId", e.target.value)} className={selectCls}>
+          <option value="">不連結</option>
+          {goals.map((g) => (
+            <option key={g.id} value={g.id}>{g.month}月 — {g.title}</option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
+}

--- a/app/components/task-detail/task-subtask-section.tsx
+++ b/app/components/task-detail/task-subtask-section.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { SubTaskList } from "../subtask-list";
+
+interface TaskSubtaskSectionProps {
+  subtasks: { id: string; title: string; done: boolean; order: number }[];
+  taskId: string;
+}
+
+export function TaskSubtaskSection({ subtasks, taskId }: TaskSubtaskSectionProps) {
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-muted-foreground mb-2">子任務清單</h3>
+      <div className="bg-muted/30 rounded-xl p-3">
+        <SubTaskList subtasks={subtasks} taskId={taskId} />
+      </div>
+    </div>
+  );
+}

--- a/app/components/version-history.tsx
+++ b/app/components/version-history.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { History, ChevronDown, ChevronUp, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { formatShortDateTime } from "@/lib/format";
 
 type DocVersion = {
   id: string;
@@ -76,9 +77,7 @@ export function VersionHistory({ documentId, currentVersion, onRestore }: Versio
                   <span className="text-xs text-muted-foreground ml-2">{v.creator.name}</span>
                 </div>
                 <span className="text-xs text-muted-foreground flex-shrink-0">
-                  {new Date(v.createdAt).toLocaleDateString("zh-TW", {
-                    month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit",
-                  })}
+                  {formatShortDateTime(v.createdAt)}
                 </span>
                 {expandedId === v.id
                   ? <ChevronUp className="h-3 w-3 text-muted-foreground" />

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,11 @@
+/**
+ * Next.js Instrumentation hook — runs once when the server starts.
+ * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  // Validate environment variables on server startup only (not during build)
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { validateEnv } = await import("@/lib/env-validator");
+    validateEnv();
+  }
+}

--- a/lib/auth-middleware.ts
+++ b/lib/auth-middleware.ts
@@ -17,15 +17,17 @@ import { requireAuth, requireRole } from "@/lib/rbac";
 import { apiHandler, RouteContext } from "@/lib/api-handler";
 import type { ApiResponse } from "@/lib/api-response";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyHandler = (req: NextRequest, context?: any) => Promise<NextResponse<ApiResponse>>;
+/** Route handler that accepts a request and optional route context. */
+type RouteHandler = (
+  req: NextRequest,
+  context?: RouteContext
+) => Promise<NextResponse<ApiResponse>>;
 
 /**
  * Wraps a route handler with requireAuth check + unified error handling.
  * Any authenticated user (MANAGER or ENGINEER) may access.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function withAuth<T extends AnyHandler>(fn: T): T {
+export function withAuth<T extends RouteHandler>(fn: T): T {
   return apiHandler(async (req: NextRequest, context?: RouteContext) => {
     await requireAuth();
     return fn(req, context);
@@ -36,8 +38,7 @@ export function withAuth<T extends AnyHandler>(fn: T): T {
  * Wraps a route handler with requireRole('MANAGER') check + error handling.
  * Only MANAGER role may access.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function withManager<T extends AnyHandler>(fn: T): T {
+export function withManager<T extends RouteHandler>(fn: T): T {
   return apiHandler(async (req: NextRequest, context?: RouteContext) => {
     await requireRole("MANAGER");
     return fn(req, context);

--- a/lib/env-validator.ts
+++ b/lib/env-validator.ts
@@ -1,0 +1,58 @@
+/**
+ * Validate required environment variables at startup.
+ * Called from instrumentation.ts so the app fails fast with a clear message
+ * instead of crashing later with cryptic errors.
+ */
+
+interface EnvRule {
+  /** At least one of these env var names must be set. */
+  keys: string[];
+  /** Human-readable description shown on failure. */
+  label: string;
+}
+
+const REQUIRED_ENV: EnvRule[] = [
+  {
+    keys: ["DATABASE_URL"],
+    label: "Database connection string (DATABASE_URL)",
+  },
+  {
+    keys: ["AUTH_SECRET", "NEXTAUTH_SECRET"],
+    label: "Auth secret (AUTH_SECRET or NEXTAUTH_SECRET)",
+  },
+  {
+    keys: ["AUTH_URL", "NEXTAUTH_URL"],
+    label: "Auth URL (AUTH_URL or NEXTAUTH_URL)",
+  },
+];
+
+export function validateEnv(): void {
+  const missing: string[] = [];
+
+  for (const rule of REQUIRED_ENV) {
+    const found = rule.keys.some(
+      (key) => process.env[key] && process.env[key]!.trim() !== ""
+    );
+    if (!found) {
+      missing.push(`  - ${rule.label} [${rule.keys.join(" | ")}]`);
+    }
+  }
+
+  if (missing.length > 0) {
+    const message = [
+      "",
+      "=== TITAN: Missing required environment variables ===",
+      ...missing,
+      "",
+      "The application cannot start without these variables.",
+      "Check your .env file or deployment environment configuration.",
+      "=====================================================",
+      "",
+    ].join("\n");
+
+    console.error(message);
+    throw new Error(
+      `Missing required environment variables: ${missing.length} rule(s) failed. See log above.`
+    );
+  }
+}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared date/time formatting utilities.
+ * Locale: zh-TW throughout for consistency.
+ */
+
+const LOCALE = "zh-TW";
+
+/** Format as date only, e.g. "2024/03/25" */
+export function formatDate(date: string | Date): string {
+  return new Date(date).toLocaleDateString(LOCALE);
+}
+
+/** Format as date + time, e.g. "2024/3/25 下午2:30:00" */
+export function formatDateTime(date: string | Date): string {
+  return new Date(date).toLocaleString(LOCALE);
+}
+
+/** Format as short date + time (MM/DD HH:mm), e.g. "03/25 14:30" */
+export function formatShortDateTime(date: string | Date): string {
+  return new Date(date).toLocaleDateString(LOCALE, {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** Format relative time description, e.g. "3 天前" */
+export function formatRelative(date: string | Date): string {
+  const now = Date.now();
+  const then = new Date(date).getTime();
+  const diffMs = now - then;
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return "剛剛";
+  if (diffMin < 60) return `${diffMin} 分鐘前`;
+  if (diffHour < 24) return `${diffHour} 小時前`;
+  if (diffDay < 30) return `${diffDay} 天前`;
+  return formatDate(date);
+}

--- a/services/document-service.ts
+++ b/services/document-service.ts
@@ -19,6 +19,7 @@ export interface UpdateDocumentInput {
   title?: string;
   content?: string;
   slug?: string;
+  parentId?: string | null;
   updatedBy: string;
 }
 
@@ -111,6 +112,7 @@ export class DocumentService {
           updates.version = existing.version + 1;
         }
         if (input.slug !== undefined) updates.slug = input.slug;
+        if (input.parentId !== undefined) updates.parentId = input.parentId;
 
         return tx.document.update({
           where: { id },

--- a/services/kpi-service.ts
+++ b/services/kpi-service.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, KPIStatus } from "@prisma/client";
 import { NotFoundError, ValidationError } from "./errors";
+import { calculateAchievement as calcAchievement } from "../lib/kpi-calculator";
 
 export interface ListKPIsFilter {
   year?: number;
@@ -156,20 +157,11 @@ export class KPIService {
 
     if (!kpi) throw new NotFoundError(`KPI not found: ${kpiId}`);
 
-    const links = kpi.taskLinks;
-    let actual = 0;
-    if (links.length > 0) {
-      const totalWeight = links.reduce((sum, l) => sum + l.weight, 0);
-      const weightedSum = links.reduce(
-        (sum, l) => sum + l.task.progressPct * l.weight,
-        0
-      );
-      actual = totalWeight > 0 ? weightedSum / totalWeight : 0;
-    }
+    const achievement = calcAchievement(kpi);
 
     return this.prisma.kPI.update({
       where: { id: kpiId },
-      data: { actual },
+      data: { actual: achievement },
     });
   }
 }

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -130,7 +130,15 @@ export class ReportService {
         status: "DONE",
         updatedAt: { gte: weekStart, lte: weekEnd },
       },
-      include: { primaryAssignee: { select: { id: true, name: true } } },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        category: true,
+        updatedAt: true,
+        primaryAssignee: { select: { id: true, name: true } },
+      },
       orderBy: { updatedAt: "desc" },
     });
 
@@ -140,7 +148,12 @@ export class ReportService {
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
-      include: { user: { select: { id: true, name: true } } },
+      select: {
+        hours: true,
+        category: true,
+        userId: true,
+        user: { select: { id: true, name: true } },
+      },
     });
 
     const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
@@ -152,7 +165,14 @@ export class ReportService {
         status: { notIn: ["DONE"] },
         dueDate: { lt: new Date() },
       },
-      include: { primaryAssignee: { select: { id: true, name: true } } },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        dueDate: true,
+        primaryAssignee: { select: { id: true, name: true } },
+      },
       orderBy: { dueDate: "asc" },
       take: 10,
     });
@@ -206,7 +226,15 @@ export class ReportService {
           { status: { notIn: ["DONE"] }, dueDate: null },
         ],
       },
-      include: {
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        category: true,
+        dueDate: true,
+        updatedAt: true,
+        progressPct: true,
         primaryAssignee: { select: { id: true, name: true } },
         monthlyGoal: { select: { id: true, title: true, month: true } },
       },
@@ -224,7 +252,12 @@ export class ReportService {
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
-      include: { user: { select: { id: true, name: true } } },
+      select: {
+        hours: true,
+        category: true,
+        userId: true,
+        user: { select: { id: true, name: true } },
+      },
     });
 
     const totalHours = timeEntries.reduce((sum, e) => sum + e.hours, 0);
@@ -318,7 +351,10 @@ export class ReportService {
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
-      include: {
+      select: {
+        hours: true,
+        category: true,
+        userId: true,
         user: { select: { id: true, name: true } },
         task: { select: { id: true, title: true, category: true } },
       },
@@ -374,7 +410,13 @@ export class ReportService {
         category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
         createdAt: { gte: startDate, lte: endDate },
       },
-      include: {
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        category: true,
+        addedSource: true,
+        createdAt: true,
         primaryAssignee: { select: { id: true, name: true } },
       },
     });


### PR DESCRIPTION
## Summary

Batch fix for 9 P2 issues (sequential commits, one per issue):

- **#384** — `kpi-service.ts` inline calculation replaced with shared `calculateAchievement` from `lib/kpi-calculator.ts`
- **#385** — Document route GET/PUT/DELETE now delegate to `DocumentService` instead of direct Prisma calls; added `parentId` to `UpdateDocumentInput`
- **#393** — Created `lib/format.ts` with `formatDate`, `formatDateTime`, `formatShortDateTime`, `formatRelative`; replaced 8 inline `toLocaleDateString`/`toLocaleString` calls across 5 files
- **#394** — Split `task-detail-modal.tsx` into `TaskFormFields`, `TaskSubtaskSection`, `TaskDeliverableSection` sub-components under `app/components/task-detail/`
- **#395** — Added explicit `select` to 10 high-traffic Prisma `findMany` queries (notifications, time-entries stats, report-service, export route)
- **#401** — Created `lib/env-validator.ts` + `instrumentation.ts` to validate `DATABASE_URL`, `AUTH_SECRET`/`NEXTAUTH_SECRET`, `AUTH_URL`/`NEXTAUTH_URL` at startup
- **#389** — Extracted hardcoded poll interval to `NOTIFICATION_POLL_INTERVAL_MS` constant
- **#388** — Replaced `eslint-disable @typescript-eslint/no-explicit-any` with proper `RouteHandler` type alias
- **#365** — Updated README: Next.js 15.5, Auth.js v5, actual test counts

**#429 skipped** — `output: 'standalone'` and Dockerfile already use standalone (commit ab5b700).

Closes #384, Closes #385, Closes #393, Closes #394, Closes #395, Closes #401, Closes #389, Closes #388, Closes #365

## Test plan

- [ ] `npx tsc --noEmit` passes (type check for auth-middleware, kpi-service, document route changes)
- [ ] `npx jest --forceExit` — existing tests pass
- [ ] Verify notification bell polls at expected interval
- [ ] Verify env validation: remove DATABASE_URL from .env and confirm startup fails with clear error
- [ ] Spot-check report pages render correctly with new formatDate utility

🤖 Generated with [Claude Code](https://claude.com/claude-code)