### PR TITLE
feat(timesheet): data layer TS-01~05 — schema + hours calc + timer + locked

### DIFF
--- a/prisma/migrations/0002_add_timesheet_timer_fields/migration.sql
+++ b/prisma/migrations/0002_add_timesheet_timer_fields/migration.sql
@@ -1,0 +1,15 @@
+-- TS-01: Add startTime/endTime for timer mode
+ALTER TABLE "time_entries" ADD COLUMN "startTime" TIMESTAMP(3);
+ALTER TABLE "time_entries" ADD COLUMN "endTime" TIMESTAMP(3);
+
+-- TS-03: Add overtime flag
+ALTER TABLE "time_entries" ADD COLUMN "overtime" BOOLEAN NOT NULL DEFAULT false;
+
+-- TS-04: Add locked flag for review locking
+ALTER TABLE "time_entries" ADD COLUMN "locked" BOOLEAN NOT NULL DEFAULT false;
+
+-- TS-05: Add isRunning flag for timer state
+ALTER TABLE "time_entries" ADD COLUMN "isRunning" BOOLEAN NOT NULL DEFAULT false;
+
+-- TS-05: Index for efficient timer lookup (one running timer per user)
+CREATE INDEX "time_entries_userId_isRunning_idx" ON "time_entries"("userId", "isRunning");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -442,12 +442,26 @@ model TimeEntry {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
 
+  // TS-01: 計時器時間欄位
+  startTime DateTime?
+  endTime   DateTime?
+
+  // TS-03: 加班標記
+  overtime Boolean @default(false)
+
+  // TS-04: 覆核鎖定
+  locked Boolean @default(false)
+
+  // TS-05: 計時器運行狀態
+  isRunning Boolean @default(false)
+
   task Task? @relation(fields: [taskId], references: [id])
   user User  @relation(fields: [userId], references: [id])
 
   @@index([taskId])
   @@index([userId])
   @@index([date])
+  @@index([userId, isRunning])
   @@map("time_entries")
 }
 

--- a/services/__tests__/time-entry-hours-calculation.test.ts
+++ b/services/__tests__/time-entry-hours-calculation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * TDD Tests for TS-02: hours 自動計算（0.25h 最小單位）
+ * and TS-05: Timer start/stop logic
+ *
+ * RED phase: these tests should FAIL before implementation.
+ */
+import { calculateHours } from "../time-entry-service";
+
+describe("calculateHours (TS-02)", () => {
+  test("returns hours rounded up to nearest 0.25", () => {
+    // 1 hour exactly
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T10:00:00Z");
+    expect(calculateHours(start, end)).toBe(1.0);
+  });
+
+  test("7 minutes rounds up to 0.25", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T09:07:00Z");
+    expect(calculateHours(start, end)).toBe(0.25);
+  });
+
+  test("16 minutes rounds up to 0.5", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T09:16:00Z");
+    expect(calculateHours(start, end)).toBe(0.5);
+  });
+
+  test("15 minutes exactly equals 0.25", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T09:15:00Z");
+    expect(calculateHours(start, end)).toBe(0.25);
+  });
+
+  test("30 minutes exactly equals 0.5", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T09:30:00Z");
+    expect(calculateHours(start, end)).toBe(0.5);
+  });
+
+  test("31 minutes rounds up to 0.75", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T09:31:00Z");
+    expect(calculateHours(start, end)).toBe(0.75);
+  });
+
+  test("8 hours 1 minute rounds up to 8.25", () => {
+    const start = new Date("2026-03-25T09:00:00Z");
+    const end = new Date("2026-03-25T17:01:00Z");
+    expect(calculateHours(start, end)).toBe(8.25);
+  });
+
+  test("returns 0 when start equals end", () => {
+    const t = new Date("2026-03-25T09:00:00Z");
+    expect(calculateHours(t, t)).toBe(0);
+  });
+
+  test("throws when end is before start", () => {
+    const start = new Date("2026-03-25T10:00:00Z");
+    const end = new Date("2026-03-25T09:00:00Z");
+    expect(() => calculateHours(start, end)).toThrow();
+  });
+
+  test("returns null when start is null", () => {
+    expect(calculateHours(null, new Date())).toBeNull();
+  });
+
+  test("returns null when end is null", () => {
+    expect(calculateHours(new Date(), null)).toBeNull();
+  });
+});

