### PR TITLE
feat: share Zod schemas between frontend and API

### DIFF
--- a/validators/kpi-validators.ts
+++ b/validators/kpi-validators.ts
@@ -1,32 +1,13 @@
-import { z } from "zod";
+/**
+ * KPI validators — re-exports from shared schemas (Issue #396)
+ *
+ * Kept for backward compatibility. New code should import from
+ * '@/validators/shared' or '@/validators/shared/kpi' directly.
+ */
 
-const KpiStatusEnum = z.enum([
-  "DRAFT",
-  "ACTIVE",
-  "ACHIEVED",
-  "MISSED",
-  "CANCELLED",
-]);
-
-export const createKpiSchema = z.object({
-  year: z.number().int().min(2000).max(2100),
-  code: z.string().min(1),
-  title: z.string().min(1),
-  description: z.string().optional(),
-  target: z.number().nonnegative(),
-  weight: z.number().positive().optional().default(1),
-  autoCalc: z.boolean().optional().default(false),
-});
-
-export const updateKpiSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional(),
-  target: z.number().nonnegative().optional(),
-  actual: z.number().nonnegative().optional(),
-  weight: z.number().positive().optional(),
-  status: KpiStatusEnum.optional(),
-  autoCalc: z.boolean().optional(),
-});
-
-export type CreateKpiInput = z.infer<typeof createKpiSchema>;
-export type UpdateKpiInput = z.infer<typeof updateKpiSchema>;
+export {
+  createKpiSchema,
+  updateKpiSchema,
+  type CreateKpiInput,
+  type UpdateKpiInput,
+} from "./shared/kpi";

--- a/validators/plan-validators.ts
+++ b/validators/plan-validators.ts
@@ -1,48 +1,19 @@
-import { z } from "zod";
+/**
+ * Plan validators — re-exports from shared schemas (Issue #396)
+ *
+ * Kept for backward compatibility. New code should import from
+ * '@/validators/shared' or '@/validators/shared/plan' directly.
+ */
 
-const GoalStatusEnum = z.enum([
-  "NOT_STARTED",
-  "IN_PROGRESS",
-  "COMPLETED",
-  "CANCELLED",
-]);
-
-export const createPlanSchema = z.object({
-  year: z.number().int().min(2000).max(2100),
-  title: z.string().min(1),
-  description: z.string().optional(),
-  implementationPlan: z.string().optional(),
-  copiedFromYear: z.number().int().optional(),
-});
-
-export const updatePlanSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional(),
-  implementationPlan: z.string().optional(),
-  progressPct: z.number().min(0).max(100).optional(),
-});
-
-export const createGoalSchema = z.object({
-  annualPlanId: z.string().min(1),
-  month: z.number().int().min(1).max(12),
-  title: z.string().min(1),
-  description: z.string().optional(),
-});
-
-export const updateGoalSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional(),
-  status: GoalStatusEnum.optional(),
-  progressPct: z.number().min(0).max(100).optional(),
-});
-
-export const copyTemplateSchema = z.object({
-  sourcePlanId: z.string().min(1),
-  targetYear: z.number().int().min(2000).max(2100),
-});
-
-export type CreatePlanInput = z.infer<typeof createPlanSchema>;
-export type UpdatePlanInput = z.infer<typeof updatePlanSchema>;
-export type CreateGoalInput = z.infer<typeof createGoalSchema>;
-export type UpdateGoalInput = z.infer<typeof updateGoalSchema>;
-export type CopyTemplateInput = z.infer<typeof copyTemplateSchema>;
+export {
+  createPlanSchema,
+  updatePlanSchema,
+  createGoalSchema,
+  updateGoalSchema,
+  copyTemplateSchema,
+  type CreatePlanInput,
+  type UpdatePlanInput,
+  type CreateGoalInput,
+  type UpdateGoalInput,
+  type CopyTemplateInput,
+} from "./shared/plan";

