### PR TITLE
feat(ui): Loading Skeleton 統一（所有頁面）

### DIFF
--- a/__tests__/components/page-skeletons.test.tsx
+++ b/__tests__/components/page-skeletons.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * Tests for page skeleton components (Task 23 — Issue #780)
+ * TDD: tests written first to define expected skeleton variants.
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  DashboardSkeleton,
+  KanbanSkeleton,
+  TimesheetSkeleton,
+  ReportSkeleton,
+  PageSkeleton,
+} from "@/app/components/page-states";
+
+describe("Page Skeletons", () => {
+  it("DashboardSkeleton renders stat card placeholders", () => {
+    const { container } = render(<DashboardSkeleton />);
+    // Should have animated pulse elements
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("KanbanSkeleton renders column placeholders", () => {
+    const { container } = render(<KanbanSkeleton />);
+    // Should render 5 kanban column skeletons
+    const columns = container.querySelectorAll("[data-testid='kanban-col-skeleton']");
+    expect(columns.length).toBe(5);
+  });
+
+  it("TimesheetSkeleton renders grid-like placeholders", () => {
+    const { container } = render(<TimesheetSkeleton />);
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("ReportSkeleton renders tab and content placeholders", () => {
+    const { container } = render(<ReportSkeleton />);
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("PageSkeleton renders a generic page skeleton with title and rows", () => {
+    const { container } = render(<PageSkeleton />);
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("PageSkeleton accepts custom rows prop", () => {
+    const { container } = render(<PageSkeleton rows={10} />);
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/app/(app)/activity/loading.tsx
+++ b/app/(app)/activity/loading.tsx
@@ -1,0 +1,13 @@
+import { ListSkeleton } from "@/app/components/page-states";
+
+export default function ActivityLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <div className="animate-pulse rounded bg-muted h-6 w-32" />
+        <div className="animate-pulse rounded bg-muted h-4 w-48" />
+      </div>
+      <ListSkeleton rows={8} />
+    </div>
+  );
+}

--- a/app/(app)/dashboard/loading.tsx
+++ b/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import { DashboardSkeleton } from "@/app/components/page-states";
+
+export default function DashboardLoading() {
+  return <DashboardSkeleton />;
+}

--- a/app/(app)/gantt/loading.tsx
+++ b/app/(app)/gantt/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/app/components/page-states";
+
+export default function GanttLoading() {
+  return <PageSkeleton rows={8} />;
+}

--- a/app/(app)/kanban/loading.tsx
+++ b/app/(app)/kanban/loading.tsx
@@ -1,0 +1,5 @@
+import { KanbanSkeleton } from "@/app/components/page-states";
+
+export default function KanbanLoading() {
+  return <KanbanSkeleton />;
+}

--- a/app/(app)/knowledge/loading.tsx
+++ b/app/(app)/knowledge/loading.tsx
@@ -1,0 +1,13 @@
+import { ListSkeleton } from "@/app/components/page-states";
+
+export default function KnowledgeLoading() {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <div className="animate-pulse rounded bg-muted h-6 w-28" />
+        <div className="animate-pulse rounded bg-muted h-4 w-48" />
+      </div>
+      <ListSkeleton rows={6} />
+    </div>
+  );
+}

--- a/app/(app)/kpi/loading.tsx
+++ b/app/(app)/kpi/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/app/components/page-states";
+
+export default function KPILoading() {
+  return <PageSkeleton rows={5} />;
+}

--- a/app/(app)/plans/loading.tsx
+++ b/app/(app)/plans/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/app/components/page-states";
+
+export default function PlansLoading() {
+  return <PageSkeleton rows={6} />;
+}

--- a/app/(app)/reports/loading.tsx
+++ b/app/(app)/reports/loading.tsx
@@ -1,0 +1,5 @@
+import { ReportSkeleton } from "@/app/components/page-states";
+
+export default function ReportsLoading() {
+  return <ReportSkeleton />;
+}

--- a/app/(app)/settings/loading.tsx
+++ b/app/(app)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { TabSkeleton } from "@/app/components/page-states";
+
+export default function SettingsLoading() {
+  return <TabSkeleton tabs={3} />;
+}

--- a/app/(app)/timesheet/loading.tsx
+++ b/app/(app)/timesheet/loading.tsx
@@ -1,0 +1,5 @@
+import { TimesheetSkeleton } from "@/app/components/page-states";
+
+export default function TimesheetLoading() {
+  return <TimesheetSkeleton />;
+}

--- a/app/components/page-states.tsx
+++ b/app/components/page-states.tsx
@@ -35,7 +35,7 @@ export function PageError({ message = "載入失敗，請稍後再試", onRetry,
 }
 
 /** Reusable skeleton pulse bar */
-function SkeletonBar({ className }: { className?: string }) {
+export function SkeletonBar({ className }: { className?: string }) {
   return <div className={cn("animate-pulse rounded bg-muted", className)} />;
 }
 
@@ -89,6 +89,147 @@ export function TabSkeleton({ tabs = 3, className }: { tabs?: number; className?
         ))}
       </div>
       <FormSkeleton fields={3} />
+    </div>
+  );
+}
+
+/** Generic page skeleton: title + subtitle + rows of content bars */
+export function PageSkeleton({ rows = 6, className }: { rows?: number; className?: string }) {
+  return (
+    <div className={cn("space-y-6", className)}>
+      <div className="space-y-2">
+        <SkeletonBar className="h-6 w-40" />
+        <SkeletonBar className="h-4 w-64" />
+      </div>
+      <div className="space-y-3">
+        {Array.from({ length: rows }).map((_, i) => (
+          <SkeletonBar key={i} className="h-10 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Dashboard skeleton: stat cards + chart area */
+export function DashboardSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("max-w-4xl mx-auto space-y-6", className)}>
+      <div className="space-y-2">
+        <SkeletonBar className="h-6 w-32" />
+        <SkeletonBar className="h-4 w-56" />
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-card rounded-xl p-4 space-y-2">
+            <SkeletonBar className="h-3 w-16" />
+            <SkeletonBar className="h-8 w-20" />
+          </div>
+        ))}
+      </div>
+      <div className="bg-card rounded-xl p-5 space-y-3">
+        <SkeletonBar className="h-4 w-40" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-1">
+            <div className="flex justify-between">
+              <SkeletonBar className="h-3 w-20" />
+              <SkeletonBar className="h-3 w-12" />
+            </div>
+            <SkeletonBar className="h-2 w-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Kanban skeleton: 5 columns with card placeholders */
+export function KanbanSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <SkeletonBar className="h-6 w-20" />
+          <SkeletonBar className="h-4 w-32" />
+        </div>
+        <SkeletonBar className="h-9 w-24" />
+      </div>
+      <div className="flex gap-3 overflow-hidden">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} data-testid="kanban-col-skeleton" className="w-72 flex-shrink-0 rounded-xl border border-border p-2 space-y-2">
+            <SkeletonBar className="h-8 w-full rounded-t-xl" />
+            {Array.from({ length: 2 + (i % 2) }).map((_, j) => (
+              <div key={j} className="bg-card rounded-lg p-3 space-y-2">
+                <SkeletonBar className="h-4 w-full" />
+                <SkeletonBar className="h-3 w-2/3" />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Timesheet skeleton: week header + grid rows */
+export function TimesheetSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="flex items-center justify-between">
+        <SkeletonBar className="h-6 w-32" />
+        <div className="flex gap-2">
+          <SkeletonBar className="h-9 w-9" />
+          <SkeletonBar className="h-9 w-40" />
+          <SkeletonBar className="h-9 w-9" />
+        </div>
+      </div>
+      <div className="bg-card rounded-xl p-4 space-y-3">
+        <div className="flex gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonBar key={i} className="h-8 flex-1" />
+          ))}
+        </div>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex gap-2">
+            <SkeletonBar className="h-10 w-32 flex-shrink-0" />
+            {Array.from({ length: 5 }).map((_, j) => (
+              <SkeletonBar key={j} className="h-10 flex-1" />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Report skeleton: tabs + stat rows + chart placeholder */
+export function ReportSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("space-y-4", className)}>
+      <div className="space-y-1">
+        <SkeletonBar className="h-6 w-24" />
+        <SkeletonBar className="h-4 w-48" />
+      </div>
+      <div className="flex gap-1 border-b border-border pb-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <SkeletonBar key={i} className="h-8 w-20" />
+        ))}
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-card rounded-xl p-4 space-y-2">
+            <SkeletonBar className="h-3 w-16" />
+            <SkeletonBar className="h-6 w-12" />
+          </div>
+        ))}
+      </div>
+      <div className="bg-card rounded-xl p-5 space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex justify-between py-2 border-b border-border/50">
+            <SkeletonBar className="h-4 w-32" />
+            <SkeletonBar className="h-4 w-16" />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `DashboardSkeleton`, `KanbanSkeleton`, `TimesheetSkeleton`, `ReportSkeleton`, `PageSkeleton` to `page-states.tsx`
- Create `loading.tsx` for all 10 routes under `app/(app)/`: dashboard, kanban, timesheet, reports, activity, settings, kpi, plans, gantt, knowledge
- Users now see skeleton placeholders instead of blank pages during navigation/data loading

## Test plan
- [x] Unit tests pass: `__tests__/components/page-skeletons.test.tsx`
- [ ] Manual: navigate between pages and verify skeletons appear during loading

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)