### PR TITLE
feat(timesheet): anomaly detection for low hours (TS-27)

### DIFF
--- a/__tests__/api/time-entries-anomaly.test.ts
+++ b/__tests__/api/time-entries-anomaly.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD tests for anomaly detection in NotificationService (TS-27)
+ *
+ * Requirements:
+ *   - Detect engineers with <5h total for 3+ consecutive work days
+ *   - Generate notification for MANAGER when anomaly detected
+ *   - Skip weekends in consecutive day calculation
+ *
+ * Tests written BEFORE implementation (Red phase).
+ */
+
+import { NotificationService, NotificationInput } from "@/services/notification-service";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+const mockTimeEntry = {
+  findMany: jest.fn(),
+};
+const mockUser = {
+  findMany: jest.fn(),
+};
+const mockNotification = {
+  findMany: jest.fn(),
+  createMany: jest.fn(),
+};
+
+const mockPrisma = {
+  timeEntry: mockTimeEntry,
+  user: mockUser,
+  notification: mockNotification,
+} as any;
+
+describe("NotificationService.buildAnomalyNotifications (TS-27)", () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new NotificationService(mockPrisma);
+    mockNotification.findMany.mockResolvedValue([]);
+  });
+
+  it("detects engineer with <5h for 3 consecutive work days", async () => {
+    const now = new Date("2026-03-25T18:00:00");
+
+    // Calculate actual work days the service will use
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < 5) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    // All 5 work days with <5h — guarantees 3+ consecutive
+    mockUser.findMany
+      .mockResolvedValueOnce([{ id: "eng-1", name: "Engineer A" }])
+      .mockResolvedValueOnce([{ id: "mgr-1", name: "Manager" }]);
+
+    mockTimeEntry.findMany.mockResolvedValue(
+      workDays.map((d) => ({ userId: "eng-1", date: new Date(d), hours: 2 }))
+    );
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildAnomalyNotifications(now, existingKeys);
+
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].type).toBe("TIMESHEET_REMINDER");
+    expect(result[0].title).toContain("異常");
+    expect(result[0].relatedType).toBe("TimeEntry");
+  });
+
+  it("does NOT flag engineer with >=5h on all days", async () => {
+    const now = new Date("2026-03-25T18:00:00");
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < 5) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    mockUser.findMany
+      .mockResolvedValueOnce([{ id: "eng-1", name: "Engineer A" }])
+      .mockResolvedValueOnce([{ id: "mgr-1", name: "Manager" }]);
+
+    mockTimeEntry.findMany.mockResolvedValue(
+      workDays.map((d) => ({ userId: "eng-1", date: new Date(d), hours: 8 }))
+    );
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildAnomalyNotifications(now, existingKeys);
+
+    expect(result.length).toBe(0);
+  });
+
+  it("does NOT flag if consecutive low days broken by a good day", async () => {
+    mockUser.findMany
+      .mockResolvedValueOnce([{ id: "eng-1", name: "Engineer A" }])
+      .mockResolvedValueOnce([{ id: "mgr-1", name: "Manager" }]);
+
+    // Use UTC dates to match service behavior.
+    // Lookback 5 work days from now — fill ALL 5 days, with 8h on one to break streak.
+    const now = new Date("2026-03-25T18:00:00");
+    // Calculate the actual work days the service will use
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < 5) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    // Fill all work days with <5h except the middle one (index 2) to break the streak
+    const entries = workDays.map((d, i) => ({
+      userId: "eng-1",
+      date: new Date(d),
+      hours: i === 2 ? 8 : 2, // middle day breaks the streak
+    }));
+
+    mockTimeEntry.findMany.mockResolvedValue(entries);
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildAnomalyNotifications(now, existingKeys);
+
+    // Max consecutive <5h = 2 (before or after the 8h day) — below threshold of 3
+    expect(result.length).toBe(0);
+  });
+
+  it("notifies MANAGER, not the engineer", async () => {
+    const now = new Date("2026-03-25T18:00:00");
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < 5) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    mockUser.findMany
+      .mockResolvedValueOnce([{ id: "eng-1", name: "Engineer A" }])
+      .mockResolvedValueOnce([{ id: "mgr-1", name: "Manager" }]);
+
+    mockTimeEntry.findMany.mockResolvedValue(
+      workDays.map((d) => ({ userId: "eng-1", date: new Date(d), hours: 2 }))
+    );
+
+    const existingKeys = new Set<string>();
+    const result = await service.buildAnomalyNotifications(now, existingKeys);
+
+    // All notifications should go to managers
+    expect(result.length).toBeGreaterThan(0);
+    for (const n of result) {
+      expect(n.userId).toBe("mgr-1");
+    }
+  });
+
+  it("skips duplicate notifications via existingKeys", async () => {
+    const now = new Date("2026-03-25T18:00:00");
+    const todayKey = now.toISOString().slice(0, 10);
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < 5) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    mockUser.findMany
+      .mockResolvedValueOnce([{ id: "eng-1", name: "Engineer A" }])
+      .mockResolvedValueOnce([{ id: "mgr-1", name: "Manager" }]);
+
+    mockTimeEntry.findMany.mockResolvedValue(
+      workDays.map((d) => ({ userId: "eng-1", date: new Date(d), hours: 2 }))
+    );
+
+    // Simulate existing notification
+    const existingKeys = new Set<string>([`mgr-1:TIMESHEET_REMINDER:anomaly:eng-1:${todayKey}`]);
+    const result = await service.buildAnomalyNotifications(now, existingKeys);
+
+    expect(result.length).toBe(0);
+  });
+});

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -348,6 +348,115 @@ export class NotificationService {
   }
 
   /**
+   * TS-27: Detect engineers with <5h total for 3+ consecutive work days.
+   * Generates TIMESHEET_REMINDER notifications sent to all MANAGERs.
+   *
+   * Looks back 5 work days from `now`. Skips weekends.
+   * Only notifies managers (not the flagged engineer).
+   */
+  async buildAnomalyNotifications(
+    now: Date,
+    existingKeys: Set<string>
+  ): Promise<NotificationInput[]> {
+    const DAILY_THRESHOLD = 5;
+    const CONSECUTIVE_DAYS_THRESHOLD = 3;
+    const LOOKBACK_WORK_DAYS = 5;
+
+    // Build list of work days to check (going back from today)
+    const workDays: Date[] = [];
+    const cursor = new Date(now);
+    cursor.setHours(0, 0, 0, 0);
+    while (workDays.length < LOOKBACK_WORK_DAYS) {
+      const day = cursor.getDay();
+      if (day !== 0 && day !== 6) {
+        workDays.unshift(new Date(cursor));
+      }
+      cursor.setDate(cursor.getDate() - 1);
+    }
+
+    if (workDays.length < CONSECUTIVE_DAYS_THRESHOLD) return [];
+
+    const rangeStart = workDays[0];
+    const rangeEnd = new Date(workDays[workDays.length - 1]);
+    rangeEnd.setHours(23, 59, 59, 999);
+
+    // Get all active engineers
+    const engineers = await this.prisma.user.findMany({
+      where: { isActive: true, role: "ENGINEER" },
+      select: { id: true, name: true },
+    });
+
+    if (engineers.length === 0) return [];
+
+    // Get all managers (to receive notifications)
+    const managers = await this.prisma.user.findMany({
+      where: { isActive: true, role: "MANAGER" },
+      select: { id: true, name: true },
+    });
+
+    if (managers.length === 0) return [];
+
+    // Get time entries in the range
+    const entries = await this.prisma.timeEntry.findMany({
+      where: {
+        userId: { in: engineers.map((e: { id: string }) => e.id) },
+        date: { gte: rangeStart, lte: rangeEnd },
+      },
+      select: { userId: true, date: true, hours: true },
+    });
+
+    // Group hours by userId and date
+    const hoursByUserDate: Record<string, Record<string, number>> = {};
+    for (const entry of entries) {
+      const dateStr = new Date(entry.date).toISOString().slice(0, 10);
+      if (!hoursByUserDate[entry.userId]) hoursByUserDate[entry.userId] = {};
+      hoursByUserDate[entry.userId][dateStr] =
+        (hoursByUserDate[entry.userId][dateStr] ?? 0) + entry.hours;
+    }
+
+    const todayKey = now.toISOString().slice(0, 10);
+    const result: NotificationInput[] = [];
+
+    for (const eng of engineers) {
+      const userDays = hoursByUserDate[eng.id] ?? {};
+
+      // Check for consecutive work days with <5h
+      let consecutive = 0;
+      let maxConsecutive = 0;
+      for (const wd of workDays) {
+        const dateStr = wd.toISOString().slice(0, 10);
+        const dayHours = userDays[dateStr] ?? 0;
+        if (dayHours < DAILY_THRESHOLD) {
+          consecutive++;
+          if (consecutive > maxConsecutive) maxConsecutive = consecutive;
+        } else {
+          consecutive = 0;
+        }
+      }
+
+      if (maxConsecutive < CONSECUTIVE_DAYS_THRESHOLD) continue;
+
+      // Generate notification for each manager
+      for (const mgr of managers) {
+        const key = `${mgr.id}:TIMESHEET_REMINDER:anomaly:${eng.id}:${todayKey}`;
+        if (existingKeys.has(key)) continue;
+
+        result.push({
+          userId: mgr.id,
+          type: "TIMESHEET_REMINDER",
+          title: `工時異常警示：${eng.name}`,
+          body: `${eng.name} 已連續 ${maxConsecutive} 個工作日填報工時低於 ${DAILY_THRESHOLD} 小時，請關注。`,
+          relatedId: `anomaly:${eng.id}:${todayKey}`,
+          relatedType: "TimeEntry",
+        });
+        existingKeys.add(key);
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * Full pipeline: build all notification payloads and persist them.
    * Returns counts for observability.
    */


### PR DESCRIPTION
## Summary
- New `buildAnomalyNotifications` method in NotificationService
- Detects engineers with <5h for 3+ consecutive work days
- Sends notifications to MANAGERs (not the flagged engineer)
- Skips weekends, deduplication via existingKeys

## Test plan
- [x] 5 TDD tests pass (time-entries-anomaly.test.ts)
- [x] Detects anomaly correctly
- [x] Does not false-positive with good hours or broken streaks

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)