### PR TITLE
feat(timesheet): Kimai CSV import (TS-31)

### DIFF
--- a/__tests__/api/kimai-import.test.ts
+++ b/__tests__/api/kimai-import.test.ts
@@ -1,0 +1,214 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { mockPrisma } from "../../__mocks__/prisma";
+import {
+  parseKimaiCsv,
+  KimaiImportService,
+  type KimaiRow,
+} from "../../services/kimai-import-service";
+
+// Mock Prisma
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn(() => mockPrisma),
+}));
+
+describe("Kimai Import", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("parseKimaiCsv", () => {
+    it("parses Kimai CSV format correctly", () => {
+      const csv = [
+        "Date,From,To,Duration,Rate,Project,Activity,Description",
+        "2026-03-20,09:00,10:30,1.50,0,TITAN Development,Coding,Implement API",
+        "2026-03-20,13:00,15:00,2.00,0,Security Review,Meeting,Weekly sync",
+      ].join("\n");
+
+      const rows = parseKimaiCsv(csv);
+
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toEqual(
+        expect.objectContaining({
+          date: "2026-03-20",
+          from: "09:00",
+          to: "10:30",
+          duration: 1.5,
+          project: "TITAN Development",
+          activity: "Coding",
+          description: "Implement API",
+        })
+      );
+      expect(rows[1].duration).toBe(2.0);
+    });
+
+    it("validates date format", () => {
+      const csv = [
+        "Date,From,To,Duration,Rate,Project,Activity,Description",
+        "20/03/2026,09:00,10:30,1.50,0,TITAN,Coding,test",
+      ].join("\n");
+
+      expect(() => parseKimaiCsv(csv)).toThrow(/日期格式/);
+    });
+
+    it("rejects empty file", () => {
+      expect(() => parseKimaiCsv("")).toThrow(/空檔案/);
+    });
+
+    it("rejects file with only headers", () => {
+      const csv = "Date,From,To,Duration,Rate,Project,Activity,Description";
+      expect(() => parseKimaiCsv(csv)).toThrow(/沒有資料/);
+    });
+
+    it("handles CSV with extra whitespace", () => {
+      const csv = [
+        "Date,From,To,Duration,Rate,Project,Activity,Description",
+        " 2026-03-20 , 09:00 , 10:30 , 1.50 , 0 , TITAN Dev , Coding , test ",
+      ].join("\n");
+
+      const rows = parseKimaiCsv(csv);
+      expect(rows[0].date).toBe("2026-03-20");
+      expect(rows[0].project).toBe("TITAN Dev");
+    });
+
+    it("handles quoted fields with commas", () => {
+      const csv = [
+        "Date,From,To,Duration,Rate,Project,Activity,Description",
+        '2026-03-20,09:00,10:30,1.50,0,TITAN,"Code, review","Fix bug, deploy"',
+      ].join("\n");
+
+      const rows = parseKimaiCsv(csv);
+      expect(rows[0].activity).toBe("Code, review");
+      expect(rows[0].description).toBe("Fix bug, deploy");
+    });
+  });
+
+  describe("KimaiImportService", () => {
+    let service: KimaiImportService;
+
+    beforeEach(() => {
+      service = new KimaiImportService(mockPrisma as any);
+    });
+
+    it("maps Kimai project to TITAN task by title", async () => {
+      const rows: KimaiRow[] = [
+        {
+          date: "2026-03-20",
+          from: "09:00",
+          to: "10:30",
+          duration: 1.5,
+          rate: 0,
+          project: "TITAN Development",
+          activity: "Coding",
+          description: "Implement API",
+        },
+      ];
+
+      // Mock: find task by title
+      (mockPrisma.task.findFirst as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        title: "TITAN Development",
+      });
+
+      (mockPrisma.timeEntry.create as jest.Mock).mockResolvedValue({
+        id: "te-1",
+      });
+
+      (mockPrisma.$transaction as jest.Mock).mockImplementation(
+        async (fn: any) => fn(mockPrisma)
+      );
+
+      const result = await service.importRows(rows, "user-1");
+
+      expect(result.created).toBe(1);
+      expect(result.errors).toHaveLength(0);
+      expect(mockPrisma.task.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            title: { contains: "TITAN Development", mode: "insensitive" },
+          }),
+        })
+      );
+    });
+
+    it("handles missing task gracefully — creates as free time", async () => {
+      const rows: KimaiRow[] = [
+        {
+          date: "2026-03-20",
+          from: "09:00",
+          to: "10:30",
+          duration: 1.5,
+          rate: 0,
+          project: "Unknown Project",
+          activity: "Meeting",
+          description: "External meeting",
+        },
+      ];
+
+      // Mock: no matching task
+      (mockPrisma.task.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockPrisma.timeEntry.create as jest.Mock).mockResolvedValue({
+        id: "te-2",
+      });
+      (mockPrisma.$transaction as jest.Mock).mockImplementation(
+        async (fn: any) => fn(mockPrisma)
+      );
+
+      const result = await service.importRows(rows, "user-1");
+
+      expect(result.created).toBe(1);
+      expect(result.errors).toHaveLength(0);
+
+      // Should create time entry without taskId (free time)
+      expect(mockPrisma.timeEntry.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            taskId: null,
+            category: "ADMIN",
+            description: expect.stringContaining("Unknown Project"),
+          }),
+        })
+      );
+    });
+
+    it("imports multiple rows and reports results", async () => {
+      const rows: KimaiRow[] = [
+        {
+          date: "2026-03-20",
+          from: "09:00",
+          to: "10:00",
+          duration: 1.0,
+          rate: 0,
+          project: "Project A",
+          activity: "Dev",
+          description: "Work 1",
+        },
+        {
+          date: "2026-03-20",
+          from: "10:00",
+          to: "12:00",
+          duration: 2.0,
+          rate: 0,
+          project: "Project B",
+          activity: "Review",
+          description: "Work 2",
+        },
+      ];
+
+      (mockPrisma.task.findFirst as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        title: "Project A",
+      });
+      (mockPrisma.timeEntry.create as jest.Mock).mockResolvedValue({
+        id: "te-new",
+      });
+      (mockPrisma.$transaction as jest.Mock).mockImplementation(
+        async (fn: any) => fn(mockPrisma)
+      );
+
+      const result = await service.importRows(rows, "user-1");
+
+      expect(result.created).toBe(2);
+      expect(mockPrisma.timeEntry.create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/api/time-entries/import-kimai/route.ts
+++ b/app/api/time-entries/import-kimai/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success, error } from "@/lib/api-response";
+import { parseKimaiCsv, KimaiImportService } from "@/services/kimai-import-service";
+
+/**
+ * POST /api/time-entries/import-kimai
+ *
+ * Accepts multipart/form-data with a CSV file from Kimai export.
+ * Parses the CSV and creates time entries for the authenticated user.
+ *
+ * Issue #740: [TS-31] Kimai 工時資料匯入功能
+ */
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return error("請上傳 CSV 檔案", 400);
+    }
+
+    // Validate file type
+    if (!file.name.endsWith(".csv") && file.type !== "text/csv") {
+      return error("僅支援 CSV 格式（.csv）", 400);
+    }
+
+    // Limit file size (1MB)
+    const MAX_SIZE = 1 * 1024 * 1024;
+    if (file.size > MAX_SIZE) {
+      return error("檔案大小不可超過 1MB", 400);
+    }
+
+    const text = await file.text();
+    const rows = parseKimaiCsv(text);
+
+    const service = new KimaiImportService(prisma);
+    const result = await service.importRows(rows, userId);
+
+    return success(result, result.errors.length > 0 ? 207 : 201);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "匯入失敗";
+    return error(message, 400);
+  }
+});

