### PR TITLE
test: unify test environment for Docker and local

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -2,7 +2,7 @@ import { chromium, FullConfig } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
 
-const BASE_URL = 'http://localhost:3100';
+const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3100';
 
 export const MANAGER_STATE_FILE = path.join(__dirname, '.auth/manager.json');
 export const ENGINEER_STATE_FILE = path.join(__dirname, '.auth/engineer.json');

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,13 @@
 import type { Config } from "jest";
 
+/**
+ * Jest configuration — unified for Docker and local environments.
+ *
+ * Environment variables:
+ *   DATABASE_URL — overridden in CI / Docker (see .env.example)
+ *   TEST_TIMEOUT — optional, default 10000ms
+ */
+
 const config: Config = {
   testEnvironment: "jsdom",
   moduleNameMapper: {
@@ -31,6 +39,8 @@ const config: Config = {
     ],
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  // Allow Docker/CI to override the default test timeout
+  testTimeout: parseInt(process.env.TEST_TIMEOUT ?? "10000", 10),
 };
 
 export default config;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,27 @@
 import { defineConfig } from '@playwright/test';
 
+/**
+ * Playwright E2E configuration — unified for Docker and local environments.
+ *
+ * Environment variables:
+ *   BASE_URL     — app base URL (default: http://localhost:3100)
+ *   CI           — set in CI environments; adjusts retries/workers
+ *   E2E_TIMEOUT  — per-test timeout in ms (default: 30000)
+ *   E2E_WORKERS  — parallel worker count (default: 3, CI: 1)
+ */
+
+const isCI = !!process.env.CI;
+
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30000,
-  retries: 1,
+  timeout: parseInt(process.env.E2E_TIMEOUT ?? '30000', 10),
+  retries: isCI ? 2 : 1,
   // Limit workers to avoid rate limiter triggering on concurrent logins
-  workers: 3,
+  workers: parseInt(process.env.E2E_WORKERS ?? (isCI ? '1' : '3'), 10),
   globalSetup: './e2e/global-setup.ts',
   expect: { timeout: 10000 },
   use: {
-    baseURL: 'http://localhost:3100',
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3100',
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },


### PR DESCRIPTION
## Summary
- Make `jest.config.ts` support `TEST_TIMEOUT` env var for Docker/CI
- Make `playwright.config.ts` use `BASE_URL`, `E2E_WORKERS`, `E2E_TIMEOUT` env vars
- CI-aware: 2 retries + 1 worker in CI, 1 retry + 3 workers locally
- Update `e2e/global-setup.ts` to use `BASE_URL` env var

Fixes #380

## Test plan
- [ ] Run `npx jest` locally — works with defaults
- [ ] Run `BASE_URL=http://app:3100 npx playwright test` in Docker — uses container URL
- [ ] Verify CI env vars are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)