### PR TITLE
feat(security): limit concurrent sessions per user

### DIFF
--- a/lib/session-limiter.ts
+++ b/lib/session-limiter.ts
@@ -1,61 +1,110 @@
 /**
- * Concurrent session limiter — Issue #184
+ * Concurrent session limiter — Issue #184, #387
  *
- * Enforces single active session per user. When a user logs in,
- * the new session token replaces the old one. The old session
- * is effectively invalidated via the JWT blacklist.
+ * Enforces a maximum number of concurrent sessions per user (default: 2).
+ * When a user logs in and the limit is exceeded, the oldest session is
+ * invalidated via the JWT blacklist.
  *
- * Uses Redis when available, falls back to in-memory Map.
+ * Uses Redis when available, falls back to in-memory store.
+ *
+ * Redis storage: sorted set per user, score = timestamp, member = sessionId.
+ * In-memory storage: Map<userId, Array<{ sessionId, createdAt }>>.
  */
 
 import { logger } from "@/lib/logger";
 import { getRedisClient } from "@/lib/redis";
 import { JwtBlacklist } from "@/lib/jwt-blacklist";
 
-const REDIS_PREFIX = "active_session:";
+const REDIS_PREFIX = "active_sessions:";
 const SESSION_TTL = 8 * 60 * 60; // 8 hours (matches JWT maxAge)
 