--- a/services/kimai-import-service.ts
+++ b/services/kimai-import-service.ts
@@ -1,0 +1,199 @@
+import { PrismaClient, TimeCategory } from "@prisma/client";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface KimaiRow {
+  date: string; // YYYY-MM-DD
+  from: string; // HH:MM
+  to: string; // HH:MM
+  duration: number; // hours (decimal)
+  rate: number;
+  project: string;
+  activity: string;
+  description: string;
+}
+
+export interface KimaiImportResult {
+  created: number;
+  errors: Array<{ rowIndex: number; message: string }>;
+}
+
+// ─── CSV Parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Parse a single CSV line, respecting quoted fields.
+ */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++; // skip escaped quote
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += ch;
+      }
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+      } else if (ch === ",") {
+        fields.push(current.trim());
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+  }
+  fields.push(current.trim());
+  return fields;
+}
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses Kimai CSV export format into structured rows.
+ *
+ * Expected columns: Date,From,To,Duration,Rate,Project,Activity,Description
+ */
+export function parseKimaiCsv(content: string): KimaiRow[] {
+  const trimmed = content.trim();
+  if (!trimmed) {
+    throw new Error("空檔案：CSV 內容為空");
+  }
+
+  const lines = trimmed.split(/\r?\n/);
+  if (lines.length < 2) {
+    throw new Error("沒有資料：CSV 只有標題行，沒有資料列");
+  }
+
+  // Skip header row
+  const rows: KimaiRow[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    const fields = parseCsvLine(line);
+
+    const date = fields[0] ?? "";
+    if (!DATE_REGEX.test(date)) {
+      throw new Error(
+        `第 ${i + 1} 行日期格式無效：'${date}'（預期 YYYY-MM-DD）`
+      );
+    }
+
+    rows.push({
+      date,
+      from: fields[1] ?? "",
+      to: fields[2] ?? "",
+      duration: parseFloat(fields[3] ?? "0"),
+      rate: parseFloat(fields[4] ?? "0"),
+      project: fields[5] ?? "",
+      activity: fields[6] ?? "",
+      description: fields[7] ?? "",
+    });
+  }
+
+  if (rows.length === 0) {
+    throw new Error("沒有資料：CSV 只有標題行，沒有資料列");
+  }
+
+  return rows;
+}
+
+// ─── Activity → Category Mapping ────────────────────────────────────────────
+
+const ACTIVITY_CATEGORY_MAP: Record<string, TimeCategory> = {
+  coding: TimeCategory.PLANNED_TASK,
+  development: TimeCategory.PLANNED_TASK,
+  dev: TimeCategory.PLANNED_TASK,
+  implementation: TimeCategory.PLANNED_TASK,
+  review: TimeCategory.PLANNED_TASK,
+  meeting: TimeCategory.ADMIN,
+  admin: TimeCategory.ADMIN,
+  support: TimeCategory.SUPPORT,
+  incident: TimeCategory.INCIDENT,
+  learning: TimeCategory.LEARNING,
+  training: TimeCategory.LEARNING,
+};
+
+function mapActivityToCategory(activity: string): TimeCategory {
+  const normalized = activity.toLowerCase().trim();
+  return ACTIVITY_CATEGORY_MAP[normalized] ?? TimeCategory.ADMIN;
+}
+
+// ─── Import Service ─────────────────────────────────────────────────────────
+
+export class KimaiImportService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Import parsed Kimai rows into TITAN time entries.
+   *
+   * For each row:
+   * 1. Try to find a matching TITAN task by project name (case-insensitive)
+   * 2. If no match, create as free time (taskId=null, category=ADMIN)
+   * 3. Map Kimai activity to TITAN TimeCategory
+   */
+  async importRows(
+    rows: KimaiRow[],
+    userId: string
+  ): Promise<KimaiImportResult> {
+    const result: KimaiImportResult = { created: 0, errors: [] };
+
+    await this.prisma.$transaction(async (tx: any) => {
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i];
+        try {
+          // Try to match project to an existing task
+          const task = await tx.task.findFirst({
+            where: {
+              title: { contains: row.project, mode: "insensitive" },
+            },
+          });
+
+          const category = task
+            ? mapActivityToCategory(row.activity)
+            : TimeCategory.ADMIN;
+
+          const description = task
+            ? `[Kimai] ${row.activity}: ${row.description}`.trim()
+            : `[Kimai] ${row.project} - ${row.activity}: ${row.description}`.trim();
+
+          await tx.timeEntry.create({
+            data: {
+              userId,
+              taskId: task?.id ?? null,
+              date: new Date(row.date),
+              hours: row.duration,
+              category,
+              description,
+              startTime: row.from
+                ? new Date(`${row.date}T${row.from}:00`)
+                : null,
+              endTime: row.to ? new Date(`${row.date}T${row.to}:00`) : null,
+            },
+          });
+
+          result.created++;
+        } catch (err) {
+          result.errors.push({
+            rowIndex: i,
+            message:
+              err instanceof Error ? err.message : "匯入失敗：未知錯誤",
+          });
+        }
+      }
+    });
+
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `parseKimaiCsv()` parser with date validation, quoted field support, empty file rejection
- Add `KimaiImportService` that maps Kimai projects to TITAN tasks by title (case-insensitive)
- Add `POST /api/time-entries/import-kimai` endpoint (multipart/form-data)
- TDD: 9 tests written first, all passing

## Test plan
- [x] 9 unit tests pass: CSV parsing, date validation, empty file, task mapping, free time fallback
- [ ] Manual test: upload Kimai CSV export via API

Closes #740

🤖 Generated with [Claude Code](https://claude.com/claude-code)