--- a/services/__tests__/time-entry-timer.test.ts
+++ b/services/__tests__/time-entry-timer.test.ts
@@ -1,0 +1,166 @@
+/**
+ * TDD Tests for TS-05: Timer unique constraint + start/stop
+ * and TS-04: locked boolean
+ *
+ * RED phase: these tests should FAIL before implementation.
+ */
+import { TimeEntryService } from "../time-entry-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { ForbiddenError, ValidationError } from "../errors";
+
+describe("Timer — start/stop (TS-05)", () => {
+  let service: TimeEntryService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new TimeEntryService(prisma as never);
+  });
+
+  test("startTimer creates entry with isRunning=true and startTime", async () => {
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.timeEntry.create as jest.Mock).mockResolvedValue({
+      id: "te-new",
+      isRunning: true,
+      startTime: new Date(),
+      endTime: null,
+    });
+
+    const result = await service.startTimer({
+      userId: "user-1",
+      taskId: "task-1",
+      category: "PLANNED_TASK",
+    });
+
+    expect(result.isRunning).toBe(true);
+    expect(prisma.timeEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          isRunning: true,
+          userId: "user-1",
+        }),
+      })
+    );
+  });
+
+  test("startTimer throws when user already has a running timer", async () => {
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({
+      id: "te-existing",
+      isRunning: true,
+      userId: "user-1",
+    });
+
+    await expect(
+      service.startTimer({
+        userId: "user-1",
+        taskId: "task-1",
+        category: "PLANNED_TASK",
+      })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("stopTimer sets endTime, calculates hours, and sets isRunning=false", async () => {
+    const startTime = new Date("2026-03-25T09:00:00Z");
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({
+      id: "te-running",
+      isRunning: true,
+      startTime,
+      userId: "user-1",
+    });
+    (prisma.timeEntry.update as jest.Mock).mockImplementation(({ data }) => ({
+      id: "te-running",
+      isRunning: false,
+      startTime,
+      endTime: data.endTime,
+      hours: data.hours,
+    }));
+
+    const result = await service.stopTimer("user-1");
+
+    expect(result.isRunning).toBe(false);
+    expect(result.endTime).toBeDefined();
+    expect(result.hours).toBeGreaterThan(0);
+    expect(prisma.timeEntry.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "te-running" },
+        data: expect.objectContaining({
+          isRunning: false,
+        }),
+      })
+    );
+  });
+
+  test("stopTimer throws when no running timer exists", async () => {
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.stopTimer("user-1")).rejects.toThrow();
+  });
+
+  test("getRunningTimer returns the running entry for user", async () => {
+    const mockEntry = { id: "te-1", isRunning: true, userId: "user-1" };
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(mockEntry);
+
+    const result = await service.getRunningTimer("user-1");
+
+    expect(result).toEqual(mockEntry);
+    expect(prisma.timeEntry.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user-1", isRunning: true },
+      })
+    );
+  });
+});
+
+describe("Locked entries (TS-04)", () => {
+  let service: TimeEntryService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new TimeEntryService(prisma as never);
+  });
+
+  test("updateTimeEntry throws ForbiddenError when entry is locked", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+      id: "te-locked",
+      userId: "user-1",
+      locked: true,
+    });
+
+    await expect(
+      service.updateTimeEntry("te-locked", { hours: 5 }, "user-1", "ENGINEER")
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  test("deleteTimeEntry throws ForbiddenError when entry is locked", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+      id: "te-locked",
+      userId: "user-1",
+      locked: true,
+    });
+
+    await expect(
+      service.deleteTimeEntry("te-locked", "user-1", "ENGINEER")
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  test("updateTimeEntry succeeds when entry is not locked", async () => {
+    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+      id: "te-unlocked",
+      userId: "user-1",
+      locked: false,
+    });
+    (prisma.timeEntry.update as jest.Mock).mockResolvedValue({
+      id: "te-unlocked",
+      hours: 5,
+    });
+
+    const result = await service.updateTimeEntry(
+      "te-unlocked",
+      { hours: 5 },
+      "user-1",
+      "ENGINEER"
+    );
+    expect(result.hours).toBe(5);
+  });
+});

--- a/services/time-entry-service.ts
+++ b/services/time-entry-service.ts
@@ -25,6 +25,13 @@ export interface UpdateTimeEntryInput {
   date?: Date | string;
 }
 
