### PR TITLE
[Sprint2-T19] LDAP/AD integration stub + config + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,17 @@ FAILOVER_FAILURE_THRESHOLD=3
 # 單次健康檢查超時（秒），預設 5
 FAILOVER_CHECK_TIMEOUT=5
 
+# ── LDAP / Active Directory（Sprint2-T19，選用）──────────────
+# 僅在對接銀行 AD 時需要設定
+# LDAP 伺服器 URL（如 ldap://ad.bank.local:389 或 ldaps://ad.bank.local:636）
+LDAP_URL=
+# Service account DN（用於 LDAP bind 查詢）
+LDAP_BIND_DN=
+# Service account 密碼（必填）
+LDAP_BIND_PASSWORD=
+# 使用者搜尋 Base DN
+LDAP_BASE_DN=
+
 # ── Plane 專案管理（T12 任務佔位符）────────────────────────
 # ⚠️  以下設定保留給 T12 實作，目前無效
 # PLANE_SECRET_KEY=

--- a/__tests__/api/ldap-stub.test.ts
+++ b/__tests__/api/ldap-stub.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @file ldap-stub.test.ts
+ * TDD tests for LDAP/AD integration stub
+ *
+ * Validates:
+ * 1. LDAP config types exist and are well-typed
+ * 2. LDAP client stub exports expected functions
+ * 3. API endpoint stub returns proper responses
+ * 4. .env.example contains LDAP env vars
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+// ── Config types ────────────────────────────────────────────
+describe("lib/auth/ldap-config", () => {
+  it("should export LdapConfig type with required fields", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("@/lib/auth/ldap-config");
+    expect(mod.DEFAULT_LDAP_CONFIG).toBeDefined();
+    const config = mod.DEFAULT_LDAP_CONFIG;
+    expect(config).toHaveProperty("url");
+    expect(config).toHaveProperty("bindDn");
+    expect(config).toHaveProperty("baseDn");
+    expect(config).toHaveProperty("searchFilter");
+  });
+
+  it("should export getLdapConfig function", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("@/lib/auth/ldap-config");
+    expect(typeof mod.getLdapConfig).toBe("function");
+  });
+
+  it("getLdapConfig should return config from env vars", () => {
+    const origUrl = process.env.LDAP_URL;
+    const origBindDn = process.env.LDAP_BIND_DN;
+    const origBaseDn = process.env.LDAP_BASE_DN;
+
+    process.env.LDAP_URL = "ldap://test.local:389";
+    process.env.LDAP_BIND_DN = "cn=admin,dc=test,dc=local";
+    process.env.LDAP_BASE_DN = "dc=test,dc=local";
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getLdapConfig } = require("@/lib/auth/ldap-config");
+    const config = getLdapConfig();
+
+    expect(config.url).toBe("ldap://test.local:389");
+    expect(config.bindDn).toBe("cn=admin,dc=test,dc=local");
+    expect(config.baseDn).toBe("dc=test,dc=local");
+
+    // Restore
+    process.env.LDAP_URL = origUrl;
+    process.env.LDAP_BIND_DN = origBindDn;
+    process.env.LDAP_BASE_DN = origBaseDn;
+  });
+});
+
+// ── LDAP Client stub ────────────────────────────────────────
+describe("lib/auth/ldap-client", () => {
+  it("should export LdapClient class", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("@/lib/auth/ldap-client");
+    expect(mod.LdapClient).toBeDefined();
+    expect(typeof mod.LdapClient).toBe("function"); // class
+  });
+
+  it("should have authenticate method", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LdapClient } = require("@/lib/auth/ldap-client");
+    const client = new LdapClient();
+    expect(typeof client.authenticate).toBe("function");
+  });
+
+  it("should have searchUser method", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LdapClient } = require("@/lib/auth/ldap-client");
+    const client = new LdapClient();
+    expect(typeof client.searchUser).toBe("function");
+  });
+
+  it("authenticate stub should return not-implemented response", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LdapClient } = require("@/lib/auth/ldap-client");
+    const client = new LdapClient();
+    const result = await client.authenticate("user", "pass");
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not implemented|stub/i);
+  });
+
+  it("searchUser stub should return not-implemented response", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LdapClient } = require("@/lib/auth/ldap-client");
+    const client = new LdapClient();
+    const result = await client.searchUser("testuser");
+    expect(result).toBeNull();
+  });
+
+  it("should have disconnect method", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { LdapClient } = require("@/lib/auth/ldap-client");
+    const client = new LdapClient();
+    expect(typeof client.disconnect).toBe("function");
+  });
+});
+
+// ── .env.example ────────────────────────────────────────────
+describe(".env.example LDAP variables", () => {
+  const envPath = join(process.cwd(), ".env.example");
+
+  it("should contain LDAP_URL", () => {
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("LDAP_URL");
+  });
+
+  it("should contain LDAP_BIND_DN", () => {
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("LDAP_BIND_DN");
+  });
+
+  it("should contain LDAP_BIND_PASSWORD", () => {
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("LDAP_BIND_PASSWORD");
+  });
+
+  it("should contain LDAP_BASE_DN", () => {
+    const content = readFileSync(envPath, "utf-8");
+    expect(content).toContain("LDAP_BASE_DN");
+  });
+});
+
+// ── API Route stub ──────────────────────────────────────────
+describe("app/api/auth/ldap/route.ts", () => {
+  it("should exist", () => {
+    const routePath = join(process.cwd(), "app", "api", "auth", "ldap", "route.ts");
+    expect(existsSync(routePath)).toBe(true);
+  });
+
+  it("should contain POST export", () => {
+    const routePath = join(process.cwd(), "app", "api", "auth", "ldap", "route.ts");
+    const content = readFileSync(routePath, "utf-8");
+    expect(content).toMatch(/export\s+async\s+function\s+POST/);
+  });
+});

