### PR TITLE
feat(i18n): add i18n foundation with next-intl evaluation

### DIFF
--- a/docs/tech-eval-i18n.md
+++ b/docs/tech-eval-i18n.md
@@ -1,0 +1,130 @@
+# Tech Evaluation: i18n Architecture
+
+> Issue: #408
+> Date: 2026-03-25
+> Status: Evaluation + Foundation Implementation
+
+## 1. 背景
+
+TITAN 目前所有 UI 文字直接寫在 JSX 中（繁體中文硬編碼）。未來可能需要支援：
+- 英文介面（國際團隊 / 外部稽核）
+- 簡體中文（跨區行處）
+- 語系切換不重載頁面
+
+## 2. 候選方案
+
+### 2.1 next-intl
+
+| 面向 | 說明 |
+|------|------|
+| 專為 Next.js 設計 | 完整支援 App Router、Server Components、Client Components |
+| 路由策略 | 支援 prefix (`/en/dashboard`)、domain、cookie-based |
+| Server Component 支援 | `getTranslations()` — 翻譯在 Server 執行，不送到 client bundle |
+| Client Component 支援 | `useTranslations()` hook |
+| 訊息格式 | JSON 檔案，支援 ICU Message Format（複數、日期、數字） |
+| 型別安全 | 支援（搭配 TypeScript namespace） |
+| Bundle 大小 | ~3.5 KB gzip |
+| 維護者 | Jan Amann（活躍維護，Next.js 社群推薦） |
+
+### 2.2 react-i18next
+
+| 面向 | 說明 |
+|------|------|
+| 通用性 | 框架無關（React、React Native、Node.js） |
+| Next.js 整合 | 需要 `next-i18next` adapter（Next.js App Router 支援仍在演進中） |
+| Server Component 支援 | 有限（需額外 wrapper） |
+| Client Component 支援 | `useTranslation()` hook |
+| 訊息格式 | JSON，支援 ICU + namespace 分割 |
+| Bundle 大小 | ~8 KB gzip（i18next + react-i18next） |
+| 生態系 | 最大（i18next 有豐富 plugin 生態） |
+
+### 2.3 比較
+
+| 面向 | next-intl | react-i18next |
+|------|-----------|---------------|
+| App Router 支援 | 原生、完整 | 需要 adapter |
+| Server Components | 一等公民 | 需額外配置 |
+| Bundle 大小 | 3.5 KB | 8 KB |
+| 學習曲線 | 低（API 簡潔） | 中（i18next 概念多） |
+| 遷移到其他框架 | 限 Next.js | 可攜帶 |
+| 社群 / 文件 | 良好 | 優秀（歷史悠久） |
+
+## 3. 建議
+
+**推薦：next-intl**
+
+理由：
+1. **與 Next.js App Router 深度整合** — Server Component 翻譯不增加 client bundle
+2. **API 簡潔** — `useTranslations('Dashboard')` 即可使用
+3. **路由策略靈活** — TITAN 初期可用 cookie-based（不改 URL 結構），之後可切換至 prefix
+4. **Bundle 更小** — 銀行環境每一 KB 都重要
+5. **型別安全** — 可配合 TypeScript 檢查翻譯 key 是否存在
+
+## 4. 基礎架構（已實作）
+
+### 目錄結構
+```
+lib/i18n/
+  config.ts        — 語系設定（支援語系列表、預設語系）
+  request.ts       — Server-side: getRequestConfig for next-intl
+messages/
+  zh-TW.json       — 繁體中文翻譯（預設）
+```
+
+### 翻譯 key 命名規範
+```json
+{
+  "Common": {
+    "loading": "載入中...",
+    "error": "發生錯誤",
+    "retry": "重試",
+    "save": "儲存",
+    "cancel": "取消",
+    "delete": "刪除",
+    "confirm": "確認"
+  },
+  "Dashboard": {
+    "title": "儀表板",
+    "managerView": "主管視角 — 團隊整體狀況",
+    "engineerView": "工程師視角 — 我的工作狀況"
+  }
+}
+```
+
+命名規則：
+- 頂層 key = 頁面/功能模組（PascalCase）
+- 子 key = 具體文字（camelCase）
+- 共用文字放在 `Common` namespace
+
+## 5. 遷移計畫
+
+### Phase 1 — 基礎建設（本 Issue，已完成）
+- 建立 `lib/i18n/` 設定檔
+- 建立 `messages/zh-TW.json` 初始翻譯
+- 評估文件
+
+### Phase 2 — 安裝 next-intl + 路由設定（1 天）
+```bash
+npm install next-intl
+```
+1. 在 `next.config.ts` 加入 `createNextIntlPlugin`
+2. 設定 middleware 語系偵測（cookie-based）
+3. 在 `app/(app)/layout.tsx` 加入 `NextIntlClientProvider`
+
+### Phase 3 — 逐步遷移硬編碼文字（持續）
+優先順序：
+1. 共用元件（PageLoading, PageError, PageEmpty）
+2. Dashboard 頁面
+3. 其餘頁面按使用頻率遷移
+
+### Phase 4 — 新增英文翻譯（視需求）
+1. 建立 `messages/en.json`
+2. 加入語系切換 UI（header dropdown）
+
+## 6. 風險
+
+| 風險 | 緩解 |
+|------|------|
+| 大量硬編碼文字需遷移 | 漸進遷移，不需一次全改 |
+| next-intl 版本更新可能有 breaking change | 鎖定版本，定期升級 |
+| 翻譯 key 不一致 | 建立命名規範文件 + TypeScript 型別檢查 |

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -1,0 +1,20 @@
+/**
+ * i18n configuration — Issue #408
+ *
+ * Central configuration for internationalization.
+ * Used by next-intl when installed (Phase 2).
+ */
+
+/** Supported locales */
+export const locales = ["zh-TW", "en"] as const;
+
+/** Default locale — Traditional Chinese for banking environment */
+export const defaultLocale = "zh-TW" as const;
+
+/** Locale display names (for language switcher UI) */
+export const localeNames: Record<(typeof locales)[number], string> = {
+  "zh-TW": "繁體中文",
+  en: "English",
+};
+
+export type Locale = (typeof locales)[number];

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -1,0 +1,6 @@
+/**
+ * i18n barrel export — Issue #408
+ */
+
+export { locales, defaultLocale, localeNames, type Locale } from "./config";
+export { loadMessages } from "./request";

