### PR TITLE
feat(reports): compliance export with Excel (TS-28)

### DIFF
--- a/__tests__/api/reports-compliance.test.ts
+++ b/__tests__/api/reports-compliance.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD tests for GET /api/reports/timesheet-compliance (TS-28)
+ *
+ * Requirements:
+ *   - Returns structured compliance report
+ *   - Includes per-user daily hours, overtime flags, locked status
+ *   - Only MANAGER can access
+ *   - Excel export endpoint available
+ *
+ * Tests written BEFORE implementation (Red phase).
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+const mockTimeEntry = {
+  findMany: jest.fn(),
+};
+const mockUser = {
+  findMany: jest.fn(),
+};
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    timeEntry: mockTimeEntry,
+    user: mockUser,
+  },
+}));
+
+// ── Auth mock ────────────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION_MANAGER = {
+  user: { id: "mgr-1", name: "Manager", email: "mgr@t.com", role: "MANAGER" },
+  expires: "2099",
+};
+const SESSION_ENGINEER = {
+  user: { id: "eng-1", name: "Engineer", email: "e@t.com", role: "ENGINEER" },
+  expires: "2099",
+};
+
+// Suppress console.error
+jest.spyOn(console, "error").mockImplementation(() => {});
+
+describe("GET /api/reports/timesheet-compliance (TS-28)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it("returns structured compliance report for MANAGER", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockUser.findMany.mockResolvedValue([
+      { id: "eng-1", name: "Engineer A", role: "ENGINEER" },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      {
+        id: "e1",
+        userId: "eng-1",
+        date: new Date("2026-03-23"),
+        hours: 9,
+        overtime: true,
+        locked: true,
+        category: "PLANNED_TASK",
+        user: { id: "eng-1", name: "Engineer A" },
+      },
+      {
+        id: "e2",
+        userId: "eng-1",
+        date: new Date("2026-03-24"),
+        hours: 8,
+        overtime: false,
+        locked: false,
+        category: "PLANNED_TASK",
+        user: { id: "eng-1", name: "Engineer A" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/timesheet-compliance/route");
+    const res = await GET(
+      createMockRequest("/api/reports/timesheet-compliance", {
+        searchParams: { startDate: "2026-03-23", endDate: "2026-03-27" },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.users).toBeDefined();
+    expect(body.data.users.length).toBeGreaterThan(0);
+
+    const user = body.data.users[0];
+    expect(user.userId).toBe("eng-1");
+    expect(user.totalHours).toBe(17);
+    expect(user.dailyEntries).toBeDefined();
+    expect(user.hasOvertime).toBe(true);
+    expect(user.hasUnlocked).toBe(true);
+  });
+
+  it("returns 403 for ENGINEER", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { GET } = await import("@/app/api/reports/timesheet-compliance/route");
+    const res = await GET(
+      createMockRequest("/api/reports/timesheet-compliance", {
+        searchParams: { startDate: "2026-03-23", endDate: "2026-03-27" },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/reports/timesheet-compliance/route");
+    const res = await GET(
+      createMockRequest("/api/reports/timesheet-compliance", {
+        searchParams: { startDate: "2026-03-23", endDate: "2026-03-27" },
+      })
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("includes locked status per entry in report", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockUser.findMany.mockResolvedValue([
+      { id: "eng-1", name: "Engineer A", role: "ENGINEER" },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      {
+        id: "e1",
+        userId: "eng-1",
+        date: new Date("2026-03-23"),
+        hours: 8,
+        overtime: false,
+        locked: true,
+        category: "PLANNED_TASK",
+        user: { id: "eng-1", name: "Engineer A" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/timesheet-compliance/route");
+    const res = await GET(
+      createMockRequest("/api/reports/timesheet-compliance", {
+        searchParams: { startDate: "2026-03-23", endDate: "2026-03-27" },
+      })
+    );
+
+    const body = await res.json();
+    const user = body.data.users[0];
+    // All entries locked → hasUnlocked should be false
+    expect(user.hasUnlocked).toBe(false);
+  });
+
+  it("returns empty users array when no entries exist", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockUser.findMany.mockResolvedValue([]);
+    mockTimeEntry.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/reports/timesheet-compliance/route");
+    const res = await GET(
+      createMockRequest("/api/reports/timesheet-compliance", {
+        searchParams: { startDate: "2026-03-23", endDate: "2026-03-27" },
+      })
+    );
+
+    const body = await res.json();
+    expect(body.data.users).toEqual([]);
+  });
+});

--- a/app/api/reports/timesheet-compliance/route.ts
+++ b/app/api/reports/timesheet-compliance/route.ts
@@ -1,0 +1,154 @@
+/**
+ * GET /api/reports/timesheet-compliance — Compliance export (TS-28)
+ *
+ * Returns structured compliance report with per-user daily hours,
+ * overtime flags, and locked status. Designed for bank audit exports.
+ * Only MANAGER role may access.
+ *
+ * Query params:
+ *   startDate — ISO date string (required)
+ *   endDate   — ISO date string (required)
+ *   format    — "json" (default) or "excel"
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+interface DailyEntry {
+  date: string;
+  hours: number;
+  overtime: boolean;
+  locked: boolean;
+  category: string;
+}
+
+interface UserComplianceRow {
+  userId: string;
+  userName: string;
+  totalHours: number;
+  dailyEntries: DailyEntry[];
+  hasOvertime: boolean;
+  hasUnlocked: boolean;
+}
+
+export const GET = withManager(async (req: NextRequest) => {
+  await requireRole("MANAGER");
+
+  const { searchParams } = new URL(req.url);
+  const startDate = searchParams.get("startDate");
+  const endDate = searchParams.get("endDate");
+  const format = searchParams.get("format") ?? "json";
+
+  const start = startDate ? new Date(startDate) : new Date();
+  const end = endDate ? new Date(endDate) : new Date();
+  end.setHours(23, 59, 59, 999);
+
+  // Get all time entries in the range
+  const entries = await prisma.timeEntry.findMany({
+    where: {
+      date: { gte: start, lte: end },
+    },
+    include: {
+      user: { select: { id: true, name: true } },
+    },
+    orderBy: [{ userId: "asc" }, { date: "asc" }],
+  });
+
+  // Group by user
+  const byUser = new Map<string, { userName: string; entries: typeof entries }>();
+
+  for (const entry of entries) {
+    const userId = entry.userId;
+    const userName = (entry as unknown as { user: { name: string } }).user?.name ?? "Unknown";
+    if (!byUser.has(userId)) {
+      byUser.set(userId, { userName, entries: [] });
+    }
+    byUser.get(userId)!.entries.push(entry);
+  }
+
+  // Build compliance rows
+  const users: UserComplianceRow[] = [];
+
+  for (const [userId, { userName, entries: userEntries }] of byUser) {
+    const dailyEntries: DailyEntry[] = userEntries.map((e) => ({
+      date: new Date(e.date).toISOString().slice(0, 10),
+      hours: e.hours,
+      overtime: Boolean((e as Record<string, unknown>).overtime),
+      locked: Boolean((e as Record<string, unknown>).locked),
+      category: e.category,
+    }));
+
+    const totalHours = userEntries.reduce((sum, e) => sum + e.hours, 0);
+    const hasOvertime = dailyEntries.some((d) => d.overtime);
+    const hasUnlocked = dailyEntries.some((d) => !d.locked);
+
+    users.push({
+      userId,
+      userName,
+      totalHours,
+      dailyEntries,
+      hasOvertime,
+      hasUnlocked,
+    });
+  }
+
+  // Excel export
+  if (format === "excel") {
+    const ExcelJS = await import("exceljs");
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("工時合規報表");
+
+    // Headers
+    sheet.columns = [
+      { header: "員工ID", key: "userId", width: 20 },
+      { header: "員工姓名", key: "userName", width: 15 },
+      { header: "日期", key: "date", width: 12 },
+      { header: "工時", key: "hours", width: 10 },
+      { header: "加班", key: "overtime", width: 8 },
+      { header: "已鎖定", key: "locked", width: 8 },
+      { header: "分類", key: "category", width: 15 },
+    ];
+
+    // Style header row
+    const headerRow = sheet.getRow(1);
+    headerRow.font = { bold: true };
+    headerRow.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: "FFD9E1F2" },
+    };
+
+    // Data rows
+    for (const user of users) {
+      for (const de of user.dailyEntries) {
+        sheet.addRow({
+          userId: user.userId,
+          userName: user.userName,
+          date: de.date,
+          hours: de.hours,
+          overtime: de.overtime ? "是" : "否",
+          locked: de.locked ? "是" : "否",
+          category: de.category,
+        });
+      }
+    }
+
+    const buffer = await workbook.xlsx.writeBuffer();
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="compliance-${startDate}-${endDate}.xlsx"`,
+      },
+    });
+  }
+
+  return success({
+    startDate: start.toISOString().slice(0, 10),
+    endDate: end.toISOString().slice(0, 10),
+    users,
+  });
+});


### PR DESCRIPTION
## Summary
- GET /api/reports/timesheet-compliance returns per-user daily hours, overtime flags, locked status
- Supports JSON (default) and Excel export (format=excel) for bank audit
- Only MANAGER role can access (403 for ENGINEER, 401 unauthenticated)

## Test plan
- [x] 5 TDD tests pass (reports-compliance.test.ts)
- [x] Structured report includes overtime and lock status

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)