### PR TITLE
fix(prisma): resolve migration issues for TaskTemplate and ApprovalRequest

### DIFF
--- a/prisma/migrations/0001_initial/migration.sql
+++ b/prisma/migrations/0001_initial/migration.sql
@@ -1,4 +1,3 @@
-npm warn exec The following package was not found and will be installed: prisma@5.22.0
 -- CreateEnum
 CREATE TYPE "Role" AS ENUM ('MANAGER', 'ENGINEER');
 
@@ -583,14 +582,3 @@ ALTER TABLE "document_versions" ADD CONSTRAINT "document_versions_documentId_fke
 
 -- AddForeignKey
 ALTER TABLE "document_versions" ADD CONSTRAINT "document_versions_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
-┌─────────────────────────────────────────────────────────┐
-│  Update available 5.22.0 -> 7.5.0                       │
-│                                                         │
-│  This is a major update - please follow the guide at    │
-│  https://pris.ly/d/major-version-upgrade                │
-│                                                         │
-│  Run the following to update                            │
-│    npm i --save-dev prisma@latest                       │
-│    npm i @prisma/client@latest                          │
-└─────────────────────────────────────────────────────────┘

--- a/prisma/migrations/0003_add_time_entry_templates/migration.sql
+++ b/prisma/migrations/0003_add_time_entry_templates/migration.sql
@@ -1,12 +1,9 @@
 -- CreateTable
 CREATE TABLE "time_entry_templates" (
     "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "taskId" TEXT,
-    "category" "TimeCategory" NOT NULL DEFAULT 'PLANNED_TASK',
-    "hours" DOUBLE PRECISION NOT NULL DEFAULT 1,
-    "description" TEXT,
+    "entries" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
@@ -17,7 +14,4 @@ CREATE TABLE "time_entry_templates" (
 CREATE INDEX "time_entry_templates_userId_idx" ON "time_entry_templates"("userId");
 
 -- AddForeignKey
-ALTER TABLE "time_entry_templates" ADD CONSTRAINT "time_entry_templates_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "time_entry_templates" ADD CONSTRAINT "time_entry_templates_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "time_entry_templates" ADD CONSTRAINT "time_entry_templates_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/0004_add_task_templates_and_approvals/migration.sql
+++ b/prisma/migrations/0004_add_task_templates_and_approvals/migration.sql
@@ -1,0 +1,65 @@
+-- AlterEnum: Add TIMESHEET_REMINDER to NotificationType
+ALTER TYPE "NotificationType" ADD VALUE 'TIMESHEET_REMINDER';
+
+-- CreateEnum
+CREATE TYPE "ApprovalStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "ApprovalType" AS ENUM ('TASK_STATUS_CHANGE', 'DELIVERABLE_ACCEPTANCE', 'PLAN_MODIFICATION');
+
+-- CreateTable
+CREATE TABLE "task_templates" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "priority" "Priority" NOT NULL DEFAULT 'P2',
+    "category" "TaskCategory" NOT NULL DEFAULT 'PLANNED',
+    "estimatedHours" DOUBLE PRECISION,
+    "creatorId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "task_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "approval_requests" (
+    "id" TEXT NOT NULL,
+    "requesterId" TEXT NOT NULL,
+    "approverId" TEXT,
+    "type" "ApprovalType" NOT NULL,
+    "status" "ApprovalStatus" NOT NULL DEFAULT 'PENDING',
+    "resourceId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL,
+    "reason" TEXT,
+    "reviewNote" TEXT,
+    "reviewedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "approval_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "task_templates_creatorId_idx" ON "task_templates"("creatorId");
+
+-- CreateIndex
+CREATE INDEX "approval_requests_requesterId_idx" ON "approval_requests"("requesterId");
+
+-- CreateIndex
+CREATE INDEX "approval_requests_approverId_idx" ON "approval_requests"("approverId");
+
+-- CreateIndex
+CREATE INDEX "approval_requests_status_idx" ON "approval_requests"("status");
+
+-- CreateIndex
+CREATE INDEX "approval_requests_resourceType_resourceId_idx" ON "approval_requests"("resourceType", "resourceId");
+
+-- AddForeignKey
+ALTER TABLE "task_templates" ADD CONSTRAINT "task_templates_creatorId_fkey" FOREIGN KEY ("creatorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approval_requests" ADD CONSTRAINT "approval_requests_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "approval_requests" ADD CONSTRAINT "approval_requests_approverId_fkey" FOREIGN KEY ("approverId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -440,7 +440,6 @@ model TimeEntry {
   hours       Float
   category    TimeCategory @default(PLANNED_TASK)
   description String?
-  locked      Boolean      @default(false)  // TS-24: Manager review lock
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
 


### PR DESCRIPTION
## Summary
- Remove duplicate `locked` field in TimeEntry model (schema.prisma)
- Clean npm warning text polluting 0001_initial migration SQL
- Fix 0003 migration to match schema definition (name/entries fields)
- Add missing 0004 migration for TaskTemplate, ApprovalRequest models and TIMESHEET_REMINDER enum value

## Test plan
- [x] `prisma migrate reset --force` successfully applies all 4 migrations
- [x] `prisma validate` passes
- [x] `prisma migrate status` shows "Database schema is up to date"

Fixes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)