### PR TITLE
feat(timesheet): dual view + list view + timer integration

### DIFF
--- a/__tests__/pages/timesheet-enhanced.test.tsx
+++ b/__tests__/pages/timesheet-enhanced.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Enhanced Timesheet Tests — TDD for Issues #717, #718, #719
+ *
+ * Tests dual view (grid/list toggle), list view rendering,
+ * and timer widget integration.
+ */
+import React from "react";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockUseSession = jest.fn();
+jest.mock("next-auth/react", () => ({
+  useSession: (...args: unknown[]) => mockUseSession(...args),
+}));
+
+jest.mock("@/app/components/timesheet-grid", () => ({
+  TimesheetGrid: () => <div data-testid="timesheet-grid">Grid View</div>,
+}));
+jest.mock("@/app/components/time-summary", () => ({
+  TimeSummary: () => <div data-testid="time-summary" />,
+}));
+jest.mock("@/app/components/timer-widget", () => ({
+  TimerWidget: () => <div data-testid="timer-widget">Timer</div>,
+}));
+jest.mock("@/app/components/timesheet-list-view", () => ({
+  TimesheetListView: () => <div data-testid="timesheet-list-view">List View</div>,
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function setSession(role: "MANAGER" | "MEMBER") {
+  mockUseSession.mockReturnValue({
+    data: { user: { id: "u1", name: "Alice", role }, expires: "2099" },
+    status: "authenticated",
+  });
+}
+
+const TIME_ENTRIES = [
+  {
+    id: "e1", userId: "u1", taskId: null, date: "2024-01-15",
+    hours: 4, category: "PLANNED_TASK", description: null,
+    startTime: "2024-01-15T08:00:00Z", endTime: "2024-01-15T12:00:00Z",
+    task: null,
+  },
+  {
+    id: "e2", userId: "u1", taskId: "t1", date: "2024-01-15",
+    hours: 3, category: "ADDED_TASK", description: "Code review",
+    startTime: "2024-01-15T13:00:00Z", endTime: "2024-01-15T16:00:00Z",
+    task: { id: "t1", title: "Dev Task", category: "PLANNED" },
+  },
+];
+
+const STATS_DATA = {
+  totalHours: 7,
+  breakdown: [
+    { category: "PLANNED_TASK", hours: 4, pct: 57 },
+    { category: "ADDED_TASK", hours: 3, pct: 43 },
+  ],
+  taskInvestmentRate: 57,
+  entryCount: 2,
+};
+
+function setupFetch(entries = TIME_ENTRIES, stats = STATS_DATA) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes("time-entries/running")) {
+      return Promise.resolve({ ok: true, json: async () => ({ ok: true, data: null }) } as Response);
+    }
+    if (url.includes("time-entries/stats")) {
+      return Promise.resolve({ ok: true, json: async () => stats } as Response);
+    }
+    if (url.includes("time-entries")) {
+      return Promise.resolve({ ok: true, json: async () => entries } as Response);
+    }
+    if (url.includes("users")) {
+      return Promise.resolve({ ok: true, json: async () => [{ id: "u1", name: "Alice" }] } as Response);
+    }
+    if (url.includes("tasks")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => [{ id: "t1", title: "Dev Task" }, { id: "t2", title: "Design" }],
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// View Toggle Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Timesheet Enhanced — View Toggle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Do not use jest.resetModules() — causes React hook resolution issues
+  });
+
+  it("renders grid view by default", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-grid")).toBeInTheDocument();
+    });
+  });
+
+  it("shows view toggle tabs (格子/列表)", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("格子")).toBeInTheDocument();
+      expect(screen.getByText("列表")).toBeInTheDocument();
+    });
+  });
+
+  it("switches to list view when clicking 列表 tab", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByText("列表")).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("列表"));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-list-view")).toBeInTheDocument();
+    });
+  });
+
+  it("switches back to grid view when clicking 格子 tab", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => { expect(screen.getByText("列表")).toBeInTheDocument(); });
+    await act(async () => { fireEvent.click(screen.getByText("列表")); });
+    await waitFor(() => { expect(screen.getByTestId("timesheet-list-view")).toBeInTheDocument(); });
+    await act(async () => { fireEvent.click(screen.getByText("格子")); });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-grid")).toBeInTheDocument();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Timer Widget Integration
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Timesheet Enhanced — Timer Widget", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Do not use jest.resetModules() — causes React hook resolution issues
+  });
+
+  it("renders timer widget on the page", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByTestId("timer-widget")).toBeInTheDocument();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Daily Totals (grid already has this, just verify the grid still renders)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Timesheet Enhanced — Data rendering", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Do not use jest.resetModules() — causes React hook resolution issues
+  });
+
+  it("renders grid with entries present", async () => {
+    setSession("MEMBER");
+    setupFetch();
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => { render(<TimesheetPage />); });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-grid")).toBeInTheDocument();
+    });
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Clock } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Grid3X3, List } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractItems, extractData } from "@/lib/api-client";
 import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
