### PR TITLE
fix(auth): Edge JWT v5 encryption — A256CBC-HS512 + HKDF update

### DIFF
--- a/lib/auth-depth.ts
+++ b/lib/auth-depth.ts
@@ -50,26 +50,29 @@ function extractToken(req: NextRequest): string | null {
 }
 
 /**
- * Derives the encryption key from NEXTAUTH_SECRET.
- * NextAuth v4 uses HKDF to derive a 32-byte key from the secret
- * for JWE (A256GCM) encryption. For JWS fallback we use the raw secret.
+ * Derives the encryption key from AUTH_SECRET.
+ * Auth.js v5 uses HKDF to derive a 64-byte key from the secret
+ * for JWE (A256CBC-HS512) encryption. For JWS fallback we use the raw secret.
+ *
+ * Key differences from v4:
+ *   - info string: "Auth.js Generated Encryption Key" (was "NextAuth.js ...")
+ *   - algorithm: A256CBC-HS512 requires 64 bytes (was A256GCM / 32 bytes)
  */
-async function getDerivedEncryptionKey(): Promise<CryptoKey | null> {
+async function getDerivedEncryptionKey(): Promise<Uint8Array | null> {
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
   if (!secret) return null;
 
   const enc = new TextEncoder();
-  // Auth.js derives key via HKDF: SHA-256, salt="", info="NextAuth.js Generated Encryption Key"
   const keyMaterial = await crypto.subtle.importKey(
-    "raw", enc.encode(secret), "HKDF", false, ["deriveKey"]
+    "raw", enc.encode(secret), "HKDF", false, ["deriveBits"]
   );
-  return crypto.subtle.deriveKey(
-    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: enc.encode("NextAuth.js Generated Encryption Key") },
+  // Auth.js v5: HKDF SHA-256, salt="", info="Auth.js Generated Encryption Key", 512 bits (64 bytes)
+  const derivedBits = await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: enc.encode("Auth.js Generated Encryption Key") },
     keyMaterial,
-    { name: "AES-GCM", length: 256 },
-    true,
-    ["decrypt"]
+    512 // 64 bytes for A256CBC-HS512
   );
+  return new Uint8Array(derivedBits);
 }
 
 function getRawSecretKey(): Uint8Array | null {
@@ -106,14 +109,14 @@ export async function checkEdgeJwt(req: NextRequest): Promise<NextResponse | nul
     const header = JSON.parse(atob(headerB64));
 
     if (header.enc) {
-      // JWE token — decrypt using HKDF-derived key
+      // JWE token — decrypt using HKDF-derived key (Auth.js v5: A256CBC-HS512)
       const encKey = await getDerivedEncryptionKey();
       if (!encKey) {
         return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
-      // Export the CryptoKey to raw bytes for jose
-      const keyBytes = new Uint8Array(await crypto.subtle.exportKey("raw", encKey));
-      await jwtDecrypt(token, keyBytes);
+      await jwtDecrypt(token, encKey, {
+        contentEncryptionAlgorithms: ["A256CBC-HS512"],
+      });
     } else {
       // JWS token — verify signature with raw secret
       await jwtVerify(token, rawKey, { algorithms: ["HS256"] });

--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -34,9 +34,8 @@ export async function checkAuth(
     return null; // allow — CSP/correlation still applied by caller
   }
 
-  // Page routes: skip Edge JWT check, let auth() in the page handle it.
-  // Auth.js v5 uses A256CBC-HS512 JWE which requires a different HKDF derivation
-  // than our Edge-compatible checkEdgeJwt(). API routes still get Edge JWT protection.
+  // Page routes: skip full Edge JWT decryption, use cookie-presence check instead.
+  // Server-side auth() in the page handles full session validation.
   if (!pathname.startsWith("/api/")) {
     // Check if session cookie exists at all (quick presence check, not cryptographic)
     const cookieHeader = req.headers.get("cookie") ?? "";
@@ -51,16 +50,8 @@ export async function checkAuth(
     return null; // has session cookie — let the page's auth() verify it
   }
 
-  // API routes: cookie presence check (same as page routes)
-  // NOTE: Edge JWT verification (checkEdgeJwt) is temporarily disabled because
-  // Auth.js v5 uses A256CBC-HS512 JWE which our HKDF derivation doesn't support yet.
+  // API routes: Edge JWT verification (Layer 1 — defense-in-depth).
+  // Auth.js v5 A256CBC-HS512 JWE is now supported in checkEdgeJwt().
   // Layer 2 auth (withAuth/withManager using auth()) still protects all API routes.
-  // TODO: Update checkEdgeJwt to support Auth.js v5 JWE format, then re-enable.
-  const cookieHeader = req.headers.get("cookie") ?? "";
-  const hasSessionApi = cookieHeader.includes("authjs.session-token");
-  if (!hasSessionApi) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  return null; // authenticated — proceed
+  return checkEdgeJwt(req);
 }


### PR DESCRIPTION
## Summary
- Updated `getDerivedEncryptionKey()` in `lib/auth-depth.ts` to use Auth.js v5 HKDF parameters: info string `"Auth.js Generated Encryption Key"` and 64-byte key for A256CBC-HS512
- Re-enabled Edge JWT verification in `lib/middleware/auth.ts` for API routes (Layer 1 defense-in-depth)
- All existing auth-depth tests pass (10/10)

## Test plan
- [x] `lib/__tests__/auth-depth.test.ts` — 10 tests pass
- [ ] Manual verification: login flow works end-to-end
- [ ] Verify Edge middleware correctly decrypts Auth.js v5 JWE tokens
- [ ] Verify API routes return 401 for invalid/missing tokens

Fixes #578, Fixes #588, Fixes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)