### PR TITLE
fix: Redis fail-fast + multi-value filters + Dashboard defensive checks

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -51,6 +51,32 @@ interface Task {
   dueDate: string | null;
 }
 
+// ── Defensive data extractor ───────────────────────────────────────────────
+
+/**
+ * Safely extract an array of items from various API response formats:
+ * - Direct array: [item, ...]
+ * - Paginated: { data: { items: [...], pagination: {...} } }
+ * - Legacy object: { tasks: [...] } or { items: [...] }
+ */
+function extractItems<T>(data: unknown, legacyKey?: string): T[] {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    // Paginated: { data: { items: [...] } }
+    if (obj.data && typeof obj.data === "object") {
+      const inner = obj.data as Record<string, unknown>;
+      if (Array.isArray(inner.items)) return inner.items as T[];
+      if (Array.isArray(inner)) return inner as T[];
+    }
+    // Legacy key (e.g. "tasks")
+    if (legacyKey && Array.isArray(obj[legacyKey])) return obj[legacyKey] as T[];
+    // Generic items
+    if (Array.isArray(obj.items)) return obj.items as T[];
+  }
+  return [];
+}
+
 // ── Today's Tasks Card ──────────────────────────────────────────────────────
 
 function dueCountdownText(dueDate: string): { text: string; urgent: boolean } {
@@ -79,7 +105,7 @@ function TodayTasksCard() {
       const res = await fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS");
       if (!res.ok) throw new Error("無法載入待辦任務");
       const data = await res.json();
-      const all: Task[] = Array.isArray(data) ? data : data.tasks ?? [];
+      const all: Task[] = extractItems<Task>(data, "tasks");
       // Sort by dueDate (closest first), tasks without dueDate go last
       const withDue = all
         .filter((t) => t.dueDate)
@@ -322,12 +348,15 @@ function ManagerDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const [wl, wr] = await Promise.all([
+      const [wlRaw, wr] = await Promise.all([
         fetch("/api/reports/workload").then((r) => { if (!r.ok) throw new Error("工作負載載入失敗"); return r.json(); }),
         fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
       ]);
-      setWorkload(wl);
-      setWeekly(wr);
+      // Defensive: handle paginated or direct response
+      const wl: WorkloadData = wlRaw?.data ?? wlRaw;
+      setWorkload(wl && typeof wl === "object" ? wl : null);
+      const weeklyData: WeeklyData = wr?.data ?? wr;
+      setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -508,10 +537,10 @@ function EngineerDashboard() {
         fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => { if (!r.ok) throw new Error("任務載入失敗"); return r.json(); }),
         fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
       ]);
-      // Support paginated response { data: { items, pagination } } and legacy formats
-      const taskPayload = taskRes?.data ?? taskRes;
-      setTasks(Array.isArray(taskPayload) ? taskPayload : Array.isArray(taskPayload?.items) ? taskPayload.items : []);
-      setWeekly(wr);
+      // Defensive: support paginated response { data: { items, pagination } } and legacy formats
+      setTasks(extractItems<Task>(taskRes, "tasks"));
+      const weeklyData: WeeklyData = wr?.data ?? wr;
+      setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -3,6 +3,9 @@
  *
  * Connects to Redis using REDIS_URL env var.
  * Falls back gracefully if Redis is unavailable.
+ *
+ * Circuit-breaker: after first connection failure, skip
+ * reconnection attempts for CIRCUIT_BREAKER_MS (60 s).
  */
 
 import Redis from "ioredis";
@@ -10,12 +13,27 @@ import { logger } from "@/lib/logger";
 
 let _redis: Redis | null = null;
 
+/** Circuit-breaker state — avoids reconnect storms. */
+let _circuitOpen = false;
+let _circuitOpenedAt = 0;
+const CIRCUIT_BREAKER_MS = 60_000; // 60 seconds
+
 /**
  * Returns the shared Redis client instance.
- * Returns null if REDIS_URL is not configured.
+ * Returns null if REDIS_URL is not configured or circuit-breaker is open.
  */
 export function getRedisClient(): Redis | null {
   if (_redis) return _redis;
+
+  // Circuit-breaker: skip reconnection for 60 s after failure
+  if (_circuitOpen) {
+    if (Date.now() - _circuitOpenedAt < CIRCUIT_BREAKER_MS) {
+      return null; // still in cooldown — no log noise
+    }
+    // Cooldown expired — allow one retry
+    _circuitOpen = false;
+    logger.info("[redis] Circuit-breaker cooldown expired, retrying connection");
+  }
 
   const url = process.env.REDIS_URL;
   if (!url) {
@@ -34,21 +52,33 @@ export function getRedisClient(): Redis | null {
     });
 
     _redis.on("error", (err) => {
-      logger.error({ err }, "[redis] Connection error");
+      // Only log once, then open circuit-breaker
+      if (!_circuitOpen) {
+        logger.error({ err }, "[redis] Connection error — opening circuit-breaker for 60 s");
+        _circuitOpen = true;
+        _circuitOpenedAt = Date.now();
+        _redis?.disconnect();
+        _redis = null;
+      }
     });
 
     _redis.on("connect", () => {
       logger.info("[redis] Connected successfully");
+      _circuitOpen = false;
     });
 
     _redis.connect().catch((err) => {
-      logger.error({ err }, "[redis] Initial connection failed — falling back to in-memory");
+      logger.error({ err }, "[redis] Initial connection failed — opening circuit-breaker for 60 s");
+      _circuitOpen = true;
+      _circuitOpenedAt = Date.now();
       _redis = null;
     });
 
     return _redis;
   } catch (err) {
     logger.error({ err }, "[redis] Failed to create client");
+    _circuitOpen = true;
+    _circuitOpenedAt = Date.now();
     return null;
   }
 }
@@ -59,4 +89,6 @@ export function resetRedisClient(): void {
     _redis.disconnect();
     _redis = null;
   }
+  _circuitOpen = false;
+  _circuitOpenedAt = 0;
 }

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -6,8 +6,8 @@ import { AuditService } from "./audit-service";
 export interface ListTasksFilter {
   assignee?: string;
   status?: TaskStatus | TaskStatus[] | string;
-  priority?: Priority | string;
-  category?: TaskCategory | string;
+  priority?: Priority | Priority[] | string;
+  category?: TaskCategory | TaskCategory[] | string;
   monthlyGoalId?: string;
   skip?: number;
   take?: number;
@@ -72,8 +72,12 @@ export class TaskService {
     if (filter.status) {
       where.status = Array.isArray(filter.status) ? { in: filter.status } : filter.status;
     }
-    if (filter.priority) where.priority = filter.priority;
-    if (filter.category) where.category = filter.category;
+    if (filter.priority) {
+      where.priority = Array.isArray(filter.priority) ? { in: filter.priority } : filter.priority;
+    }
+    if (filter.category) {
+      where.category = Array.isArray(filter.category) ? { in: filter.category } : filter.category;
+    }
     if (filter.monthlyGoalId) where.monthlyGoalId = filter.monthlyGoalId;
 
     const [tasks, total] = await Promise.all([


### PR DESCRIPTION
## Summary
Closes #598

- **Redis circuit-breaker**: After first connection failure, skip reconnection attempts for 60 seconds. Reduces log noise when Redis is unavailable.
- **Multi-value filters**: Apply `Array.isArray + { in: [...] }` pattern to `priority` and `category` filters in `task-service.ts` (status already had this).
- **Dashboard defensive checks**: Add `extractItems()` utility and defensive response parsing in `ManagerDashboard`, `EngineerDashboard`, and `TodayTasksCard` to handle paginated API response formats.

## Files Changed
- `lib/redis.ts` — circuit-breaker with 60s cooldown
- `services/task-service.ts` — multi-value filter support for priority/category
- `app/(app)/dashboard/page.tsx` — defensive API response parsing

## Test Plan
- [ ] Verify Redis falls back gracefully when Redis is down (no log spam)
- [ ] Verify task list API with `?priority=P0,P1` and `?category=PLANNED,INCIDENT`
- [ ] Verify Dashboard loads correctly with both paginated and legacy response formats