### PR TITLE
test(tdd-8): ReportService + ChangeTrackingService TDD tests

### DIFF
--- a/services/__tests__/tdd8-change-tracking-service.test.ts
+++ b/services/__tests__/tdd8-change-tracking-service.test.ts
@@ -1,0 +1,375 @@
+/**
+ * TDD-8: ChangeTrackingService tests
+ *
+ * Tests for:
+ * - detectDelay: DELAY type creation, date comparison logic
+ * - detectScopeChange: SCOPE_CHANGE type, title significance threshold
+ * - detectAndRecordAll: combined detection in single transaction
+ * - getChangeHistory: ordered history retrieval
+ * - getDelayCount / getChangeCount: date-range filtered counts
+ *
+ * Fixes #562
+ */
+import { ChangeTrackingService } from "../change-tracking-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+describe("ChangeTrackingService", () => {
+  let service: ChangeTrackingService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ChangeTrackingService(prisma as never);
+    // Make $transaction execute the callback with prisma as the tx
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) => fn(prisma)
+    );
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // detectDelay
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("detectDelay", () => {
+    it("creates DELAY record when new due date is later", async () => {
+      const oldDate = new Date("2026-04-01");
+      const newDate = new Date("2026-04-15");
+      const mockChange = {
+        id: "c1",
+        taskId: "task-1",
+        changeType: "DELAY",
+        reason: "Due date extended",
+        oldValue: oldDate.toISOString(),
+        newValue: newDate.toISOString(),
+        changedBy: "user-1",
+      };
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue(mockChange);
+
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: oldDate,
+        newDueDate: newDate,
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeTruthy();
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            taskId: "task-1",
+            changeType: "DELAY",
+            oldValue: oldDate.toISOString(),
+            newValue: newDate.toISOString(),
+          }),
+        })
+      );
+    });
+
+    it("returns null when new date is earlier (not a delay)", async () => {
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: new Date("2026-04-15"),
+        newDueDate: new Date("2026-04-01"),
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeNull();
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+    });
+
+    it("returns null when dates are equal", async () => {
+      const sameDate = new Date("2026-04-01");
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: sameDate,
+        newDueDate: new Date(sameDate.getTime()),
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when oldDueDate is null", async () => {
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: null,
+        newDueDate: new Date("2026-04-15"),
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when newDueDate is null", async () => {
+      const result = await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: new Date("2026-04-01"),
+        newDueDate: null,
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("uses custom reason when provided", async () => {
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue({ id: "c1" });
+
+      await service.detectDelay({
+        taskId: "task-1",
+        oldDueDate: new Date("2026-04-01"),
+        newDueDate: new Date("2026-04-15"),
+        changedBy: "user-1",
+        reason: "Customer requested extension",
+      });
+
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            reason: "Customer requested extension",
+          }),
+        })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // detectScopeChange
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("detectScopeChange", () => {
+    it("creates SCOPE_CHANGE when title is significantly different", async () => {
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue({
+        id: "c1",
+        changeType: "SCOPE_CHANGE",
+      });
+
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Build login page",
+        newTitle: "Completely redesign authentication system",
+        oldDescription: null,
+        newDescription: null,
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeTruthy();
+      expect(prisma.taskChange.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            changeType: "SCOPE_CHANGE",
+          }),
+        })
+      );
+    });
+
+    it("creates SCOPE_CHANGE when description changes", async () => {
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue({
+        id: "c1",
+        changeType: "SCOPE_CHANGE",
+      });
+
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Same Title",
+        newTitle: "Same Title",
+        oldDescription: "Original scope",
+        newDescription: "Completely different scope with new requirements",
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    it("returns null when title and description are unchanged", async () => {
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Same Title",
+        newTitle: "Same Title",
+        oldDescription: "Same description",
+        newDescription: "Same description",
+        changedBy: "user-1",
+      });
+
+      expect(result).toBeNull();
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+    });
+
+    it("returns null for minor title changes (below threshold)", async () => {
+      const result = await service.detectScopeChange({
+        taskId: "task-1",
+        oldTitle: "Build login page",
+        newTitle: "Build login pages",
+        oldDescription: null,
+        newDescription: null,
+        changedBy: "user-1",
+      });
+
+      // Minor title change (one character) should not trigger scope change
+      expect(result).toBeNull();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // detectAndRecordAll
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("detectAndRecordAll", () => {
+    it("records both delay and scope change in single transaction", async () => {
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue({ id: "c1" });
+
+      const results = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: new Date("2026-04-01"),
+          newDueDate: new Date("2026-05-01"),
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Build login page",
+          newTitle: "Completely redesign authentication system",
+          oldDescription: null,
+          newDescription: null,
+          changedBy: "user-1",
+        }
+      );
+
+      expect(prisma.$transaction).toHaveBeenCalled();
+      expect(prisma.taskChange.create).toHaveBeenCalledTimes(2);
+      expect(results).toHaveLength(2);
+    });
+
+    it("records only delay when scope is unchanged", async () => {
+      (prisma.taskChange.create as jest.Mock).mockResolvedValue({ id: "c1" });
+
+      const results = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: new Date("2026-04-01"),
+          newDueDate: new Date("2026-05-01"),
+          changedBy: "user-1",
+        },
+        null
+      );
+
+      expect(prisma.taskChange.create).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(1);
+    });
+
+    it("returns empty array when neither delay nor scope change detected", async () => {
+      const results = await service.detectAndRecordAll(
+        {
+          taskId: "task-1",
+          oldDueDate: null,
+          newDueDate: null,
+          changedBy: "user-1",
+        },
+        {
+          taskId: "task-1",
+          oldTitle: "Same",
+          newTitle: "Same",
+          oldDescription: null,
+          newDescription: null,
+          changedBy: "user-1",
+        }
+      );
+
+      expect(results).toHaveLength(0);
+      expect(prisma.taskChange.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getChangeHistory
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getChangeHistory", () => {
+    it("returns changes ordered by changedAt desc", async () => {
+      const changes = [
+        { id: "c2", changedAt: new Date("2026-03-25") },
+        { id: "c1", changedAt: new Date("2026-03-20") },
+      ];
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue(changes);
+
+      const result = await service.getChangeHistory("task-1");
+
+      expect(result).toHaveLength(2);
+      expect(prisma.taskChange.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { taskId: "task-1" },
+          orderBy: { changedAt: "desc" },
+        })
+      );
+    });
+
+    it("returns empty array for task with no changes", async () => {
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getChangeHistory("task-1");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getDelayCount / getChangeCount
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getDelayCount", () => {
+    it("counts DELAY records in date range", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(3);
+
+      const result = await service.getDelayCount({
+        start: new Date("2026-01-01"),
+        end: new Date("2026-03-31"),
+      });
+
+      expect(result).toBe(3);
+      expect(prisma.taskChange.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            changeType: "DELAY",
+          }),
+        })
+      );
+    });
+
+    it("filters by taskId when provided", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(1);
+
+      await service.getDelayCount({
+        start: new Date("2026-01-01"),
+        end: new Date("2026-03-31"),
+        taskId: "task-1",
+      });
+
+      expect(prisma.taskChange.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            taskId: "task-1",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("getChangeCount", () => {
+    it("counts SCOPE_CHANGE records in date range", async () => {
+      (prisma.taskChange.count as jest.Mock).mockResolvedValue(5);
+
+      const result = await service.getChangeCount({
+        start: new Date("2026-01-01"),
+        end: new Date("2026-03-31"),
+      });
+
+      expect(result).toBe(5);
+      expect(prisma.taskChange.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            changeType: "SCOPE_CHANGE",
+          }),
+        })
+      );
+    });
+  });
+});

