### PR TITLE
feat(timesheet): batch create + copy week + audit trail

### DIFF
--- a/__tests__/api/time-entries-batch.test.ts
+++ b/__tests__/api/time-entries-batch.test.ts
@@ -1,0 +1,371 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD tests for:
+ *   - POST /api/time-entries/batch (TS-06)
+ *   - POST /api/time-entries/copy-week (TS-07)
+ *   - Audit trail on update/delete (TS-08)
+ *
+ * Tests written BEFORE implementation (Red phase).
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+const mockTimeEntry = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  create: jest.fn(),
+  createMany: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+const mockAuditLog = {
+  create: jest.fn(),
+  findMany: jest.fn(),
+};
+const mockTransaction = jest.fn();
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    timeEntry: mockTimeEntry,
+    auditLog: mockAuditLog,
+    $transaction: mockTransaction,
+  },
+}));
+
+// ── Auth mock ────────────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION_ENGINEER = {
+  user: { id: "u1", name: "Engineer", email: "e@t.com", role: "ENGINEER" },
+  expires: "2099",
+};
+
+const SESSION_MANAGER = {
+  user: { id: "m1", name: "Manager", email: "m@t.com", role: "MANAGER" },
+  expires: "2099",
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TS-06: Batch time entries
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/time-entries/batch", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+  });
+
+  test("creates multiple entries in a single request", async () => {
+    const created = [
+      { id: "e1", userId: "u1", date: new Date("2026-03-23"), hours: 4, category: "PLANNED_TASK" },
+      { id: "e2", userId: "u1", date: new Date("2026-03-24"), hours: 3, category: "SUPPORT" },
+    ];
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: jest.fn()
+            .mockResolvedValueOnce(created[0])
+            .mockResolvedValueOnce(created[1]),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [
+            { date: "2026-03-23", hours: 4, category: "PLANNED_TASK" },
+            { date: "2026-03-24", hours: 3, category: "SUPPORT" },
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveLength(2);
+  });
+
+  test("rejects overlapping times (same date + same task)", async () => {
+    // Simulate existing entry on 2026-03-23 for same task
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([
+            { id: "existing", userId: "u1", date: new Date("2026-03-23"), hours: 4, taskId: "t1" },
+          ]),
+          create: jest.fn(),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [
+            { date: "2026-03-23", hours: 4, taskId: "t1", category: "PLANNED_TASK" },
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  test("validates all entries before creating any", async () => {
+    // Second entry has invalid hours (-1), entire batch should fail
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [
+            { date: "2026-03-23", hours: 4, category: "PLANNED_TASK" },
+            { date: "2026-03-24", hours: -1, category: "SUPPORT" },
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  test("rejects batch with more than 50 entries", async () => {
+    const entries = Array.from({ length: 51 }, (_, i) => ({
+      date: "2026-03-23",
+      hours: 1,
+      category: "PLANNED_TASK",
+    }));
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: { entries },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: { entries: [{ date: "2026-03-23", hours: 4 }] },
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  test("rejects empty entries array", async () => {
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: { entries: [] },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TS-07: Copy week
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/time-entries/copy-week", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+  });
+
+  test("copies entries from source week +7 days", async () => {
+    const sourceEntries = [
+      { id: "s1", userId: "u1", taskId: "t1", date: new Date("2026-03-16"), hours: 4, category: "PLANNED_TASK", description: "coding" },
+      { id: "s2", userId: "u1", taskId: "t2", date: new Date("2026-03-17"), hours: 3, category: "SUPPORT", description: null },
+    ];
+
+    mockTimeEntry.findMany
+      .mockResolvedValueOnce(sourceEntries)   // source week entries
+      .mockResolvedValueOnce([]);              // target week entries (empty)
+
+    const created = [
+      { ...sourceEntries[0], id: "c1", date: new Date("2026-03-23") },
+      { ...sourceEntries[1], id: "c2", date: new Date("2026-03-24") },
+    ];
+    mockTimeEntry.createMany.mockResolvedValue({ count: 2 });
+    mockTimeEntry.findMany.mockResolvedValueOnce(created); // final fetch
+
+    const { POST } = await import("@/app/api/time-entries/copy-week/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/copy-week", {
+        method: "POST",
+        body: { sourceWeekStart: "2026-03-16" },
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  test("skips copy if target week already has entries", async () => {
+    const sourceEntries = [
+      { id: "s1", userId: "u1", taskId: "t1", date: new Date("2026-03-16"), hours: 4, category: "PLANNED_TASK", description: null },
+    ];
+    const targetEntries = [
+      { id: "x1", userId: "u1", taskId: "t1", date: new Date("2026-03-23"), hours: 4, category: "PLANNED_TASK", description: null },
+    ];
+
+    mockTimeEntry.findMany
+      .mockResolvedValueOnce(sourceEntries)   // source week
+      .mockResolvedValueOnce(targetEntries);  // target week has entries
+
+    const { POST } = await import("@/app/api/time-entries/copy-week/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/copy-week", {
+        method: "POST",
+        body: { sourceWeekStart: "2026-03-16" },
+      })
+    );
+
+    // Should skip duplicates; either 200 with message or partial copy
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    // createMany should not have been called for the duplicate
+    expect(mockTimeEntry.createMany).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/time-entries/copy-week/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/copy-week", {
+        method: "POST",
+        body: { sourceWeekStart: "2026-03-16" },
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 400 when sourceWeekStart is missing", async () => {
+    const { POST } = await import("@/app/api/time-entries/copy-week/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/copy-week", {
+        method: "POST",
+        body: {},
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TS-08: Audit trail
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Audit trail for time entry changes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+  });
+
+  test("updating time entry creates audit log", async () => {
+    const existing = {
+      id: "entry-1",
+      userId: "u1",
+      taskId: null,
+      date: new Date("2026-03-23"),
+      hours: 4,
+      category: "PLANNED_TASK",
+      description: "original",
+    };
+    mockTimeEntry.findUnique.mockResolvedValue(existing);
+    mockTimeEntry.update.mockResolvedValue({ ...existing, hours: 6, task: null });
+    mockAuditLog.create.mockResolvedValue({ id: "audit-1" });
+
+    const { PUT } = await import("@/app/api/time-entries/[id]/route");
+    const res = await PUT(
+      createMockRequest("/api/time-entries/entry-1", {
+        method: "PUT",
+        body: { hours: 6 },
+      }),
+      { params: Promise.resolve({ id: "entry-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    // Audit log should be created with old/new values
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "UPDATE_TIME_ENTRY",
+          resourceType: "TimeEntry",
+          resourceId: "entry-1",
+          userId: "u1",
+        }),
+      })
+    );
+  });
+
+  test("deleting time entry creates audit log", async () => {
+    const existing = {
+      id: "entry-1",
+      userId: "u1",
+      taskId: null,
+      date: new Date("2026-03-23"),
+      hours: 4,
+      category: "PLANNED_TASK",
+      description: null,
+    };
+    mockTimeEntry.findUnique.mockResolvedValue(existing);
+    mockTimeEntry.delete.mockResolvedValue(existing);
+    mockAuditLog.create.mockResolvedValue({ id: "audit-2" });
+
+    const { DELETE } = await import("@/app/api/time-entries/[id]/route");
+    const res = await DELETE(
+      createMockRequest("/api/time-entries/entry-1", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "entry-1" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "DELETE_TIME_ENTRY",
+          resourceType: "TimeEntry",
+          resourceId: "entry-1",
+          userId: "u1",
+        }),
+      })
+    );
+  });
+});

--- a/__tests__/api/time-entries.test.ts
+++ b/__tests__/api/time-entries.test.ts
@@ -7,8 +7,9 @@
 import { createMockRequest } from "../utils/test-utils";
 
 const mockTimeEntry = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockAuditLog = { create: jest.fn() };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { timeEntry: mockTimeEntry } }));
+jest.mock("@/lib/prisma", () => ({ prisma: { timeEntry: mockTimeEntry, auditLog: mockAuditLog } }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -1,3 +1,10 @@
+/**
+ * PUT / DELETE /api/time-entries/[id]
+ *
+ * Updated to include explicit audit trail logging (TS-08).
+ * Every update/delete records the action, old values, and who did it.
+ */
+
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { TimeCategory } from "@prisma/client";
@@ -44,6 +51,26 @@ export const PUT = withAuth(async (
     },
   });
 
+  // TS-08: Explicit audit trail for time entry updates
+  await prisma.auditLog.create({
+    data: {
+      userId: callerId,
+      action: "UPDATE_TIME_ENTRY",
+      resourceType: "TimeEntry",
+      resourceId: id,
+      detail: JSON.stringify({
+        oldValues: {
+          hours: existing.hours,
+          category: existing.category,
+          description: existing.description,
+          date: existing.date,
+          taskId: existing.taskId,
+        },
+        newValues: updates,
+      }),
+    },
+  });
+
   return success(entry);
 });
 
@@ -66,5 +93,25 @@ export const DELETE = withAuth(async (
   }
 
   await prisma.timeEntry.delete({ where: { id } });
+
+  // TS-08: Explicit audit trail for time entry deletions
+  await prisma.auditLog.create({
+    data: {
+      userId: callerId,
+      action: "DELETE_TIME_ENTRY",
+      resourceType: "TimeEntry",
+      resourceId: id,
+      detail: JSON.stringify({
+        deletedEntry: {
+          hours: existing.hours,
+          category: existing.category,
+          description: existing.description,
+          date: existing.date,
+          taskId: existing.taskId,
+        },
+      }),
+    },
+  });
+
   return success({ success: true });
 });

--- a/app/api/time-entries/batch/route.ts
+++ b/app/api/time-entries/batch/route.ts
@@ -1,0 +1,108 @@
+/**
+ * POST /api/time-entries/batch — Batch create time entries (TS-06)
+ *
+ * Creates multiple time entries in a single transactional request.
+ * Validates all entries upfront; rejects if any overlap with existing entries
+ * (same date + same taskId for the same user).
+ *
+ * Limits: max 50 entries per request.
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { TimeCategory } from "@prisma/client";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success, error } from "@/lib/api-response";
+import { TimeCategoryEnum } from "@/validators/shared/enums";
+import { ValidationError } from "@/services/errors";
+
+const batchEntrySchema = z.object({
+  date: z.string().date(),
+  hours: z.number().min(0).max(24),
+  taskId: z.string().optional(),
+  category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
+  description: z.string().optional(),
+});
+
+const batchCreateSchema = z.object({
+  entries: z
+    .array(batchEntrySchema)
+    .min(1, "至少需要一筆工時記錄")
+    .max(50, "單次最多 50 筆工時記錄"),
+});
+
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const raw = await req.json();
+  const { entries } = validateBody(batchCreateSchema, raw);
+
+  // Use a transaction to ensure atomicity — all or nothing
+  const created = await prisma.$transaction(async (tx) => {
+    // Collect all target dates to check for overlaps in one query
+    const dates = entries.map((e) => new Date(e.date));
+    const minDate = new Date(Math.min(...dates.map((d) => d.getTime())));
+    const maxDate = new Date(Math.max(...dates.map((d) => d.getTime())));
+
+    const existing = await tx.timeEntry.findMany({
+      where: {
+        userId,
+        date: { gte: minDate, lte: maxDate },
+      },
+      select: { date: true, taskId: true },
+    });
+
+    // Build a set of existing date+taskId keys for overlap detection
+    const existingKeys = new Set(
+      existing.map((e) => {
+        const dateStr = new Date(e.date).toISOString().slice(0, 10);
+        return `${dateStr}:${e.taskId ?? ""}`;
+      })
+    );
+
+    // Also detect duplicates within the batch itself
+    const batchKeys = new Set<string>();
+
+    for (const entry of entries) {
+      const key = `${entry.date}:${entry.taskId ?? ""}`;
+      if (existingKeys.has(key)) {
+        throw new ValidationError(
+          `重複：${entry.date} 的任務 ${entry.taskId ?? "(無任務)"} 已有工時記錄`
+        );
+      }
+      if (batchKeys.has(key)) {
+        throw new ValidationError(
+          `批次內重複：${entry.date} 的任務 ${entry.taskId ?? "(無任務)"} 出現多次`
+        );
+      }
+      batchKeys.add(key);
+    }
+
+    // Create entries one by one within the transaction (for include support)
+    const results = [];
+    for (const entry of entries) {
+      const result = await tx.timeEntry.create({
+        data: {
+          userId,
+          taskId: entry.taskId || null,
+          date: new Date(entry.date),
+          hours: entry.hours,
+          category: (entry.category as TimeCategory) ?? "PLANNED_TASK",
+          description: entry.description || null,
+        },
+        include: {
+          task: { select: { id: true, title: true, category: true } },
+        },
+      });
+      results.push(result);
+    }
+
+    return results;
+  });
+
+  return success(created, 201);
+});

--- a/app/api/time-entries/copy-week/route.ts
+++ b/app/api/time-entries/copy-week/route.ts
@@ -1,0 +1,113 @@
+/**
+ * POST /api/time-entries/copy-week — Copy previous week entries (TS-07)
+ *
+ * Deep copies all time entries from sourceWeekStart..+6 days to the next week
+ * (date + 7 days). Skips entries where target date + taskId already exist.
+ *
+ * Copied fields: taskId, hours, category, description
+ * NOT copied: id, locked, isRunning, startTime, endTime
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success } from "@/lib/api-response";
+
+const copyWeekSchema = z.object({
+  sourceWeekStart: z.string().date(),
+});
+
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const raw = await req.json();
+  const { sourceWeekStart } = validateBody(copyWeekSchema, raw);
+
+  const srcStart = new Date(sourceWeekStart);
+  const srcEnd = new Date(srcStart);
+  srcEnd.setDate(srcEnd.getDate() + 6);
+
+  const tgtStart = new Date(srcStart);
+  tgtStart.setDate(tgtStart.getDate() + 7);
+  const tgtEnd = new Date(tgtStart);
+  tgtEnd.setDate(tgtEnd.getDate() + 6);
+
+  // Fetch source week entries
+  const sourceEntries = await prisma.timeEntry.findMany({
+    where: {
+      userId,
+      date: { gte: srcStart, lte: srcEnd },
+    },
+  });
+
+  if (sourceEntries.length === 0) {
+    return success({ copied: 0, skipped: 0, message: "來源週無工時記錄" });
+  }
+
+  // Fetch target week entries to detect duplicates
+  const targetEntries = await prisma.timeEntry.findMany({
+    where: {
+      userId,
+      date: { gte: tgtStart, lte: tgtEnd },
+    },
+    select: { date: true, taskId: true },
+  });
+
+  const targetKeys = new Set(
+    targetEntries.map((e) => {
+      const dateStr = new Date(e.date).toISOString().slice(0, 10);
+      return `${dateStr}:${e.taskId ?? ""}`;
+    })
+  );
+
+  // Build entries to copy, skipping duplicates
+  const toCopy = [];
+  let skipped = 0;
+
+  for (const entry of sourceEntries) {
+    const srcDate = new Date(entry.date);
+    const tgtDate = new Date(srcDate);
+    tgtDate.setDate(tgtDate.getDate() + 7);
+    const tgtDateStr = tgtDate.toISOString().slice(0, 10);
+
+    const key = `${tgtDateStr}:${entry.taskId ?? ""}`;
+    if (targetKeys.has(key)) {
+      skipped++;
+      continue;
+    }
+
+    toCopy.push({
+      userId,
+      taskId: entry.taskId,
+      date: tgtDate,
+      hours: entry.hours,
+      category: entry.category,
+      description: entry.description,
+    });
+    targetKeys.add(key); // prevent duplicates within copy batch
+  }
+
+  if (toCopy.length === 0) {
+    return success({ copied: 0, skipped, message: "目標週已有相同記錄，全部跳過" });
+  }
+
+  await prisma.timeEntry.createMany({ data: toCopy });
+
+  // Fetch the newly created entries
+  const newEntries = await prisma.timeEntry.findMany({
+    where: {
+      userId,
+      date: { gte: tgtStart, lte: tgtEnd },
+    },
+    include: {
+      task: { select: { id: true, title: true, category: true } },
+    },
+    orderBy: [{ date: "asc" }],
+  });
+
+  return success({ copied: toCopy.length, skipped, entries: newEntries }, 201);
+});


### PR DESCRIPTION
## Summary
- **TS-06 Batch create**: `POST /api/time-entries/batch` — create multiple entries in a single transactional request with overlap detection (max 50 entries)
- **TS-07 Copy week**: `POST /api/time-entries/copy-week` — deep copy source week entries +7 days, skipping duplicates in target week
- **TS-08 Audit trail**: `PUT/DELETE /api/time-entries/[id]` now writes explicit audit logs with old/new values to `AuditLog` model

## Test plan
- [x] 12 new TDD tests (written before implementation) covering:
  - Batch: creates multiple, rejects overlapping, validates all before creating, rejects >50, rejects empty, requires auth
  - Copy-week: copies +7 days, skips if target has entries, requires auth, validates input
  - Audit: update creates audit log, delete creates audit log
- [x] Existing time-entries tests updated for auditLog mock compatibility (14 tests still pass)
- [x] Pre-existing API test failures (3 tests in security-controls + bulk-operations) are unrelated

Closes #703, Closes #704, Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)