### PR TITLE
test(frontend): add RTL tests for Dashboard, Kanban, Timesheet

### DIFF
--- a/__tests__/pages/dashboard-extended.test.tsx
+++ b/__tests__/pages/dashboard-extended.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * Extended RTL tests for Dashboard page — Issue #373
+ *
+ * Focuses on:
+ *  - Role-based rendering differences (Manager vs Engineer)
+ *  - User interaction: retry buttons, conditional sections
+ *  - Data-driven rendering: KPI section, today tasks, overdue highlight
+ *  - Edge cases: mixed data states
+ */
+import React from "react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Session mock ──────────────────────────────────────────────────────────────
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn() })),
+  usePathname: jest.fn(() => "/dashboard"),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let DashboardPage: React.ComponentType<any>;
+beforeAll(async () => {
+  const mod = await import("@/app/(app)/dashboard/page");
+  DashboardPage = mod.default;
+});
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const WORKLOAD_HAPPY = {
+  byPerson: [
+    { userId: "u1", name: "Alice", total: 40, planned: 30, unplanned: 10 },
+    { userId: "u2", name: "Bob", total: 35, planned: 25, unplanned: 10 },
+  ],
+  plannedRate: 75,
+  unplannedRate: 25,
+  totalHours: 75,
+};
+
+const WEEKLY_HAPPY = {
+  completedCount: 5,
+  overdueCount: 2,
+  delayCount: 1,
+  scopeChangeCount: 0,
+  totalHours: 38,
+};
+
+const TASKS_HAPPY = [
+  { id: "t1", title: "Task One", status: "IN_PROGRESS", priority: "HIGH", dueDate: null },
+  { id: "t2", title: "Task Two", status: "TODO", priority: "MEDIUM", dueDate: "2099-12-31" },
+  { id: "t3", title: "Overdue Task", status: "IN_PROGRESS", priority: "URGENT", dueDate: "2020-01-01" },
+];
+
+const KPI_HAPPY = [
+  {
+    id: "k1", code: "KPI-01", title: "Revenue Growth",
+    target: 100, actual: 80, status: "ON_TRACK",
+    autoCalc: false, taskLinks: [],
+  },
+  {
+    id: "k2", code: "KPI-02", title: "Customer Satisfaction",
+    target: 90, actual: 85, status: "AT_RISK",
+    autoCalc: false, taskLinks: [],
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function setSession(role: "MANAGER" | "MEMBER") {
+  mockUseSession.mockReturnValue({
+    data: { user: { id: "u1", name: "Alice", role }, expires: "2099" },
+    status: "authenticated",
+  });
+}
+
+function setupFetch(
+  workload: unknown = WORKLOAD_HAPPY,
+  weekly: unknown = WEEKLY_HAPPY,
+  tasks: unknown = TASKS_HAPPY,
+  kpi: unknown = KPI_HAPPY,
+) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes("workload")) return Promise.resolve({ ok: true, json: async () => workload } as Response);
+    if (url.includes("weekly")) return Promise.resolve({ ok: true, json: async () => weekly } as Response);
+    if (url.includes("tasks")) return Promise.resolve({ ok: true, json: async () => tasks } as Response);
+    if (url.includes("kpi")) return Promise.resolve({ ok: true, json: async () => kpi } as Response);
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Dashboard Extended — Role-based rendering", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("Manager sees 團隊工時分佈 section with team member names", async () => {
+    setSession("MANAGER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("團隊工時分佈（本月）")).toBeInTheDocument();
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+  });
+
+  it("Manager sees 投入率分析 section with planned/unplanned rates", async () => {
+    setSession("MANAGER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("投入率分析（計畫任務 vs 加入任務）")).toBeInTheDocument();
+      expect(screen.getByText("計畫內投入")).toBeInTheDocument();
+      expect(screen.getByText("計畫外投入")).toBeInTheDocument();
+    });
+  });
+
+  it("Engineer sees 我的任務 section with task titles", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("我的任務（待辦 + 進行中）")).toBeInTheDocument();
+      expect(screen.getByText("Task One")).toBeInTheDocument();
+      expect(screen.getByText("Task Two")).toBeInTheDocument();
+    });
+  });
+
+  it("Engineer sees 本週工時進度 progress bar section", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("本週工時進度")).toBeInTheDocument();
+    });
+  });
+
+  it("Engineer sees overdue task count as stat card with accent", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("逾期任務")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Dashboard Extended — KPI section", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders KPI progress bars with code and title", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("KPI-01")).toBeInTheDocument();
+      expect(screen.getByText("Revenue Growth")).toBeInTheDocument();
+      expect(screen.getByText("KPI-02")).toBeInTheDocument();
+      expect(screen.getByText("Customer Satisfaction")).toBeInTheDocument();
+    });
+  });
+
+  it("renders KPI status badges (ON_TRACK / AT_RISK)", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("進行中")).toBeInTheDocument(); // ON_TRACK
+      expect(screen.getByText("風險")).toBeInTheDocument();   // AT_RISK
+    });
+  });
+});
+
+describe("Dashboard Extended — Error recovery interaction", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("Manager: error state shows 發生錯誤 and retry triggers re-fetch", async () => {
+    setSession("MANAGER");
+    // First call fails, second succeeds
+    let callCount = 0;
+    mockFetch.mockImplementation((url: string) => {
+      callCount++;
+      if (callCount <= 2) {
+        // First round: both workload + weekly fail
+        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+      }
+      // After retry
+      if (url.includes("workload")) return Promise.resolve({ ok: true, json: async () => WORKLOAD_HAPPY } as Response);
+      if (url.includes("weekly")) return Promise.resolve({ ok: true, json: async () => WEEKLY_HAPPY } as Response);
+      if (url.includes("kpi")) return Promise.resolve({ ok: true, json: async () => KPI_HAPPY } as Response);
+      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    });
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getAllByText("發生錯誤").length).toBeGreaterThan(0);
+    });
+
+    // Click retry button
+    const retryButtons = screen.getAllByText("重試");
+    expect(retryButtons.length).toBeGreaterThan(0);
+    await act(async () => { fireEvent.click(retryButtons[0]); });
+
+    // After retry, data should load
+    await waitFor(() => {
+      expect(screen.getByText("儀表板")).toBeInTheDocument();
+    });
+  });
+
+  it("Engineer: empty tasks + zero weekly hours shows 尚無待處理任務 guidance", async () => {
+    setSession("MEMBER");
+    setupFetch(
+      WORKLOAD_HAPPY,
+      { completedCount: 0, overdueCount: 0, delayCount: 0, scopeChangeCount: 0, totalHours: 0 },
+      [],
+      KPI_HAPPY,
+    );
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("尚無待處理任務")).toBeInTheDocument();
+      expect(screen.getByText("開始使用")).toBeInTheDocument();
+    });
+  });
+
+  it("Manager with zero data shows 尚無團隊數據 guidance", async () => {
+    setSession("MANAGER");
+    setupFetch(
+      { byPerson: [], plannedRate: 0, unplannedRate: 0, totalHours: 0 },
+      { completedCount: 0, overdueCount: 0, delayCount: 0, scopeChangeCount: 0, totalHours: 0 },
+      [],
+      [],
+    );
+    await act(async () => { render(<DashboardPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("尚無團隊數據")).toBeInTheDocument();
+      expect(screen.getByText("快速開始指南")).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/pages/kanban-extended.test.tsx
+++ b/__tests__/pages/kanban-extended.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Extended RTL tests for Kanban page — Issue #373
+ *
+ * Focuses on:
+ *  - All 5 column headers render correctly
+ *  - Task count badge per column
+ *  - "新增任務" button presence
+ *  - Empty column placeholder text
+ *  - Error state rendering
+ *  - Network rejection handling
+ *  - Multiple tasks distributed across columns
+ */
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("next-auth/react", () => ({
+  useSession: jest.fn(() => ({
+    data: { user: { id: "u1", name: "Alice", role: "MEMBER" }, expires: "2099" },
+    status: "authenticated",
+  })),
+}));
+
+jest.mock("@/app/components/task-card", () => ({
+  TaskCard: ({ task }: { task: { title: string } }) => (
+    <div data-testid="task-card">{task.title}</div>
+  ),
+}));
+jest.mock("@/app/components/task-filters", () => ({
+  TaskFilters: () => <div data-testid="task-filters" />,
+}));
+jest.mock("@/app/components/task-detail-modal", () => ({
+  TaskDetailModal: () => <div data-testid="task-detail-modal" />,
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const TASKS_ALL_COLUMNS = [
+  { id: "t1", title: "Backlog Item", status: "BACKLOG", priority: "P2", category: "PLANNED" },
+  { id: "t2", title: "Todo Item", status: "TODO", priority: "P1", category: "PLANNED" },
+  { id: "t3", title: "WIP Item", status: "IN_PROGRESS", priority: "P0", category: "INCIDENT" },
+  { id: "t4", title: "Review Item", status: "REVIEW", priority: "P2", category: "PLANNED" },
+  { id: "t5", title: "Done Item", status: "DONE", priority: "P3", category: "PLANNED" },
+];
+
+describe("Kanban Extended", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => TASKS_ALL_COLUMNS,
+    } as Response);
+  });
+
+  it("renders all 5 column headers", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("待辦清單")).toBeInTheDocument();
+      expect(screen.getByText("待處理")).toBeInTheDocument();
+      expect(screen.getByText("進行中")).toBeInTheDocument();
+      expect(screen.getByText("審核中")).toBeInTheDocument();
+      expect(screen.getByText("已完成")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 新增任務 button", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    expect(screen.getByText("新增任務")).toBeInTheDocument();
+  });
+
+  it("renders the correct total task count in header", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText(/共 5 項任務/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders task cards in each column (5 tasks across 5 columns)", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("Backlog Item")).toBeInTheDocument();
+      expect(screen.getByText("Todo Item")).toBeInTheDocument();
+      expect(screen.getByText("WIP Item")).toBeInTheDocument();
+      expect(screen.getByText("Review Item")).toBeInTheDocument();
+      expect(screen.getByText("Done Item")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 看板 heading", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    expect(screen.getByText("看板")).toBeInTheDocument();
+  });
+
+  it("renders 載入看板 while loading", async () => {
+    // Make fetch never resolve to keep loading state
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    expect(screen.getByText("載入看板...")).toBeInTheDocument();
+  });
+
+  it("shows error message on fetch error with retry", async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({}) } as Response);
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("發生錯誤")).toBeInTheDocument();
+    });
+  });
+
+  it("handles network rejection without crashing", async () => {
+    mockFetch.mockRejectedValue(new Error("Network failure"));
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("發生錯誤")).toBeInTheDocument();
+    });
+  });
+
+  it("supports paginated response format { data: { items } }", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          items: [TASKS_ALL_COLUMNS[0]],
+          pagination: { page: 1, limit: 20, total: 1 },
+        },
+      }),
+    } as Response);
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("Backlog Item")).toBeInTheDocument();
+    });
+  });
+
+  it("renders kanban region with aria-label for accessibility", async () => {
+    const { default: KanbanPage } = await import("@/app/(app)/kanban/page");
+    await act(async () => { render(<KanbanPage />); });
+    await waitFor(() => {
+      expect(screen.getByRole("region", { name: "看板欄位" })).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/pages/timesheet-extended.test.tsx
+++ b/__tests__/pages/timesheet-extended.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Extended RTL tests for Timesheet page — Issue #373
+ *
+ * Focuses on:
+ *  - Page heading and week label render
+ *  - Manager role: user filter dropdown visible
+ *  - MEMBER role: user filter NOT visible
+ *  - Week navigation buttons (本週, prev, next)
+ *  - Refresh button present
+ *  - Error state with retry
+ *  - Loading state text
+ *  - Stats summary rendering when data is present
+ */
+import React from "react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+jest.mock("@/app/components/timesheet-grid", () => ({
+  TimesheetGrid: () => <div data-testid="timesheet-grid" />,
+}));
+jest.mock("@/app/components/time-summary", () => ({
+  TimeSummary: ({ totalHours }: { totalHours: number }) => (
+    <div data-testid="time-summary">Total: {totalHours}h</div>
+  ),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function setSession(role: "MANAGER" | "MEMBER") {
+  mockUseSession.mockReturnValue({
+    data: { user: { id: "u1", name: "Alice", role }, expires: "2099" },
+    status: "authenticated",
+  });
+}
+
+const TIME_ENTRIES = [
+  { id: "e1", userId: "u1", taskId: null, date: "2024-01-15", hours: 4, category: "PLANNED_TASK", description: null, task: null },
+  { id: "e2", userId: "u1", taskId: "t1", date: "2024-01-16", hours: 6, category: "PLANNED_TASK", description: null, task: { id: "t1", title: "Dev Task" } },
+];
+
+const STATS_DATA = {
+  totalHours: 10,
+  breakdown: [{ category: "PLANNED_TASK", hours: 10, pct: 100 }],
+  taskInvestmentRate: 60,
+  entryCount: 2,
+};
+
+function setupFetchWithEntries(entries: unknown[] = TIME_ENTRIES, stats: unknown = STATS_DATA) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes("time-entries/stats")) {
+      return Promise.resolve({ ok: true, json: async () => stats } as Response);
+    }
+    if (url.includes("time-entries")) {
+      return Promise.resolve({ ok: true, json: async () => entries } as Response);
+    }
+    if (url.includes("users")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: "u1", name: "Alice" },
+          { id: "u2", name: "Bob" },
+        ],
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  });
+}
+
+describe("Timesheet Extended — Basic render", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders 工時紀錄 heading", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    expect(screen.getByText("工時紀錄")).toBeInTheDocument();
+  });
+
+  it("renders week label with year and date range", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    // The label format: "YYYY 年　M/D — M/D"
+    const weekLabel = screen.getByText(/\d{4} 年/);
+    expect(weekLabel).toBeInTheDocument();
+  });
+
+  it("renders 本週 navigation button", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    expect(screen.getByText("本週")).toBeInTheDocument();
+  });
+
+  it("renders help text about cell interaction", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByText(/點擊格子可輸入工時與分類/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Timesheet Extended — Role-based rendering", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("MANAGER sees user filter dropdown", async () => {
+    setSession("MANAGER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByLabelText("篩選使用者")).toBeInTheDocument();
+    });
+  });
+
+  it("MEMBER does NOT see user filter dropdown", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.queryByLabelText("篩選使用者")).not.toBeInTheDocument();
+    });
+  });
+
+  it("MANAGER user filter shows team member names", async () => {
+    setSession("MANAGER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      const select = screen.getByLabelText("篩選使用者");
+      expect(select).toBeInTheDocument();
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Timesheet Extended — Data states", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders TimesheetGrid when entries exist", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-grid")).toBeInTheDocument();
+    });
+  });
+
+  it("renders TimeSummary when stats have positive totalHours", async () => {
+    setSession("MEMBER");
+    setupFetchWithEntries();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByTestId("time-summary")).toBeInTheDocument();
+      expect(screen.getByText("Total: 10h")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error state with 發生錯誤 on fetch failure", async () => {
+    setSession("MEMBER");
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("users")) return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      if (url.includes("stats")) return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("發生錯誤")).toBeInTheDocument();
+    });
+  });
+
+  it("shows loading state text 載入工時", async () => {
+    setSession("MEMBER");
+    // Never resolve fetch to keep loading
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("users")) return Promise.resolve({ ok: true, json: async () => [] } as Response);
+      return new Promise(() => {});
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    expect(screen.getByText("載入工時...")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Add 10 extended RTL tests for Dashboard (role-based views, KPI, error recovery)
- Add 10 extended RTL tests for Kanban (5 columns, task count, loading/error, a11y)
- Add 11 extended RTL tests for Timesheet (role-based filter, data states, week nav)

Fixes #373

## Test plan
- [ ] Run `npx jest __tests__/pages/dashboard-extended.test.tsx`
- [ ] Run `npx jest __tests__/pages/kanban-extended.test.tsx`
- [ ] Run `npx jest __tests__/pages/timesheet-extended.test.tsx`
- [ ] Verify all new tests pass without modifying existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)