### PR TITLE
fix(tasks): auto-calculate parent task progress from subtask completion

### DIFF
--- a/app/api/subtasks/[id]/route.ts
+++ b/app/api/subtasks/[id]/route.ts
@@ -4,6 +4,7 @@ import { ValidationError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 import { updateSubTaskSchema } from "@/validators/subtask-validators";
+import { recalcParentProgress } from "@/lib/subtask-progress";
 
 export const PATCH = withAuth(async (
   req: NextRequest,
@@ -32,6 +33,11 @@ export const PATCH = withAuth(async (
     },
   });
 
+  // Recalculate parent task progress when done status changes (Issue #421)
+  if (done !== undefined) {
+    await recalcParentProgress(subtask.taskId);
+  }
+
   return success(subtask);
 });
 
@@ -40,6 +46,19 @@ export const DELETE = withAuth(async (
   context: { params: Promise<Record<string, string>> }
 ) => {
   const { id } = await context.params;
+
+  // Get taskId before deleting so we can recalculate parent progress
+  const subtask = await prisma.subTask.findUnique({
+    where: { id },
+    select: { taskId: true },
+  });
+
   await prisma.subTask.delete({ where: { id } });
+
+  // Recalculate parent task progress after subtask removal (Issue #421)
+  if (subtask) {
+    await recalcParentProgress(subtask.taskId);
+  }
+
   return success({ success: true });
 });

--- a/app/api/subtasks/route.ts
+++ b/app/api/subtasks/route.ts
@@ -4,6 +4,7 @@ import { ValidationError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 import { createSubTaskSchema } from "@/validators/subtask-validators";
+import { recalcParentProgress } from "@/lib/subtask-progress";
 
 export const POST = withAuth(async (req: NextRequest) => {
   const body = await req.json();
@@ -26,6 +27,9 @@ export const POST = withAuth(async (req: NextRequest) => {
       order,
     },
   });
+
+  // Recalculate parent task progress after new subtask added (Issue #421)
+  await recalcParentProgress(taskId);
 
   return success(subtask, 201);
 });

--- a/lib/subtask-progress.ts
+++ b/lib/subtask-progress.ts
@@ -1,0 +1,33 @@
+/**
+ * Subtask progress aggregation — Issue #421
+ *
+ * Recalculates a parent Task's progressPct based on the completion
+ * ratio of its subtasks: (completed / total) * 100.
+ *
+ * When a task has no subtasks, progressPct is left unchanged
+ * (manual control is preserved).
+ */
+
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Recalculate and update the parent task's progressPct based on
+ * the done/total ratio of its subtasks.
+ */
+export async function recalcParentProgress(taskId: string): Promise<void> {
+  const subtasks = await prisma.subTask.findMany({
+    where: { taskId },
+    select: { done: true },
+  });
+
+  // No subtasks — leave progressPct as-is (manual mode)
+  if (subtasks.length === 0) return;
+
+  const completed = subtasks.filter((s) => s.done).length;
+  const progressPct = Math.round((completed / subtasks.length) * 100);
+
+  await prisma.task.update({
+    where: { id: taskId },
+    data: { progressPct },
+  });
+}


### PR DESCRIPTION
## Summary
- 新增 `lib/subtask-progress.ts` — `recalcParentProgress(taskId)` 共用函式
- 當 SubTask 的 `done` 狀態變更（PATCH）、新增（POST）、刪除（DELETE）時，自動重算母任務 `progressPct`
- 計算公式：`(completedSubtasks / totalSubtasks) * 100`（四捨五入為整數）
- 無子任務的 Task 保留手動 progressPct 控制

## Affected endpoints
- `PATCH /api/subtasks/[id]` — done 變更時觸發
- `DELETE /api/subtasks/[id]` — 刪除後重算
- `POST /api/subtasks` — 新增後重算

## Test plan
- [ ] 建立含 4 個 SubTask 的 Task，完成 2 個，確認 progressPct = 50
- [ ] 完成第 3 個，確認 progressPct = 75
- [ ] 全部完成，確認 progressPct = 100
- [ ] 刪除 1 個已完成的 SubTask（剩 3 個全完成），確認 progressPct = 100
- [ ] 新增 1 個未完成 SubTask（3 完成 + 1 未完成），確認 progressPct = 75
- [ ] 無 SubTask 的 Task，progressPct 不受影響

Fixes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)