+import { TimesheetListView } from "@/app/components/timesheet-list-view";
 import { TimeSummary } from "@/app/components/time-summary";
+import { TimerWidget } from "@/app/components/timer-widget";
 import { type TimeEntry } from "@/app/components/time-entry-cell";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 
@@ -20,6 +22,8 @@ type StatsData = {
   taskInvestmentRate: number;
   entryCount: number;
 };
+
+type ViewMode = "grid" | "list";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -57,12 +61,25 @@ export default function TimesheetPage() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [tasks, setTasks] = useState<{ id: string; title: string }[]>([]);
 
   // Load users
   useEffect(() => {
     fetch("/api/users")
       .then((r) => r.json())
       .then((body) => setUsers(extractItems<User>(body)))
+      .catch(() => {});
+  }, []);
+
+  // Load tasks for timer widget task selector
+  useEffect(() => {
+    fetch("/api/tasks")
+      .then((r) => r.json())
+      .then((body) => {
+        const items = extractItems<{ id: string; title: string }>(body);
+        setTasks(items);
+      })
       .catch(() => {});
   }, []);
 
@@ -173,6 +190,11 @@ export default function TimesheetPage() {
     }
   }
 
+  function handleTimerChange() {
+    loadEntries();
+    loadStats();
+  }
+
   function prevWeek() {
     setWeekStart((d) => { const n = new Date(d); n.setDate(n.getDate() - 7); return n; });
   }
@@ -206,6 +228,34 @@ export default function TimesheetPage() {
             </select>
           )}
 
