### PR TITLE
ci: add dependency audit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,91 @@ jobs:
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXTAUTH_URL: http://localhost:3000
 
-      - name: Security audit
-        run: npm audit --audit-level=high || true
+  dependency-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Security audit (moderate+)
+        run: npm audit --audit-level=moderate
+
+      - name: Check for outdated critical packages
+        run: npm outdated --long || true
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: titan
+          POSTGRES_PASSWORD: titan_test
+          POSTGRES_DB: titan_test
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx prisma generate
+
+      - name: Run database migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Seed database
+        run: npx prisma db seed
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Build application
+        run: npm run build
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3100
+
+      - name: Start server and run E2E tests
+        run: |
+          npm run start &
+          npx wait-on http://localhost:3100 --timeout 30000
+          npx playwright test
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+          NEXTAUTH_SECRET: test-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3100
+          PORT: 3100
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## Summary
- Add standalone `dependency-audit` job (runs in parallel, no DB required)
- Strict `npm audit --audit-level=moderate` — fails CI on moderate+ findings
- `npm outdated --long` for visibility into stale packages
- Includes E2E job (overlaps with #376)

Fixes #405

## Test plan
- [ ] Verify CI YAML is valid
- [ ] Confirm dependency-audit runs in parallel with test job
- [ ] Verify npm audit exits non-zero on moderate+ findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)