### PR TITLE
test(e2e): Activity + Settings + Admin deep E2E tests

### DIFF
--- a/e2e/activity-deep.spec.ts
+++ b/e2e/activity-deep.spec.ts
@@ -1,0 +1,228 @@
+import { test, expect } from '@playwright/test';
+import { MANAGER_STATE_FILE, ENGINEER_STATE_FILE } from './helpers/auth';
+
+/**
+ * E2E deep tests for /activity page — Issue #608
+ *
+ * Covers:
+ *   - Page load with heading and subtitle
+ *   - Activity items or empty state
+ *   - Source type badges (任務 / 系統)
+ *   - User names and action labels displayed
+ *   - Timestamps rendered
+ *   - Pagination controls (next/prev)
+ *   - Pagination info text (共 N 筆)
+ *   - Navigation does not crash for Engineer
+ *   - Console error free
+ *   - Multiple page transitions
+ */
+
+const NOISE_PATTERNS = [
+  'Warning:', 'hydrat', 'Expected server HTML',
+  'next-auth', 'CLIENT_FETCH_ERROR', 'favicon',
+  'ERR_INCOMPLETE_CHUNKED_ENCODING', 'ERR_ABORTED', 'net::ERR',
+];
+
+function collectConsoleErrors(page: import('@playwright/test').Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      if (!NOISE_PATTERNS.some((p) => text.includes(p))) {
+        errors.push(text);
+      }
+    }
+  });
+  return errors;
+}
+
+test.describe('活動紀錄頁面 — 深度測試 (/activity)', () => {
+
+  // ── Manager tests ──────────────────────────────────────────────────────
+
+  test.describe('Manager 視角', () => {
+    test.use({ storageState: MANAGER_STATE_FILE });
+
+    test('頁面載入無 console error，顯示標題與副標題', async ({ page }) => {
+      const errors = collectConsoleErrors(page);
+
+      const response = await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      expect(response?.status()).toBe(200);
+
+      await expect(page.locator('h1')).toContainText('團隊動態');
+      await expect(page.locator('text=查看團隊成員的最新操作紀錄')).toBeVisible({ timeout: 15000 });
+
+      expect(errors, `Console errors: ${errors.join(', ')}`).toHaveLength(0);
+    });
+
+    test('顯示活動項目列表或空白狀態', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Either activity items with timeline dots, or empty state
+      const hasItems = await page.locator('.space-y-1 > div').first().isVisible().catch(() => false);
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+
+      expect(hasItems || hasEmpty).toBeTruthy();
+    });
+
+    test('活動項目顯示來源類型標籤（任務/系統）', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) {
+        // Empty state — just verify page is stable
+        expect(page.url()).toContain('/activity');
+        return;
+      }
+
+      // At least one badge should exist
+      const taskBadge = page.locator('text=任務').first();
+      const systemBadge = page.locator('text=系統').first();
+
+      const hasBadges = await taskBadge.isVisible().catch(() => false) ||
+                        await systemBadge.isVisible().catch(() => false);
+      expect(hasBadges).toBeTruthy();
+    });
+
+    test('活動項目顯示使用者名稱', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // User names or "系統" should appear in activity items
+      const nameElements = page.locator('.space-y-1 > div .font-medium').first();
+      await expect(nameElements).toBeVisible({ timeout: 10000 });
+      const text = await nameElements.textContent();
+      expect(text!.length).toBeGreaterThan(0);
+    });
+
+    test('活動項目顯示操作動作標籤', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Action labels like 建立, 更新, 刪除 should appear
+      const actionLabels = ['建立', '更新', '刪除', '變更狀態', '留言', '指派', '建立任務', '更新任務', '刪除任務', '角色變更', '密碼變更', '登入失敗'];
+      const allText = await page.locator('.space-y-1').first().textContent() ?? '';
+      const hasAction = actionLabels.some((label) => allText.includes(label));
+      expect(hasAction).toBeTruthy();
+    });
+
+    test('活動項目顯示時間戳', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Timestamp elements (formatRelative output) should exist
+      // They appear as small muted text at the bottom of each item
+      const timestamps = page.locator('.space-y-1 > div .text-muted-foreground\\/60');
+      const count = await timestamps.count();
+      expect(count).toBeGreaterThan(0);
+    });
+
+    test('分頁資訊文字顯示（共 N 筆）', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Pagination info: "共 N 筆，第 M/T 頁" — only visible when totalPages > 1
+      const paginationInfo = page.locator('text=/共 \\d+ 筆/');
+      const hasPagination = await paginationInfo.isVisible().catch(() => false);
+
+      // If only one page, pagination won't show — that's acceptable
+      expect(page.url()).toContain('/activity');
+      if (hasPagination) {
+        const text = await paginationInfo.textContent();
+        expect(text).toMatch(/共 \d+ 筆/);
+      }
+    });
+
+    test('分頁按鈕（上一頁/下一頁）可操作', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Pagination uses aria-label 上一頁/下一頁
+      const prevBtn = page.locator('button[aria-label="上一頁"]');
+      const nextBtn = page.locator('button[aria-label="下一頁"]');
+
+      const hasPagination = await nextBtn.isVisible().catch(() => false);
+      if (!hasPagination) return; // Only 1 page of data
+
+      // On page 1, prev should be disabled
+      await expect(prevBtn).toBeDisabled();
+
+      // If next is enabled, click it
+      if (await nextBtn.isEnabled().catch(() => false)) {
+        await nextBtn.click();
+        await page.waitForLoadState('networkidle');
+
+        // After going to page 2, prev should be enabled
+        await expect(prevBtn).toBeEnabled();
+
+        // Go back
+        await prevBtn.click();
+        await page.waitForLoadState('networkidle');
+        await expect(prevBtn).toBeDisabled();
+      }
+    });
+
+    test('空白狀態顯示正確圖示與描述', async ({ page }) => {
+      // This test verifies the empty state renders properly when no data
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+      if (!hasEmpty) {
+        // Has data — skip empty state check
+        return;
+      }
+
+      await expect(page.locator('text=系統尚未記錄任何操作')).toBeVisible();
+    });
+
+    test('頁面 URL 保持正確', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      expect(page.url()).toContain('/activity');
+
+      // No unexpected redirects
+      await page.waitForLoadState('networkidle');
+      expect(page.url()).toContain('/activity');
+    });
+  });
+
+  // ── Engineer tests ─────────────────────────────────────────────────────
+
+  test.describe('Engineer 視角', () => {
+    test.use({ storageState: ENGINEER_STATE_FILE });
+
+    test('Engineer 可以存取活動紀錄頁面', async ({ page }) => {
+      const response = await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      expect(response?.status()).toBe(200);
+
+      await expect(page.locator('h1')).toContainText('團隊動態');
+    });
+
+    test('Engineer 看到活動項目或空白狀態', async ({ page }) => {
+      await page.goto('/activity', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const hasItems = await page.locator('.space-y-1 > div').first().isVisible().catch(() => false);
+      const hasEmpty = await page.locator('text=尚無活動紀錄').isVisible().catch(() => false);
+
+      expect(hasItems || hasEmpty).toBeTruthy();
+    });
+  });
+});

