### PR TITLE
fix(api): include milestones in plan template copy

### DIFF
--- a/services/plan-service.ts
+++ b/services/plan-service.ts
@@ -1,6 +1,15 @@
 import { PrismaClient } from "@prisma/client";
 import { NotFoundError, ValidationError } from "./errors";
 
+/**
+ * Shift a Date by a given number of years, preserving month/day.
+ */
+function shiftDateByYears(date: Date, years: number): Date {
+  const shifted = new Date(date);
+  shifted.setFullYear(shifted.getFullYear() + years);
+  return shifted;
+}
+
 export interface ListPlansFilter {
   year?: number;
 }
@@ -130,6 +139,12 @@ export class PlanService {
     return this.prisma.annualPlan.delete({ where: { id } });
   }
 
+  /**
+   * Copy an annual plan as a template to a new target year.
+   * Copies: plan metadata, monthly goals, and milestones.
+   * Milestone dates are shifted by the year delta (e.g. 2025→2026 shifts +1 year).
+   * Monthly goals and milestones are reset to initial status.
+   */
   async copyTemplate(sourcePlanId: string, targetYear: number, createdBy: string) {
     const source = await this.prisma.annualPlan.findUnique({
       where: { id: sourcePlanId },
@@ -144,6 +159,9 @@ export class PlanService {
     });
 
     if (!source) throw new NotFoundError(`Plan not found: ${sourcePlanId}`);
+
+    // Shift milestone dates by the year delta
+    const yearDelta = targetYear - source.year;
 
     return this.prisma.annualPlan.create({
       data: {
@@ -169,8 +187,10 @@ export class PlanService {
               create: source.milestones.map((m) => ({
                 title: m.title,
                 description: m.description ?? null,
-                plannedStart: m.plannedStart ?? null,
-                plannedEnd: m.plannedEnd,
+                plannedStart: m.plannedStart
+                  ? shiftDateByYears(m.plannedStart, yearDelta)
+                  : null,
+                plannedEnd: shiftDateByYears(m.plannedEnd, yearDelta),
                 actualStart: null,
                 actualEnd: null,
                 status: "PENDING" as const,


### PR DESCRIPTION
## Summary
- Fix milestone date offset when copying plan templates across years
- Previously: milestones kept source year dates (2025 dates in 2026 plan)
- Now: `shiftDateByYears()` adjusts plannedStart/plannedEnd by year delta
- Milestone status reset to PENDING, actual dates cleared

## Test plan
- [ ] Copy 2025 plan to 2026 — milestones should have 2026 dates
- [ ] Verify milestone month/day preserved (only year changes)
- [ ] Verify status reset to PENDING
- [ ] Verify actualStart/actualEnd are null

Closes #371