### PR TITLE
fix: 全面遷移前端頁面使用 extractData/extractItems

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": "AwaitExpression > CallExpression > MemberExpression[property.name='json']",
+        "message": "Use extractData() or extractItems() from @/lib/api-client instead of raw .json(). See lib/api-client.ts for usage."
+      }
+    ]
+  }
+}

--- a/app/(app)/activity/page.tsx
+++ b/app/(app)/activity/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Activity, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
 import { PageError, PageEmpty, ListSkeleton } from "@/app/components/page-states";
 import { formatRelative } from "@/lib/format";
 
@@ -63,10 +64,10 @@ export default function ActivityPage() {
     try {
       const res = await fetch(`/api/activity?page=${page}&limit=30`);
       if (!res.ok) throw new Error("活動紀錄載入失敗");
-      const json = await res.json();
-      const data = json?.data ?? json;
-      setItems(data.items ?? []);
-      setPagination(data.pagination ?? null);
+      const body = await res.json();
+      const data = extractData<{ items: ActivityItem[]; pagination: PaginationMeta }>(body);
+      setItems(data?.items ?? []);
+      setPagination(data?.pagination ?? null);
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/app/(app)/admin/notifications/page.tsx
+++ b/app/(app)/admin/notifications/page.tsx
@@ -8,6 +8,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
+import { extractData } from "@/lib/api-client";
 
 interface NotificationPref {
   type: string;
@@ -37,9 +38,10 @@ export default function NotificationPreferencesPage() {
     if (!userId) return;
     try {
       const res = await fetch(`/api/users/${userId}/notification-preferences`);
-      const json = await res.json();
-      if (json.ok) {
-        setPreferences(json.data.preferences);
+      const body = await res.json();
+      const data = extractData<{ preferences: NotificationPref[] }>(body);
+      if (data?.preferences) {
+        setPreferences(data.preferences);
       }
     } catch {
       setMessage("載入通知偏好失敗");
@@ -69,12 +71,13 @@ export default function NotificationPreferencesPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ preferences }),
       });
-      const json = await res.json();
-      if (json.ok) {
+      const body = await res.json();
+      const data = extractData<{ preferences: NotificationPref[] }>(body);
+      if (res.ok && data?.preferences) {
         setMessage("通知偏好已儲存");
-        setPreferences(json.data.preferences);
+        setPreferences(data.preferences);
       } else {
-        setMessage(json.message || "儲存失敗");
+        setMessage((body as { message?: string })?.message || "儲存失敗");
       }
     } catch {
       setMessage("網路錯誤，請稍後再試");

--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -15,6 +15,7 @@ import {
   Filter,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData, extractItems } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -58,8 +59,8 @@ function BackupStatusSection() {
     try {
       const res = await fetch("/api/admin/backup-status");
       if (!res.ok) throw new Error("備份狀態載入失敗");
-      const json = await res.json();
-      setStatus(json.data ?? json);
+      const body = await res.json();
+      setStatus(extractData<BackupStatus>(body));
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -196,8 +197,8 @@ function AuditLogSection() {
       if (actionFilter) params.set("action", actionFilter);
       const res = await fetch(`/api/audit?${params.toString()}`);
       if (!res.ok) throw new Error("稽核日誌載入失敗");
-      const json = await res.json();
-      setLogs(json.data ?? json);
+      const body = await res.json();
+      setLogs(extractItems<AuditLogEntry>(body));
       setPage(0);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { safeFixed, safePct } from "@/lib/safe-number";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { formatDate } from "@/lib/format";
+import { extractItems, extractData } from "@/lib/api-client";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -51,32 +52,6 @@ interface Task {
   dueDate: string | null;
 }
 
-// ── Defensive data extractor ───────────────────────────────────────────────
-
-/**
- * Safely extract an array of items from various API response formats:
- * - Direct array: [item, ...]
- * - Paginated: { data: { items: [...], pagination: {...} } }
- * - Legacy object: { tasks: [...] } or { items: [...] }
- */
-function extractItems<T>(data: unknown, legacyKey?: string): T[] {
-  if (Array.isArray(data)) return data;
-  if (data && typeof data === "object") {
-    const obj = data as Record<string, unknown>;
-    // Paginated: { data: { items: [...] } }
-    if (obj.data && typeof obj.data === "object") {
-      const inner = obj.data as Record<string, unknown>;
-      if (Array.isArray(inner.items)) return inner.items as T[];
-      if (Array.isArray(inner)) return inner as T[];
-    }
-    // Legacy key (e.g. "tasks")
-    if (legacyKey && Array.isArray(obj[legacyKey])) return obj[legacyKey] as T[];
-    // Generic items
-    if (Array.isArray(obj.items)) return obj.items as T[];
-  }
-  return [];
-}
-
 // ── Today's Tasks Card ──────────────────────────────────────────────────────
 
 function dueCountdownText(dueDate: string): { text: string; urgent: boolean } {
@@ -104,8 +79,8 @@ function TodayTasksCard() {
     try {
       const res = await fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS");
       if (!res.ok) throw new Error("無法載入待辦任務");
-      const data = await res.json();
-      const all: Task[] = extractItems<Task>(data, "tasks");
+      const body = await res.json();
+      const all: Task[] = extractItems<Task>(body);
       // Sort by dueDate (closest first), tasks without dueDate go last
       const withDue = all
         .filter((t) => t.dueDate)
@@ -215,12 +190,13 @@ function KPIAchievementSection() {
     try {
       const res = await fetch(`/api/kpi?year=${new Date().getFullYear()}`);
       if (!res.ok) throw new Error("無法載入 KPI");
-      const data: Array<{
+      const body = await res.json();
+      const data = extractItems<{
         id: string; code: string; title: string; target: number; actual: number; status: string;
         taskLinks: Array<{ weight: number; task: { status: string; progressPct: number } }>;
         autoCalc: boolean;
-      }> = await res.json();
-      const mapped: KPIAchievement[] = (Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []).map((k) => {
+      }>(body);
+      const mapped: KPIAchievement[] = data.map((k) => {
         let rate = 0;
         if (k.autoCalc && k.taskLinks.length > 0) {
           const totalW = k.taskLinks.reduce((s, l) => s + l.weight, 0);
@@ -348,14 +324,13 @@ function ManagerDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const [wlRaw, wr] = await Promise.all([
+      const [wlRaw, wrRaw] = await Promise.all([
         fetch("/api/reports/workload").then((r) => { if (!r.ok) throw new Error("工作負載載入失敗"); return r.json(); }),
         fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
       ]);
-      // Defensive: handle paginated or direct response
-      const wl: WorkloadData = wlRaw?.data ?? wlRaw;
+      const wl = extractData<WorkloadData>(wlRaw);
       setWorkload(wl && typeof wl === "object" ? wl : null);
-      const weeklyData: WeeklyData = wr?.data ?? wr;
+      const weeklyData = extractData<WeeklyData>(wrRaw);
       setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");
@@ -533,13 +508,12 @@ function EngineerDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const [taskRes, wr] = await Promise.all([
+      const [taskBody, wrBody] = await Promise.all([
         fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => { if (!r.ok) throw new Error("任務載入失敗"); return r.json(); }),
         fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
       ]);
-      // Defensive: support paginated response { data: { items, pagination } } and legacy formats
-      setTasks(extractItems<Task>(taskRes, "tasks"));
-      const weeklyData: WeeklyData = wr?.data ?? wr;
+      setTasks(extractItems<Task>(taskBody));
+      const weeklyData = extractData<WeeklyData>(wrBody);
       setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");

--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { ChevronLeft, ChevronRight, Diamond, BarChart2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData, extractItems } from "@/lib/api-client";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
@@ -292,7 +293,7 @@ export default function GanttPage() {
       const res = await fetch(`/api/tasks/gantt?${params}`);
       if (!res.ok) throw new Error("甘特圖資料載入失敗");
       const body = await res.json();
-      setData(body?.data ?? body);
+      setData(extractData<{ annualPlan: AnnualPlan | null; year: number }>(body));
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -303,7 +304,7 @@ export default function GanttPage() {
   useEffect(() => { fetchData(); }, [fetchData]);
 
   useEffect(() => {
-    fetch("/api/users").then((r) => r.json()).then((raw) => { const d = raw?.data ?? raw; setUsers(Array.isArray(d) ? d : Array.isArray(d?.items) ? d.items : []); }).catch(() => {});
+    fetch("/api/users").then((r) => r.json()).then((body) => setUsers(extractItems<User>(body))).catch(() => {});
   }, []);
 
   const plan = data?.annualPlan;

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Plus, Kanban, Loader2, CheckSquare, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
 import { TaskCard, type TaskCardData } from "@/app/components/task-card";
 import { TaskFilters, type TaskFilters as FiltersType } from "@/app/components/task-filters";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
@@ -74,10 +75,8 @@ export default function KanbanPage() {
       if (filters.category) params.set("category", filters.category);
       const res = await fetch(`/api/tasks?${params}`);
       if (!res.ok) throw new Error("任務載入失敗");
-      const json = await res.json();
-      // Support paginated response { data: { items, pagination } } and legacy array
-      const payload = json?.data ?? json;
-      setTasks(Array.isArray(payload) ? payload : Array.isArray(payload?.items) ? payload.items : []);
+      const body = await res.json();
+      setTasks(extractItems<TaskCardData>(body));
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -91,10 +90,9 @@ export default function KanbanPage() {
   useEffect(() => {
     fetch("/api/users")
       .then((r) => r.json())
-      .then((json) => {
-        const data = json?.data ?? json;
-        const list = Array.isArray(data) ? data : Array.isArray(data?.items) ? data.items : [];
-        setUsers(list.map((u: { id: string; name: string }) => ({ id: u.id, name: u.name })));
+      .then((body) => {
+        const list = extractItems<{ id: string; name: string }>(body);
+        setUsers(list.map((u) => ({ id: u.id, name: u.name })));
       })
       .catch(() => {});
   }, []);
@@ -204,7 +202,7 @@ export default function KanbanPage() {
               body: JSON.stringify({ title: title.trim(), status: "BACKLOG", priority: "P2", category: "PLANNED" }),
             });
             if (res.ok) fetchTasks();
-            else { const err = await res.json().catch(() => ({})); alert(err?.message ?? "建立失敗"); }
+            else { const errBody = await res.json().catch(() => ({})); alert(errBody?.message ?? errBody?.error ?? "建立失敗"); }
           }}
           className="flex items-center justify-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-primary text-primary-foreground rounded-lg shadow-sm transition-all hover:opacity-90 w-full sm:w-auto"
         >

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Loader2, Save, Plus, BookOpen, ExternalLink, FileEdit, Globe, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems, extractData } from "@/lib/api-client";
 import { DocumentTree, type DocNode } from "@/app/components/document-tree";
 import { MarkdownEditor } from "@/app/components/markdown-editor";
 import { DocumentSearch } from "@/app/components/document-search";
@@ -47,10 +48,8 @@ export default function KnowledgePage() {
     try {
       const res = await fetch("/api/documents");
       if (!res.ok) throw new Error("文件載入失敗");
-      const json = await res.json();
-      // Support paginated response { data: { items, pagination } } and legacy array
-      const payload = json?.data ?? json;
-      setDocs(Array.isArray(payload) ? payload : Array.isArray(payload?.items) ? payload.items : []);
+      const body = await res.json();
+      setDocs(extractItems<DocNode>(body));
     } catch (e) {
       setDocsError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -67,7 +66,7 @@ export default function KnowledgePage() {
     fetch(`/api/documents/${selectedId}`)
       .then((r) => r.ok ? r.json() : null)
       .then((raw) => {
-        const d = raw?.data ?? raw;
+        const d = raw ? extractData<DocDetail>(raw) : null;
         if (d) {
           setDocDetail(d);
           setEditTitle(d.title ?? "");
@@ -89,7 +88,7 @@ export default function KnowledgePage() {
       });
       if (res.ok) {
         const body = await res.json();
-        const updated = body?.data ?? body;
+        const updated = extractData<DocDetail>(body);
         setDocDetail(updated);
         setDirty(false);
         setDocs((prev) =>
@@ -111,12 +110,12 @@ export default function KnowledgePage() {
     });
     if (res.ok) {
       const body = await res.json();
-      const doc = body?.data ?? body;
+      const doc = extractData<{ id: string }>(body);
       await loadDocs();
       setSelectedId(doc.id);
     } else {
-      const err = await res.json().catch(() => ({}));
-      alert(err?.message ?? "文件建立失敗");
+      const errBody = await res.json().catch(() => ({}));
+      alert(errBody?.message ?? "文件建立失敗");
     }
   }
 

--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from "next-auth/react";
 import { Target, Plus, Unlink, ChevronDown, ChevronRight } from "lucide-react";
 import { z } from "zod";
 import { cn } from "@/lib/utils";
+import { extractItems, extractData } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { FormError, FormBanner } from "@/app/components/form-error";
 import { safeFixed, safePct } from "@/lib/safe-number";
@@ -147,12 +148,12 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
         body: JSON.stringify(parsed),
       });
       if (!res.ok) {
-        const data = await res.json();
-        setBannerError(data.error ?? "建立失敗");
+        const errBody = await res.json().catch(() => ({}));
+        setBannerError(errBody?.error ?? errBody?.message ?? "建立失敗");
         return;
       }
       const body = await res.json();
-      const kpi = body?.data ?? body;
+      const kpi = extractData<KPI>(body);
       onCreated(kpi);
     } finally {
       setSubmitting(false);
@@ -407,8 +408,8 @@ export default function KPIPage() {
     try {
       const res = await fetch(`/api/kpi?year=${year}`);
       if (!res.ok) throw new Error("KPI 載入失敗");
-      const data = await res.json();
-      const kpiItems = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []; setKpis(kpiItems);
+      const body = await res.json();
+      setKpis(extractItems<KPI>(body));
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Plus, Loader2, ChevronRight, X, Target, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems, extractData } from "@/lib/api-client";
 import { PlanTree } from "@/app/components/plan-tree";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
 import { PageEmpty } from "@/app/components/page-states";
@@ -88,9 +89,8 @@ export default function PlansPage() {
     try {
       const res = await fetch("/api/plans");
       if (res.ok) {
-        const data = await res.json();
-        const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : [];
-        setPlans(items);
+        const body = await res.json();
+        setPlans(extractItems<AnnualPlan>(body));
       }
     } finally {
       setLoading(false);
@@ -105,7 +105,7 @@ export default function PlansPage() {
       const res = await fetch(`/api/goals/${goalId}`);
       if (res.ok) {
         const body = await res.json();
-        setSelectedGoal(body?.data ?? body);
+        setSelectedGoal(extractData<MonthlyGoal>(body));
       }
     } finally {
       setGoalLoading(false);
@@ -126,8 +126,8 @@ export default function PlansPage() {
         setShowPlanForm(false);
         fetchPlans();
       } else {
-        const err = await res.json().catch(() => ({}));
-        alert(err?.message ?? err?.error ?? "建立失敗");
+        const errBody = await res.json().catch(() => ({}));
+        alert(errBody?.message ?? errBody?.error ?? "建立失敗");
       }
     } finally {
       setCreatingPlan(false);
@@ -168,8 +168,8 @@ export default function PlansPage() {
         setShowCopyForm(false);
         fetchPlans();
       } else {
-        const data = await res.json().catch(() => ({}));
-        setCopyError(data?.error ?? "複製失敗，請再試一次");
+        const errBody = await res.json().catch(() => ({}));
+        setCopyError(errBody?.error ?? "複製失敗，請再試一次");
       }
     } finally {
       setCopyingTemplate(false);

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Download, RefreshCw, BarChart3, Printer } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { safeFixed, safePct } from "@/lib/safe-number";
 import { formatDate } from "@/lib/format";
@@ -97,7 +98,7 @@ function WeeklyReport() {
     setError(null);
     fetch("/api/reports/weekly")
       .then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); })
-      .then(setData)
+      .then((body) => setData(extractData<WeeklyData>(body)))
       .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, []);
@@ -216,7 +217,7 @@ function MonthlyReport() {
     setError(null);
     fetch(`/api/reports/monthly?month=${month}`)
       .then((r) => { if (!r.ok) throw new Error("月報載入失敗"); return r.json(); })
-      .then(setData)
+      .then((body) => setData(extractData<MonthlyData>(body)))
       .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [month]);
@@ -347,7 +348,7 @@ function KPIReport() {
     setError(null);
     fetch(`/api/reports/kpi?year=${year}`)
       .then((r) => { if (!r.ok) throw new Error("KPI 報表載入失敗"); return r.json(); })
-      .then(setData)
+      .then((body) => setData(extractData<KPIReportData>(body)))
       .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [year]);
@@ -483,7 +484,7 @@ function WorkloadReport() {
     setError(null);
     fetch(`/api/reports/workload?startDate=${startDate}`)
       .then((r) => { if (!r.ok) throw new Error("負荷報表載入失敗"); return r.json(); })
-      .then(setData)
+      .then((body) => setData(extractData<WorkloadData>(body)))
       .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
       .finally(() => setLoading(false));
   }, [startDate]);
@@ -653,8 +654,8 @@ function TrendsReport() {
     try {
       const res = await fetch(`/api/reports/trends?metric=${metric}&years=${years.join(",")}`);
       if (!res.ok) throw new Error("趨勢資料載入失敗");
-      const json = await res.json();
-      setData(json.data ?? {});
+      const body = await res.json();
+      setData(extractData<Record<number, Array<{ month: number; value: number }>>>(body) ?? {});
     } catch (e) {
       setError(e instanceof Error ? e.message : "載入失敗");
     } finally {

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { User, Bell, Lock, Save, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData, extractItems } from "@/lib/api-client";
 import { PageError, TabSkeleton } from "@/app/components/page-states";
 
 interface UserProfile {
@@ -50,23 +51,22 @@ export default function SettingsPage() {
     try {
       const res = await fetch("/api/auth/session");
       if (!res.ok) throw new Error("無法取得使用者資訊");
-      const session = await res.json();
-      const userId = session?.user?.id;
+      const sessionBody = await res.json();
+      const userId = sessionBody?.user?.id;
       if (!userId) throw new Error("未登入");
 
       const userRes = await fetch(`/api/users/${userId}`);
       if (!userRes.ok) throw new Error("無法取得使用者資料");
-      const userJson = await userRes.json();
-      const userData = userJson?.data ?? userJson;
+      const userBody = await userRes.json();
+      const userData = extractData<UserProfile>(userBody);
       setProfile(userData);
-      setName(userData.name ?? "");
+      setName(userData?.name ?? "");
 
       // Fetch notification preferences
       const prefRes = await fetch(`/api/users/${userId}/notification-preferences`);
       if (prefRes.ok) {
-        const prefJson = await prefRes.json();
-        const prefData = prefJson?.data ?? prefJson;
-        setPrefs(Array.isArray(prefData) ? prefData : []);
+        const prefBody = await prefRes.json();
+        setPrefs(extractItems<NotificationPref>(prefBody));
       }
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems, extractData } from "@/lib/api-client";
 import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
 import { TimeSummary } from "@/app/components/time-summary";
 import { type TimeEntry } from "@/app/components/time-entry-cell";
@@ -61,7 +62,7 @@ export default function TimesheetPage() {
   useEffect(() => {
     fetch("/api/users")
       .then((r) => r.json())
-      .then((raw) => { const d = raw?.data ?? raw; setUsers(Array.isArray(d) ? d : Array.isArray(d?.items) ? d.items : []); })
+      .then((body) => setUsers(extractItems<User>(body)))
       .catch(() => {});
   }, []);
 
@@ -76,8 +77,8 @@ export default function TimesheetPage() {
       if (userFilter) params.set("userId", userFilter);
       const res = await fetch(`/api/time-entries?${params}`);
       if (!res.ok) throw new Error("工時資料載入失敗");
-      const data: (TimeEntry & { task?: { id: string; title: string } | null })[] =
-        await res.json();
+      const body = await res.json();
+      const data = extractItems<TimeEntry & { task?: { id: string; title: string } | null }>(body);
       setEntries(data);
 
       // Build task rows from entries + a free row
@@ -114,7 +115,7 @@ export default function TimesheetPage() {
       });
       if (userFilter) params.set("userId", userFilter);
       const res = await fetch(`/api/time-entries/stats?${params}`);
-      if (res.ok) { const b = await res.json(); setStats(b?.data ?? b); }
+      if (res.ok) { const b = await res.json(); setStats(extractData<StatsData>(b)); }
     } finally {
       setStatsLoading(false);
     }
@@ -138,7 +139,7 @@ export default function TimesheetPage() {
         body: JSON.stringify({ date, hours, category, description }),
       });
       if (res.ok) {
-        const ub = await res.json(); const updated: TimeEntry = ub?.data ?? ub;
+        const ub = await res.json(); const updated = extractData<TimeEntry>(ub);
         setEntries((prev) => prev.map((e) => e.id === existingId ? updated : e));
       }
     } else {
@@ -148,7 +149,7 @@ export default function TimesheetPage() {
         body: JSON.stringify({ taskId, date, hours, category, description }),
       });
       if (res.ok) {
-        const cb = await res.json(); const created: TimeEntry = cb?.data ?? cb;
+        const cb = await res.json(); const created = extractData<TimeEntry>(cb);
         setEntries((prev) => [...prev, created]);
         // Add task row if new task
         if (taskId && !taskRows.find((r) => r.taskId === taskId)) {

--- a/app/components/command-palette.tsx
+++ b/app/components/command-palette.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
+import { extractData } from "@/lib/api-client";
 import {
   Search,
   ClipboardList,
@@ -158,8 +159,9 @@ export function CommandPalette() {
           setSearchResults([]);
           return;
         }
-        const json: ApiSearchResponse = await res.json();
-        if (!json.ok || !json.data) {
+        const body = await res.json();
+        const json = { ...body, data: extractData<ApiSearchResponse["data"]>(body) };
+        if (!json.data) {
           setSearchResults([]);
           return;
         }

--- a/app/components/deliverable-list.tsx
+++ b/app/components/deliverable-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Plus, Trash2, FileText, Monitor, BarChart2, Stamp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
 
 type DeliverableType = "DOCUMENT" | "SYSTEM" | "REPORT" | "APPROVAL";
 type DeliverableStatus = "NOT_STARTED" | "IN_PROGRESS" | "DELIVERED" | "ACCEPTED";
@@ -89,7 +90,8 @@ export function DeliverableList({ deliverables: initial, taskId, onUpdate }: Del
         body: JSON.stringify({ title: newTitle.trim(), type: newType, taskId }),
       });
       if (res.ok) {
-        const created = await res.json();
+        const body = await res.json();
+        const created = extractData<Deliverable>(body);
         const updated = [...items, created];
         setItems(updated);
         onUpdate?.(updated);

--- a/app/components/document-search.tsx
+++ b/app/components/document-search.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef } from "react";
 import { Search, X, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
 
 type SearchResult = {
   id: string;
@@ -33,8 +34,8 @@ export function DocumentSearch({ onSelect }: DocumentSearchProps) {
     try {
       const res = await fetch(`/api/documents/search?q=${encodeURIComponent(q)}`);
       if (res.ok) {
-        const data = await res.json();
-        setResults(Array.isArray(data) ? data : Array.isArray(data?.data?.items) ? data.data.items : Array.isArray(data?.data) ? data.data : []);
+        const body = await res.json();
+        setResults(extractItems<SearchResult>(body));
         setOpen(true);
       }
     } finally {

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Bell, CheckCheck, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
 
 interface Notification {
   id: string;
@@ -61,9 +62,8 @@ export function NotificationBell() {
     try {
       const res = await fetch("/api/notifications?limit=15");
       if (res.ok) {
-        const json = await res.json();
-        // Support paginated response { data: { items, unreadCount, pagination } }
-        const payload = json?.data ?? json;
+        const body = await res.json();
+        const payload = extractData<{ items?: Notification[]; notifications?: Notification[]; unreadCount?: number }>(body);
         setNotifications(payload?.items ?? payload?.notifications ?? []);
         setUnreadCount(payload?.unreadCount ?? 0);
       }

--- a/app/components/subtask-list.tsx
+++ b/app/components/subtask-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { Plus, Trash2, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
 
 type SubTask = {
   id: string;
@@ -71,7 +72,8 @@ export function SubTaskList({ subtasks: initial, taskId, onUpdate }: SubTaskList
         body: JSON.stringify({ taskId, title: newTitle.trim(), order: subtasks.length }),
       });
       if (res.ok) {
-        const created = await res.json();
+        const body = await res.json();
+        const created = extractData<SubTask>(body);
         const updated = [...subtasks, created];
         setSubtasks(updated);
         onUpdate?.(updated);

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { X, Save, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractData, extractItems } from "@/lib/api-client";
 import { TaskFormFields, TaskSubtaskSection, TaskDeliverableSection, initialForm } from "./task-detail/index";
 import type { TaskForm } from "./task-detail/index";
 
@@ -60,7 +61,8 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
     try {
       const res = await fetch(`/api/tasks/${taskId}`);
       if (res.ok) {
-        const data: TaskDetail = await res.json();
+        const body = await res.json();
+        const data = extractData<TaskDetail>(body);
         setTask(data);
         setForm({
           title: data.title,
@@ -82,8 +84,8 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
 
   useEffect(() => {
     loadTask();
-    fetch("/api/users").then((r) => r.json()).then((d) => setUsers(Array.isArray(d) ? d : [])).catch(() => {});
-    fetch("/api/goals").then((r) => r.json()).then((d) => setGoals(Array.isArray(d) ? d : [])).catch(() => {});
+    fetch("/api/users").then((r) => r.json()).then((body) => setUsers(extractItems<User>(body))).catch(() => {});
+    fetch("/api/goals").then((r) => r.json()).then((body) => setGoals(extractItems<MonthlyGoal>(body))).catch(() => {});
   }, [loadTask]);
 
   async function save() {

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Filter, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
 
 export type TaskFilters = {
   assignee: string;
@@ -41,7 +42,7 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
   useEffect(() => {
     fetch("/api/users")
       .then((r) => r.json())
-      .then((data) => setUsers(Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []))
+      .then((body) => setUsers(extractItems<User>(body)))
       .catch(() => {});
   }, []);
 

--- a/app/components/version-history.tsx
+++ b/app/components/version-history.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { History, ChevronDown, ChevronUp, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
 import { formatShortDateTime } from "@/lib/format";
 
 type DocVersion = {
@@ -30,8 +31,8 @@ export function VersionHistory({ documentId, currentVersion, onRestore }: Versio
     try {
       const res = await fetch(`/api/documents/${documentId}/versions`);
       if (res.ok) {
-        const data = await res.json();
-        setVersions(Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []);
+        const body = await res.json();
+        setVersions(extractItems<DocVersion>(body));
       }
     } finally {
       setLoading(false);

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,8 +1,17 @@
 /**
- * Client-side API helper — automatically unwraps { ok, data } response format.
+ * ============================================================================
+ * MANDATORY: All frontend code MUST use extractData() or extractItems() from
+ * this module to consume API responses. Direct use of res.json() is FORBIDDEN.
  *
  * All TITAN API routes return: { ok: boolean, data: T } or { ok: false, error, message }
- * This helper extracts the `data` field so callers get the payload directly.
+ * These helpers extract the `data` field so callers get the payload directly.
+ *
+ * Usage:
+ *   import { extractItems, extractData } from "@/lib/api-client";
+ *   const body = await res.json();
+ *   const items = extractItems<Task>(body);      // for arrays
+ *   const item  = extractData<TaskDetail>(body);  // for single objects
+ * ============================================================================
  */
 
 export async function apiFetch<T = unknown>(


### PR DESCRIPTION
## Summary
- 系統性修復所有 20 個前端檔案，統一使用 `extractData()` / `extractItems()` 消費 API 回應
- 移除所有 ad-hoc 的 `json?.data ?? json` 手動解包模式
- 新增 `.eslintrc.json` 的 `no-restricted-syntax` 規則，防止未來直接使用 `.json()` 而不經過 helper
- 更新 `lib/api-client.ts` 加入 MANDATORY 使用說明

## Changed Files (22)
- `lib/api-client.ts` — 加入 MANDATORY 使用說明
- `.eslintrc.json` — 新增 ESLint 規則
- 12 個頁面元件 (`dashboard`, `kanban`, `reports`, `kpi`, `timesheet`, `activity`, `gantt`, `plans`, `knowledge`, `settings`, `admin`, `admin/notifications`)
- 8 個共用元件 (`task-detail-modal`, `task-filters`, `notification-bell`, `command-palette`, `document-search`, `version-history`, `deliverable-list`, `subtask-list`)

## Test plan
- [ ] 所有頁面正常載入，資料正確顯示
- [ ] ESLint 規則對直接使用 `.json()` 發出警告
- [ ] TypeScript 編譯無新增錯誤

Closes #688

Generated with [Claude Code](https://claude.com/claude-code)