+export interface StartTimerInput {
+  userId: string;
+  taskId?: string | null;
+  category: TimeCategory | string;
+  description?: string | null;
+}
+
 export interface TimeEntryStats {
   totalHours: number;
   byCategory: Record<string, number>;
@@ -34,6 +41,28 @@ export interface TimeEntryStats {
 export type CallerRole = string;
 
 const READ_ALL_ROLES = new Set(["MANAGER", "ADMIN"]);
+
+/**
+ * TS-02: Calculate hours from startTime/endTime, rounded up to nearest 0.25h.
+ *
+ * Returns null if either argument is null/undefined (fallback to manual hours).
+ * Throws if end is before start.
+ */
+export function calculateHours(
+  start: Date | null | undefined,
+  end: Date | null | undefined
+): number | null {
+  if (start == null || end == null) return null;
+
+  const diffMs = end.getTime() - start.getTime();
+  if (diffMs < 0) {
+    throw new ValidationError("結束時間不能早於開始時間");
+  }
+  if (diffMs === 0) return 0;
+
+  const diffMinutes = diffMs / (1000 * 60);
+  return Math.ceil(diffMinutes / 15) * 0.25;
+}
 
 export class TimeEntryService {
   constructor(private readonly prisma: PrismaClient) {}
@@ -122,6 +151,8 @@ export class TimeEntryService {
    * IDOR rules:
    * - All roles (including MANAGER): must own the entry to write.
    *   → Single query fetches the entry; ownership check in the same round-trip.
+   *
+   * TS-04: Locked entries cannot be updated.
    */
   async updateTimeEntry(
     id: string,
@@ -131,6 +162,11 @@ export class TimeEntryService {
   ) {
     const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+    // TS-04: Locked entries cannot be modified
+    if ((existing as Record<string, unknown>).locked) {
+      throw new ForbiddenError("已鎖定的時間記錄無法修改");
+    }
 
     // Write is always restricted to the owner regardless of role.
     if (existing.userId !== callerId) {
@@ -158,16 +194,98 @@ export class TimeEntryService {
    *
    * IDOR rules:
    * - All roles (including MANAGER): must own the entry to delete.
+   *
+   * TS-04: Locked entries cannot be deleted.
    */
   async deleteTimeEntry(id: string, callerId: string, callerRole: CallerRole) {
     const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
+
+    // TS-04: Locked entries cannot be deleted
+    if ((existing as Record<string, unknown>).locked) {
+      throw new ForbiddenError("已鎖定的時間記錄無法刪除");
+    }
 
     if (existing.userId !== callerId) {
       throw new ForbiddenError("只能刪除自己的時間記錄");
     }
 
     return this.prisma.timeEntry.delete({ where: { id } });
+  }
+
+  /**
+   * TS-05: Start a timer for the user.
+   * Creates a new entry with isRunning=true, startTime=now.
+   * Throws if user already has a running timer.
+   */
+  async startTimer(input: StartTimerInput) {
+    // Check for existing running timer
+    const running = await this.prisma.timeEntry.findFirst({
+      where: { userId: input.userId, isRunning: true },
+    });
+    if (running) {
+      throw new ValidationError("已有計時器正在運行，請先停止後再啟動新的");
+    }
+
+    const now = new Date();
+    return this.prisma.timeEntry.create({
+      data: {
+        userId: input.userId,
+        taskId: input.taskId ?? null,
+        category: (input.category as TimeCategory) ?? "PLANNED_TASK",
+        description: input.description ?? null,
+        date: now,
+        hours: 0,
+        startTime: now,
+        isRunning: true,
+      },
+      include: {
+        task: { select: { id: true, title: true } },
+        user: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  /**
+   * TS-05: Stop the running timer for the user.
+   * Sets endTime=now, calculates hours, sets isRunning=false.
+   */
+  async stopTimer(userId: string) {
+    const running = await this.prisma.timeEntry.findFirst({
+      where: { userId, isRunning: true },
+    });
+    if (!running) {
+      throw new NotFoundError("沒有正在運行的計時器");
+    }
+
+    const endTime = new Date();
+    const hours = calculateHours(running.startTime, endTime) ?? 0;
+
+    return this.prisma.timeEntry.update({
+      where: { id: running.id },
+      data: {
+        endTime,
+        hours,
+        isRunning: false,
+      },
+      include: {
+        task: { select: { id: true, title: true } },
+        user: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  /**
+   * TS-05: Get the running timer for a user.
+   */
+  async getRunningTimer(userId: string) {
+    return this.prisma.timeEntry.findFirst({
+      where: { userId, isRunning: true },
+      include: {
+        task: { select: { id: true, title: true } },
+        user: { select: { id: true, name: true } },
+      },
+    });
   }
 
   async getStats(


### PR DESCRIPTION
## Summary
- **TS-01** (#698): 新增 `startTime`/`endTime` nullable DateTime 欄位至 TimeEntry
- **TS-02** (#699): 實作 `calculateHours(start, end)` 函數，0.25h 最小單位向上取整
- **TS-03** (#700): 新增 `overtime` boolean 欄位（default false）
- **TS-04** (#701): 新增 `locked` boolean 欄位，update/delete 時檢查鎖定狀態回傳 403
- **TS-05** (#702): 新增 `isRunning` boolean + `startTimer`/`stopTimer`/`getRunningTimer` 方法，每 user 最多一個 running timer

## Changes
- `prisma/schema.prisma`: 5 個新欄位 + userId/isRunning 複合索引
- `prisma/migrations/0002_add_timesheet_timer_fields/`: Migration SQL
- `services/time-entry-service.ts`: `calculateHours` export + 3 個新 service methods + locked guard
- 2 個新測試檔（19 個新測試），全部 285 個 service tests 通過

## TDD Evidence
1. RED: 先寫 19 個失敗測試（calculateHours 11 tests + timer 5 tests + locked 3 tests）
2. GREEN: 實作最小程式碼讓全部通過
3. 無 REFACTOR 需求（程式碼已經乾淨）

Fixes #698, Fixes #699, Fixes #700, Fixes #701, Fixes #702

## Test plan
- [x] 19 個新單元測試全部通過
- [x] 既有 285 個 service tests 無 regression
- [ ] Migration 需在 Docker 環境執行 `npx prisma migrate deploy` 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)