### PR TITLE
fix(qa): CSV BOM + specific login errors + error report button

### DIFF
--- a/app/(app)/error.tsx
+++ b/app/(app)/error.tsx
@@ -34,12 +34,20 @@ export default function AppError({
         <p className="text-muted-foreground">
           很抱歉，載入此頁面時發生問題。錯誤已自動回報。
         </p>
-        <button
-          onClick={reset}
-          className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
-        >
-          重試
-        </button>
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={reset}
+            className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            重試
+          </button>
+          <a
+            href={`mailto:admin@titan.local?subject=${encodeURIComponent("TITAN 錯誤回報")}&body=${encodeURIComponent(`錯誤訊息: ${error.message}\nDigest: ${error.digest ?? "N/A"}\n頁面: ${typeof window !== "undefined" ? window.location.pathname : "unknown"}\n時間: ${new Date().toISOString()}`)}`}
+            className="inline-flex items-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+          >
+            回報問題
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -17,7 +17,16 @@ export default function LoginPage() {
     setLoading(true);
     setError("");
     const result = await signIn("credentials", { username, password, redirect: false });
-    if (result?.error) { setError("帳號或密碼錯誤，請重新輸入"); setLoading(false); }
+    if (result?.error) {
+      if (result.code === "credentials") {
+        setError("帳號或密碼錯誤");
+      } else if (result.code?.includes("locked")) {
+        setError("帳號已被鎖定，請等待 15 分鐘後再試");
+      } else {
+        setError("登入失敗，請稍後再試");
+      }
+      setLoading(false);
+    }
     else { router.push("/dashboard"); }
   }
 

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -202,7 +202,9 @@ export const GET = withAuth(async (req: NextRequest) => {
       result.rows as Record<string, unknown>[],
       result.columns,
     );
-    return new NextResponse(csvString, {
+    // Prepend UTF-8 BOM so Excel correctly recognises CJK characters
+    const csvWithBom = "\uFEFF" + csvString;
+    return new NextResponse(csvWithBom, {
       status: 200,
       headers: {
         "Content-Type": "text/csv; charset=utf-8",


### PR DESCRIPTION
## Summary
- **CSV BOM** (#659): Prepend `\uFEFF` UTF-8 BOM to CSV export so Excel correctly renders CJK characters
- **Login errors** (#660): Differentiate error messages — credentials error / account locked / generic failure
- **Error report** (#661): Add "回報問題" mailto button on app error page with error details

Closes #659
Closes #660
Closes #661

## Test plan
- [ ] Export CSV report, open in Excel → verify Chinese text is not garbled
- [ ] Login with wrong password → see "帳號或密碼錯誤"
- [ ] Login with locked account → see "帳號已被鎖定，請等待 15 分鐘後再試"
- [ ] Trigger an app error → verify "回報問題" button opens mailto with error details

🤖 Generated with [Claude Code](https://claude.com/claude-code)