### PR TITLE
feat(db): configure connection pooling limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,9 @@ REDIS_URL=redis://:changeme_redis_password_here@titan-redis:6379
 AUTH_SECRET=changeme_auth_secret_here
 # TITAN 對外 URL（Nginx 反向代理後的完整 URL）
 TITAN_URL=https://titan.bank.local/titan
+# TITAN App 資料庫連線字串（含連線池上限）
+# connection_limit: Prisma 單一實例最多持有的 DB 連線數（預設無限制，建議 ≤ 10）
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?connection_limit=10
 
 # ── MinIO 物件儲存 ───────────────────────────────────────────
 # Root 帳號（等同 AWS Access Key）

--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ titan/
 | [支援計畫](docs/support-plan.md) | L1/L2 支援架構 |
 | [測試指南](TESTING.md) | 測試架構與執行指令 |
 
+## Database Connection Pooling
+
+TITAN 使用 Prisma 的 `connection_limit` 參數控制資料庫連線池上限。預設設為 **10**，適合 5 人團隊的銀行內網環境。
+
+```
+DATABASE_URL=postgresql://user:password@host:5432/db?connection_limit=10
+```
+
+- `connection_limit=10`：每個 Prisma Client 實例最多持有 10 條連線
+- 若部署多個 replica，總連線數 = replica 數 × connection_limit
+- PostgreSQL 預設 `max_connections=100`，建議保留餘裕給管理工具與監控
+
 ## 設計原則
 
 1. **簡約** — 乾淨清爽的 UI，明亮專業風格

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
       titan-redis:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://titan:titan_dev_password@titan-db:5432/titan_dev
+      DATABASE_URL: postgresql://titan:titan_dev_password@titan-db:5432/titan_dev?connection_limit=10
       REDIS_URL: redis://titan-redis:6379
       NEXTAUTH_URL: http://mac-mini.tailde842d.ts.net:3100
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?請在 .env 設定 NEXTAUTH_SECRET（openssl rand -hex 32）}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,7 +322,7 @@ services:
       redis:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}?connection_limit=10
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       NEXTAUTH_URL: ${TITAN_URL:-https://titan.bank.local/titan}
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}


### PR DESCRIPTION
## Summary
- Add `?connection_limit=10` to DATABASE_URL in `.env.example`, `docker-compose.yml`, and `docker-compose.dev.yml`
- Document connection pooling configuration in README

## Test plan
- [ ] Verify `.env.example` has DATABASE_URL with connection_limit parameter
- [ ] Verify docker-compose.yml titan-app service uses connection_limit
- [ ] Verify README documents pooling configuration

Closes #386