### PR TITLE
feat: Outline graceful degradation, CSV BOM, error reporting, login messages

### DIFF
--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { MessageSquareWarning } from "lucide-react";
 
 /**
  * App-level Error Boundary (Issue #196).
@@ -34,12 +35,24 @@ export default function AppError({
         <p className="text-muted-foreground">
           很抱歉，載入此頁面時發生問題。錯誤已自動回報。
         </p>
-        <button
-          onClick={reset}
-          className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
-        >
-          重試
-        </button>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            重試
+          </button>
+          <a
+            href="mailto:admin@titan.local?subject=TITAN%20系統錯誤回報&body=錯誤資訊%3A%20"
+            className="inline-flex items-center gap-1.5 rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            <MessageSquareWarning className="h-4 w-4" />
+            回報問題
+          </a>
+        </div>
+        {error.digest && (
+          <p className="text-xs text-muted-foreground/60">錯誤代碼：{error.digest}</p>
+        )}
       </div>
     </div>
   );

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -24,7 +24,9 @@ type DocDetail = {
 
 type ViewMode = "editor" | "outline";
 
-const OUTLINE_URL = process.env.NEXT_PUBLIC_OUTLINE_URL || "/outline";
+const OUTLINE_URL = process.env.NEXT_PUBLIC_OUTLINE_URL || "";
+/** Outline is considered available if the env var is set to a non-empty value */
+const OUTLINE_AVAILABLE = OUTLINE_URL.length > 0;
 
 export default function KnowledgePage() {
   const [docs, setDocs] = useState<DocNode[]>([]);
@@ -146,33 +148,35 @@ export default function KnowledgePage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {/* View mode toggle */}
-          <div className="flex items-center bg-muted rounded-lg p-0.5">
-            <button
-              onClick={() => setViewMode("editor")}
-              className={cn(
-                "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
-                viewMode === "editor"
-                  ? "bg-card text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              <FileEdit className="h-3.5 w-3.5" />
-              文件編輯器
-            </button>
-            <button
-              onClick={() => setViewMode("outline")}
-              className={cn(
-                "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
-                viewMode === "outline"
-                  ? "bg-card text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              <Globe className="h-3.5 w-3.5" />
-              Outline Wiki
-            </button>
-          </div>
+          {/* View mode toggle — only show if Outline is available */}
+          {OUTLINE_AVAILABLE && (
+            <div className="flex items-center bg-muted rounded-lg p-0.5">
+              <button
+                onClick={() => setViewMode("editor")}
+                className={cn(
+                  "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                  viewMode === "editor"
+                    ? "bg-card text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <FileEdit className="h-3.5 w-3.5" />
+                文件編輯器
+              </button>
+              <button
+                onClick={() => setViewMode("outline")}
+                className={cn(
+                  "flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md transition-colors",
+                  viewMode === "outline"
+                    ? "bg-card text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <Globe className="h-3.5 w-3.5" />
+                Outline Wiki
+              </button>
+            </div>
+          )}
 
           {viewMode === "editor" && (
             <button
@@ -184,7 +188,7 @@ export default function KnowledgePage() {
             </button>
           )}
 
-          {viewMode === "outline" && (
+          {viewMode === "outline" && OUTLINE_AVAILABLE && (
             <a
               href={OUTLINE_URL}
               target="_blank"
@@ -199,7 +203,7 @@ export default function KnowledgePage() {
       </div>
 
       {/* Outline iframe view */}
-      {viewMode === "outline" && (
+      {viewMode === "outline" && OUTLINE_AVAILABLE && (
         <div className="flex-1 min-h-0 border border-border rounded-xl overflow-hidden">
           <iframe
             src={OUTLINE_URL}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -16,9 +16,30 @@ export default function LoginPage() {
     e.preventDefault();
     setLoading(true);
     setError("");
+
+    if (!username.trim()) {
+      setError("請輸入帳號");
+      setLoading(false);
+      return;
+    }
+    if (!password) {
+      setError("請輸入密碼");
+      setLoading(false);
+      return;
+    }
+
     const result = await signIn("credentials", { username, password, redirect: false });
-    if (result?.error) { setError("帳號或密碼錯誤，請重新輸入"); setLoading(false); }
-    else { router.push("/dashboard"); }
+    if (result?.error) {
+      // Provide more specific guidance based on error context
+      if (result.error === "CredentialsSignin") {
+        setError("帳號或密碼不正確，請確認後重試。連續多次失敗將暂時鎖定帳號。");
+      } else {
+        setError("登入失敗，請稍後再試或聯繫系統管理員。");
+      }
+      setLoading(false);
+    } else {
+      router.push("/dashboard");
+    }
   }
 
   return (

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -106,7 +106,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       tasks,
     });
 
-  // ── kpi ───────────────────────────────────────────────────────────────────
+  // ── kpi ─────────────────────────────────────────────────────────────────
   } else if (type === "kpi") {
     const year = searchParams.get("year")
       ? parseInt(searchParams.get("year")!)
@@ -202,7 +202,9 @@ export const GET = withAuth(async (req: NextRequest) => {
       result.rows as Record<string, unknown>[],
       result.columns,
     );
-    return new NextResponse(csvString, {
+    // Prepend UTF-8 BOM so Excel on Windows displays CJK characters correctly
+    const csvWithBom = "\uFEFF" + csvString;
+    return new NextResponse(csvWithBom, {
       status: 200,
       headers: {
         "Content-Type": "text/csv; charset=utf-8",


### PR DESCRIPTION
## Summary
Closes #600

- **Outline graceful degradation**: Hide "Outline Wiki" tab in knowledge page when `NEXT_PUBLIC_OUTLINE_URL` is not set
- **CSV BOM header**: Add UTF-8 BOM (`\uFEFF`) to CSV export so Excel on Windows displays CJK characters correctly
- **Error page reporting**: Add "回報問題" button with mailto link to admin in app error boundary
- **Login error messages**: Replace generic "帳號或密碼錯誤" with specific messages (CredentialsSignin vs generic error) and add account lockout warning

## Files Changed
- `app/(app)/knowledge/page.tsx` — conditional Outline tab rendering
- `app/api/reports/export/route.ts` — UTF-8 BOM prepended to CSV output
- `app/(app)/error.tsx` — "回報問題" button added
- `app/(auth)/login/page.tsx` — specific error messages, client-side validation

## Test Plan
- [ ] Verify knowledge page hides Outline tab when env var is unset
- [ ] Verify CSV export opens correctly in Excel with CJK characters
- [ ] Verify error page shows "回報問題" button
- [ ] Verify login shows specific messages for wrong credentials vs server errors