### PR TITLE
feat(api): add task template CRUD and apply endpoint

### DIFF
--- a/app/api/task-templates/[id]/apply/route.ts
+++ b/app/api/task-templates/[id]/apply/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { NotFoundError } from "@/services/errors";
+import { z } from "zod";
+import { validateBody } from "@/lib/validate";
+
+/**
+ * Optional overrides when applying a template to create a task.
+ */
+const applyTemplateSchema = z.object({
+  primaryAssigneeId: z.string().optional(),
+  backupAssigneeId: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  dueDate: z.string().datetime().optional(),
+  startDate: z.string().datetime().optional(),
+});
+
+/**
+ * POST /api/task-templates/[id]/apply
+ * Creates a new task based on the template, with optional overrides.
+ */
+export const POST = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+
+  const template = await prisma.taskTemplate.findUnique({
+    where: { id },
+  });
+
+  if (!template) {
+    throw new NotFoundError("任務模板不存在");
+  }
+
+  const raw = await req.json();
+  const overrides = validateBody(applyTemplateSchema, raw);
+
+  const task = await prisma.task.create({
+    data: {
+      title: template.title,
+      description: template.description,
+      priority: template.priority,
+      category: template.category,
+      estimatedHours: template.estimatedHours,
+      creatorId: session.user.id,
+      status: "BACKLOG",
+      ...(overrides.primaryAssigneeId && { primaryAssigneeId: overrides.primaryAssigneeId }),
+      ...(overrides.backupAssigneeId && { backupAssigneeId: overrides.backupAssigneeId }),
+      ...(overrides.monthlyGoalId && { monthlyGoalId: overrides.monthlyGoalId }),
+      ...(overrides.dueDate && { dueDate: new Date(overrides.dueDate) }),
+      ...(overrides.startDate && { startDate: new Date(overrides.startDate) }),
+    },
+    include: {
+      primaryAssignee: { select: { id: true, name: true } },
+      backupAssignee: { select: { id: true, name: true } },
+      creator: { select: { id: true, name: true } },
+    },
+  });
+
+  return success(task, 201);
+});

--- a/app/api/task-templates/[id]/route.ts
+++ b/app/api/task-templates/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { NotFoundError, ForbiddenError } from "@/services/errors";
+
+/**
+ * GET /api/task-templates/[id]
+ * Returns a single task template by ID.
+ */
+export const GET = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+
+  const template = await prisma.taskTemplate.findUnique({
+    where: { id },
+    include: {
+      creator: { select: { id: true, name: true } },
+    },
+  });
+
+  if (!template) {
+    throw new NotFoundError("任務模板不存在");
+  }
+
+  return success(template);
+});
+
+/**
+ * DELETE /api/task-templates/[id]
+ * Deletes a task template. Only the creator or MANAGER can delete.
+ */
+export const DELETE = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+
+  const template = await prisma.taskTemplate.findUnique({
+    where: { id },
+    select: { creatorId: true },
+  });
+
+  if (!template) {
+    throw new NotFoundError("任務模板不存在");
+  }
+
+  if (session.user.role !== "MANAGER" && template.creatorId !== session.user.id) {
+    throw new ForbiddenError("僅限模板建立者或管理員可刪除");
+  }
+
+  await prisma.taskTemplate.delete({ where: { id } });
+
+  return success({ success: true });
+});

--- a/app/api/task-templates/route.ts
+++ b/app/api/task-templates/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { validateBody } from "@/lib/validate";
+import { createTaskTemplateSchema } from "@/validators/task-template-validators";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
+
+/**
+ * GET /api/task-templates
+ * Lists all task templates with pagination.
+ */
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const { page, limit, skip } = parsePagination(searchParams);
+
+  const [templates, total] = await Promise.all([
+    prisma.taskTemplate.findMany({
+      skip,
+      take: limit,
+      orderBy: { createdAt: "desc" },
+      include: {
+        creator: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.taskTemplate.count(),
+  ]);
+
+  return success({
+    items: templates,
+    pagination: buildPaginationMeta(total, { page, limit, skip }),
+  });
+});
+
+/**
+ * POST /api/task-templates
+ * Creates a new task template. Any authenticated user can create.
+ */
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const raw = await req.json();
+  const body = validateBody(createTaskTemplateSchema, raw);
+
+  const template = await prisma.taskTemplate.create({
+    data: {
+      ...body,
+      creatorId: session.user.id,
+    },
+    include: {
+      creator: { select: { id: true, name: true } },
+    },
+  });
+
+  return success(template, 201);
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,7 @@ model User {
   passwordHistory          PasswordHistory[]
   notificationPreferences  NotificationPreference[]
   passwordResetTokens      PasswordResetToken[]
+  createdTemplates         TaskTemplate[]        @relation("TemplateCreator")
 
   @@map("users")
 }
@@ -553,6 +554,27 @@ model DocumentVersion {
 
   @@index([documentId])
   @@map("document_versions")
+}
+
+// ═══════════════════════════════════════
+// 任務模板
+// ═══════════════════════════════════════
+
+model TaskTemplate {
+  id             String       @id @default(cuid())
+  title          String
+  description    String?
+  priority       Priority     @default(P2)
+  category       TaskCategory @default(PLANNED)
+  estimatedHours Float?
+  creatorId      String
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  creator User @relation("TemplateCreator", fields: [creatorId], references: [id])
+
+  @@index([creatorId])
+  @@map("task_templates")
 }
 
 // ═══════════════════════════════════════

--- a/validators/task-template-validators.ts
+++ b/validators/task-template-validators.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const PriorityEnum = z.enum(["P0", "P1", "P2", "P3"]);
+
+const TaskCategoryEnum = z.enum([
+  "PLANNED",
+  "ADDED",
+  "INCIDENT",
+  "SUPPORT",
+  "ADMIN",
+  "LEARNING",
+]);
+
+export const createTaskTemplateSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  priority: PriorityEnum.optional().default("P2"),
+  category: TaskCategoryEnum.optional().default("PLANNED"),
+  estimatedHours: z.number().nonnegative().optional(),
+});
+
+export type CreateTaskTemplateInput = z.infer<typeof createTaskTemplateSchema>;


### PR DESCRIPTION
## Summary
- Add `TaskTemplate` Prisma model with title, description, priority, category, estimatedHours, creatorId
- Implement GET/POST `/api/task-templates` with pagination support
- Implement GET/DELETE `/api/task-templates/[id]` with creator/manager ownership check
- Implement POST `/api/task-templates/[id]/apply` to create task from template with optional overrides

Closes #416

## Test plan
- [ ] Verify `TaskTemplate` migration runs cleanly
- [ ] Test CRUD operations via API (create, list, get, delete)
- [ ] Test apply endpoint creates task with template defaults
- [ ] Test apply endpoint respects overrides (assignee, dates, goal)
- [ ] Verify only creator or MANAGER can delete templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)