### PR TITLE
fix(test): R5-Q1 全量回歸測試 — 修復 40 個失敗測試

### DIFF
--- a/__tests__/api/audit-integration.test.ts
+++ b/__tests__/api/audit-integration.test.ts
@@ -368,6 +368,7 @@ describe("DELETE /api/documents/[id] — audit DELETE_DOCUMENT", () => {
   });
 
   it("creates audit log after deleting a document", async () => {
+    mockDocument.findUnique.mockResolvedValue({ id: "doc-1", title: "Test" });
     mockDocument.delete.mockResolvedValue({ id: "doc-1" });
 
     const { DELETE } = await import("@/app/api/documents/[id]/route");

--- a/__tests__/api/documents-version-snapshot.test.ts
+++ b/__tests__/api/documents-version-snapshot.test.ts
@@ -14,10 +14,15 @@ const mockDocumentVersion = {
   create: jest.fn(),
 };
 
+const mockTransaction = jest.fn().mockImplementation((cb: (tx: unknown) => unknown) =>
+  cb({ document: mockDocument, documentVersion: mockDocumentVersion })
+);
+
 jest.mock("@/lib/prisma", () => ({
   prisma: {
     document: mockDocument,
     documentVersion: mockDocumentVersion,
+    $transaction: mockTransaction,
   },
 }));
 

--- a/__tests__/api/documents.test.ts
+++ b/__tests__/api/documents.test.ts
@@ -6,7 +6,7 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockDocument = { findMany: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockDocument = { findMany: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), count: jest.fn().mockResolvedValue(0), findUnique: jest.fn() };
 
 jest.mock("@/lib/prisma", () => ({ prisma: { document: mockDocument } }));
 
@@ -37,11 +37,12 @@ describe("GET /api/documents", () => {
   });
 
   it("returns document list when authenticated", async () => {
+    mockDocument.count.mockResolvedValue(1);
     const { GET } = await import("@/app/api/documents/route");
     const res = await (GET as Function)(createMockRequest("/api/documents"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("doc-1");
+    expect(body.data.items[0].id).toBe("doc-1");
   });
 
   it("returns 401 when no session", async () => {

--- a/__tests__/api/notifications.test.ts
+++ b/__tests__/api/notifications.test.ts
@@ -37,7 +37,7 @@ describe("GET /api/notifications", () => {
     const res = await GET(createMockRequest("/api/notifications"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data.notifications).toHaveLength(1);
+    expect(body.data.items).toHaveLength(1);
     expect(body.data.unreadCount).toBe(1);
   });
 

--- a/__tests__/api/subtasks.test.ts
+++ b/__tests__/api/subtasks.test.ts
@@ -6,9 +6,10 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockSubTask = { create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockSubTask = { create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn() };
+const mockTask = { update: jest.fn() };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { subTask: mockSubTask } }));
+jest.mock("@/lib/prisma", () => ({ prisma: { subTask: mockSubTask, task: mockTask } }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
@@ -65,6 +66,8 @@ describe("PATCH/DELETE /api/subtasks/[id]", () => {
     mockGetServerSession.mockResolvedValue(SESSION);
     mockSubTask.update.mockResolvedValue({ ...MOCK_SUBTASK, done: true });
     mockSubTask.delete.mockResolvedValue(MOCK_SUBTASK);
+    mockSubTask.findUnique.mockResolvedValue({ taskId: "task-1" });
+    mockSubTask.findMany.mockResolvedValue([]);
   });
 
   it("PATCH updates subtask done status", async () => {

--- a/__tests__/api/tasks.test.ts
+++ b/__tests__/api/tasks.test.ts
@@ -16,6 +16,7 @@ const mockTask = {
   create: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  count: jest.fn().mockResolvedValue(0),
 };
 const mockTaskChange = { create: jest.fn() };
 const mockTaskActivity = { create: jest.fn() };
@@ -69,12 +70,13 @@ describe("GET /api/tasks", () => {
   });
 
   it("returns task list when authenticated", async () => {
+    mockTask.count.mockResolvedValue(1);
     const { GET } = await import("@/app/api/tasks/route");
     const req = createMockRequest("/api/tasks");
     const res = await GET(req);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("task-1");
+    expect(body.data.items[0].id).toBe("task-1");
   });
 
   it("returns 401 when no session", async () => {
@@ -193,7 +195,7 @@ describe("PUT /api/tasks/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MEMBER_SESSION);
-    mockTask.findUnique.mockResolvedValue(MOCK_TASK);
+    mockTask.findUnique.mockResolvedValue({ ...MOCK_TASK, primaryAssigneeId: "user-1", backupAssigneeId: null });
     mockTask.update.mockResolvedValue({ ...MOCK_TASK, title: "Updated" });
     mockTaskChange.create.mockResolvedValue({});
     // $transaction used by ChangeTrackingService.detectDelay/detectScopeChange
@@ -233,7 +235,7 @@ describe("PUT /api/tasks/[id]", () => {
   });
 
   it("creates TaskChange when dueDate changes", async () => {
-    mockTask.findUnique.mockResolvedValue({ ...MOCK_TASK, dueDate: new Date("2024-01-01T00:00:00.000Z") });
+    mockTask.findUnique.mockResolvedValue({ ...MOCK_TASK, primaryAssigneeId: "user-1", backupAssigneeId: null, dueDate: new Date("2024-01-01T00:00:00.000Z") });
     mockTaskChange.create.mockResolvedValue({});
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
       return fn({ task: mockTask, taskActivity: mockTaskActivity, taskChange: mockTaskChange });
@@ -289,6 +291,7 @@ describe("PATCH /api/tasks/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MEMBER_SESSION);
+    mockTask.findUnique.mockResolvedValue({ ...MOCK_TASK, primaryAssigneeId: "user-1", backupAssigneeId: null });
     mockTask.update.mockResolvedValue({ ...MOCK_TASK, status: "DONE" });
     mockTaskActivity.create.mockResolvedValue({});
     // $transaction receives a callback; simulate calling it with a tx proxy

--- a/__tests__/integration/api-security-middleware.test.ts
+++ b/__tests__/integration/api-security-middleware.test.ts
@@ -16,6 +16,7 @@ const mockTask = {
   create: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  count: jest.fn().mockResolvedValue(0),
 };
 const mockUser = {
   findMany: jest.fn(),
@@ -135,12 +136,13 @@ describe("A1: GET /api/tasks — withAuth middleware", () => {
   });
 
   it("authenticated engineer receives task list with status 200", async () => {
+    mockTask.count.mockResolvedValue(1);
     const { GET } = await import("@/app/api/tasks/route");
     const res = await GET(createMockRequest("/api/tasks"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(Array.isArray(body.data)).toBe(true);
-    expect(body.data[0].id).toBe("task-1");
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].id).toBe("task-1");
   });
 
   it("unauthenticated request blocked with 401", async () => {

--- a/__tests__/integration/rbac-combinations.test.ts
+++ b/__tests__/integration/rbac-combinations.test.ts
@@ -10,7 +10,7 @@
 import { createMockRequest } from "../utils/test-utils";
 
 // ── Mock Prisma ────────────────────────────────────────────────────────────
-const mockTask = { findMany: jest.fn(), create: jest.fn(), findUnique: jest.fn() };
+const mockTask = { findMany: jest.fn(), create: jest.fn(), findUnique: jest.fn(), count: jest.fn().mockResolvedValue(0) };
 const mockUser = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn() };
 const mockKPI = { findMany: jest.fn(), create: jest.fn() };
 const mockTimeEntry = { findMany: jest.fn(), create: jest.fn() };
@@ -87,22 +87,24 @@ describe("C1: Manager receives all tasks without scope restriction", () => {
   });
 
   it("GET /api/tasks returns 200 with multiple tasks for manager", async () => {
+    mockTask.count.mockResolvedValue(2);
     const { GET } = await import("@/app/api/tasks/route");
     const res = await GET(createMockRequest("/api/tasks"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data).toHaveLength(2);
+    expect(body.data.items).toHaveLength(2);
   });
 
   it("manager can filter by any assignee userId", async () => {
     mockTask.findMany.mockResolvedValue([TASK_2]);
+    mockTask.count.mockResolvedValue(1);
     const { GET } = await import("@/app/api/tasks/route");
     const res = await GET(
       createMockRequest("/api/tasks", { searchParams: { assignee: "other-user" } })
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("t-2");
+    expect(body.data.items[0].id).toBe("t-2");
   });
 });
 

--- a/__tests__/integration/schema-drift-protection.test.ts
+++ b/__tests__/integration/schema-drift-protection.test.ts
@@ -56,8 +56,9 @@ describe("D1: TaskService — graceful handling of missing relation fields", () 
       },
     ]);
 
-    const tasks = await service.listTasks({});
-    expect(tasks[0].monthlyGoal).toBeNull();
+    (prisma.task.count as jest.Mock).mockResolvedValue(1);
+    const result = await service.listTasks({});
+    expect(result.tasks[0].monthlyGoal).toBeNull();
     // must not throw
   });
 });
@@ -199,7 +200,7 @@ describe("D5: API response always includes success wrapper fields", () => {
   const mockGetServerSession = jest.fn();
 
   const mockKPI = { findMany: jest.fn() };
-  const mockTask = { findMany: jest.fn() };
+  const mockTask = { findMany: jest.fn(), count: jest.fn().mockResolvedValue(0) };
 
   jest.mock("@/lib/prisma", () => ({
     prisma: {
@@ -244,11 +245,12 @@ describe("D5: API response always includes success wrapper fields", () => {
 
   it("GET /api/tasks response has data array even if DB returns empty list", async () => {
     mockTask.findMany.mockResolvedValue([]);
+    mockTask.count.mockResolvedValue(0);
     const { GET } = await import("@/app/api/tasks/route");
     const res = await GET(createMockRequest("/api/tasks"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toHaveProperty("data");
-    expect(Array.isArray(body.data)).toBe(true);
+    expect(Array.isArray(body.data.items)).toBe(true);
   });
 });

--- a/__tests__/integration/service-logic.test.ts
+++ b/__tests__/integration/service-logic.test.ts
@@ -260,6 +260,9 @@ describe("B5: KPIService — calculateAchievement with edge cases", () => {
   it("calculates weighted average achievement correctly", async () => {
     (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
       id: "kpi-1",
+      autoCalc: true,
+      target: 100,
+      actual: 0,
       taskLinks: [
         { weight: 2, task: { progressPct: 80, status: "IN_PROGRESS" } },
         { weight: 1, task: { progressPct: 50, status: "TODO" } },
@@ -269,7 +272,7 @@ describe("B5: KPIService — calculateAchievement with edge cases", () => {
 
     await service.calculateAchievement("kpi-1");
 
-    // (80*2 + 50*1) / (2+1) = 210/3 = 70
+    // (80/100*2 + 50/100*1) / (2+1) * 100 = (1.6+0.5)/3 * 100 = 70
     expect(prisma.kPI.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: { actual: 70 } })
     );

--- a/__tests__/pages/dashboard-extended.test.tsx
+++ b/__tests__/pages/dashboard-extended.test.tsx
@@ -128,8 +128,8 @@ describe("Dashboard Extended — Role-based rendering", () => {
     await act(async () => { render(<DashboardPage />); });
     await waitFor(() => {
       expect(screen.getByText("我的任務（待辦 + 進行中）")).toBeInTheDocument();
-      expect(screen.getByText("Task One")).toBeInTheDocument();
-      expect(screen.getByText("Task Two")).toBeInTheDocument();
+      expect(screen.getAllByText("Task One").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Task Two").length).toBeGreaterThan(0);
     });
   });
 
@@ -147,7 +147,7 @@ describe("Dashboard Extended — Role-based rendering", () => {
     setupFetch();
     await act(async () => { render(<DashboardPage />); });
     await waitFor(() => {
-      expect(screen.getByText("逾期任務")).toBeInTheDocument();
+      expect(screen.getAllByText("逾期任務").length).toBeGreaterThan(0);
     });
   });
 });
@@ -172,8 +172,8 @@ describe("Dashboard Extended — KPI section", () => {
     setupFetch();
     await act(async () => { render(<DashboardPage />); });
     await waitFor(() => {
-      expect(screen.getByText("進行中")).toBeInTheDocument(); // ON_TRACK
-      expect(screen.getByText("風險")).toBeInTheDocument();   // AT_RISK
+      expect(screen.getAllByText("進行中").length).toBeGreaterThan(0); // ON_TRACK
+      expect(screen.getAllByText("風險").length).toBeGreaterThan(0);   // AT_RISK
     });
   });
 });

--- a/app/(app)/activity/page.tsx
+++ b/app/(app)/activity/page.tsx
@@ -146,7 +146,7 @@ export default function ActivityPage() {
                     </div>
 
                     {/* Detail */}
-                    {item.detail && typeof item.detail === "string" && (
+                    {typeof item.detail === "string" && item.detail && (
                       <p className="text-xs text-muted-foreground mt-0.5 truncate">
                         {item.detail}
                       </p>

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -301,6 +301,7 @@ export default function KanbanPage() {
           />
         </div>
       ) : (
+        <>
         {/* Desktop: horizontal scroll board / Mobile: vertical stack */}
         <div
           className="flex-1 flex flex-col md:flex-row gap-3 overflow-y-auto md:overflow-x-auto md:overflow-y-hidden pb-4 min-h-0"
@@ -402,6 +403,7 @@ export default function KanbanPage() {
             );
           })}
         </div>
+        </>
       )}
 
       {/* Task detail modal */}

--- a/app/components/command-palette.tsx
+++ b/app/components/command-palette.tsx
@@ -107,7 +107,7 @@ export function CommandPalette() {
   const [searching, setSearching] = useState(false);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const router = useRouter();
 
   // Filter route items locally

--- a/lib/__tests__/rbac-coverage.test.ts
+++ b/lib/__tests__/rbac-coverage.test.ts
@@ -144,6 +144,8 @@ describe("documents DELETE /api/documents/[id]", () => {
   test("returns 200 for MANAGER", async () => {
     const { prisma } = await import("@/lib/prisma");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (prisma.document.findUnique as any).mockResolvedValue({ id: "doc-1", title: "Test" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (prisma.document.delete as any).mockResolvedValue({});
     mockGetServerSession.mockResolvedValue(makeManagerSession());
     const req = makeRequest("http://localhost/api/documents/1", "DELETE");

--- a/lib/auth-middleware.ts
+++ b/lib/auth-middleware.ts
@@ -18,10 +18,8 @@ import { apiHandler, RouteContext } from "@/lib/api-handler";
 import type { ApiResponse } from "@/lib/api-response";
 
 /** Route handler that accepts a request and optional route context. */
-type RouteHandler = (
-  req: NextRequest,
-  context?: RouteContext
-) => Promise<NextResponse<ApiResponse>>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type RouteHandler = (req: NextRequest, context?: any) => Promise<NextResponse<ApiResponse>>;
 
 /**
  * Wraps a route handler with requireAuth check + unified error handling.

--- a/services/__tests__/kpi-service.test.ts
+++ b/services/__tests__/kpi-service.test.ts
@@ -258,6 +258,8 @@ describe("KPIService", () => {
       const mockKPI = {
         id: "kpi-1",
         autoCalc: true,
+        target: 100,
+        actual: 0,
         taskLinks: [
           { task: { progressPct: 100, status: "DONE" }, weight: 1 },
           { task: { progressPct: 50, status: "IN_PROGRESS" }, weight: 1 },
@@ -300,6 +302,9 @@ describe("KPIService", () => {
     test("calculates weighted average correctly", async () => {
       const mockKPI = {
         id: "kpi-1",
+        autoCalc: true,
+        target: 100,
+        actual: 0,
         taskLinks: [
           { task: { progressPct: 100, status: "DONE" }, weight: 2 },
           { task: { progressPct: 0, status: "TODO" }, weight: 1 },

--- a/services/__tests__/task-service.test.ts
+++ b/services/__tests__/task-service.test.ts
@@ -22,12 +22,13 @@ describe("TaskService", () => {
       ];
       (prisma.task.findMany as jest.Mock).mockResolvedValue(mockTasks);
 
+      (prisma.task.count as jest.Mock).mockResolvedValue(2);
       const result = await service.listTasks({});
 
       expect(prisma.task.findMany).toHaveBeenCalledWith(
         expect.objectContaining({ where: {} })
       );
-      expect(result).toEqual(mockTasks);
+      expect(result).toEqual({ tasks: mockTasks, total: 2 });
     });
 
     test("listTasks filters by assignee", async () => {


### PR DESCRIPTION
## Summary
- 修復 40+ PR 合併後 16 個測試套件、40 個測試案例的失敗
- 修復 kanban 頁面 JSX 語法錯誤、TypeScript 嚴格模式問題
- 所有 93 個測試套件、1158 個測試案例全部通過

## Changes
- 14 個測試檔案：補齊 Prisma mock 方法（count, findUnique, findMany）
- 更新測試預期值以匹配新的分頁回應格式（items/pagination）
- 修復 kanban page JSX fragment 包裝
- 修復 activity page unknown type narrowing
- 修復 RouteHandler type 支援 required context
- 修復 api-handler implicit any types
- 修復 push-notification pino logger 呼叫簽名

## Test plan
- [x] Jest 全量測試：93 suites, 1158 tests passed
- [x] TypeScript 編譯通過（Compiled successfully）
- [x] ESLint 通過

Fixes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)