### PR TITLE
ci: add Playwright E2E test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,73 @@ jobs:
 
       - name: Security audit
         run: npm audit --audit-level=high || true
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: titan
+          POSTGRES_PASSWORD: titan_test
+          POSTGRES_DB: titan_test
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - name: Run database migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Seed database
+        run: npx prisma db seed
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build application
+        run: npm run build
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3100
+
+      - name: Start server and run E2E tests
+        run: |
+          npm run start &
+          npx wait-on http://localhost:3100 --timeout 30000
+          npx playwright test
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3100
+          PORT: 3100
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add separate `e2e` job to CI pipeline with PostgreSQL service container
- Runs Prisma migrations + seed, installs Playwright, builds app, runs E2E tests
- Uploads Playwright report artifact on failure for debugging

Fixes #376

## Test plan
- [ ] Verify CI workflow YAML is valid
- [ ] Confirm E2E job runs after test job passes
- [ ] Check Playwright report artifact is uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)