--- a/app/api/auth/ldap/route.ts
+++ b/app/api/auth/ldap/route.ts
@@ -1,0 +1,60 @@
+/**
+ * LDAP Authentication API Endpoint (Stub)
+ * Sprint 2 — Task 19
+ *
+ * POST /api/auth/ldap
+ * Body: { username: string, password: string }
+ *
+ * Returns 501 Not Implemented until LDAP is connected.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { LdapClient } from "@/lib/auth/ldap-client";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { username, password } = body;
+
+    if (!username || !password) {
+      return NextResponse.json(
+        { error: "Missing username or password" },
+        { status: 400 }
+      );
+    }
+
+    const client = new LdapClient();
+
+    try {
+      const result = await client.authenticate(username, password);
+
+      if (result.success && result.user) {
+        return NextResponse.json({
+          success: true,
+          user: {
+            name: result.user.displayName,
+            email: result.user.mail,
+            department: result.user.department,
+          },
+        });
+      }
+
+      // Stub returns 501 until real LDAP is configured
+      return NextResponse.json(
+        {
+          success: false,
+          error: result.error || "Authentication failed",
+          stub: true,
+        },
+        { status: 501 }
+      );
+    } finally {
+      await client.disconnect();
+    }
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/auth/ldap-client.ts
+++ b/lib/auth/ldap-client.ts
@@ -1,0 +1,102 @@
+/**
+ * LDAP Client Stub — Connection Pooling + Auth
+ * Sprint 2 — Task 19
+ *
+ * Stub implementation for LDAP/AD integration.
+ * Replace with real ldapjs implementation when AD connectivity is available.
+ *
+ * Real implementation will use:
+ *   npm install ldapjs
+ *   import ldap from 'ldapjs';
+ */
+
+import { getLdapConfig, type LdapConfig } from "./ldap-config";
+
+export interface LdapAuthResult {
+  success: boolean;
+  user?: LdapUser | null;
+  error?: string;
+}
+
+export interface LdapUser {
+  dn: string;
+  sAMAccountName: string;
+  displayName: string;
+  mail: string;
+  memberOf: string[];
+  department?: string;
+  title?: string;
+}
+
+/**
+ * LDAP Client with connection pooling (stub).
+ *
+ * Usage:
+ *   const client = new LdapClient();
+ *   const result = await client.authenticate('username', 'password');
+ *   await client.disconnect();
+ */
+export class LdapClient {
+  private config: LdapConfig;
+  private connected: boolean = false;
+
+  constructor(config?: Partial<LdapConfig>) {
+    this.config = { ...getLdapConfig(), ...config };
+  }
+
+  /**
+   * Authenticate a user against LDAP/AD.
+   * Stub: always returns not-implemented error.
+   */
+  async authenticate(
+    username: string,
+    _password: string
+  ): Promise<LdapAuthResult> {
+    // Stub — will be replaced with real LDAP bind + search
+    void username;
+    return {
+      success: false,
+      error:
+        "LDAP authentication is not implemented yet (stub). " +
+        `Waiting for AD connectivity from IT. Server: ${this.config.url}`,
+    };
+  }
+
+  /**
+   * Search for a user by sAMAccountName or email.
+   * Stub: always returns null.
+   */
+  async searchUser(_identifier: string): Promise<LdapUser | null> {
+    // Stub — will be replaced with real LDAP search
+    return null;
+  }
+
+  /**
+   * Connect to LDAP server (stub — no-op).
+   */
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  /**
+   * Disconnect from LDAP server (stub — no-op).
+   */
+  async disconnect(): Promise<void> {
+    this.connected = false;
+  }
+
+  /**
+   * Check if connected.
+   */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Get current config (for diagnostics).
+   */
+  getConfig(): Omit<LdapConfig, "bindPassword"> {
+    const { bindPassword: _, ...safeConfig } = this.config;
+    return safeConfig;
+  }
+}