--- a/validators/shared/enums.ts
+++ b/validators/shared/enums.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared Zod enum schemas — Issue #396
+ *
+ * Single source of truth for enum values used by both frontend forms
+ * and API route validation. Import from here to avoid duplication.
+ */
+
+import { z } from "zod";
+
+// ── Task ────────────────────────────────────────────────────────────────────
+
+export const TaskStatusEnum = z.enum([
+  "BACKLOG",
+  "TODO",
+  "IN_PROGRESS",
+  "REVIEW",
+  "DONE",
+]);
+
+export const PriorityEnum = z.enum(["P0", "P1", "P2", "P3"]);
+
+export const TaskCategoryEnum = z.enum([
+  "PLANNED",
+  "ADDED",
+  "INCIDENT",
+  "SUPPORT",
+  "ADMIN",
+  "LEARNING",
+]);
+
+// ── Plan / Goal ─────────────────────────────────────────────────────────────
+
+export const GoalStatusEnum = z.enum([
+  "NOT_STARTED",
+  "IN_PROGRESS",
+  "COMPLETED",
+  "CANCELLED",
+]);
+
+// ── KPI ─────────────────────────────────────────────────────────────────────
+
+export const KpiStatusEnum = z.enum([
+  "DRAFT",
+  "ACTIVE",
+  "ACHIEVED",
+  "MISSED",
+  "CANCELLED",
+]);
+
+// ── Time Entry ──────────────────────────────────────────────────────────────
+
+export const TimeCategoryEnum = z.enum([
+  "PLANNED_TASK",
+  "ADDED_TASK",
+  "INCIDENT",
+  "SUPPORT",
+  "ADMIN",
+  "LEARNING",
+]);
+
+// ── User ────────────────────────────────────────────────────────────────────
+
+export const RoleEnum = z.enum(["MANAGER", "ENGINEER"]);
+
+// ── Inferred TypeScript types ───────────────────────────────────────────────
+
+export type TaskStatus = z.infer<typeof TaskStatusEnum>;
+export type Priority = z.infer<typeof PriorityEnum>;
+export type TaskCategory = z.infer<typeof TaskCategoryEnum>;
+export type GoalStatus = z.infer<typeof GoalStatusEnum>;
+export type KpiStatus = z.infer<typeof KpiStatusEnum>;
+export type TimeCategory = z.infer<typeof TimeCategoryEnum>;
+export type Role = z.infer<typeof RoleEnum>;

--- a/validators/shared/index.ts
+++ b/validators/shared/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Barrel export for shared validators — Issue #396
+ *
+ * Import from '@/validators/shared' to get schemas and types
+ * usable in both frontend forms and API route handlers.
+ *
+ * Example:
+ *   import { createTaskSchema, type CreateTaskInput } from '@/validators/shared';
+ */
+
+export * from "./enums";
+export * from "./task";
+export * from "./plan";
+export * from "./kpi";
+export * from "./time-entry";
+export * from "./user";

--- a/validators/shared/kpi.ts
+++ b/validators/shared/kpi.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared KPI schemas — Issue #396
+ *
+ * Used by both:
+ *   - Frontend form validation (client components)
+ *   - API route validation (POST /api/kpi, PATCH /api/kpi/[id])
+ */
+
+import { z } from "zod";
+import { KpiStatusEnum } from "./enums";
+
+export const createKpiSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  code: z.string().min(1),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  target: z.number().nonnegative(),
+  weight: z.number().positive().optional().default(1),
+  autoCalc: z.boolean().optional().default(false),
+});
+
+export const updateKpiSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  target: z.number().nonnegative().optional(),
+  actual: z.number().nonnegative().optional(),
+  weight: z.number().positive().optional(),
+  status: KpiStatusEnum.optional(),
+  autoCalc: z.boolean().optional(),
+});
+
+export type CreateKpiInput = z.infer<typeof createKpiSchema>;
+export type UpdateKpiInput = z.infer<typeof updateKpiSchema>;