--- a/e2e/admin-deep.spec.ts
+++ b/e2e/admin-deep.spec.ts
@@ -1,0 +1,236 @@
+import { test, expect } from '@playwright/test';
+import { MANAGER_STATE_FILE, ENGINEER_STATE_FILE } from './helpers/auth';
+
+/**
+ * E2E deep tests for /admin page — Issue #608
+ *
+ * Covers:
+ *   - Page loads for Manager with heading
+ *   - Backup status section: stats cards, recent backups table
+ *   - Audit log section: table with columns
+ *   - Audit log pagination (next/prev)
+ *   - Audit log filter by action type
+ *   - Audit log date range filter
+ *   - Clear filters button
+ *   - Refresh buttons work
+ *   - Engineer gets redirected or sees permission error
+ *   - Console error free
+ */
+
+const NOISE_PATTERNS = [
+  'Warning:', 'hydrat', 'Expected server HTML',
+  'next-auth', 'CLIENT_FETCH_ERROR', 'favicon',
+  'ERR_INCOMPLETE_CHUNKED_ENCODING', 'ERR_ABORTED', 'net::ERR',
+];
+
+function collectConsoleErrors(page: import('@playwright/test').Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      if (!NOISE_PATTERNS.some((p) => text.includes(p))) {
+        errors.push(text);
+      }
+    }
+  });
+  return errors;
+}
+
+test.describe('系統管理頁面 — 深度測試 (/admin)', () => {
+
+  // ── Manager tests ──────────────────────────────────────────────────────
+
+  test.describe('Manager 視角', () => {
+    test.use({ storageState: MANAGER_STATE_FILE });
+
+    test('頁面載入無 console error，顯示標題', async ({ page }) => {
+      const errors = collectConsoleErrors(page);
+
+      const response = await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      expect(response?.status()).toBe(200);
+
+      await expect(page.locator('h1')).toContainText('系統管理', { timeout: 20000 });
+      await expect(page.locator('text=備份狀態監控與稽核日誌檢視')).toBeVisible();
+
+      expect(errors, `Console errors: ${errors.join(', ')}`).toHaveLength(0);
+    });
+
+    test('備份狀態區塊標題與重新整理按鈕', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Backup status heading
+      await expect(page.locator('h2', { hasText: '備份狀態' })).toBeVisible({ timeout: 20000 });
+
+      // Refresh button
+      const refreshBtn = page.locator('h2', { hasText: '備份狀態' }).locator('..').locator('button', { hasText: '重新整理' });
+      await expect(refreshBtn).toBeVisible();
+    });
+
+    test('備份狀態統計卡片顯示', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Wait for backup section to load
+      await expect(page.locator('h2', { hasText: '備份狀態' })).toBeVisible({ timeout: 20000 });
+
+      // Stats cards: 最後備份時間, 備份總數, 總容量, 備份路徑
+      await expect(page.locator('text=最後備份時間')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('text=備份總數')).toBeVisible();
+      await expect(page.locator('text=總容量')).toBeVisible();
+      await expect(page.locator('text=備份路徑')).toBeVisible();
+    });
+
+    test('備份狀態：最近備份表格或空狀態', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '備份狀態' })).toBeVisible({ timeout: 20000 });
+
+      // Either recent backups table or empty state
+      const hasTable = await page.locator('text=最近備份').isVisible().catch(() => false);
+      const hasEmpty = await page.locator('text=尚無備份紀錄').isVisible().catch(() => false);
+
+      expect(hasTable || hasEmpty).toBeTruthy();
+    });
+
+    test('稽核日誌區塊標題與重新整理按鈕', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Audit log heading
+      await expect(page.locator('h2', { hasText: '稽核日誌' })).toBeVisible({ timeout: 20000 });
+
+      // Refresh button for audit section
+      const auditSection = page.locator('h2', { hasText: '稽核日誌' }).locator('..');
+      await expect(auditSection.locator('button', { hasText: '重新整理' })).toBeVisible();
+    });
+
+    test('稽核日誌：篩選區域存在（操作類型、日期）', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '稽核日誌' })).toBeVisible({ timeout: 20000 });
+
+      // Filter labels
+      await expect(page.locator('text=操作類型')).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('text=起始日期')).toBeVisible();
+      await expect(page.locator('text=結束日期')).toBeVisible();
+
+      // Action filter select
+      const actionSelect = page.locator('select').first();
+      await expect(actionSelect).toBeVisible();
+
+      // Date inputs
+      const dateInputs = page.locator('input[type="date"]');
+      expect(await dateInputs.count()).toBeGreaterThanOrEqual(2);
+    });
+
+    test('稽核日誌：操作類型篩選可操作', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '稽核日誌' })).toBeVisible({ timeout: 20000 });
+
+      const actionSelect = page.locator('select').first();
+      await expect(actionSelect).toBeVisible({ timeout: 15000 });
+
+      // Should have "全部" as default option
+      const options = await actionSelect.locator('option').allTextContents();
+      expect(options[0]).toBe('全部');
+
+      // If there are action options beyond "全部", select one
+      if (options.length > 1) {
+        await actionSelect.selectOption({ index: 1 });
+        await page.waitForLoadState('networkidle');
+
+        // Clear filter button should appear
+        const clearBtn = page.locator('button', { hasText: '清除篩選' });
+        await expect(clearBtn).toBeVisible({ timeout: 10000 });
+
+        // Click clear
+        await clearBtn.click();
+        await page.waitForLoadState('networkidle');
+      }
+    });
+
+    test('稽核日誌表格欄位標題正確', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '稽核日誌' })).toBeVisible({ timeout: 20000 });
+
+      const hasEmpty = await page.locator('text=尚無稽核紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Table headers
+      const headers = ['時間', '操作', '資源類型', '資源 ID', '詳情', 'IP'];
+      for (const header of headers) {
+        await expect(page.locator('th', { hasText: header }).first()).toBeVisible({ timeout: 10000 });
+      }
+    });
+
+    test('稽核日誌分頁控制', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '稽核日誌' })).toBeVisible({ timeout: 20000 });
+
+      const hasEmpty = await page.locator('text=尚無稽核紀錄').isVisible().catch(() => false);
+      if (hasEmpty) return;
+
+      // Pagination info text
+      const paginationInfo = page.locator('text=/共 \\d+ 筆，第 \\d+ \\/ \\d+ 頁/');
+      await expect(paginationInfo).toBeVisible({ timeout: 15000 });
+
+      // Pagination buttons exist
+      const buttons = page.locator('.border-t button');
+      const count = await buttons.count();
+      expect(count).toBeGreaterThanOrEqual(2); // prev + next
+    });
+
+    test('備份重新整理按鈕可點擊', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h2', { hasText: '備份狀態' })).toBeVisible({ timeout: 20000 });
+
+      // Click refresh for backup section
+      const refreshBtn = page.locator('h2', { hasText: '備份狀態' }).locator('..').locator('button', { hasText: '重新整理' });
+      await refreshBtn.click();
+
+      // Should show loading or refresh data without crashing
+      await page.waitForLoadState('networkidle');
+      await expect(page.locator('h2', { hasText: '備份狀態' })).toBeVisible();
+    });
+  });
+
+  // ── Engineer tests ─────────────────────────────────────────────────────
+
+  test.describe('Engineer 視角', () => {
+    test.use({ storageState: ENGINEER_STATE_FILE });
+
+    test('Engineer 被拒絕存取或重導向', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Engineer should either be redirected to /dashboard or see permission error
+      const isRedirected = page.url().includes('/dashboard');
+      const hasPermError = await page.locator('text=權限不足').isVisible().catch(() => false);
+
+      expect(isRedirected || hasPermError).toBeTruthy();
+    });
+
+    test('Engineer 不會看到管理內容', async ({ page }) => {
+      await page.goto('/admin', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Should NOT see backup or audit log sections
+      const hasBackup = await page.locator('h2', { hasText: '備份狀態' }).isVisible().catch(() => false);
+      const hasAudit = await page.locator('h2', { hasText: '稽核日誌' }).isVisible().catch(() => false);
+
+      expect(hasBackup).toBeFalsy();
+      expect(hasAudit).toBeFalsy();
+    });
+  });
+});

