### PR TITLE
fix(auth): Edge JWT HKDF match Auth.js v5 key derivation

### DIFF
--- a/__tests__/api/edge-jwt.test.ts
+++ b/__tests__/api/edge-jwt.test.ts
@@ -1,0 +1,227 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Edge JWT verification tests — Issue #757
+ *
+ * TDD: Tests that checkEdgeJwt can decrypt Auth.js v5 JWE tokens.
+ *
+ * Since jose is ESM-only and cannot be imported directly in Jest,
+ * we mock the jose module and test the HKDF key derivation logic
+ * and the checkEdgeJwt flow separately.
+ */
+
+import { NextRequest } from "next/server";
+
+const TEST_SECRET = "test-secret-must-be-at-least-32-characters-long!!";
+const COOKIE_NAME = "authjs.session-token";
+
+// Mock jose since it's ESM-only
+const mockJwtDecrypt = jest.fn();
+const mockJwtVerify = jest.fn();
+jest.mock("jose", () => ({
+  jwtDecrypt: (...args: unknown[]) => mockJwtDecrypt(...args),
+  jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
+}));
+
+// Mock logger
+jest.mock("@/lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+/**
+ * Replicate Auth.js v5's HKDF key derivation using Web Crypto.
+ * This is the EXPECTED correct behavior:
+ *   hkdf("sha256", secret, salt=cookieName, info="Auth.js Generated Encryption Key (cookieName)", 64 bytes)
+ */
+async function authJsV5DeriveKey(secret: string, salt: string): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    "HKDF",
+    false,
+    ["deriveBits"]
+  );
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: enc.encode(salt),
+      info: enc.encode(`Auth.js Generated Encryption Key (${salt})`),
+    },
+    keyMaterial,
+    512 // 64 bytes for A256CBC-HS512
+  );
+  return new Uint8Array(derivedBits);
+}
+
+describe("Edge JWT verification (Auth.js v5 compatible)", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, AUTH_SECRET: TEST_SECRET };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("HKDF key derivation", () => {
+    it("should derive key using Auth.js v5 parameters (salt=cookieName, info includes salt)", async () => {
+      // Setup: jwtDecrypt succeeds, capturing the key passed to it
+      let capturedKey: Uint8Array | null = null;
+      mockJwtDecrypt.mockImplementation(async (_token: string, key: Uint8Array) => {
+        capturedKey = key;
+        return { payload: { sub: "user-1" } };
+      });
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      // Create a fake JWE token (5 dot-separated parts with enc header)
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      await checkEdgeJwt(req);
+
+      // Verify jwtDecrypt was called
+      expect(mockJwtDecrypt).toHaveBeenCalled();
+
+      // The key should match Auth.js v5's HKDF derivation
+      const expectedKey = await authJsV5DeriveKey(TEST_SECRET, COOKIE_NAME);
+      expect(capturedKey).not.toBeNull();
+      expect(Buffer.from(capturedKey!).toString("hex")).toBe(
+        Buffer.from(expectedKey).toString("hex")
+      );
+    });
+
+    it("should produce 64-byte key for A256CBC-HS512", async () => {
+      let capturedKey: Uint8Array | null = null;
+      mockJwtDecrypt.mockImplementation(async (_token: string, key: Uint8Array) => {
+        capturedKey = key;
+        return { payload: { sub: "user-1" } };
+      });
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      await checkEdgeJwt(req);
+
+      expect(capturedKey).not.toBeNull();
+      expect(capturedKey!.byteLength).toBe(64);
+    });
+  });
+
+  describe("checkEdgeJwt flow", () => {
+    it("should return null when JWE decryption succeeds", async () => {
+      mockJwtDecrypt.mockResolvedValue({ payload: { sub: "user-1" } });
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      const result = await checkEdgeJwt(req);
+      expect(result).toBeNull();
+    });
+
+    it("should return 401 when JWE decryption fails", async () => {
+      mockJwtDecrypt.mockRejectedValue(new Error("decryption failed"));
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      const result = await checkEdgeJwt(req);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("should return 401 when no token is present", async () => {
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const req = new NextRequest("http://localhost:3000/api/tasks");
+      const result = await checkEdgeJwt(req);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("should return 401 when AUTH_SECRET is not set", async () => {
+      delete process.env.AUTH_SECRET;
+      delete process.env.NEXTAUTH_SECRET;
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      const result = await checkEdgeJwt(req);
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(401);
+    });
+
+    it("should accept token from Authorization Bearer header", async () => {
+      mockJwtDecrypt.mockResolvedValue({ payload: { sub: "user-1" } });
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256CBC-HS512" })).toString("base64");
+      const fakeToken = `${header}.iv.ciphertext.tag.aad`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { authorization: `Bearer ${fakeToken}` },
+      });
+
+      const result = await checkEdgeJwt(req);
+      expect(result).toBeNull();
+    });
+
+    it("should handle JWS tokens with jwtVerify", async () => {
+      mockJwtVerify.mockResolvedValue({ payload: { sub: "user-1" } });
+
+      const { checkEdgeJwt } = await import("@/lib/auth-depth");
+
+      // JWS header (no enc field)
+      const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64");
+      const fakeToken = `${header}.payload.signature`;
+
+      const req = new NextRequest("http://localhost:3000/api/tasks", {
+        headers: { cookie: `${COOKIE_NAME}=${fakeToken}` },
+      });
+
+      const result = await checkEdgeJwt(req);
+      expect(result).toBeNull();
+      expect(mockJwtVerify).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/auth-depth.ts
+++ b/lib/auth-depth.ts
@@ -50,15 +50,23 @@ function extractToken(req: NextRequest): string | null {
 }
 
 /**
+ * Default cookie name used by Auth.js v5 as HKDF salt.
+ * Must match the sessionToken cookie name configured in auth.ts.
+ */
+const DEFAULT_SESSION_COOKIE = "authjs.session-token";
+
+/**
  * Derives the encryption key from AUTH_SECRET.
  * Auth.js v5 uses HKDF to derive a 64-byte key from the secret
  * for JWE (A256CBC-HS512) encryption. For JWS fallback we use the raw secret.
  *
- * Key differences from v4:
- *   - info string: "Auth.js Generated Encryption Key" (was "NextAuth.js ...")
- *   - algorithm: A256CBC-HS512 requires 64 bytes (was A256GCM / 32 bytes)
+ * Verified against @auth/core/jwt.js getDerivedEncryptionKey():
+ *   hkdf("sha256", secret, salt, `Auth.js Generated Encryption Key (${salt})`, 64)
+ * where salt = cookie name (e.g. "authjs.session-token").
  */
-async function getDerivedEncryptionKey(): Promise<Uint8Array | null> {
+async function getDerivedEncryptionKey(
+  salt: string = DEFAULT_SESSION_COOKIE
+): Promise<Uint8Array | null> {
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
   if (!secret) return null;
 
@@ -66,9 +74,14 @@ async function getDerivedEncryptionKey(): Promise<Uint8Array | null> {
   const keyMaterial = await crypto.subtle.importKey(
     "raw", enc.encode(secret), "HKDF", false, ["deriveBits"]
   );
-  // Auth.js v5: HKDF SHA-256, salt="", info="Auth.js Generated Encryption Key", 512 bits (64 bytes)
+  // Auth.js v5: HKDF SHA-256, salt=cookieName, info="Auth.js Generated Encryption Key ({cookieName})", 512 bits
   const derivedBits = await crypto.subtle.deriveBits(
-    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: enc.encode("Auth.js Generated Encryption Key") },
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: enc.encode(salt),
+      info: enc.encode(`Auth.js Generated Encryption Key (${salt})`),
+    },
     keyMaterial,
     512 // 64 bytes for A256CBC-HS512
   );

--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -50,14 +50,8 @@ export async function checkAuth(
     return null; // has session cookie — let the page's auth() verify it
   }
 
-  // API routes: cookie presence check (Layer 1).
-  // NOTE: Edge JWT decryption (checkEdgeJwt) is disabled because Auth.js v5's
-  // A256CBC-HS512 JWE encryption key derivation does not match our HKDF implementation.
-  // Layer 2 auth (withAuth/withManager using auth()) fully protects all API routes.
-  // TODO: Fix checkEdgeJwt HKDF to match Auth.js v5, then re-enable.
-  const apiCookie = req.headers.get("cookie") ?? "";
-  if (!apiCookie.includes("authjs.session-token")) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  return null; // has session cookie — Layer 2 auth() validates it
+  // API routes: Edge JWT decryption (Layer 1).
+  // HKDF parameters fixed in Issue #757 to match Auth.js v5's key derivation.
+  // Layer 2 auth (withAuth/withManager using auth()) still fully protects all API routes.
+  return await checkEdgeJwt(req);
 }


### PR DESCRIPTION
## Summary
- Fix HKDF parameters in `lib/auth-depth.ts` to match `@auth/core/jwt.js` exactly
- Salt: empty `Uint8Array(0)` → cookie name (`authjs.session-token`)
- Info: `"Auth.js Generated Encryption Key"` → `"Auth.js Generated Encryption Key (authjs.session-token)"`
- Re-enable Edge JWT decryption in middleware (replaces cookie-presence workaround)

## Test plan
- [x] 8 unit tests covering HKDF derivation, JWE/JWS flow, error cases
- [ ] Playwright E2E: login flow still works with re-enabled Edge JWT

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)