--- a/lib/auth/ldap-config.ts
+++ b/lib/auth/ldap-config.ts
@@ -1,0 +1,63 @@
+/**
+ * LDAP/AD Configuration Types and Helpers
+ * Sprint 2 — Task 19
+ *
+ * Provides typed configuration for LDAP integration.
+ * Environment variables:
+ *   LDAP_URL, LDAP_BIND_DN, LDAP_BIND_PASSWORD, LDAP_BASE_DN
+ */
+
+export interface LdapConfig {
+  /** LDAP server URL (e.g., ldap://ad.bank.local:389) */
+  url: string;
+  /** Service account DN for LDAP bind */
+  bindDn: string;
+  /** Service account password */
+  bindPassword: string;
+  /** Base DN for user search */
+  baseDn: string;
+  /** LDAP search filter template. Use {{username}} as placeholder */
+  searchFilter: string;
+  /** Connection timeout in milliseconds */
+  connectTimeout: number;
+  /** Whether to use TLS (ldaps://) */
+  useTls: boolean;
+  /** Connection pool size */
+  poolSize: number;
+}
+
+/** Default configuration — safe fallbacks for development */
+export const DEFAULT_LDAP_CONFIG: LdapConfig = {
+  url: "ldap://localhost:389",
+  bindDn: "cn=admin,dc=example,dc=com",
+  bindPassword: "",
+  baseDn: "dc=example,dc=com",
+  searchFilter: "(&(objectClass=person)(sAMAccountName={{username}}))",
+  connectTimeout: 5000,
+  useTls: false,
+  poolSize: 5,
+};
+
+/**
+ * Build LDAP config from environment variables.
+ * Falls back to DEFAULT_LDAP_CONFIG for missing values.
+ */
+export function getLdapConfig(): LdapConfig {
+  return {
+    url: process.env.LDAP_URL || DEFAULT_LDAP_CONFIG.url,
+    bindDn: process.env.LDAP_BIND_DN || DEFAULT_LDAP_CONFIG.bindDn,
+    bindPassword: process.env.LDAP_BIND_PASSWORD || DEFAULT_LDAP_CONFIG.bindPassword,
+    baseDn: process.env.LDAP_BASE_DN || DEFAULT_LDAP_CONFIG.baseDn,
+    searchFilter:
+      process.env.LDAP_SEARCH_FILTER || DEFAULT_LDAP_CONFIG.searchFilter,
+    connectTimeout: parseInt(
+      process.env.LDAP_CONNECT_TIMEOUT || String(DEFAULT_LDAP_CONFIG.connectTimeout),
+      10
+    ),
+    useTls: process.env.LDAP_USE_TLS === "true",
+    poolSize: parseInt(
+      process.env.LDAP_POOL_SIZE || String(DEFAULT_LDAP_CONFIG.poolSize),
+      10
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- LDAP config types with env var support (`lib/auth/ldap-config.ts`)
- LDAP client stub with connection pooling pattern (`lib/auth/ldap-client.ts`)
- API endpoint stub at `POST /api/auth/ldap` — returns 501 until AD is connected
- LDAP env vars (`LDAP_URL`, `LDAP_BIND_DN`, `LDAP_BIND_PASSWORD`, `LDAP_BASE_DN`) added to `.env.example`
- 15 unit tests covering config, client, env vars, and route

## Test plan
- [x] Unit tests pass (`npx jest __tests__/api/ldap-stub.test.ts`)
- [ ] Verify stub returns 501 on `POST /api/auth/ldap`

Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)