+          {/* View toggle — grid / list */}
+          <div className="flex items-center bg-background border border-border rounded-md overflow-hidden">
+            <button
+              onClick={() => setViewMode("grid")}
+              className={cn(
+                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
+                viewMode === "grid"
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+            >
+              <Grid3X3 className="h-3.5 w-3.5" />
+              格子
+            </button>
+            <button
+              onClick={() => setViewMode("list")}
+              className={cn(
+                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
+                viewMode === "list"
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+            >
+              <List className="h-3.5 w-3.5" />
+              列表
+            </button>
+          </div>
+
           {/* Week navigation */}
           <div className="flex items-center gap-1 bg-background border border-border rounded-md">
             <button onClick={prevWeek} className="p-1.5 hover:bg-accent rounded-l-md transition-colors">
@@ -234,27 +284,32 @@ export default function TimesheetPage() {
 
       {/* Content */}
       <div className="flex-1 flex flex-col gap-4 min-h-0 overflow-auto">
-        {/* Stats summary */}
-        {statsLoading ? (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            計算中...
+        {/* Timer widget + Stats summary — side by side on desktop */}
+        <div className="flex flex-col sm:flex-row gap-4">
+          <TimerWidget tasks={tasks} onTimerChange={handleTimerChange} />
+          <div className="flex-1">
+            {statsLoading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                計算中...
+              </div>
+            ) : stats && stats.totalHours > 0 ? (
+              <TimeSummary
+                totalHours={stats.totalHours}
+                breakdown={stats.breakdown}
+                taskInvestmentRate={stats.taskInvestmentRate}
+              />
+            ) : null}
           </div>
-        ) : stats && stats.totalHours > 0 ? (
-          <TimeSummary
-            totalHours={stats.totalHours}
-            breakdown={stats.breakdown}
-            taskInvestmentRate={stats.taskInvestmentRate}
-          />
-        ) : null}
+        </div>
 
-        {/* Grid — horizontally scrollable on mobile for the wide time table */}
+        {/* Grid or List view — horizontally scrollable on mobile */}
         <div className="border border-border rounded-xl overflow-x-auto bg-card">
           {loading ? (
             <PageLoading message="載入工時..." className="py-12" />
           ) : loadError ? (
             <PageError message={loadError} onRetry={loadEntries} className="py-12" />
-          ) : (
+          ) : viewMode === "grid" ? (
             <>
               {entries.length === 0 && (
                 <div className="text-center py-3 text-xs text-muted-foreground border-b border-border">
@@ -269,6 +324,11 @@ export default function TimesheetPage() {
                 onCellDelete={handleCellDelete}
               />
             </>
+          ) : (
+            <TimesheetListView
+              entries={entries}
+              onDelete={handleCellDelete}
+            />
           )}
         </div>
 

--- a/app/components/timesheet-list-view.tsx
+++ b/app/components/timesheet-list-view.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { safeFixed } from "@/lib/safe-number";
+import { type TimeEntry, CATEGORIES } from "./time-entry-cell";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type TimesheetListViewProps = {
+  entries: TimeEntry[];
+  onDelete?: (id: string) => Promise<void>;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getCategoryLabel(cat: string): string {
+  return CATEGORIES.find((c) => c.value === cat)?.label ?? cat;
+}
+
+function getCategoryColor(cat: string): string {
+  return CATEGORIES.find((c) => c.value === cat)?.color ?? "bg-muted text-muted-foreground border-border";
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+}
+
+function formatTime(timeStr: string | null | undefined): string {
+  if (!timeStr) return "—";
+  const d = new Date(timeStr);
+  return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps) {
+  // Sort by date descending, then by startTime descending
+  const sorted = [...entries].sort((a, b) => {
+    const dateCompare = b.date.localeCompare(a.date);
+    if (dateCompare !== 0) return dateCompare;
+    if (a.startTime && b.startTime) return b.startTime.localeCompare(a.startTime);
+    return 0;
+  });
+
+  // Calculate daily totals
+  const dailyTotals = new Map<string, number>();
+  for (const entry of entries) {
+    const dateKey = entry.date.split("T")[0];
+    dailyTotals.set(dateKey, (dailyTotals.get(dateKey) ?? 0) + entry.hours);
+  }
+
+  const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="text-center py-8 text-sm text-muted-foreground">
+        本週尚無工時記錄
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm" data-testid="list-view-table">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">日期</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">開始</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">結束</th>
+            <th className="text-right px-3 py-2.5 text-xs font-medium text-muted-foreground">工時</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">任務</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">分類</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">備註</th>
+            {onDelete && (
+              <th className="text-center px-3 py-2.5 text-xs font-medium text-muted-foreground w-16">操作</th>
+            )}
+          </tr>
+        </thead>
+
+        <tbody>
+          {sorted.map((entry) => {
+            const task = (entry as Record<string, unknown>).task as { title: string } | null | undefined;
+            return (
+              <tr
+                key={entry.id}
+                className="border-b border-border/50 hover:bg-accent/20 transition-colors"
+                data-testid="list-view-row"
+              >
+                <td className="px-3 py-2 text-xs text-foreground whitespace-nowrap">
+                  {formatDate(entry.date)}
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground tabular-nums" data-testid="start-time">
+                  {formatTime(entry.startTime)}
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground tabular-nums" data-testid="end-time">
+                  {formatTime(entry.endTime)}
+                </td>
+                <td className="px-3 py-2 text-right text-xs font-medium text-foreground tabular-nums">
+                  {safeFixed(entry.hours, 1)}h
+                </td>
+                <td className="px-3 py-2 text-xs text-foreground max-w-[200px] truncate" title={task?.title ?? "自由工時"}>
+                  {task?.title ?? "自由工時"}
+                </td>
+                <td className="px-3 py-2">
+                  <span className={cn("inline-block px-2 py-0.5 text-xs rounded-md border", getCategoryColor(entry.category))}>
+                    {getCategoryLabel(entry.category)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground max-w-[200px] truncate" title={entry.description ?? ""}>
+                  {entry.description ?? "—"}
+                </td>
+                {onDelete && (
+                  <td className="px-3 py-2 text-center">
+                    <button
+                      onClick={() => onDelete(entry.id)}
+                      className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                    >
+                      刪除
+                    </button>
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+
+        <tfoot>
+          <tr className="border-t border-border bg-muted/30">
+            <td className="px-3 py-2.5 text-xs font-semibold text-muted-foreground" colSpan={3}>
+              合計
+            </td>
+            <td className="px-3 py-2.5 text-right text-xs font-bold text-foreground tabular-nums">
+              {safeFixed(totalHours, 1)}h
+            </td>
+            <td colSpan={onDelete ? 4 : 3} />
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Dual View Toggle**: tab switch UI (格子/列表) to switch between grid and list views on the timesheet page
- **TimesheetListView**: new table component showing entries with date, start time, end time, hours, task, category (colored badge), and description columns
- **Timer Widget Integration**: timer widget embedded in the timesheet page header, with task selector loaded from API
- **Category Colors**: list view uses colored badges matching the grid cell category colors

## Test plan
- [x] TDD: 6 enhanced page tests written first, all passing
- [x] All 48 related tests pass across 5 test suites
- [x] Pre-existing `timesheet.test.tsx` failure (expects "本週尚無工時記錄" text) is NOT introduced by this PR — was already failing on main
- [ ] Playwright e2e verification on deployed instance

Closes #717, Closes #718, Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)