--- a/services/__tests__/tdd8-report-service.test.ts
+++ b/services/__tests__/tdd8-report-service.test.ts
@@ -1,0 +1,339 @@
+/**
+ * TDD-8: ReportService tests
+ *
+ * Tests for:
+ * - getWeeklyReport: date bounds, user filters, hours/category aggregation
+ * - getMonthlyReport: completion rate, monthly goals, changes
+ * - getWorkloadReport: planned vs unplanned hours, byPerson breakdown
+ * - getKPIReport: achievement calc, average, filters
+ *
+ * Fixes #562
+ */
+import { ReportService } from "../report-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+describe("ReportService", () => {
+  let service: ReportService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new ReportService(prisma as never);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getWeeklyReport
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getWeeklyReport", () => {
+    beforeEach(() => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("returns weekly report with correct period bounds", async () => {
+      const refDate = new Date("2026-03-25"); // Wednesday
+      const result = await service.getWeeklyReport({
+        isManager: true,
+        refDate,
+      });
+
+      expect(result.period.start).toBeDefined();
+      expect(result.period.end).toBeDefined();
+      // Monday of that week = March 23, 2026
+      expect(result.period.start.getDay()).toBe(1); // Monday
+    });
+
+    it("filters by userId for non-managers", async () => {
+      const result = await service.getWeeklyReport({
+        isManager: false,
+        userId: "user-1",
+        refDate: new Date("2026-03-25"),
+      });
+
+      expect(prisma.task.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            primaryAssigneeId: "user-1",
+          }),
+        })
+      );
+      expect(result.completedCount).toBe(0);
+    });
+
+    it("shows all tasks for manager (no userId filter)", async () => {
+      await service.getWeeklyReport({
+        isManager: true,
+        refDate: new Date("2026-03-25"),
+      });
+
+      const firstCallArgs = (prisma.task.findMany as jest.Mock).mock.calls[0][0];
+      expect(firstCallArgs.where).not.toHaveProperty("primaryAssigneeId");
+    });
+
+    it("aggregates hours by category", async () => {
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([
+        { hours: 4, category: "PLANNED_TASK", userId: "u1", user: { id: "u1", name: "A" } },
+        { hours: 2, category: "PLANNED_TASK", userId: "u1", user: { id: "u1", name: "A" } },
+        { hours: 3, category: "INCIDENT", userId: "u1", user: { id: "u1", name: "A" } },
+      ]);
+
+      const result = await service.getWeeklyReport({ isManager: true });
+
+      expect(result.totalHours).toBe(9);
+      expect(result.hoursByCategory.PLANNED_TASK).toBe(6);
+      expect(result.hoursByCategory.INCIDENT).toBe(3);
+    });
+
+    it("counts delay and scope changes correctly", async () => {
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue([
+        { changeType: "DELAY", changedAt: new Date() },
+        { changeType: "DELAY", changedAt: new Date() },
+        { changeType: "SCOPE_CHANGE", changedAt: new Date() },
+      ]);
+
+      const result = await service.getWeeklyReport({ isManager: true });
+
+      expect(result.delayCount).toBe(2);
+      expect(result.scopeChangeCount).toBe(1);
+    });
+
+    it("returns completed and overdue task counts", async () => {
+      // First call: completed tasks, second call: overdue tasks
+      (prisma.task.findMany as jest.Mock)
+        .mockResolvedValueOnce([{ id: "t1" }, { id: "t2" }]) // completed
+        .mockResolvedValueOnce([{ id: "t3" }]); // overdue
+
+      const result = await service.getWeeklyReport({ isManager: true });
+
+      expect(result.completedCount).toBe(2);
+      expect(result.overdueCount).toBe(1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getMonthlyReport
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getMonthlyReport", () => {
+    beforeEach(() => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.taskChange.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("returns monthly report with specified year and month", async () => {
+      const result = await service.getMonthlyReport({
+        isManager: true,
+        year: 2026,
+        month: 3,
+      });
+
+      expect(result.period.year).toBe(2026);
+      expect(result.period.month).toBe(3);
+    });
+
+    it("calculates completion rate correctly", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { id: "t1", status: "DONE" },
+        { id: "t2", status: "DONE" },
+        { id: "t3", status: "IN_PROGRESS" },
+        { id: "t4", status: "BACKLOG" },
+      ]);
+
+      const result = await service.getMonthlyReport({
+        isManager: true,
+        year: 2026,
+        month: 3,
+      });
+
+      expect(result.totalTasks).toBe(4);
+      expect(result.completedTasks).toBe(2);
+      expect(result.completionRate).toBe(50);
+    });
+
+    it("returns 0 completion rate when no tasks exist", async () => {
+      const result = await service.getMonthlyReport({
+        isManager: true,
+        year: 2026,
+        month: 1,
+      });
+
+      expect(result.completionRate).toBe(0);
+    });
+
+    it("includes monthly goals in report", async () => {
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([
+        { id: "g1", title: "Goal 1", tasks: [] },
+      ]);
+
+      const result = await service.getMonthlyReport({
+        isManager: true,
+        year: 2026,
+        month: 3,
+      });
+
+      expect(result.monthlyGoals).toHaveLength(1);
+    });
+
+    it("uses current date when year/month not specified", async () => {
+      const result = await service.getMonthlyReport({ isManager: true });
+
+      const now = new Date();
+      expect(result.period.year).toBe(now.getFullYear());
+      expect(result.period.month).toBe(now.getMonth() + 1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getWorkloadReport
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getWorkloadReport", () => {
+    beforeEach(() => {
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it("separates planned vs unplanned hours", async () => {
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([
+        { hours: 8, category: "PLANNED_TASK", userId: "u1", user: { id: "u1", name: "A" }, task: { id: "t1", title: "T", category: "PLANNED" } },
+        { hours: 3, category: "ADDED_TASK", userId: "u1", user: { id: "u1", name: "A" }, task: { id: "t2", title: "T2", category: "ADDED" } },
+        { hours: 2, category: "INCIDENT", userId: "u1", user: { id: "u1", name: "A" }, task: { id: "t3", title: "T3", category: "INCIDENT" } },
+      ]);
+
+      const result = await service.getWorkloadReport({ isManager: true });
+
+      expect(result.totalHours).toBe(13);
+      expect(result.plannedHours).toBe(8);
+      expect(result.unplannedHours).toBe(5);
+    });
+
+    it("calculates planned and unplanned rates", async () => {
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([
+        { hours: 8, category: "PLANNED_TASK", userId: "u1", user: { id: "u1", name: "A" }, task: { id: "t1", title: "T", category: "PLANNED" } },
+        { hours: 2, category: "INCIDENT", userId: "u1", user: { id: "u1", name: "A" }, task: { id: "t2", title: "T2", category: "INCIDENT" } },
+      ]);
+
+      const result = await service.getWorkloadReport({ isManager: true });
+
+      expect(result.plannedRate).toBe(80);
+      expect(result.unplannedRate).toBe(20);
+    });
+
+    it("returns 0 rates when no hours", async () => {
+      const result = await service.getWorkloadReport({ isManager: true });
+
+      expect(result.plannedRate).toBe(0);
+      expect(result.unplannedRate).toBe(0);
+      expect(result.totalHours).toBe(0);
+    });
+
+    it("groups hours by person", async () => {
+      (prisma.timeEntry.findMany as jest.Mock).mockResolvedValue([
+        { hours: 4, category: "PLANNED_TASK", userId: "u1", user: { id: "u1", name: "Alice" }, task: {} },
+        { hours: 2, category: "INCIDENT", userId: "u1", user: { id: "u1", name: "Alice" }, task: {} },
+        { hours: 6, category: "PLANNED_TASK", userId: "u2", user: { id: "u2", name: "Bob" }, task: {} },
+      ]);
+
+      const result = await service.getWorkloadReport({ isManager: true });
+
+      expect(result.byPerson).toHaveLength(2);
+      const alice = result.byPerson.find((p) => p.userId === "u1");
+      expect(alice?.total).toBe(6);
+      expect(alice?.planned).toBe(4);
+      expect(alice?.unplanned).toBe(2);
+    });
+
+    it("groups unplanned tasks by source", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { id: "t1", category: "ADDED", addedSource: "客戶要求" },
+        { id: "t2", category: "INCIDENT", addedSource: "客戶要求" },
+        { id: "t3", category: "SUPPORT", addedSource: null },
+      ]);
+
+      const result = await service.getWorkloadReport({ isManager: true });
+
+      expect(result.unplannedBySource["客戶要求"]).toBe(2);
+      expect(result.unplannedBySource["未填寫"]).toBe(1);
+    });
+
+    it("applies date range filter", async () => {
+      const start = new Date("2026-01-01");
+      const end = new Date("2026-01-31");
+
+      await service.getWorkloadReport({
+        isManager: true,
+        dateRange: { startDate: start, endDate: end },
+      });
+
+      expect(prisma.timeEntry.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            date: { gte: start, lte: end },
+          }),
+        })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // getKPIReport
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("getKPIReport", () => {
+    it("returns KPI report with achievement calculations", async () => {
+      (prisma.kPI.findMany as jest.Mock).mockResolvedValue([
+        { id: "k1", target: 100, actual: 100, autoCalc: false, taskLinks: [] },
+        { id: "k2", target: 100, actual: 50, autoCalc: false, taskLinks: [] },
+        { id: "k3", target: 100, actual: 80, autoCalc: false, taskLinks: [] },
+      ]);
+
+      const result = await service.getKPIReport(2026);
+
+      expect(result.year).toBe(2026);
+      expect(result.totalCount).toBe(3);
+      expect(result.achievedCount).toBe(1); // only k1 >= 100
+      expect(result.avgAchievement).toBeGreaterThan(0);
+    });
+
+    it("uses current year when not specified", async () => {
+      (prisma.kPI.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getKPIReport();
+
+      expect(result.year).toBe(new Date().getFullYear());
+    });
+
+    it("returns 0 avg achievement for empty KPI list", async () => {
+      (prisma.kPI.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.getKPIReport(2026);
+
+      expect(result.avgAchievement).toBe(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.achievedCount).toBe(0);
+    });
+
+    it("calculates auto-calc KPI achievement from task links", async () => {
+      (prisma.kPI.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: "k1",
+          target: 100,
+          actual: 0,
+          autoCalc: true,
+          taskLinks: [
+            { weight: 1, task: { id: "t1", title: "A", status: "DONE", progressPct: 100 } },
+          ],
+        },
+      ]);
+
+      const result = await service.getKPIReport(2026);
+
+      expect(result.totalCount).toBe(1);
+      expect(result.achievedCount).toBe(1); // 100% achievement
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 39 TDD tests covering ReportService (weekly, monthly, workload, KPI reports) and ChangeTrackingService (delay detection, scope change detection, combined tracking, history, counts)
- Tests validate filter logic, aggregation, date range handling, threshold-based scope detection, and edge cases

## Test plan
- [x] All 39 tests pass locally
- [x] Uses createMockPrisma pattern consistent with existing service tests

Fixes #562

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>