--- a/validators/shared/plan.ts
+++ b/validators/shared/plan.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared plan/goal schemas — Issue #396
+ *
+ * Used by both:
+ *   - Frontend form validation (client components)
+ *   - API route validation (POST /api/plans, PATCH /api/plans/[id])
+ */
+
+import { z } from "zod";
+import { GoalStatusEnum } from "./enums";
+
+export const createPlanSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  title: z.string().min(1),
+  description: z.string().optional(),
+  implementationPlan: z.string().optional(),
+  copiedFromYear: z.number().int().optional(),
+});
+
+export const updatePlanSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  implementationPlan: z.string().optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+});
+
+export const createGoalSchema = z.object({
+  annualPlanId: z.string().min(1),
+  month: z.number().int().min(1).max(12),
+  title: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export const updateGoalSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  status: GoalStatusEnum.optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+});
+
+export const copyTemplateSchema = z.object({
+  sourcePlanId: z.string().min(1),
+  targetYear: z.number().int().min(2000).max(2100),
+});
+
+export type CreatePlanInput = z.infer<typeof createPlanSchema>;
+export type UpdatePlanInput = z.infer<typeof updatePlanSchema>;
+export type CreateGoalInput = z.infer<typeof createGoalSchema>;
+export type UpdateGoalInput = z.infer<typeof updateGoalSchema>;
+export type CopyTemplateInput = z.infer<typeof copyTemplateSchema>;

