### PR TITLE
feat(search): enhance Ctrl+K with multi-resource search

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success, error } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+
+/**
+ * GET /api/search?q=keyword
+ *
+ * Unified search endpoint that searches across tasks, documents, KPIs, and users.
+ * Returns up to 5 results per resource type.
+ */
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const { searchParams } = new URL(req.url);
+  const q = searchParams.get("q")?.trim();
+
+  if (!q || q.length < 1) {
+    return error("ValidationError", "搜尋關鍵字不得為空", 400);
+  }
+
+  const isManager = session.user.role === "MANAGER";
+  const userId = session.user.id;
+  const containsQuery = { contains: q, mode: "insensitive" as const };
+
+  // Run all searches in parallel
+  const [tasks, documents, kpis, users] = await Promise.all([
+    // Tasks: search by title — engineers see only their assigned tasks
+    prisma.task.findMany({
+      where: {
+        title: containsQuery,
+        ...(isManager
+          ? {}
+          : {
+              OR: [
+                { primaryAssigneeId: userId },
+                { backupAssigneeId: userId },
+                { creatorId: userId },
+              ],
+            }),
+      },
+      select: {
+        id: true,
+        title: true,
+        status: true,
+        priority: true,
+        dueDate: true,
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+    }),
+
+    // Documents: search by title
+    prisma.document.findMany({
+      where: { title: containsQuery },
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        updatedAt: true,
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+    }),
+
+    // KPIs: search by code or title
+    prisma.kPI.findMany({
+      where: {
+        OR: [
+          { code: containsQuery },
+          { title: containsQuery },
+        ],
+      },
+      select: {
+        id: true,
+        code: true,
+        title: true,
+        status: true,
+        year: true,
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+    }),
+
+    // Users: search by name (manager only)
+    isManager
+      ? prisma.user.findMany({
+          where: {
+            name: containsQuery,
+            isActive: true,
+          },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            role: true,
+          },
+          orderBy: { name: "asc" },
+          take: 5,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return success({
+    tasks: tasks.map((t) => ({ ...t, type: "task" as const })),
+    documents: documents.map((d) => ({ ...d, type: "document" as const })),
+    kpis: kpis.map((k) => ({ ...k, type: "kpi" as const })),
+    users: users.map((u) => ({ ...u, type: "user" as const })),
+  });
+});

--- a/app/components/command-palette.tsx
+++ b/app/components/command-palette.tsx
@@ -2,44 +2,217 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Search } from "lucide-react";
+import {
+  Search,
+  ClipboardList,
+  FileText,
+  Target,
+  User,
+  Clock,
+  Loader2,
+} from "lucide-react";
 
-const ROUTES = [
-  { href: "/dashboard", label: "儀表板", shortcut: "G D", keywords: ["dashboard", "首頁"] },
-  { href: "/kanban", label: "看板", shortcut: "G K", keywords: ["kanban", "任務"] },
-  { href: "/gantt", label: "甘特圖", shortcut: "G G", keywords: ["gantt", "排程"] },
-  { href: "/plans", label: "年度計畫", shortcut: "G P", keywords: ["plans", "計畫"] },
-  { href: "/kpi", label: "KPI", shortcut: "G I", keywords: ["kpi", "指標"] },
-  { href: "/knowledge", label: "知識庫", shortcut: "G B", keywords: ["knowledge", "文件"] },
-  { href: "/timesheet", label: "工時紀錄", shortcut: "G T", keywords: ["timesheet", "工時"] },
-  { href: "/reports", label: "報表", shortcut: "G R", keywords: ["reports", "統計"] },
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface SearchResultItem {
+  id: string;
+  type: "route" | "task" | "document" | "kpi" | "user";
+  label: string;
+  sub?: string;
+  href: string;
+  shortcut?: string;
+}
+
+interface ApiSearchResponse {
+  ok: boolean;
+  data?: {
+    tasks: Array<{ id: string; title: string; status: string; priority: string }>;
+    documents: Array<{ id: string; title: string; slug: string }>;
+    kpis: Array<{ id: string; code: string; title: string; year: number }>;
+    users: Array<{ id: string; name: string; email: string; role: string }>;
+  };
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const ROUTES: SearchResultItem[] = [
+  { id: "r-dashboard", type: "route", href: "/dashboard", label: "儀表板", shortcut: "G D" },
+  { id: "r-kanban", type: "route", href: "/kanban", label: "看板", shortcut: "G K" },
+  { id: "r-gantt", type: "route", href: "/gantt", label: "甘特圖", shortcut: "G G" },
+  { id: "r-plans", type: "route", href: "/plans", label: "年度計畫", shortcut: "G P" },
+  { id: "r-kpi", type: "route", href: "/kpi", label: "KPI", shortcut: "G I" },
+  { id: "r-knowledge", type: "route", href: "/knowledge", label: "知識庫", shortcut: "G B" },
+  { id: "r-timesheet", type: "route", href: "/timesheet", label: "工時紀錄", shortcut: "G T" },
+  { id: "r-reports", type: "route", href: "/reports", label: "報表", shortcut: "G R" },
 ];
+
+const ROUTE_KEYWORDS: Record<string, string[]> = {
+  "/dashboard": ["dashboard", "首頁"],
+  "/kanban": ["kanban", "任務"],
+  "/gantt": ["gantt", "排程"],
+  "/plans": ["plans", "計畫"],
+  "/kpi": ["kpi", "指標"],
+  "/knowledge": ["knowledge", "文件"],
+  "/timesheet": ["timesheet", "工時"],
+  "/reports": ["reports", "統計"],
+};
+
+const RECENT_SEARCH_KEY = "titan-recent-searches";
+const MAX_RECENT = 5;
+
+const TYPE_ICON: Record<string, React.ReactNode> = {
+  task: <ClipboardList className="h-3.5 w-3.5" />,
+  document: <FileText className="h-3.5 w-3.5" />,
+  kpi: <Target className="h-3.5 w-3.5" />,
+  user: <User className="h-3.5 w-3.5" />,
+  route: <Search className="h-3.5 w-3.5" />,
+};
+
+const TYPE_LABEL: Record<string, string> = {
+  task: "任務",
+  document: "文件",
+  kpi: "KPI",
+  user: "使用者",
+  route: "頁面",
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function getRecentSearches(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENT_SEARCH_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentSearch(q: string) {
+  try {
+    const recent = getRecentSearches().filter((s) => s !== q);
+    recent.unshift(q);
+    localStorage.setItem(RECENT_SEARCH_KEY, JSON.stringify(recent.slice(0, MAX_RECENT)));
+  } catch {
+    // localStorage unavailable — ignore
+  }
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const router = useRouter();
 
-  const filtered = ROUTES.filter((r) => {
+  // Filter route items locally
+  const filteredRoutes = ROUTES.filter((r) => {
     if (!query) return true;
     const q = query.toLowerCase();
+    const keywords = ROUTE_KEYWORDS[r.href] ?? [];
     return (
       r.label.toLowerCase().includes(q) ||
       r.href.includes(q) ||
-      r.keywords.some((k) => k.includes(q))
+      keywords.some((k) => k.includes(q))
     );
   });
 
+  // Combined results: routes first, then API search results
+  const allResults: SearchResultItem[] = query
+    ? [...filteredRoutes, ...searchResults]
+    : filteredRoutes;
+
   const navigate = useCallback(
     (href: string) => {
+      if (query.trim()) {
+        saveRecentSearch(query.trim());
+      }
       setOpen(false);
       setQuery("");
+      setSearchResults([]);
       router.push(href);
     },
-    [router]
+    [router, query]
   );
+
+  // Debounced API search when query changes
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!query || query.trim().length < 2) {
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+
+    setSearching(true);
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(query.trim())}`);
+        if (!res.ok) {
+          setSearchResults([]);
+          return;
+        }
+        const json: ApiSearchResponse = await res.json();
+        if (!json.ok || !json.data) {
+          setSearchResults([]);
+          return;
+        }
+
+        const items: SearchResultItem[] = [];
+        for (const t of json.data.tasks) {
+          items.push({
+            id: `task-${t.id}`,
+            type: "task",
+            label: t.title,
+            sub: `${t.status} · ${t.priority}`,
+            href: `/kanban?task=${t.id}`,
+          });
+        }
+        for (const d of json.data.documents) {
+          items.push({
+            id: `doc-${d.id}`,
+            type: "document",
+            label: d.title,
+            sub: d.slug,
+            href: `/knowledge/${d.slug}`,
+          });
+        }
+        for (const k of json.data.kpis) {
+          items.push({
+            id: `kpi-${k.id}`,
+            type: "kpi",
+            label: `${k.code} — ${k.title}`,
+            sub: `${k.year} 年度`,
+            href: `/kpi?id=${k.id}`,
+          });
+        }
+        for (const u of json.data.users) {
+          items.push({
+            id: `user-${u.id}`,
+            type: "user",
+            label: u.name,
+            sub: `${u.email} · ${u.role}`,
+            href: `/admin/users?id=${u.id}`,
+          });
+        }
+        setSearchResults(items);
+      } catch {
+        setSearchResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
 
   // Ctrl+K / Cmd+K to open, Escape to close
   useEffect(() => {
@@ -60,7 +233,7 @@ export function CommandPalette() {
     let timer: ReturnType<typeof setTimeout>;
 
     function onKeyDown(e: KeyboardEvent) {
-      if (open) return; // Don't capture when palette is open
+      if (open) return;
       const target = e.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return;
 
@@ -86,11 +259,13 @@ export function CommandPalette() {
     };
   }, [open, navigate]);
 
-  // Focus input when opened
+  // Focus input when opened, load recent searches
   useEffect(() => {
     if (open) {
       setSelectedIndex(0);
       setQuery("");
+      setSearchResults([]);
+      setRecentSearches(getRecentSearches());
       setTimeout(() => inputRef.current?.focus(), 0);
     }
   }, [open]);
@@ -99,13 +274,18 @@ export function CommandPalette() {
   function onPaletteKeyDown(e: React.KeyboardEvent) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+      setSelectedIndex((i) => Math.min(i + 1, allResults.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && filtered[selectedIndex]) {
-      navigate(filtered[selectedIndex].href);
+    } else if (e.key === "Enter" && allResults[selectedIndex]) {
+      navigate(allResults[selectedIndex].href);
     }
+  }
+
+  function handleRecentClick(recent: string) {
+    setQuery(recent);
+    setSelectedIndex(0);
   }
 
   if (!open) return null;
@@ -119,7 +299,7 @@ export function CommandPalette() {
       <div
         className="relative w-full max-w-lg rounded-xl border border-border bg-card shadow-2xl overflow-hidden"
         role="dialog"
-        aria-label="快速導航"
+        aria-label="快速搜尋"
         onKeyDown={onPaletteKeyDown}
       >
         {/* Search input */}
@@ -129,32 +309,71 @@ export function CommandPalette() {
             ref={inputRef}
             value={query}
             onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
-            placeholder="搜尋頁面…"
+            placeholder="搜尋頁面、任務、文件、KPI、使用者…"
             className="flex-1 h-12 bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none"
           />
+          {searching && <Loader2 className="h-4 w-4 text-muted-foreground animate-spin flex-shrink-0" />}
           <kbd className="text-[10px] text-muted-foreground border border-border rounded px-1.5 py-0.5">ESC</kbd>
         </div>
 
+        {/* Recent searches (only when no query) */}
+        {!query && recentSearches.length > 0 && (
+          <div className="border-b border-border px-4 py-2">
+            <p className="text-[10px] text-muted-foreground mb-1.5 flex items-center gap-1">
+              <Clock className="h-3 w-3" /> 最近搜尋
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {recentSearches.map((s) => (
+                <button
+                  key={s}
+                  onClick={() => handleRecentClick(s)}
+                  className="text-xs px-2 py-0.5 rounded-full border border-border text-muted-foreground hover:bg-accent/50 transition-colors"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Results */}
-        <ul className="max-h-64 overflow-y-auto py-1">
-          {filtered.map((route, i) => (
-            <li key={route.href}>
+        <ul className="max-h-72 overflow-y-auto py-1">
+          {allResults.map((item, i) => (
+            <li key={item.id}>
               <button
-                onClick={() => navigate(route.href)}
-                className={`w-full flex items-center justify-between px-4 py-2.5 text-sm transition-colors ${
+                onClick={() => navigate(item.href)}
+                className={`w-full flex items-center gap-3 px-4 py-2.5 text-sm transition-colors ${
                   i === selectedIndex
                     ? "bg-accent text-accent-foreground"
                     : "text-foreground hover:bg-accent/50"
                 }`}
               >
-                <span>{route.label}</span>
-                <kbd className="text-[10px] text-muted-foreground font-mono">{route.shortcut}</kbd>
+                <span className="text-muted-foreground flex-shrink-0">
+                  {TYPE_ICON[item.type]}
+                </span>
+                <span className="flex-1 text-left truncate">{item.label}</span>
+                {item.sub && (
+                  <span className="text-[10px] text-muted-foreground flex-shrink-0 truncate max-w-[120px]">
+                    {item.sub}
+                  </span>
+                )}
+                {item.shortcut && (
+                  <kbd className="text-[10px] text-muted-foreground font-mono flex-shrink-0">{item.shortcut}</kbd>
+                )}
+                <span className="text-[9px] text-muted-foreground/60 flex-shrink-0">
+                  {TYPE_LABEL[item.type]}
+                </span>
               </button>
             </li>
           ))}
-          {filtered.length === 0 && (
+          {allResults.length === 0 && !searching && (
             <li className="px-4 py-6 text-sm text-muted-foreground text-center">
-              找不到符合的頁面
+              找不到符合的結果
+            </li>
+          )}
+          {allResults.length === 0 && searching && (
+            <li className="px-4 py-6 text-sm text-muted-foreground text-center flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" /> 搜尋中…
             </li>
           )}
         </ul>


### PR DESCRIPTION
## Summary
- Create `/api/search?q=keyword` unified search endpoint (tasks, documents, KPIs, users)
- Enhance command palette with debounced API search, type icons, and result categories
- Add recent search history stored in localStorage (max 5 entries)

Closes #419

## Test plan
- [ ] Verify Ctrl+K opens palette and route navigation still works
- [ ] Verify typing 2+ chars triggers API search with loading spinner
- [ ] Verify results show correct type icons (task, document, KPI, user)
- [ ] Verify recent searches appear when palette opens with no query
- [ ] Verify engineers only see their own tasks; managers see all

🤖 Generated with [Claude Code](https://claude.com/claude-code)