### PR TITLE
feat(timesheet): overtime badge and toggle (TS-19)

### DIFF
--- a/__tests__/components/overtime-badge.test.tsx
+++ b/__tests__/components/overtime-badge.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Component tests: Overtime badge in TimeEntryCell
+ * Issue #723: [TS-19] 加班標記顯示
+ *
+ * TDD: Tests written first.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// We test the overtime logic and badge rendering
+import { TimeEntryCell, type TimeEntry } from "@/app/components/time-entry-cell";
+
+describe("Overtime Badge", () => {
+  const baseProps = {
+    taskId: "task-1",
+    date: "2026-03-20",
+    onSave: jest.fn(),
+    onDelete: jest.fn(),
+  };
+
+  it("shows overtime badge when entry has overtime=true", () => {
+    const entry: TimeEntry = {
+      id: "e1",
+      taskId: "task-1",
+      date: "2026-03-20",
+      hours: 2,
+      category: "PLANNED_TASK",
+      description: null,
+      overtime: true,
+    };
+
+    render(<TimeEntryCell {...baseProps} entry={entry} />);
+    expect(screen.getByText("OT")).toBeInTheDocument();
+  });
+
+  it("does not show overtime badge when overtime=false", () => {
+    const entry: TimeEntry = {
+      id: "e2",
+      taskId: "task-1",
+      date: "2026-03-20",
+      hours: 2,
+      category: "PLANNED_TASK",
+      description: null,
+      overtime: false,
+    };
+
+    render(<TimeEntryCell {...baseProps} entry={entry} />);
+    expect(screen.queryByText("OT")).not.toBeInTheDocument();
+  });
+
+  it("does not show overtime badge when overtime is undefined", () => {
+    const entry: TimeEntry = {
+      id: "e3",
+      taskId: "task-1",
+      date: "2026-03-20",
+      hours: 2,
+      category: "PLANNED_TASK",
+      description: null,
+    };
+
+    render(<TimeEntryCell {...baseProps} entry={entry} />);
+    expect(screen.queryByText("OT")).not.toBeInTheDocument();
+  });
+
+  it("shows overtime toggle in the edit popover", async () => {
+    const entry: TimeEntry = {
+      id: "e4",
+      taskId: "task-1",
+      date: "2026-03-20",
+      hours: 4,
+      category: "PLANNED_TASK",
+      description: null,
+      overtime: false,
+    };
+
+    render(<TimeEntryCell {...baseProps} entry={entry} />);
+
+    // Open popover by clicking the cell
+    const cellButton = screen.getByText("4h");
+    fireEvent.click(cellButton);
+
+    // Should have overtime toggle
+    expect(screen.getByLabelText("加班")).toBeInTheDocument();
+  });
+
+  it("overtime toggle is checked when entry.overtime=true", () => {
+    const entry: TimeEntry = {
+      id: "e5",
+      taskId: "task-1",
+      date: "2026-03-20",
+      hours: 4,
+      category: "PLANNED_TASK",
+      description: null,
+      overtime: true,
+    };
+
+    render(<TimeEntryCell {...baseProps} entry={entry} />);
+    fireEvent.click(screen.getByText("4h"));
+
+    const checkbox = screen.getByLabelText("加班") as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+});

--- a/app/components/time-entry-cell.tsx
+++ b/app/components/time-entry-cell.tsx
@@ -11,6 +11,7 @@ export type TimeEntry = {
   startTime?: string | null;
   endTime?: string | null;
   isRunning?: boolean;
+  overtime?: boolean;
   category: string;
   description: string | null;
 };
@@ -41,6 +42,7 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
   const [hours, setHours] = useState(entry?.hours?.toString() ?? "");
   const [category, setCategory] = useState(entry?.category ?? "PLANNED_TASK");
   const [description, setDescription] = useState(entry?.description ?? "");
+  const [overtime, setOvertime] = useState(entry?.overtime ?? false);
   const [saving, setSaving] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -50,6 +52,7 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
       setHours(entry?.hours?.toString() ?? "");
       setCategory(entry?.category ?? "PLANNED_TASK");
       setDescription(entry?.description ?? "");
+      setOvertime(entry?.overtime ?? false);
     }
   }, [entry, open]);
 
@@ -99,7 +102,14 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
         )}
       >
         {entry && entry.hours > 0 ? (
-          <span className="tabular-nums">{entry.hours}h</span>
+          <span className="tabular-nums inline-flex items-center gap-1">
+            {entry.hours}h
+            {entry.overtime && (
+              <span className="inline-block px-1 py-0.5 text-[10px] font-bold leading-none bg-amber-500/30 text-amber-400 border border-amber-500/40 rounded">
+                OT
+              </span>
+            )}
+          </span>
         ) : (
           <span>+</span>
         )}
@@ -147,6 +157,19 @@ export function TimeEntryCell({ entry, taskId, date, onSave, onDelete }: TimeEnt
               className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               placeholder="可選備註..."
             />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id={`overtime-${entry?.id ?? 'new'}-${date}`}
+              checked={overtime}
+              onChange={(e) => setOvertime(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border text-amber-500 focus:ring-amber-500/50"
+            />
+            <label htmlFor={`overtime-${entry?.id ?? 'new'}-${date}`} className="text-xs text-muted-foreground cursor-pointer">
+              加班
+            </label>
           </div>
 
           <div className="flex items-center gap-2 pt-1">


### PR DESCRIPTION
## Summary
- Add `overtime` field to `TimeEntry` type
- Display amber "OT" badge on time entry cells when overtime=true
- Add overtime checkbox toggle in the cell edit popover
- TDD: 5 tests written first, all passing

## Test plan
- [x] 5 component tests pass (badge visible/hidden, toggle in popover, checked state)
- [x] Existing timesheet-grid tests still pass (7/7)

Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)