--- a/validators/shared/task.ts
+++ b/validators/shared/task.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared task schemas — Issue #396
+ *
+ * Used by both:
+ *   - Frontend form validation (client components)
+ *   - API route validation (POST /api/tasks, PATCH /api/tasks/[id])
+ */
+
+import { z } from "zod";
+import { TaskStatusEnum, PriorityEnum, TaskCategoryEnum } from "./enums";
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  primaryAssigneeId: z.string().optional(),
+  backupAssigneeId: z.string().optional(),
+  status: TaskStatusEnum.optional().default("BACKLOG"),
+  priority: PriorityEnum.optional().default("P2"),
+  category: TaskCategoryEnum.optional().default("PLANNED"),
+  dueDate: z.string().datetime().optional(),
+  startDate: z.string().datetime().optional(),
+  estimatedHours: z.number().nonnegative().optional(),
+  tags: z.array(z.string()).optional(),
+  addedDate: z.string().datetime().optional(),
+  addedReason: z.string().optional(),
+  addedSource: z.string().optional(),
+});
+
+export const updateTaskSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional(),
+  monthlyGoalId: z.string().optional(),
+  primaryAssigneeId: z.string().nullable().optional(),
+  backupAssigneeId: z.string().nullable().optional(),
+  status: TaskStatusEnum.optional(),
+  priority: PriorityEnum.optional(),
+  category: TaskCategoryEnum.optional(),
+  dueDate: z.string().datetime().nullable().optional(),
+  startDate: z.string().datetime().nullable().optional(),
+  estimatedHours: z.number().nonnegative().optional(),
+  progressPct: z.number().min(0).max(100).optional(),
+  tags: z.array(z.string()).optional(),
+  addedReason: z.string().optional(),
+  addedSource: z.string().optional(),
+  changedBy: z.string().optional(),
+  changeReason: z.string().optional(),
+});
+
+export const updateTaskStatusSchema = z.object({
+  status: TaskStatusEnum,
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;
+export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;
+export type UpdateTaskStatusInput = z.infer<typeof updateTaskStatusSchema>;

--- a/validators/shared/time-entry.ts
+++ b/validators/shared/time-entry.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared time entry schemas — Issue #396
+ *
+ * Used by both:
+ *   - Frontend form validation (client components)
+ *   - API route validation (POST /api/time-entries, PATCH /api/time-entries/[id])
+ */
+
+import { z } from "zod";
+import { TimeCategoryEnum } from "./enums";
+
+export const createTimeEntrySchema = z.object({
+  date: z.string().date(),
+  hours: z.number().min(0).max(24),
+  taskId: z.string().optional(),
+  category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
+  description: z.string().optional(),
+});
+
+export const updateTimeEntrySchema = z.object({
+  date: z.string().date().optional(),
+  hours: z.number().min(0).max(24).optional(),
+  taskId: z.string().optional(),
+  category: TimeCategoryEnum.optional(),
+  description: z.string().optional(),
+});
+
+export type CreateTimeEntryInput = z.infer<typeof createTimeEntrySchema>;
+export type UpdateTimeEntryInput = z.infer<typeof updateTimeEntrySchema>;

--- a/validators/shared/user.ts
+++ b/validators/shared/user.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared user schemas — Issue #396
+ *
+ * Used by both:
+ *   - Frontend form validation (client components)
+ *   - API route validation (POST /api/users, PATCH /api/users/[id])
+ *
+ * Note: password policy refinement is imported from lib/password-policy
+ * which works in both client and server environments.
+ */
+
+import { z } from "zod";
+import { RoleEnum } from "./enums";
+import {
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_RULES,
+  PASSWORD_POLICY_DESCRIPTION,
+} from "@/lib/password-policy";
+
+const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, `密碼至少 ${PASSWORD_MIN_LENGTH} 個字元`)
+  .refine(
+    (pw) => PASSWORD_RULES.every((rule) => rule.regex.test(pw)),
+    { message: PASSWORD_POLICY_DESCRIPTION }
+  );
+
+export const createUserSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: passwordSchema,
+  role: RoleEnum.optional().default("ENGINEER"),
+  avatar: z.string().optional(),
+});
+
+export const updateUserSchema = z.object({
+  name: z.string().min(1).optional(),
+  email: z.string().email().optional(),
+  password: passwordSchema.optional(),
+  avatar: z.string().optional(),
+  role: RoleEnum.optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export type CreateUserInput = z.infer<typeof createUserSchema>;
+export type UpdateUserInput = z.infer<typeof updateUserSchema>;
+export type LoginInput = z.infer<typeof loginSchema>;

--- a/validators/task-validators.ts
+++ b/validators/task-validators.ts
@@ -1,66 +1,15 @@
-import { z } from "zod";
+/**
+ * Task validators — re-exports from shared schemas (Issue #396)
+ *
+ * Kept for backward compatibility. New code should import from
+ * '@/validators/shared' or '@/validators/shared/task' directly.
+ */
 
-const TaskStatusEnum = z.enum([
-  "BACKLOG",
-  "TODO",
-  "IN_PROGRESS",
-  "REVIEW",
-  "DONE",
-]);
-
-const PriorityEnum = z.enum(["P0", "P1", "P2", "P3"]);
-
-const TaskCategoryEnum = z.enum([
-  "PLANNED",
-  "ADDED",
-  "INCIDENT",
-  "SUPPORT",
-  "ADMIN",
-  "LEARNING",
-]);
-
-export const createTaskSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  monthlyGoalId: z.string().optional(),
-  primaryAssigneeId: z.string().optional(),
-  backupAssigneeId: z.string().optional(),
-  status: TaskStatusEnum.optional().default("BACKLOG"),
-  priority: PriorityEnum.optional().default("P2"),
-  category: TaskCategoryEnum.optional().default("PLANNED"),
-  dueDate: z.string().datetime().optional(),
-  startDate: z.string().datetime().optional(),
-  estimatedHours: z.number().nonnegative().optional(),
-  tags: z.array(z.string()).optional(),
-  addedDate: z.string().datetime().optional(),
-  addedReason: z.string().optional(),
-  addedSource: z.string().optional(),
-});
-
-export const updateTaskSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional(),
-  monthlyGoalId: z.string().optional(),
-  primaryAssigneeId: z.string().nullable().optional(),
-  backupAssigneeId: z.string().nullable().optional(),
-  status: TaskStatusEnum.optional(),
-  priority: PriorityEnum.optional(),
-  category: TaskCategoryEnum.optional(),
-  dueDate: z.string().datetime().nullable().optional(),
-  startDate: z.string().datetime().nullable().optional(),
-  estimatedHours: z.number().nonnegative().optional(),
-  progressPct: z.number().min(0).max(100).optional(),
-  tags: z.array(z.string()).optional(),
-  addedReason: z.string().optional(),
-  addedSource: z.string().optional(),
-  changedBy: z.string().optional(),
-  changeReason: z.string().optional(),
-});
-
-export const updateTaskStatusSchema = z.object({
-  status: TaskStatusEnum,
-});
-
-export type CreateTaskInput = z.infer<typeof createTaskSchema>;
-export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;
-export type UpdateTaskStatusInput = z.infer<typeof updateTaskStatusSchema>;
+export {
+  createTaskSchema,
+  updateTaskSchema,
+  updateTaskStatusSchema,
+  type CreateTaskInput,
+  type UpdateTaskInput,
+  type UpdateTaskStatusInput,
+} from "./shared/task";

