### PR TITLE
chore(release): bump version to 1.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titan",
-  "version": "0.1.0",
+  "version": "1.0.0-rc.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.1.0` to `1.0.0-rc.1`
- Reflects project readiness for release candidate phase

## Test plan
- [ ] Verify build passes with new version
- [ ] Verify no version-dependent logic is affected

Fixes #587, Fixes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)