-/** In-memory fallback: userId → sessionId */
-const memStore = new Map<string, string>();
+/** Maximum concurrent sessions per user — configurable via env */
+const MAX_CONCURRENT_SESSIONS = parseInt(
+  process.env.MAX_CONCURRENT_SESSIONS ?? "2",
+  10
+);
+
+/** In-memory fallback: userId → list of { sessionId, createdAt } */
+const memStore = new Map<string, Array<{ sessionId: string; createdAt: number }>>();
 
 /**
- * Register a new session for a user, invalidating any previous session.
+ * Register a new session for a user.
+ * If the user already has MAX_CONCURRENT_SESSIONS, the oldest is invalidated.
  */
 export async function registerSession(
   userId: string,
   sessionId: string
 ): Promise<void> {
+  const now = Date.now();
   const redis = getRedisClient();
-
-  // Get the old session ID
-  let oldSessionId: string | null = null;
 
   if (redis) {
     try {
-      oldSessionId = await redis.get(`${REDIS_PREFIX}${userId}`);
-      await redis.set(`${REDIS_PREFIX}${userId}`, sessionId, "EX", SESSION_TTL);
+      const key = `${REDIS_PREFIX}${userId}`;
+
+      // Add the new session with current timestamp as score
+      await redis.zadd(key, now, sessionId);
+      await redis.expire(key, SESSION_TTL);
+
+      // Check if we exceed the limit
+      const count = await redis.zcard(key);
+      if (count > MAX_CONCURRENT_SESSIONS) {
+        // Get the oldest sessions that exceed the limit
+        const excess = count - MAX_CONCURRENT_SESSIONS;
+        const oldSessions = await redis.zrange(key, 0, excess - 1);
+
+        // Remove them from the sorted set
+        if (oldSessions.length > 0) {
+          await redis.zrem(key, ...oldSessions);
+
+          // Blacklist each evicted session
+          for (const oldId of oldSessions) {
+            JwtBlacklist.add(`session:${oldId}`);
+          }
+
+          logger.info(
+            { userId, evictedCount: oldSessions.length, maxAllowed: MAX_CONCURRENT_SESSIONS },
+            "[session-limiter] Oldest session(s) invalidated — concurrent limit exceeded"
+          );
+        }
+      }
+      return;
     } catch (err) {
       logger.error({ err }, "[session-limiter] Redis error, using memory fallback");
-      oldSessionId = memStore.get(userId) ?? null;
-      memStore.set(userId, sessionId);
+      // Fall through to memory store
     }
-  } else {
-    oldSessionId = memStore.get(userId) ?? null;
-    memStore.set(userId, sessionId);
   }
 
-  // Blacklist the old session if it exists and differs
-  if (oldSessionId && oldSessionId !== sessionId) {
-    JwtBlacklist.add(`session:${oldSessionId}`);
+  // In-memory fallback
+  let sessions = memStore.get(userId);
+  if (!sessions) {
+    sessions = [];
+    memStore.set(userId, sessions);
+  }
+
+  sessions.push({ sessionId, createdAt: now });
+
+  // Evict oldest if over limit
+  if (sessions.length > MAX_CONCURRENT_SESSIONS) {
+    // Sort ascending by createdAt
+    sessions.sort((a, b) => a.createdAt - b.createdAt);
+
+    const excess = sessions.length - MAX_CONCURRENT_SESSIONS;
+    const evicted = sessions.splice(0, excess);
+
+    for (const old of evicted) {
+      JwtBlacklist.add(`session:${old.sessionId}`);
+    }
+
     logger.info(
-      { userId },
-      "[session-limiter] Previous session invalidated (concurrent login)"
+      { userId, evictedCount: evicted.length, maxAllowed: MAX_CONCURRENT_SESSIONS },
+      "[session-limiter] Oldest session(s) invalidated — concurrent limit exceeded"
     );
   }
 }
 
 /**
- * Check if a session is still the active one for its user.
+ * Check if a session is still active for its user.
  */
 export async function isSessionActive(
   userId: string,
@@ -65,30 +114,73 @@ export async function isSessionActive(
 
   if (redis) {
     try {
-      const active = await redis.get(`${REDIS_PREFIX}${userId}`);
-      return active === sessionId;
+      // zscore returns null if member doesn't exist
+      const score = await redis.zscore(`${REDIS_PREFIX}${userId}`, sessionId);
+      return score !== null;
     } catch {
       // fallback
     }
   }
 
-  return memStore.get(userId) === sessionId;
+  const sessions = memStore.get(userId);
+  if (!sessions) return false;
+  return sessions.some((s) => s.sessionId === sessionId);
 }
 
 /**
- * Clear a user's active session (on logout).
+ * Clear a specific session for a user (on logout).
  */
-export async function clearSession(userId: string): Promise<void> {
+export async function clearSession(
+  userId: string,
+  sessionId?: string
+): Promise<void> {
   const redis = getRedisClient();
 
   if (redis) {
     try {
-      await redis.del(`${REDIS_PREFIX}${userId}`);
+      if (sessionId) {
+        await redis.zrem(`${REDIS_PREFIX}${userId}`, sessionId);
+      } else {
+        await redis.del(`${REDIS_PREFIX}${userId}`);
+      }
       return;
     } catch {
       // fallback
     }
   }
 
-  memStore.delete(userId);
+  if (sessionId) {
+    const sessions = memStore.get(userId);
+    if (sessions) {
+      const idx = sessions.findIndex((s) => s.sessionId === sessionId);
+      if (idx >= 0) sessions.splice(idx, 1);
+      if (sessions.length === 0) memStore.delete(userId);
+    }
+  } else {
+    memStore.delete(userId);
+  }
 }
+
+/**
+ * Get the count of active sessions for a user.
+ */
+export async function getActiveSessionCount(userId: string): Promise<number> {
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      return await redis.zcard(`${REDIS_PREFIX}${userId}`);
+    } catch {
+      // fallback
+    }
+  }
+
+  return memStore.get(userId)?.length ?? 0;
+}
+
+/** Exported for testing — allows overriding the max concurrent sessions */
+export const _config = {
+  get maxConcurrentSessions() {
+    return MAX_CONCURRENT_SESSIONS;
+  },
+};


### PR DESCRIPTION
## Summary
- Upgrade session-limiter from single-session (1:1) to configurable max concurrent sessions (default: 2)
- Configurable via `MAX_CONCURRENT_SESSIONS` env var
- Redis: uses sorted set (ZADD) with timestamp scores for efficient oldest-session eviction
- In-memory fallback maintains sorted array
- Added `getActiveSessionCount()` and optional `sessionId` param to `clearSession()`
- Backward compatible — `auth.ts` `registerSession()` call signature unchanged

## Test plan
- [ ] Login with user A on browser 1 — session active
- [ ] Login with user A on browser 2 — both sessions active (limit=2)
- [ ] Login with user A on browser 3 — oldest session (browser 1) invalidated
- [ ] Verify invalidated session gets 401 on next API call
- [ ] Test with `MAX_CONCURRENT_SESSIONS=1` to verify single-session mode

Closes #387

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>