### PR TITLE
feat(timesheet): daily limit warning colors (TS-23)

### DIFF
--- a/__tests__/components/timesheet-grid.test.tsx
+++ b/__tests__/components/timesheet-grid.test.tsx
@@ -76,4 +76,51 @@ describe("TimesheetGrid", () => {
     render(<TimesheetGrid {...defaultProps} taskRows={[]} />);
     expect(screen.queryByTestId("time-entry-cell")).not.toBeInTheDocument();
   });
+
+  describe("daily limit warnings", () => {
+    it("shows orange warning when daily total > 10h", () => {
+      const highEntries = [
+        { id: "e1", taskId: "task-1", date: "2024-01-15T00:00:00Z", hours: 8, category: "PLANNED_TASK", description: null },
+        { id: "e2", taskId: null, date: "2024-01-15T00:00:00Z", hours: 3, category: "ADMIN", description: null },
+      ];
+      const { container } = render(
+        <TimesheetGrid {...defaultProps} entries={highEntries} />
+      );
+      // 11h total on Monday - should have orange text and lightning emoji
+      const footerSpans = container.querySelectorAll("tfoot span");
+      const mondaySpan = Array.from(footerSpans).find((s) =>
+        s.textContent?.includes("11.0")
+      );
+      expect(mondaySpan).toBeTruthy();
+      expect(mondaySpan?.className).toContain("text-orange-500");
+    });
+
+    it("shows red warning when daily total > 12h", () => {
+      const veryHighEntries = [
+        { id: "e1", taskId: "task-1", date: "2024-01-15T00:00:00Z", hours: 8, category: "PLANNED_TASK", description: null },
+        { id: "e2", taskId: null, date: "2024-01-15T00:00:00Z", hours: 5, category: "ADMIN", description: null },
+      ];
+      const { container } = render(
+        <TimesheetGrid {...defaultProps} entries={veryHighEntries} />
+      );
+      // 13h total on Monday - should have red text and warning emoji
+      const footerSpans = container.querySelectorAll("tfoot span");
+      const mondaySpan = Array.from(footerSpans).find((s) =>
+        s.textContent?.includes("13.0")
+      );
+      expect(mondaySpan).toBeTruthy();
+      expect(mondaySpan?.className).toContain("text-red-500");
+    });
+
+    it("shows green for normal daily total <= 8h", () => {
+      const { container } = render(<TimesheetGrid {...defaultProps} />);
+      // Monday has 4h - should be green
+      const footerSpans = container.querySelectorAll("tfoot span");
+      const mondaySpan = Array.from(footerSpans).find((s) =>
+        s.textContent?.includes("4.0")
+      );
+      expect(mondaySpan).toBeTruthy();
+      expect(mondaySpan?.className).toContain("text-emerald-500");
+    });
+  });
 });

--- a/app/components/timesheet-grid.tsx
+++ b/app/components/timesheet-grid.tsx
@@ -117,8 +117,30 @@ export function TimesheetGrid({ weekStart, taskRows, entries, onCellSave, onCell
             </td>
             {dailyTotals.map((total, i) => (
               <td key={i} className="px-2 py-2.5 text-center">
-                <span className={cn("text-xs font-semibold tabular-nums", total > 8 ? "text-amber-500" : total > 0 ? "text-emerald-500" : "text-muted-foreground/40")}>
+                <span
+                  className={cn(
+                    "text-xs font-semibold tabular-nums",
+                    total > 12
+                      ? "text-red-500"
+                      : total > 10
+                        ? "text-orange-500"
+                        : total > 8
+                          ? "text-amber-500"
+                          : total > 0
+                            ? "text-emerald-500"
+                            : "text-muted-foreground/40"
+                  )}
+                  title={
+                    total > 12
+                      ? "超時警告：超過 12 小時"
+                      : total > 10
+                        ? "超時警告：超過 10 小時"
+                        : undefined
+                  }
+                >
                   {total > 0 ? safeFixed(total, 1) : "—"}
+                  {total > 12 && " ⚠"}
+                  {total > 10 && total <= 12 && " ⚡"}
                 </span>
               </td>
             ))}


### PR DESCRIPTION
## Summary
- >12h daily total: red text with warning icon
- >10h daily total: orange text with lightning icon  
- >8h: amber (existing behavior preserved)
- <=8h: green (existing behavior preserved)
- Tooltip on hover explains the warning threshold

## Test plan
- [x] 3 new tests verify color classes (orange for >10h, red for >12h, green for <=8h)
- [x] All 10 timesheet-grid tests pass

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)