--- a/e2e/settings-deep.spec.ts
+++ b/e2e/settings-deep.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect } from '@playwright/test';
+import { MANAGER_STATE_FILE, ENGINEER_STATE_FILE } from './helpers/auth';
+
+/**
+ * E2E deep tests for /settings page — Issue #608
+ *
+ * Covers:
+ *   - Page load with heading
+ *   - Three tabs visible (個人資料, 通知偏好, 安全設定)
+ *   - Profile tab: name input, email disabled, role badge, save button
+ *   - Notification tab: toggle switches for each type
+ *   - Security tab: change password link, account security info
+ *   - RBAC: Manager sees 管理員 badge, Engineer sees 工程師
+ *   - Console error free
+ */
+
+const NOISE_PATTERNS = [
+  'Warning:', 'hydrat', 'Expected server HTML',
+  'next-auth', 'CLIENT_FETCH_ERROR', 'favicon',
+  'ERR_INCOMPLETE_CHUNKED_ENCODING', 'ERR_ABORTED', 'net::ERR',
+];
+
+function collectConsoleErrors(page: import('@playwright/test').Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      if (!NOISE_PATTERNS.some((p) => text.includes(p))) {
+        errors.push(text);
+      }
+    }
+  });
+  return errors;
+}
+
+test.describe('設定頁面 — 深度測試 (/settings)', () => {
+
+  // ── Manager tests ──────────────────────────────────────────────────────
+
+  test.describe('Manager 視角', () => {
+    test.use({ storageState: MANAGER_STATE_FILE });
+
+    test('頁面載入無 console error，顯示標題', async ({ page }) => {
+      const errors = collectConsoleErrors(page);
+
+      const response = await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      expect(response?.status()).toBe(200);
+
+      await expect(page.locator('h1')).toContainText('個人設定', { timeout: 20000 });
+      await expect(page.locator('text=管理你的個人資料、通知偏好與安全設定')).toBeVisible();
+
+      expect(errors, `Console errors: ${errors.join(', ')}`).toHaveLength(0);
+    });
+
+    test('顯示三個分頁標籤', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Three tabs: 個人資料, 通知偏好, 安全設定
+      await expect(page.locator('button', { hasText: '個人資料' })).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('button', { hasText: '通知偏好' })).toBeVisible();
+      await expect(page.locator('button', { hasText: '安全設定' })).toBeVisible();
+    });
+
+    test('個人資料分頁：名稱欄位有值', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Profile tab should be active by default
+      const nameInput = page.locator('input[type="text"]').first();
+      await expect(nameInput).toBeVisible({ timeout: 15000 });
+
+      const value = await nameInput.inputValue();
+      expect(value.length).toBeGreaterThan(0);
+    });
+
+    test('個人資料分頁：電子信箱欄位不可編輯', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      const emailInput = page.locator('input[type="email"]');
+      await expect(emailInput).toBeVisible({ timeout: 15000 });
+      await expect(emailInput).toBeDisabled();
+
+      // Shows helper text
+      await expect(page.locator('text=電子信箱由管理員設定，無法自行修改')).toBeVisible();
+    });
+
+    test('個人資料分頁：Manager 看到管理員角色標籤', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('text=管理員')).toBeVisible({ timeout: 15000 });
+    });
+
+    test('個人資料分頁：儲存按鈕可見', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('button', { hasText: '儲存變更' })).toBeVisible({ timeout: 15000 });
+    });
+
+    test('通知偏好分頁：顯示所有通知類型與切換開關', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Click notifications tab
+      await page.locator('button', { hasText: '通知偏好' }).click();
+      await page.waitForLoadState('networkidle');
+
+      // Verify description text
+      await expect(page.locator('text=選擇要接收的通知類型')).toBeVisible({ timeout: 15000 });
+
+      // All 8 notification types should be visible
+      const notifTypes = [
+        '任務指派',
+        '任務即將到期',
+        '任務逾期',
+        '任務留言',
+        '里程碑到期',
+        'B 角啟動',
+        '任務變更',
+        '工時填報提醒',
+      ];
+
+      for (const label of notifTypes) {
+        await expect(page.locator(`text=${label}`).first()).toBeVisible({ timeout: 10000 });
+      }
+
+      // Verify toggle switches exist (role="switch")
+      const switches = page.locator('[role="switch"]');
+      const switchCount = await switches.count();
+      expect(switchCount).toBeGreaterThanOrEqual(8);
+    });
+
+    test('通知偏好分頁：切換開關可操作', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await page.locator('button', { hasText: '通知偏好' }).click();
+      await page.waitForLoadState('networkidle');
+
+      // Get first switch and toggle it
+      const firstSwitch = page.locator('[role="switch"]').first();
+      await expect(firstSwitch).toBeVisible({ timeout: 15000 });
+
+      const initialState = await firstSwitch.getAttribute('aria-checked');
+      await firstSwitch.click();
+
+      // State should change
+      await page.waitForTimeout(500);
+      const newState = await firstSwitch.getAttribute('aria-checked');
+      expect(newState).not.toBe(initialState);
+
+      // Toggle back to restore original state
+      await firstSwitch.click();
+    });
+
+    test('安全設定分頁：變更密碼連結存在', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Click security tab
+      await page.locator('button', { hasText: '安全設定' }).click();
+
+      // Verify change password section
+      await expect(page.locator('h3', { hasText: '變更密碼' })).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('text=密碼需定期更換')).toBeVisible();
+
+      // Link to change password page
+      const link = page.locator('a[href="/change-password"]');
+      await expect(link).toBeVisible();
+      await expect(link).toContainText('前往變更密碼');
+    });
+
+    test('安全設定分頁：帳號安全資訊區塊', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await page.locator('button', { hasText: '安全設定' }).click();
+
+      await expect(page.locator('h3', { hasText: '帳號安全' })).toBeVisible({ timeout: 15000 });
+      await expect(page.locator('text=如有帳號安全疑慮')).toBeVisible();
+    });
+
+    test('分頁切換不會產生錯誤', async ({ page }) => {
+      const errors = collectConsoleErrors(page);
+
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      // Cycle through all tabs
+      await page.locator('button', { hasText: '通知偏好' }).click();
+      await page.waitForTimeout(500);
+
+      await page.locator('button', { hasText: '安全設定' }).click();
+      await page.waitForTimeout(500);
+
+      await page.locator('button', { hasText: '個人資料' }).click();
+      await page.waitForTimeout(500);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  // ── Engineer tests ─────────────────────────────────────────────────────
+
+  test.describe('Engineer 視角', () => {
+    test.use({ storageState: ENGINEER_STATE_FILE });
+
+    test('Engineer 看到工程師角色標籤', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await expect(page.locator('h1')).toContainText('個人設定', { timeout: 20000 });
+      await expect(page.locator('text=工程師')).toBeVisible({ timeout: 15000 });
+    });
+
+    test('Engineer 同樣可以切換分頁', async ({ page }) => {
+      await page.goto('/settings', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle');
+
+      await page.locator('button', { hasText: '通知偏好' }).click();
+      await expect(page.locator('text=選擇要接收的通知類型')).toBeVisible({ timeout: 15000 });
+
+      await page.locator('button', { hasText: '安全設定' }).click();
+      await expect(page.locator('h3', { hasText: '變更密碼' })).toBeVisible({ timeout: 15000 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `e2e/activity-deep.spec.ts` — 11 tests covering activity items, source badges, pagination, timestamps, empty state, and Engineer access
- Add `e2e/settings-deep.spec.ts` — 12 tests covering 3 tabs (profile/notifications/security), RBAC role badges, toggle switches, save button
- Add `e2e/admin-deep.spec.ts` — 12 tests covering backup status, audit log table, action type filter, date filters, pagination, Engineer denied access

Closes #608

## Test plan
- [ ] Run `npx playwright test e2e/activity-deep.spec.ts` against dev environment
- [ ] Run `npx playwright test e2e/settings-deep.spec.ts` against dev environment
- [ ] Run `npx playwright test e2e/admin-deep.spec.ts` against dev environment
- [ ] Verify Manager sees all admin features, Engineer is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)