--- a/lib/i18n/request.ts
+++ b/lib/i18n/request.ts
@@ -1,0 +1,25 @@
+/**
+ * Server-side i18n request config — Issue #408
+ *
+ * This file will be used by next-intl's getRequestConfig() when installed.
+ * For now, it provides a utility to load messages for a given locale.
+ */
+
+import { defaultLocale, type Locale } from "./config";
+
+/**
+ * Load messages for the given locale.
+ * Falls back to default locale if the requested locale file is missing.
+ */
+export async function loadMessages(
+  locale: Locale = defaultLocale
+): Promise<Record<string, unknown>> {
+  try {
+    const messages = await import(`../../messages/${locale}.json`);
+    return messages.default ?? messages;
+  } catch {
+    // Fallback to default locale
+    const fallback = await import(`../../messages/${defaultLocale}.json`);
+    return fallback.default ?? fallback;
+  }
+}

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1,0 +1,122 @@
+{
+  "Common": {
+    "loading": "載入中...",
+    "error": "發生錯誤",
+    "retry": "重試",
+    "save": "儲存",
+    "cancel": "取消",
+    "delete": "刪除",
+    "confirm": "確認",
+    "create": "建立",
+    "edit": "編輯",
+    "search": "搜尋",
+    "noData": "暫無資料",
+    "networkError": "網路錯誤：無法連線至伺服器",
+    "permissionDenied": "權限不足：您沒有存取此資源的權限",
+    "rateLimited": "請求過於頻繁，請稍後重試",
+    "serverError": "伺服器回應錯誤"
+  },
+  "Auth": {
+    "login": "登入",
+    "logout": "登出",
+    "username": "帳號",
+    "password": "密碼",
+    "changePassword": "變更密碼",
+    "loginFailed": "登入失敗",
+    "sessionExpired": "連線逾時，請重新登入",
+    "accountLocked": "帳號已鎖定"
+  },
+  "Dashboard": {
+    "title": "儀表板",
+    "managerView": "主管視角 — 團隊整體狀況",
+    "engineerView": "工程師視角 — 我的工作狀況",
+    "todayTasks": "今日待辦",
+    "recentItems": "最近 5 項",
+    "noPendingTasks": "沒有待辦任務",
+    "noPendingDescription": "目前沒有進行中或待辦的任務",
+    "kpiTitle": "KPI 達成狀況",
+    "noKpi": "尚無 KPI",
+    "noKpiDescription": "本年度尚未建立 KPI 指標",
+    "weeklyCompleted": "本週完成任務",
+    "weeklyHours": "本週總工時 (h)",
+    "overdueTasks": "逾期任務",
+    "unplannedRate": "本月計畫外比例",
+    "teamWorkload": "團隊工時分佈（本月）",
+    "utilizationAnalysis": "投入率分析（計畫任務 vs 加入任務）",
+    "plannedUtilization": "計畫內投入",
+    "unplannedUtilization": "計畫外投入",
+    "myTasks": "我的任務（待辦 + 進行中）",
+    "weeklyProgress": "本週工時進度",
+    "noTeamData": "尚無團隊數據",
+    "noTeamDataDescription": "目前沒有任務完成紀錄與工時資料。當團隊成員開始記錄工時與完成任務後，此處將自動顯示團隊整體狀況。"
+  },
+  "Task": {
+    "title": "任務",
+    "create": "建立任務",
+    "backlog": "待排",
+    "todo": "待辦",
+    "inProgress": "進行中",
+    "review": "檢閱",
+    "done": "完成",
+    "priority": "優先級",
+    "urgent": "緊急",
+    "high": "高",
+    "medium": "中",
+    "low": "低",
+    "dueDate": "截止日",
+    "noDueDate": "無截止日",
+    "overdue": "逾期",
+    "overdueBy": "逾期 {days} 天",
+    "dueToday": "今天截止",
+    "dueTomorrow": "明天截止",
+    "dueInDays": "{days} 天後截止"
+  },
+  "Plan": {
+    "title": "年度計畫",
+    "create": "建立計畫",
+    "goal": "月度目標",
+    "createGoal": "建立目標"
+  },
+  "KPI": {
+    "title": "KPI",
+    "create": "建立 KPI",
+    "onTrack": "進行中",
+    "atRisk": "風險",
+    "behind": "落後",
+    "achieved": "達成",
+    "target": "目標值",
+    "actual": "實際值",
+    "achievementRate": "達成率"
+  },
+  "Timesheet": {
+    "title": "工時",
+    "create": "記錄工時",
+    "date": "日期",
+    "hours": "時數",
+    "category": "類別",
+    "planned": "計畫任務",
+    "added": "加入任務",
+    "incident": "事件處理",
+    "support": "支援",
+    "admin": "行政",
+    "learning": "學習"
+  },
+  "Report": {
+    "title": "報表",
+    "weekly": "週報",
+    "monthly": "月報",
+    "workload": "工作負載",
+    "export": "匯出"
+  },
+  "Admin": {
+    "title": "系統管理",
+    "users": "使用者管理",
+    "notifications": "通知管理"
+  },
+  "Error": {
+    "pageError": "此頁面發生錯誤",
+    "pageErrorDescription": "很抱歉，載入此頁面時發生問題。錯誤已自動回報。",
+    "notFound": "找不到頁面",
+    "notFoundDescription": "您要找的頁面不存在或已移除。"
+  }
+}


### PR DESCRIPTION
## Summary
- Evaluate next-intl vs react-i18next; recommend next-intl for native App Router integration
- Create `lib/i18n/` with config, request loader, and barrel export
- Create `messages/zh-TW.json` with complete translations for all major UI sections

## Test plan
- [ ] `lib/i18n/config.ts` exports correct locale types
- [ ] `loadMessages('zh-TW')` returns valid JSON
- [ ] Messages file covers all existing hardcoded UI strings

Closes #408

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>