### PR TITLE
feat(timesheet): monthly settlement API (TS-25)

### DIFF
--- a/__tests__/api/time-entries-settle-month.test.ts
+++ b/__tests__/api/time-entries-settle-month.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD tests for POST /api/time-entries/settle-month (TS-25)
+ *
+ * Requirements:
+ *   - POST locks all entries for a given month (sets locked=true)
+ *   - Only MANAGER can settle
+ *   - Already settled month returns 409
+ *
+ * Tests written BEFORE implementation (Red phase).
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+const mockTimeEntry = {
+  findMany: jest.fn(),
+  updateMany: jest.fn(),
+};
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    timeEntry: mockTimeEntry,
+  },
+}));
+
+// ── Auth mock ────────────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION_MANAGER = {
+  user: { id: "mgr-1", name: "Manager", email: "mgr@t.com", role: "MANAGER" },
+  expires: "2099",
+};
+const SESSION_ENGINEER = {
+  user: { id: "eng-1", name: "Engineer", email: "e@t.com", role: "ENGINEER" },
+  expires: "2099",
+};
+
+// Suppress console.error from apiHandler
+jest.spyOn(console, "error").mockImplementation(() => {});
+
+describe("POST /api/time-entries/settle-month (TS-25)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it("locks all entries for the given month when called by MANAGER", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    // Unsettled entries exist
+    mockTimeEntry.findMany.mockResolvedValue([
+      { id: "e1", locked: false },
+      { id: "e2", locked: false },
+    ]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 2 });
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 3 },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.lockedCount).toBe(2);
+    expect(mockTimeEntry.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { locked: true },
+      })
+    );
+  });
+
+  it("returns 403 when ENGINEER tries to settle", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 3 },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 3 },
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 409 when month is already fully settled", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    // All entries are already locked
+    mockTimeEntry.findMany.mockResolvedValue([
+      { id: "e1", locked: true },
+      { id: "e2", locked: true },
+    ]);
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 3 },
+      })
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 400 for invalid year/month", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 13 },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/time-entries/settle-month/route.ts
+++ b/app/api/time-entries/settle-month/route.ts
@@ -1,0 +1,64 @@
+/**
+ * POST /api/time-entries/settle-month — Monthly settlement (TS-25)
+ *
+ * Locks all time entries for a given year/month.
+ * Only MANAGER role may call this endpoint.
+ * Returns 409 if the month is already fully settled.
+ *
+ * Body: { year: number, month: number }
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success } from "@/lib/api-response";
+import { ConflictError } from "@/services/errors";
+
+const settleMonthSchema = z.object({
+  year: z.number().int().min(2000).max(2100),
+  month: z.number().int().min(1).max(12),
+});
+
+export const POST = withManager(async (req: NextRequest) => {
+  await requireRole("MANAGER");
+
+  const raw = await req.json();
+  const { year, month } = validateBody(settleMonthSchema, raw);
+
+  // Calculate month date range
+  const monthStart = new Date(year, month - 1, 1);
+  const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
+
+  // Find all entries in this month
+  const entries = await prisma.timeEntry.findMany({
+    where: {
+      date: { gte: monthStart, lte: monthEnd },
+    },
+    select: { id: true, locked: true },
+  });
+
+  // Check if already fully settled (all locked or no entries)
+  const unlocked = entries.filter((e) => !e.locked);
+  if (unlocked.length === 0) {
+    throw new ConflictError("該月份已全部結算完成");
+  }
+
+  // Lock all unlocked entries
+  const result = await prisma.timeEntry.updateMany({
+    where: {
+      date: { gte: monthStart, lte: monthEnd },
+      locked: false,
+    },
+    data: { locked: true },
+  });
+
+  return success({
+    year,
+    month,
+    lockedCount: result.count,
+    totalEntries: entries.length,
+  });
+});


### PR DESCRIPTION
## Summary
- POST /api/time-entries/settle-month locks all entries for a given year/month
- Only MANAGER role can settle (403 for ENGINEER, 401 for unauthenticated)
- Already settled month returns 409 Conflict

## Test plan
- [x] 5 TDD tests pass (time-entries-settle-month.test.ts)
- [x] Validates year/month input (400 for invalid)

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)