--- a/validators/time-entry-validators.ts
+++ b/validators/time-entry-validators.ts
@@ -1,29 +1,13 @@
-import { z } from "zod";
+/**
+ * Time entry validators — re-exports from shared schemas (Issue #396)
+ *
+ * Kept for backward compatibility. New code should import from
+ * '@/validators/shared' or '@/validators/shared/time-entry' directly.
+ */
 
-const TimeCategoryEnum = z.enum([
-  "PLANNED_TASK",
-  "ADDED_TASK",
-  "INCIDENT",
-  "SUPPORT",
-  "ADMIN",
-  "LEARNING",
-]);
-
-export const createTimeEntrySchema = z.object({
-  date: z.string().date(),
-  hours: z.number().min(0).max(24),
-  taskId: z.string().optional(),
-  category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
-  description: z.string().optional(),
-});
-
-export const updateTimeEntrySchema = z.object({
-  date: z.string().date().optional(),
-  hours: z.number().min(0).max(24).optional(),
-  taskId: z.string().optional(),
-  category: TimeCategoryEnum.optional(),
-  description: z.string().optional(),
-});
-
-export type CreateTimeEntryInput = z.infer<typeof createTimeEntrySchema>;
-export type UpdateTimeEntryInput = z.infer<typeof updateTimeEntrySchema>;
+export {
+  createTimeEntrySchema,
+  updateTimeEntrySchema,
+  type CreateTimeEntryInput,
+  type UpdateTimeEntryInput,
+} from "./shared/time-entry";

--- a/validators/user-validators.ts
+++ b/validators/user-validators.ts
@@ -1,46 +1,15 @@
-import { z } from "zod";
-import {
-  PASSWORD_MIN_LENGTH,
-  PASSWORD_RULES,
-  PASSWORD_POLICY_DESCRIPTION,
-} from "@/lib/password-policy";
-
-const RoleEnum = z.enum(["MANAGER", "ENGINEER"]);
-
 /**
- * Zod refinement: validates password against full complexity policy.
- * 金管會 + ISO 27001 A.9.4.3 — Issue #180
+ * User validators — re-exports from shared schemas (Issue #396)
+ *
+ * Kept for backward compatibility. New code should import from
+ * '@/validators/shared' or '@/validators/shared/user' directly.
  */
-const passwordSchema = z
-  .string()
-  .min(PASSWORD_MIN_LENGTH, `密碼至少 ${PASSWORD_MIN_LENGTH} 個字元`)
-  .refine(
-    (pw) => PASSWORD_RULES.every((rule) => rule.regex.test(pw)),
-    { message: PASSWORD_POLICY_DESCRIPTION }
-  );
 
-export const createUserSchema = z.object({
-  name: z.string().min(1),
-  email: z.string().email(),
-  password: passwordSchema,
-  role: RoleEnum.optional().default("ENGINEER"),
-  avatar: z.string().optional(),
-});
-
-export const updateUserSchema = z.object({
-  name: z.string().min(1).optional(),
-  email: z.string().email().optional(),
-  password: passwordSchema.optional(),
-  avatar: z.string().optional(),
-  role: RoleEnum.optional(),
-  isActive: z.boolean().optional(),
-});
-
-export const loginSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(1),
-});
-
-export type CreateUserInput = z.infer<typeof createUserSchema>;
-export type UpdateUserInput = z.infer<typeof updateUserSchema>;
-export type LoginInput = z.infer<typeof loginSchema>;
+export {
+  createUserSchema,
+  updateUserSchema,
+  loginSchema,
+  type CreateUserInput,
+  type UpdateUserInput,
+  type LoginInput,
+} from "./shared/user";


### PR DESCRIPTION
## Summary
- Extract all Zod enums and validation schemas into `validators/shared/` as single source of truth
- Existing validator files now re-export from shared for backward compatibility
- Frontend forms can import the same schemas used by API route handlers

## Test plan
- [ ] Existing validator tests still pass (`validators/__tests__/`)
- [ ] API routes using validators still compile
- [ ] Import from `@/validators/shared` works in both client and server components

Closes #396

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>