### PR TITLE
refactor(timesheet): Clockify-style inline grid + timer redesign

### DIFF
--- a/__tests__/components/timesheet-grid.test.tsx
+++ b/__tests__/components/timesheet-grid.test.tsx
@@ -1,80 +1,162 @@
 /**
- * Component tests: TimesheetGrid
+ * Component tests: TimesheetGrid (redesigned) + TimesheetCell + TimesheetTimer
+ *
+ * Tests cover:
+ *  - Grid rendering (headers, rows, totals, empty state)
+ *  - Inline edit flow (click → type → Enter → save)
+ *  - Keyboard navigation (Tab, Shift+Tab, Escape)
+ *  - Timer start/stop flow
+ *  - Overtime indicator display
+ *  - Empty state display
+ *  - Daily totals correctness
+ *  - Week navigation (prev/next)
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { TimesheetGrid, TaskRow } from "@/app/components/timesheet-grid";
+import { TimesheetGrid } from "@/app/components/timesheet/timesheet-grid";
+import { TimesheetCell } from "@/app/components/timesheet/timesheet-cell";
+import { TimesheetTimer } from "@/app/components/timesheet/timesheet-timer";
+import { TimesheetToolbar } from "@/app/components/timesheet/timesheet-toolbar";
+import type { TimeEntry, TaskRow, OvertimeType, TaskOption } from "@/app/components/timesheet/use-timesheet";
 
-// Mock TimeEntryCell
-jest.mock("@/app/components/time-entry-cell", () => ({
-  TimeEntryCell: ({ hours }: { hours?: number }) => (
-    <div data-testid="time-entry-cell">{hours ?? "-"}</div>
-  ),
+// ─── Mock lucide-react icons ─────────────────────────────────────────────────
+jest.mock("lucide-react", () => ({
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+  Play: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-play" {...props} />,
+  Square: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-square" {...props} />,
+  Clock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-clock" {...props} />,
+  ChevronLeft: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-left" {...props} />,
+  ChevronRight: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-right" {...props} />,
+  Grid3X3: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-grid" {...props} />,
+  List: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-list" {...props} />,
+  Copy: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-copy" {...props} />,
+  FileDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-file-down" {...props} />,
+  RefreshCw: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-refresh" {...props} />,
 }));
+
+// ─── Test data ───────────────────────────────────────────────────────────────
 
 const WEEK_START = new Date("2024-01-15"); // Monday
 
+const DAY_LABELS = ["一", "二", "三", "四", "五", "六", "日"];
+const DAYS_COUNT = 7;
+
+function getDateStr(offset: number): string {
+  const d = new Date(WEEK_START);
+  d.setDate(d.getDate() + offset);
+  return d.toISOString().split("T")[0];
+}
+
+function formatDateLabel(offset: number): string {
+  const d = new Date(WEEK_START);
+  d.setDate(d.getDate() + offset);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
 const TASK_ROWS: TaskRow[] = [
   { taskId: "task-1", label: "Feature Development" },
-  { taskId: null, label: "Meeting" },
+  { taskId: null, label: "自由工時（無任務）" },
 ];
 
-const ENTRIES = [
-  { id: "e1", taskId: "task-1", date: "2024-01-15T00:00:00Z", hours: 4, category: "PLANNED_TASK", description: null },
-  { id: "e2", taskId: null, date: "2024-01-16T00:00:00Z", hours: 2, category: "ADMIN", description: "Meeting" },
+const ENTRIES: TimeEntry[] = [
+  {
+    id: "e1",
+    taskId: "task-1",
+    date: "2024-01-15",
+    hours: 4,
+    category: "PLANNED_TASK",
+    description: null,
+    overtimeType: "NONE",
+  },
+  {
+    id: "e2",
+    taskId: null,
+    date: "2024-01-16",
+    hours: 2,
+    category: "ADMIN",
+    description: "Meeting",
+    overtimeType: "NONE",
+  },
 ];
+
+const TASKS: TaskOption[] = [
+  { id: "task-1", title: "Feature Development" },
+  { id: "task-2", title: "Bug Fix" },
+];
+
+function getEntriesForCell(taskId: string | null, dateStr: string): TimeEntry[] {
+  return ENTRIES.filter(
+    (e) => (e.taskId ?? null) === (taskId ?? null) && e.date.split("T")[0] === dateStr
+  );
+}
+
+function computeDailyTotals(entries: TimeEntry[]): number[] {
+  return Array.from({ length: DAYS_COUNT }, (_, i) => {
+    const dateStr = getDateStr(i);
+    return entries
+      .filter((e) => e.date.split("T")[0] === dateStr)
+      .reduce((sum, e) => sum + e.hours, 0);
+  });
+}
+
+// ─── TimesheetGrid Tests ─────────────────────────────────────────────────────
 
 describe("TimesheetGrid", () => {
+  const dailyTotals = computeDailyTotals(ENTRIES);
+  const weeklyTotal = ENTRIES.reduce((sum, e) => sum + e.hours, 0);
+
   const defaultProps = {
     weekStart: WEEK_START,
     taskRows: TASK_ROWS,
     entries: ENTRIES,
-    onCellSave: jest.fn(),
-    onCellDelete: jest.fn(),
+    tasks: TASKS,
+    dailyTotals,
+    weeklyTotal,
+    dayLabels: DAY_LABELS,
+    daysCount: DAYS_COUNT,
+    getDateStr,
+    formatDateLabel,
+    getEntriesForCell,
+    onQuickSave: jest.fn().mockResolvedValue(undefined),
+    onFullSave: jest.fn().mockResolvedValue(undefined),
+    onDelete: jest.fn().mockResolvedValue(undefined),
+    onAddTaskRow: jest.fn(),
   };
 
-  it("renders day headers (Mon-Fri)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders day headers (Mon-Sun)", () => {
     render(<TimesheetGrid {...defaultProps} />);
     expect(screen.getByText("週一")).toBeInTheDocument();
     expect(screen.getByText("週二")).toBeInTheDocument();
     expect(screen.getByText("週三")).toBeInTheDocument();
     expect(screen.getByText("週四")).toBeInTheDocument();
     expect(screen.getByText("週五")).toBeInTheDocument();
+    expect(screen.getByText("週六")).toBeInTheDocument();
+    expect(screen.getByText("週日")).toBeInTheDocument();
   });
 
   it("renders task row labels", () => {
     render(<TimesheetGrid {...defaultProps} />);
-    expect(screen.getByText("Feature Development")).toBeInTheDocument();
-    expect(screen.getByText("Meeting")).toBeInTheDocument();
+    expect(screen.getByText("Feature Development", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("自由工時（無任務）")).toBeInTheDocument();
   });
 
   it("renders date labels for the week", () => {
     render(<TimesheetGrid {...defaultProps} />);
     expect(screen.getByText("1/15")).toBeInTheDocument();
+    expect(screen.getByText("1/16")).toBeInTheDocument();
   });
 
-  it("renders time entry cells for each row-day combination", () => {
+  it("renders timesheet cells for each row-day combination", () => {
     render(<TimesheetGrid {...defaultProps} />);
-    const cells = screen.getAllByTestId("time-entry-cell");
-    // 2 rows x 5 days = 10 cells
-    expect(cells.length).toBe(10);
-  });
-
-  it("renders daily totals row", () => {
-    render(<TimesheetGrid {...defaultProps} />);
-    // Row total for task-1 row should be 4.0 (may appear in row total and daily total column)
-    expect(screen.getAllByText("4.0").length).toBeGreaterThan(0);
-  });
-
-  it("renders empty grid with no entries", () => {
-    render(<TimesheetGrid {...defaultProps} entries={[]} />);
-    expect(screen.getAllByTestId("time-entry-cell").length).toBe(10);
-  });
-
-  it("renders correctly with no task rows", () => {
-    render(<TimesheetGrid {...defaultProps} taskRows={[]} />);
-    expect(screen.queryByTestId("time-entry-cell")).not.toBeInTheDocument();
+    const cells = screen.getAllByTestId("timesheet-cell");
+    // 2 rows x 7 days = 14 cells
+    expect(cells.length).toBe(14);
   });
 
   it("shows '每日合計' label in footer row", () => {
@@ -82,17 +164,11 @@ describe("TimesheetGrid", () => {
     expect(screen.getByText("每日合計")).toBeInTheDocument();
   });
 
-  it("shows grand total of all hours in footer", () => {
-    render(<TimesheetGrid {...defaultProps} />);
-    // Total = 4 + 2 = 6.0
-    expect(screen.getByText("6.0")).toBeInTheDocument();
-  });
-
+  // (f) Daily totals: bottom row shows correct sum of column hours
   it("shows daily column total for Monday (4.0)", () => {
     render(<TimesheetGrid {...defaultProps} />);
     // Monday has 4h from entry e1
     const allFourZero = screen.getAllByText("4.0");
-    // Should appear at least once (in daily total and/or row total)
     expect(allFourZero.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -101,5 +177,370 @@ describe("TimesheetGrid", () => {
     // Tuesday has 2h from entry e2
     const allTwoZero = screen.getAllByText("2.0");
     expect(allTwoZero.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows grand total of all hours (6.0)", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByText("6.0")).toBeInTheDocument();
+  });
+
+  // (e) Empty state: grid shows "—" in all cells when no entries
+  it("shows dashes in empty cells when no entries", () => {
+    const emptyProps = {
+      ...defaultProps,
+      entries: [] as TimeEntry[],
+      dailyTotals: Array(7).fill(0),
+      weeklyTotal: 0,
+      getEntriesForCell: () => [] as TimeEntry[],
+    };
+    render(<TimesheetGrid {...emptyProps} />);
+    const cells = screen.getAllByTestId("timesheet-cell");
+    // All cells should show "—"
+    cells.forEach((cell) => {
+      expect(within(cell).getByText("—")).toBeInTheDocument();
+    });
+  });
+
+  it("renders empty message with no task rows", () => {
+    render(<TimesheetGrid {...defaultProps} taskRows={[]} />);
+    expect(screen.getByText("本週尚無工時記錄")).toBeInTheDocument();
+  });
+
+  it("renders add-task-row button", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByTestId("add-task-row-btn")).toBeInTheDocument();
+  });
+});
+
+// ─── TimesheetCell: Inline Edit Flow ─────────────────────────────────────────
+
+describe("TimesheetCell — inline edit flow", () => {
+  const defaultCellProps = {
+    entries: [] as TimeEntry[],
+    taskId: "task-1",
+    date: "2024-01-15",
+    onQuickSave: jest.fn().mockResolvedValue(undefined),
+    onFullSave: jest.fn().mockResolvedValue(undefined),
+    onDelete: jest.fn().mockResolvedValue(undefined),
+    onNavigate: jest.fn(),
+    isWeekend: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // (a) Inline edit flow: click cell -> input appears -> type "3" -> press Enter -> save called with hours=3
+  it("click cell -> input appears -> type '3' -> Enter -> save called with hours=3", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetCell {...defaultCellProps} />);
+
+    // Click cell button to start editing
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    // Input should appear
+    const input = screen.getByTestId("cell-input");
+    expect(input).toBeInTheDocument();
+
+    // Type "3"
+    await user.type(input, "3");
+
+    // Press Enter
+    await user.keyboard("{Enter}");
+
+    // onQuickSave should be called with hours=3
+    expect(defaultCellProps.onQuickSave).toHaveBeenCalledWith("task-1", "2024-01-15", 3, undefined);
+  });
+
+  // (b) Keyboard navigation: Tab moves to next cell
+  it("Tab calls onNavigate('next')", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetCell {...defaultCellProps} />);
+
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    const input = screen.getByTestId("cell-input");
+    await user.type(input, "2");
+    await user.keyboard("{Tab}");
+
+    expect(defaultCellProps.onNavigate).toHaveBeenCalledWith("next");
+  });
+
+  // (b) Keyboard navigation: Shift+Tab moves back
+  it("Shift+Tab calls onNavigate('prev')", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetCell {...defaultCellProps} />);
+
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    const input = screen.getByTestId("cell-input");
+    await user.type(input, "1");
+    await user.keyboard("{Shift>}{Tab}{/Shift}");
+
+    expect(defaultCellProps.onNavigate).toHaveBeenCalledWith("prev");
+  });
+
+  // (b) Keyboard navigation: Escape cancels edit
+  it("Escape cancels edit without saving", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetCell {...defaultCellProps} />);
+
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    const input = screen.getByTestId("cell-input");
+    await user.type(input, "5");
+    await user.keyboard("{Escape}");
+
+    // Should not save
+    expect(defaultCellProps.onQuickSave).not.toHaveBeenCalled();
+    // Input should disappear, button should be back
+    expect(screen.getByTestId("cell-button")).toBeInTheDocument();
+  });
+
+  // (d) Overtime indicator: cell shows overtime indicator
+  it("shows overtime indicator when entry has WEEKDAY overtime", () => {
+    const overtimeEntry: TimeEntry[] = [
+      {
+        id: "ot1",
+        taskId: "task-1",
+        date: "2024-01-15",
+        hours: 2,
+        category: "PLANNED_TASK",
+        description: null,
+        overtimeType: "WEEKDAY",
+      },
+    ];
+    render(
+      <TimesheetCell
+        {...defaultCellProps}
+        entries={overtimeEntry}
+      />
+    );
+    // Should show overtime dot with title "平日加班"
+    const btn = screen.getByTestId("cell-button");
+    const overtimeDot = btn.querySelector('[title="平日加班"]');
+    expect(overtimeDot).toBeInTheDocument();
+  });
+
+  it("shows holiday overtime indicator when entry has HOLIDAY overtime", () => {
+    const holidayEntry: TimeEntry[] = [
+      {
+        id: "ot2",
+        taskId: "task-1",
+        date: "2024-01-15",
+        hours: 3,
+        category: "PLANNED_TASK",
+        description: null,
+        overtimeType: "HOLIDAY",
+      },
+    ];
+    render(
+      <TimesheetCell
+        {...defaultCellProps}
+        entries={holidayEntry}
+      />
+    );
+    const btn = screen.getByTestId("cell-button");
+    const overtimeDot = btn.querySelector('[title="假日加班"]');
+    expect(overtimeDot).toBeInTheDocument();
+  });
+
+  // (e) Empty state: single cell shows "—"
+  it("shows dash when no entries", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[]} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  // Item 5: Enter → blur sequence only triggers one save call (double save prevention)
+  it("Enter then blur only triggers one save (no double save)", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetCell {...defaultCellProps} />);
+
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    const input = screen.getByTestId("cell-input");
+    await user.type(input, "5");
+
+    // Press Enter (saves + sets savedByKeyboard flag)
+    await user.keyboard("{Enter}");
+
+    // The blur event fires after Enter sets editing=false, but savedByKeyboard
+    // flag prevents duplicate save. Verify only one save call.
+    expect(defaultCellProps.onQuickSave).toHaveBeenCalledTimes(1);
+    expect(defaultCellProps.onQuickSave).toHaveBeenCalledWith("task-1", "2024-01-15", 5, undefined);
+  });
+
+  // Inline edit with existing entry pre-fills hours
+  it("pre-fills input with existing entry hours", async () => {
+    const user = userEvent.setup();
+    const existingEntry: TimeEntry[] = [
+      {
+        id: "e1",
+        taskId: "task-1",
+        date: "2024-01-15",
+        hours: 4,
+        category: "PLANNED_TASK",
+        description: null,
+        overtimeType: "NONE",
+      },
+    ];
+    render(<TimesheetCell {...defaultCellProps} entries={existingEntry} />);
+
+    const btn = screen.getByTestId("cell-button");
+    await user.click(btn);
+
+    const input = screen.getByTestId("cell-input") as HTMLInputElement;
+    expect(input.value).toBe("4.0");
+  });
+});
+
+// ─── TimesheetTimer Tests ────────────────────────────────────────────────────
+
+describe("TimesheetTimer", () => {
+  const defaultTimerProps = {
+    timer: null,
+    elapsed: 0,
+    tasks: TASKS,
+    onStart: jest.fn().mockResolvedValue({ ok: true, error: null }),
+    onStop: jest.fn().mockResolvedValue({ ok: true, error: null }),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // (c) Timer: start button -> elapsed time display -> stop button
+  it("shows start button when timer is not running", () => {
+    render(<TimesheetTimer {...defaultTimerProps} />);
+    expect(screen.getByTestId("timer-start-btn")).toBeInTheDocument();
+    expect(screen.getByText("開始計時")).toBeInTheDocument();
+  });
+
+  it("clicking start calls onStart", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetTimer {...defaultTimerProps} />);
+
+    await user.click(screen.getByTestId("timer-start-btn"));
+    expect(defaultTimerProps.onStart).toHaveBeenCalledWith(null);
+  });
+
+  it("shows elapsed time when timer is running", () => {
+    const runningProps = {
+      ...defaultTimerProps,
+      timer: {
+        isRunning: true,
+        taskId: "task-1",
+        taskLabel: "Feature Development",
+        startTime: Date.now() - 3661000,
+        entryId: "entry-1",
+      },
+      elapsed: 3661, // 1h 1m 1s
+    };
+    render(<TimesheetTimer {...runningProps} />);
+
+    const display = screen.getByTestId("timer-display");
+    expect(display.textContent).toBe("01:01:01");
+  });
+
+  it("shows stop button and running task label when timer is running", () => {
+    const runningProps = {
+      ...defaultTimerProps,
+      timer: {
+        isRunning: true,
+        taskId: "task-1",
+        taskLabel: "Feature Development",
+        startTime: Date.now(),
+        entryId: "entry-1",
+      },
+      elapsed: 60,
+    };
+    render(<TimesheetTimer {...runningProps} />);
+
+    expect(screen.getByTestId("timer-stop-btn")).toBeInTheDocument();
+    expect(screen.getByText("正在計時：Feature Development")).toBeInTheDocument();
+  });
+
+  it("clicking stop calls onStop", async () => {
+    const user = userEvent.setup();
+    const runningProps = {
+      ...defaultTimerProps,
+      timer: {
+        isRunning: true,
+        taskId: "task-1",
+        taskLabel: "Feature Development",
+        startTime: Date.now(),
+        entryId: "entry-1",
+      },
+      elapsed: 120,
+    };
+    render(<TimesheetTimer {...runningProps} />);
+
+    await user.click(screen.getByTestId("timer-stop-btn"));
+    expect(defaultTimerProps.onStop).toHaveBeenCalled();
+  });
+
+  it("shows task selector when timer is not running", () => {
+    render(<TimesheetTimer {...defaultTimerProps} />);
+    expect(screen.getByTestId("timer-task-select")).toBeInTheDocument();
+  });
+
+  it("shows 00:00:00 when elapsed is 0", () => {
+    render(<TimesheetTimer {...defaultTimerProps} />);
+    expect(screen.getByTestId("timer-display").textContent).toBe("00:00:00");
+  });
+});
+
+// ─── TimesheetToolbar: Week Navigation ───────────────────────────────────────
+
+describe("TimesheetToolbar — week navigation", () => {
+  const defaultToolbarProps = {
+    weekRange: "2024/01/15 — 2024/01/21",
+    viewMode: "grid" as const,
+    onViewModeChange: jest.fn(),
+    onPrevWeek: jest.fn(),
+    onNextWeek: jest.fn(),
+    onThisWeek: jest.fn(),
+    onCopyPreviousWeek: jest.fn().mockResolvedValue(true),
+    onRefresh: jest.fn(),
+    loading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // (g) Week navigation: clicking prev/next changes date range
+  it("clicking prev-week button calls onPrevWeek", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetToolbar {...defaultToolbarProps} />);
+
+    await user.click(screen.getByTestId("prev-week-btn"));
+    expect(defaultToolbarProps.onPrevWeek).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking next-week button calls onNextWeek", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetToolbar {...defaultToolbarProps} />);
+
+    await user.click(screen.getByTestId("next-week-btn"));
+    expect(defaultToolbarProps.onNextWeek).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking this-week button calls onThisWeek", async () => {
+    const user = userEvent.setup();
+    render(<TimesheetToolbar {...defaultToolbarProps} />);
+
+    await user.click(screen.getByTestId("this-week-btn"));
+    expect(defaultToolbarProps.onThisWeek).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays week range text", () => {
+    render(<TimesheetToolbar {...defaultToolbarProps} />);
+    expect(screen.getByText("2024/01/15 — 2024/01/21")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/timesheet-phase1-track-a.test.tsx
+++ b/__tests__/components/timesheet-phase1-track-a.test.tsx
@@ -1,0 +1,399 @@
+/**
+ * Tests for Timesheet Phase 1 Track A: Items 2, 7, 6
+ *
+ * Item 2: Locked entry frontend protection
+ * Item 7: Multi-entry individual editing UI
+ * Item 6: Template UI integration MVP
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Mock lucide-react icons ──────────────────────────────────────────────────
+jest.mock("lucide-react", () => ({
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+  Lock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-lock" {...props} />,
+  ChevronLeft: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-left" {...props} />,
+  ChevronRight: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-right" {...props} />,
+  Grid3X3: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-grid" {...props} />,
+  List: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-list" {...props} />,
+  Copy: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-copy" {...props} />,
+  FileDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-file-down" {...props} />,
+  RefreshCw: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-refresh" {...props} />,
+  Play: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-play" {...props} />,
+  Square: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-square" {...props} />,
+  Clock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-clock" {...props} />,
+  FileText: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-file-text" {...props} />,
+  Save: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-save" {...props} />,
+  ChevronDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-down" {...props} />,
+  Trash2: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-trash" {...props} />,
+  X: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-x" {...props} />,
+}));
+
+import { TimesheetCell } from "@/app/components/timesheet/timesheet-cell";
+import { TemplateSelector } from "@/app/components/timesheet/template-selector";
+import type { TimeEntry } from "@/app/components/timesheet/use-timesheet";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const UNLOCKED_ENTRY: TimeEntry = {
+  id: "e1",
+  taskId: "task-1",
+  date: "2026-03-23",
+  hours: 8,
+  category: "PLANNED_TASK",
+  description: "API work",
+  overtimeType: "NONE",
+  locked: false,
+};
+
+const LOCKED_ENTRY: TimeEntry = {
+  id: "e2",
+  taskId: "task-1",
+  date: "2026-03-23",
+  hours: 4,
+  category: "PLANNED_TASK",
+  description: "Locked entry",
+  overtimeType: "NONE",
+  locked: true,
+};
+
+const MULTI_ENTRIES: TimeEntry[] = [
+  {
+    id: "m1",
+    taskId: "task-1",
+    date: "2026-03-23",
+    hours: 4,
+    category: "PLANNED_TASK",
+    description: "Morning work",
+    overtimeType: "NONE",
+    locked: false,
+  },
+  {
+    id: "m2",
+    taskId: "task-1",
+    date: "2026-03-23",
+    hours: 3,
+    category: "ADDED_TASK",
+    description: "Afternoon work",
+    overtimeType: "WEEKDAY",
+    locked: false,
+  },
+  {
+    id: "m3",
+    taskId: "task-1",
+    date: "2026-03-23",
+    hours: 1,
+    category: "SUPPORT",
+    description: "Locked record",
+    overtimeType: "NONE",
+    locked: true,
+  },
+];
+
+const defaultCellProps = {
+  entries: [] as TimeEntry[],
+  taskId: "task-1" as string | null,
+  date: "2026-03-23",
+  onQuickSave: jest.fn().mockResolvedValue(undefined),
+  onFullSave: jest.fn().mockResolvedValue(undefined),
+  onDelete: jest.fn().mockResolvedValue(undefined),
+};
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Item 2: Locked entry frontend protection
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("Item 2: Locked entry protection", () => {
+  it("shows lock icon on all-locked cell instead of category dot", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[LOCKED_ENTRY]} />);
+    expect(screen.getByTestId("icon-lock")).toBeInTheDocument();
+  });
+
+  it("does not enter editing mode when clicking a locked cell", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[LOCKED_ENTRY]} />);
+    fireEvent.click(screen.getByTestId("cell-button"));
+    // Should NOT show the input
+    expect(screen.queryByTestId("cell-input")).not.toBeInTheDocument();
+  });
+
+  it("enters editing mode when clicking an unlocked cell", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[UNLOCKED_ENTRY]} />);
+    fireEvent.click(screen.getByTestId("cell-button"));
+    expect(screen.getByTestId("cell-input")).toBeInTheDocument();
+  });
+
+  it("does not call onQuickSave for locked entry on Enter", async () => {
+    const onQuickSave = jest.fn().mockResolvedValue(undefined);
+    // First entry unlocked but with inline editing targeting it
+    render(
+      <TimesheetCell
+        {...defaultCellProps}
+        entries={[{ ...UNLOCKED_ENTRY, locked: true }]}
+        onQuickSave={onQuickSave}
+      />
+    );
+    // Locked cell won't enter editing mode, so quickSave won't be called
+    fireEvent.click(screen.getByTestId("cell-button"));
+    expect(screen.queryByTestId("cell-input")).not.toBeInTheDocument();
+    expect(onQuickSave).not.toHaveBeenCalled();
+  });
+
+  it("shows locked badge in expanded editor for locked entries", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[LOCKED_ENTRY]} />);
+    // Double click to open expanded (allowed for locked entries to view)
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    expect(screen.getByText("已鎖定")).toBeInTheDocument();
+  });
+
+  it("does not show save/delete buttons for locked entries in expanded editor", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[LOCKED_ENTRY]} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    // Should NOT have save/delete buttons for the locked entry
+    expect(screen.queryByTestId("entry-save-0")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("entry-delete-0")).not.toBeInTheDocument();
+  });
+
+  it("applies cursor-not-allowed class on locked cells", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={[LOCKED_ENTRY]} />);
+    const button = screen.getByTestId("cell-button");
+    expect(button.className).toContain("cursor-not-allowed");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Item 7: Multi-entry individual editing UI
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("Item 7: Multi-entry individual editing", () => {
+  it("renders all entries in expanded editor on double-click", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    // Should show 3 entry editors
+    expect(screen.getByTestId("entry-editor-0")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-editor-1")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-editor-2")).toBeInTheDocument();
+  });
+
+  it("shows individual save button for each unlocked entry", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    // m1 (unlocked) and m2 (unlocked) should have save buttons
+    expect(screen.getByTestId("entry-save-0")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-save-1")).toBeInTheDocument();
+    // m3 (locked) should NOT have save button
+    expect(screen.queryByTestId("entry-save-2")).not.toBeInTheDocument();
+  });
+
+  it("shows individual delete button for each unlocked entry", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    expect(screen.getByTestId("entry-delete-0")).toBeInTheDocument();
+    expect(screen.getByTestId("entry-delete-1")).toBeInTheDocument();
+    // m3 (locked) should NOT have delete button
+    expect(screen.queryByTestId("entry-delete-2")).not.toBeInTheDocument();
+  });
+
+  it("shows + 新增記錄 button in expanded editor", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    expect(screen.getByTestId("add-entry-btn")).toBeInTheDocument();
+  });
+
+  it("shows new entry form when + 新增記錄 is clicked", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    fireEvent.click(screen.getByTestId("add-entry-btn"));
+    expect(screen.getByTestId("new-entry-form")).toBeInTheDocument();
+    expect(screen.getByTestId("new-entry-save")).toBeInTheDocument();
+  });
+
+  it("calls onFullSave for individual entry save", async () => {
+    const onFullSave = jest.fn().mockResolvedValue(undefined);
+    render(
+      <TimesheetCell
+        {...defaultCellProps}
+        entries={[UNLOCKED_ENTRY]}
+        onFullSave={onFullSave}
+      />
+    );
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    fireEvent.click(screen.getByTestId("entry-save-0"));
+    await waitFor(() => {
+      expect(onFullSave).toHaveBeenCalledWith(
+        "task-1",
+        "2026-03-23",
+        8,
+        "PLANNED_TASK",
+        "API work",
+        "NONE",
+        "e1"
+      );
+    });
+  });
+
+  it("calls onDelete for individual entry delete", async () => {
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    render(
+      <TimesheetCell
+        {...defaultCellProps}
+        entries={[UNLOCKED_ENTRY]}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.doubleClick(screen.getByTestId("cell-button"));
+    fireEvent.click(screen.getByTestId("entry-delete-0"));
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("e1");
+    });
+  });
+
+  it("shows +N indicator for multiple entries in cell display", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    // Should show "+2" for 3 entries (first one shown, +2 more)
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+
+  it("shows total hours of all entries in cell display", () => {
+    render(<TimesheetCell {...defaultCellProps} entries={MULTI_ENTRIES} />);
+    // Total = 4 + 3 + 1 = 8.0
+    expect(screen.getByText("8.0")).toBeInTheDocument();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Item 6: Template UI integration
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("Item 6: Template selector", () => {
+  const WEEK_START = new Date("2026-03-23");
+
+  const defaultTemplateProps = {
+    weekStart: WEEK_START,
+    entries: [] as TimeEntry[],
+    daysCount: 7,
+    getDateStr: (offset: number) => {
+      const d = new Date(WEEK_START);
+      d.setDate(d.getDate() + offset);
+      return d.toISOString().split("T")[0];
+    },
+    onRefresh: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+  });
+
+  it("renders template button and save-as-template button", () => {
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    expect(screen.getByTestId("template-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("save-template-btn")).toBeInTheDocument();
+    expect(screen.getByText("模板")).toBeInTheDocument();
+    expect(screen.getByText("儲存為模板")).toBeInTheDocument();
+  });
+
+  it("opens dropdown when template button clicked", async () => {
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    fireEvent.click(screen.getByTestId("template-btn"));
+    await waitFor(() => {
+      expect(screen.getByTestId("template-dropdown")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no templates exist", async () => {
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    fireEvent.click(screen.getByTestId("template-btn"));
+    await waitFor(() => {
+      expect(screen.getByText(/尚無模板/)).toBeInTheDocument();
+    });
+  });
+
+  it("opens save form when save-as-template button clicked", () => {
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    fireEvent.click(screen.getByTestId("save-template-btn"));
+    expect(screen.getByTestId("save-template-form")).toBeInTheDocument();
+    expect(screen.getByTestId("template-name-input")).toBeInTheDocument();
+  });
+
+  it("shows template items when templates exist", async () => {
+    const mockTemplates = [
+      { id: "t1", name: "標準工時", entries: '[{"hours":8,"category":"PLANNED_TASK"}]', createdAt: "2026-03-20" },
+      { id: "t2", name: "半天模板", entries: '[{"hours":4,"category":"ADMIN"}]', createdAt: "2026-03-21" },
+    ];
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockTemplates }),
+    });
+
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    fireEvent.click(screen.getByTestId("template-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("標準工時")).toBeInTheDocument();
+      expect(screen.getByText("半天模板")).toBeInTheDocument();
+    });
+  });
+
+  it("shows confirmation dialog when template is selected", async () => {
+    const mockTemplates = [
+      { id: "t1", name: "標準工時", entries: '[{"hours":8}]', createdAt: "2026-03-20" },
+    ];
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: mockTemplates }),
+    });
+
+    render(<TemplateSelector {...defaultTemplateProps} />);
+    fireEvent.click(screen.getByTestId("template-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("標準工時")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("標準工時"));
+    expect(screen.getByTestId("template-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("template-apply-confirm")).toBeInTheDocument();
+  });
+
+  it("calls save API when template name is submitted", async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+    (global.fetch as jest.Mock) = mockFetch;
+
+    const entriesWithData = [
+      { id: "x1", taskId: "task-1", date: "2026-03-23", hours: 8, category: "PLANNED_TASK", description: "test", overtimeType: "NONE" as const, locked: false },
+    ];
+
+    render(<TemplateSelector {...defaultTemplateProps} entries={entriesWithData} />);
+
+    // Click save-as-template (this does NOT trigger loadTemplates since open isn't in template-list mode)
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("save-template-btn"));
+    });
+
+    const input = screen.getByTestId("template-name-input");
+    fireEvent.change(input, { target: { value: "我的模板" } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("template-save-confirm"));
+    });
+
+    await waitFor(() => {
+      // Should have POST call for saving template
+      const postCalls = mockFetch.mock.calls.filter(
+        (c: unknown[]) => typeof c[1] === "object" && (c[1] as { method?: string }).method === "POST"
+      );
+      expect(postCalls.length).toBe(1);
+      // Verify the payload includes the template name
+      const payload = JSON.parse((postCalls[0][1] as { body: string }).body);
+      expect(payload.name).toBe("我的模板");
+      expect(payload.entries.length).toBe(1);
+    });
+  });
+});

--- a/__tests__/components/timesheet-redesign.test.tsx
+++ b/__tests__/components/timesheet-redesign.test.tsx
@@ -1,0 +1,429 @@
+/**
+ * Component tests: Timesheet Redesign (Clockify-style grid)
+ * Tests the new TimesheetGrid, TimesheetCell, TimesheetToolbar, TimesheetTimer
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Mock lucide-react icons ──────────────────────────────────────────────────
+jest.mock("lucide-react", () => ({
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+  ChevronLeft: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-left" {...props} />,
+  ChevronRight: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-right" {...props} />,
+  Grid3X3: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-grid" {...props} />,
+  List: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-list" {...props} />,
+  Copy: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-copy" {...props} />,
+  FileDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-file-down" {...props} />,
+  RefreshCw: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-refresh" {...props} />,
+  Play: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-play" {...props} />,
+  Square: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-square" {...props} />,
+  Clock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-clock" {...props} />,
+  Loader2: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-loader" {...props} />,
+}));
+
+import { TimesheetGrid } from "@/app/components/timesheet/timesheet-grid";
+import { TimesheetToolbar } from "@/app/components/timesheet/timesheet-toolbar";
+import { TimesheetTimer } from "@/app/components/timesheet/timesheet-timer";
+import { TimesheetCell } from "@/app/components/timesheet/timesheet-cell";
+import type { TimeEntry, TaskRow, TaskOption } from "@/app/components/timesheet/use-timesheet";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const WEEK_START = new Date("2026-03-23"); // Monday
+
+const TASK_ROWS: TaskRow[] = [
+  { taskId: "task-1", label: "API 開發" },
+  { taskId: "task-2", label: "前端重構" },
+  { taskId: null, label: "自由工時（無任務）" },
+];
+
+const TASKS: TaskOption[] = [
+  { id: "task-1", title: "API 開發" },
+  { id: "task-2", title: "前端重構" },
+  { id: "task-3", title: "文件撰寫" },
+];
+
+const ENTRIES: TimeEntry[] = [
+  {
+    id: "e1",
+    taskId: "task-1",
+    date: "2026-03-23T00:00:00Z",
+    hours: 8,
+    category: "PLANNED_TASK",
+    description: "完成 REST API",
+    overtimeType: "NONE",
+  },
+  {
+    id: "e2",
+    taskId: "task-1",
+    date: "2026-03-24T00:00:00Z",
+    hours: 7.5,
+    category: "PLANNED_TASK",
+    description: null,
+    overtimeType: "NONE",
+  },
+  {
+    id: "e3",
+    taskId: "task-2",
+    date: "2026-03-24T00:00:00Z",
+    hours: 0.5,
+    category: "ADDED_TASK",
+    description: "Bug fix",
+    overtimeType: "WEEKDAY",
+  },
+  {
+    id: "e4",
+    taskId: null,
+    date: "2026-03-28T00:00:00Z",
+    hours: 4,
+    category: "ADMIN",
+    description: "週六加班",
+    overtimeType: "HOLIDAY",
+  },
+];
+
+function getDateStr(offset: number): string {
+  const d = new Date(WEEK_START);
+  d.setDate(d.getDate() + offset);
+  return d.toISOString().split("T")[0];
+}
+
+function formatDateLabel(offset: number): string {
+  const d = new Date(WEEK_START);
+  d.setDate(d.getDate() + offset);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function getEntriesForCell(taskId: string | null, dateStr: string): TimeEntry[] {
+  return ENTRIES.filter(
+    (e) => (e.taskId ?? null) === (taskId ?? null) && e.date.split("T")[0] === dateStr
+  );
+}
+
+const DAY_LABELS = ["一", "二", "三", "四", "五", "六", "日"];
+const DAYS_COUNT = 7;
+const DAILY_TOTALS = Array.from({ length: 7 }, (_, i) => {
+  const ds = getDateStr(i);
+  return ENTRIES.filter((e) => e.date.split("T")[0] === ds).reduce((s, e) => s + e.hours, 0);
+});
+const WEEKLY_TOTAL = ENTRIES.reduce((s, e) => s + e.hours, 0);
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TimesheetGrid tests
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("TimesheetGrid", () => {
+  const defaultProps = {
+    weekStart: WEEK_START,
+    taskRows: TASK_ROWS,
+    entries: ENTRIES,
+    tasks: TASKS,
+    dailyTotals: DAILY_TOTALS,
+    weeklyTotal: WEEKLY_TOTAL,
+    dayLabels: DAY_LABELS,
+    daysCount: DAYS_COUNT,
+    getDateStr,
+    formatDateLabel,
+    getEntriesForCell,
+    onQuickSave: jest.fn(),
+    onFullSave: jest.fn(),
+    onDelete: jest.fn(),
+    onAddTaskRow: jest.fn(),
+  };
+
+  it("renders 7 day headers (Mon-Sun)", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByText("週一")).toBeInTheDocument();
+    expect(screen.getByText("週二")).toBeInTheDocument();
+    expect(screen.getByText("週三")).toBeInTheDocument();
+    expect(screen.getByText("週四")).toBeInTheDocument();
+    expect(screen.getByText("週五")).toBeInTheDocument();
+    expect(screen.getByText("週六")).toBeInTheDocument();
+    expect(screen.getByText("週日")).toBeInTheDocument();
+  });
+
+  it("renders task row labels", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByText(/API 開發/)).toBeInTheDocument();
+    expect(screen.getByText(/前端重構/)).toBeInTheDocument();
+    expect(screen.getByText(/自由工時/)).toBeInTheDocument();
+  });
+
+  it("renders date labels for the week", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByText("3/23")).toBeInTheDocument();
+    expect(screen.getByText("3/29")).toBeInTheDocument();
+  });
+
+  it("renders cells for each row-day combination (3 rows x 7 days = 21)", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    const cells = screen.getAllByTestId("timesheet-cell");
+    expect(cells.length).toBe(21);
+  });
+
+  it("shows daily total footer with '每日合計' label", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByText("每日合計")).toBeInTheDocument();
+  });
+
+  it("renders weekly total", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    // Total = 8 + 7.5 + 0.5 + 4 = 20.0
+    expect(screen.getByText("20.0")).toBeInTheDocument();
+  });
+
+  it("renders '+ 新增任務列' button", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    expect(screen.getByTestId("add-task-row-btn")).toBeInTheDocument();
+    expect(screen.getByText("新增任務列")).toBeInTheDocument();
+  });
+
+  it("shows task search input when add-task-row is clicked", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("add-task-row-btn"));
+    expect(screen.getByTestId("task-search-input")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no task rows", () => {
+    render(<TimesheetGrid {...defaultProps} taskRows={[]} />);
+    expect(screen.getByText("本週尚無工時記錄")).toBeInTheDocument();
+  });
+
+  it("renders daily totals correctly", () => {
+    render(<TimesheetGrid {...defaultProps} />);
+    // Monday: 8.0
+    const eightZero = screen.getAllByText("8.0");
+    expect(eightZero.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TimesheetCell tests
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("TimesheetCell", () => {
+  const defaultProps = {
+    entries: [] as TimeEntry[],
+    taskId: "task-1" as string | null,
+    date: "2026-03-23",
+    onQuickSave: jest.fn(),
+    onFullSave: jest.fn(),
+    onDelete: jest.fn(),
+  };
+
+  it("renders empty cell with dash", () => {
+    render(<TimesheetCell {...defaultProps} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders cell with hours when entry exists", () => {
+    const entry: TimeEntry = {
+      id: "e1",
+      taskId: "task-1",
+      date: "2026-03-23",
+      hours: 8,
+      category: "PLANNED_TASK",
+      description: null,
+      overtimeType: "NONE",
+    };
+    render(<TimesheetCell {...defaultProps} entries={[entry]} />);
+    expect(screen.getByText("8.0")).toBeInTheDocument();
+  });
+
+  it("enters editing mode on click", () => {
+    render(<TimesheetCell {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("cell-button"));
+    expect(screen.getByTestId("cell-input")).toBeInTheDocument();
+  });
+
+  it("calls onQuickSave on Enter with valid input", async () => {
+    const onQuickSave = jest.fn().mockResolvedValue(undefined);
+    render(<TimesheetCell {...defaultProps} onQuickSave={onQuickSave} />);
+
+    fireEvent.click(screen.getByTestId("cell-button"));
+    const input = screen.getByTestId("cell-input");
+    fireEvent.change(input, { target: { value: "7.5" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(onQuickSave).toHaveBeenCalledWith("task-1", "2026-03-23", 7.5, undefined);
+    });
+  });
+
+  it("exits editing on Escape", () => {
+    render(<TimesheetCell {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("cell-button"));
+    const input = screen.getByTestId("cell-input");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByTestId("cell-input")).not.toBeInTheDocument();
+  });
+
+  it("shows overtime indicator for WEEKDAY overtime", () => {
+    const entry: TimeEntry = {
+      id: "e1",
+      taskId: "task-1",
+      date: "2026-03-23",
+      hours: 2,
+      category: "ADDED_TASK",
+      description: null,
+      overtimeType: "WEEKDAY",
+    };
+    render(<TimesheetCell {...defaultProps} entries={[entry]} />);
+    // Should have an overtime dot with amber color (title = 平日加班)
+    const dot = screen.getByTitle("平日加班");
+    expect(dot).toBeInTheDocument();
+  });
+
+  it("shows overtime indicator for HOLIDAY overtime", () => {
+    const entry: TimeEntry = {
+      id: "e1",
+      taskId: null,
+      date: "2026-03-28",
+      hours: 4,
+      category: "ADMIN",
+      description: null,
+      overtimeType: "HOLIDAY",
+    };
+    render(<TimesheetCell {...defaultProps} taskId={null} entries={[entry]} />);
+    const dot = screen.getByTitle("假日加班");
+    expect(dot).toBeInTheDocument();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TimesheetToolbar tests
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("TimesheetToolbar", () => {
+  const defaultProps = {
+    weekRange: "2026/03/23 — 2026/03/29",
+    viewMode: "grid" as const,
+    onViewModeChange: jest.fn(),
+    onPrevWeek: jest.fn(),
+    onNextWeek: jest.fn(),
+    onThisWeek: jest.fn(),
+    onCopyPreviousWeek: jest.fn().mockResolvedValue(true),
+    onRefresh: jest.fn(),
+    loading: false,
+  };
+
+  it("renders week range", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    expect(screen.getByText("2026/03/23 — 2026/03/29")).toBeInTheDocument();
+  });
+
+  it("renders week navigation buttons", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    expect(screen.getByTestId("prev-week-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("this-week-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("next-week-btn")).toBeInTheDocument();
+  });
+
+  it("calls onPrevWeek when previous button clicked", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("prev-week-btn"));
+    expect(defaultProps.onPrevWeek).toHaveBeenCalled();
+  });
+
+  it("calls onNextWeek when next button clicked", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("next-week-btn"));
+    expect(defaultProps.onNextWeek).toHaveBeenCalled();
+  });
+
+  it("calls onThisWeek when '本週' clicked", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("this-week-btn"));
+    expect(defaultProps.onThisWeek).toHaveBeenCalled();
+  });
+
+  it("renders view toggle buttons", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    expect(screen.getByTestId("view-grid-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("view-list-btn")).toBeInTheDocument();
+  });
+
+  it("renders copy-week button", () => {
+    render(<TimesheetToolbar {...defaultProps} />);
+    expect(screen.getByTestId("copy-week-btn")).toBeInTheDocument();
+    expect(screen.getByText("複製上週")).toBeInTheDocument();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TimesheetTimer tests
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("TimesheetTimer", () => {
+  const defaultProps = {
+    timer: null,
+    elapsed: 0,
+    tasks: TASKS,
+    onStart: jest.fn().mockResolvedValue({ ok: true, error: null }),
+    onStop: jest.fn().mockResolvedValue({ ok: true, error: null }),
+  };
+
+  it("renders timer display showing 00:00:00", () => {
+    render(<TimesheetTimer {...defaultProps} />);
+    expect(screen.getByTestId("timer-display")).toHaveTextContent("00:00:00");
+  });
+
+  it("renders start button when not running", () => {
+    render(<TimesheetTimer {...defaultProps} />);
+    expect(screen.getByTestId("timer-start-btn")).toBeInTheDocument();
+  });
+
+  it("renders stop button when running", () => {
+    render(
+      <TimesheetTimer
+        {...defaultProps}
+        timer={{ isRunning: true, taskId: "task-1", taskLabel: "API 開發", startTime: Date.now(), entryId: "e1" }}
+        elapsed={3661}
+      />
+    );
+    expect(screen.getByTestId("timer-stop-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("timer-display")).toHaveTextContent("01:01:01");
+  });
+
+  it("renders task selector when not running", () => {
+    render(<TimesheetTimer {...defaultProps} />);
+    expect(screen.getByTestId("timer-task-select")).toBeInTheDocument();
+  });
+
+  it("shows running task label when running", () => {
+    render(
+      <TimesheetTimer
+        {...defaultProps}
+        timer={{ isRunning: true, taskId: "task-1", taskLabel: "API 開發", startTime: Date.now(), entryId: "e1" }}
+        elapsed={10}
+      />
+    );
+    expect(screen.getByTestId("timer-running-label")).toHaveTextContent("正在計時：API 開發");
+  });
+
+  it("calls onStart when start button clicked", async () => {
+    const onStart = jest.fn().mockResolvedValue({ ok: true, error: null });
+    render(<TimesheetTimer {...defaultProps} onStart={onStart} />);
+    fireEvent.click(screen.getByTestId("timer-start-btn"));
+    await waitFor(() => {
+      expect(onStart).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it("calls onStop when stop button clicked", async () => {
+    const onStop = jest.fn().mockResolvedValue({ ok: true, error: null });
+    render(
+      <TimesheetTimer
+        {...defaultProps}
+        onStop={onStop}
+        timer={{ isRunning: true, taskId: null, taskLabel: "自由工時", startTime: Date.now(), entryId: "e1" }}
+        elapsed={100}
+      />
+    );
+    fireEvent.click(screen.getByTestId("timer-stop-btn"));
+    await waitFor(() => {
+      expect(onStop).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/pages/timesheet-enhanced.test.tsx
+++ b/__tests__/pages/timesheet-enhanced.test.tsx
@@ -165,7 +165,7 @@ describe("Timesheet Enhanced — Timer Widget", () => {
     const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
     await act(async () => { render(<TimesheetPage />); });
     await waitFor(() => {
-      expect(screen.getByTestId("timer-widget")).toBeInTheDocument();
+      expect(screen.getByTestId("timesheet-timer")).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/pages/timesheet-extended.test.tsx
+++ b/__tests__/pages/timesheet-extended.test.tsx
@@ -88,9 +88,8 @@ describe("Timesheet Extended — Basic render", () => {
     setupFetchWithEntries();
     const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
     await act(async () => { render(<TimesheetPage />); });
-    // The label format: "YYYY 年　M/D — M/D"
-    const weekLabel = screen.getByText(/\d{4} 年/);
-    expect(weekLabel).toBeInTheDocument();
+    // Refactored toolbar shows page title
+    expect(screen.getByText("工時紀錄")).toBeInTheDocument();
   });
 
   it("renders 本週 navigation button", async () => {
@@ -107,7 +106,7 @@ describe("Timesheet Extended — Basic render", () => {
     const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
     await act(async () => { render(<TimesheetPage />); });
     await waitFor(() => {
-      expect(screen.getByText(/點擊格子可輸入工時與分類/)).toBeInTheDocument();
+      expect(screen.getByText(/點擊格子直接輸入數字/)).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/pages/timesheet.test.tsx
+++ b/__tests__/pages/timesheet.test.tsx
@@ -98,7 +98,8 @@ describe("Timesheet Page", () => {
     });
     await waitFor(() => {
       // 空資料時仍顯示 grid（讓使用者可以點擊格子輸入），但有引導提示
-      expect(screen.getAllByText(/點擊格子可輸入工時/).length).toBeGreaterThanOrEqual(1);
+      // Refactored page shows help text
+      expect(screen.getByText(/點擊格子直接輸入數字/)).toBeInTheDocument();
     });
   });
 

--- a/__tests__/utils/date.test.ts
+++ b/__tests__/utils/date.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for lib/utils/date.ts — formatLocalDate
+ *
+ * Verifies that formatLocalDate produces YYYY-MM-DD based on
+ * the Date object's LOCAL timezone, NOT UTC (which toISOString uses).
+ */
+import { formatLocalDate } from "@/lib/utils/date";
+
+describe("formatLocalDate", () => {
+  it("formats a regular date correctly", () => {
+    const date = new Date(2026, 2, 24); // March 24, 2026
+    expect(formatLocalDate(date)).toBe("2026-03-24");
+  });
+
+  it("pads single-digit month and day", () => {
+    const date = new Date(2026, 0, 5); // Jan 5
+    expect(formatLocalDate(date)).toBe("2026-01-05");
+  });
+
+  it("handles midnight (00:00) correctly — the toISOString danger zone", () => {
+    const date = new Date(2026, 2, 24, 0, 0, 0, 0); // March 24, 00:00 local
+    expect(formatLocalDate(date)).toBe("2026-03-24");
+  });
+
+  it("handles 00:30 — the problematic time in UTC+8", () => {
+    // In UTC+8, 2026-03-24 00:30 = 2026-03-23 16:30 UTC
+    // toISOString().split("T")[0] would return "2026-03-23" (WRONG)
+    const date = new Date(2026, 2, 24, 0, 30, 0, 0);
+    expect(formatLocalDate(date)).toBe("2026-03-24");
+  });
+
+  it("handles 23:59 — end of day", () => {
+    const date = new Date(2026, 2, 24, 23, 59, 59, 999);
+    expect(formatLocalDate(date)).toBe("2026-03-24");
+  });
+
+  it("handles year boundary — Dec 31 to Jan 1", () => {
+    const dec31 = new Date(2026, 11, 31, 0, 0, 0, 0); // Dec 31, 2026
+    expect(formatLocalDate(dec31)).toBe("2026-12-31");
+
+    const jan1 = new Date(2027, 0, 1, 0, 0, 0, 0); // Jan 1, 2027
+    expect(formatLocalDate(jan1)).toBe("2027-01-01");
+  });
+
+  it("handles month boundary — Jan 31 to Feb 1", () => {
+    const jan31 = new Date(2026, 0, 31);
+    expect(formatLocalDate(jan31)).toBe("2026-01-31");
+
+    const feb1 = new Date(2026, 1, 1);
+    expect(formatLocalDate(feb1)).toBe("2026-02-01");
+  });
+
+  it("handles leap year Feb 29", () => {
+    const leapDay = new Date(2028, 1, 29); // 2028 is a leap year
+    expect(formatLocalDate(leapDay)).toBe("2028-02-29");
+  });
+
+  it("handles month boundary — Feb 28 to Mar 1 (non-leap year)", () => {
+    const feb28 = new Date(2026, 1, 28);
+    expect(formatLocalDate(feb28)).toBe("2026-02-28");
+
+    const mar1 = new Date(2026, 2, 1);
+    expect(formatLocalDate(mar1)).toBe("2026-03-01");
+  });
+});

--- a/__tests__/utils/overtime.test.ts
+++ b/__tests__/utils/overtime.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for lib/overtime.ts — monthly overtime calculation & thresholds
+ */
+import {
+  OVERTIME_CONFIG,
+  getWorkingDaysInMonth,
+  calculateMonthlyOvertime,
+  getOvertimeLevel,
+  getOvertimeInfo,
+} from "@/lib/overtime";
+
+describe("getWorkingDaysInMonth", () => {
+  it("calculates working days for March 2026 (22 working days)", () => {
+    // March 2026: starts on Sunday, 31 days
+    // Weekends: 1,7,8,14,15,21,22,28,29 = 9 weekend days
+    // Working days: 31 - 9 = 22
+    expect(getWorkingDaysInMonth(2026, 2)).toBe(22);
+  });
+
+  it("calculates working days for February 2026 (20 working days)", () => {
+    // Feb 2026: starts on Sunday, 28 days
+    // Weekends: 1,7,8,14,15,21,22,28 = 8 weekend days
+    // Working days: 28 - 8 = 20
+    expect(getWorkingDaysInMonth(2026, 1)).toBe(20);
+  });
+
+  it("calculates working days for February 2028 — leap year (21 working days)", () => {
+    // Feb 2028: starts on Tuesday, 29 days
+    // Weekdays: Mon-Fri covers well
+    expect(getWorkingDaysInMonth(2028, 1)).toBe(21);
+  });
+
+  it("calculates working days for April 2026 (22 working days)", () => {
+    // April 2026: starts on Wednesday, 30 days
+    expect(getWorkingDaysInMonth(2026, 3)).toBe(22);
+  });
+});
+
+describe("calculateMonthlyOvertime", () => {
+  it("returns 0 when total hours are below base hours", () => {
+    // March 2026: 22 working days × 8h = 176h base
+    expect(calculateMonthlyOvertime(160, 2026, 2)).toBe(0);
+  });
+
+  it("returns 0 when total hours equal base hours", () => {
+    // March 2026: 22 × 8 = 176h
+    expect(calculateMonthlyOvertime(176, 2026, 2)).toBe(0);
+  });
+
+  it("returns overtime when exceeding base hours", () => {
+    // 176h base + 20h overtime = 196h
+    expect(calculateMonthlyOvertime(196, 2026, 2)).toBe(20);
+  });
+
+  it("calculates overtime for short month (February 2026, 20 working days)", () => {
+    // Feb 2026: 20 × 8 = 160h base
+    // 180h total → 20h overtime
+    expect(calculateMonthlyOvertime(180, 2026, 1)).toBe(20);
+  });
+
+  it("returns 0 for zero hours", () => {
+    expect(calculateMonthlyOvertime(0, 2026, 2)).toBe(0);
+  });
+});
+
+describe("getOvertimeLevel", () => {
+  it("returns 'safe' when below warning threshold", () => {
+    expect(getOvertimeLevel(0)).toBe("safe");
+    expect(getOvertimeLevel(10)).toBe("safe");
+    expect(getOvertimeLevel(35)).toBe("safe");
+    expect(getOvertimeLevel(35.9)).toBe("safe");
+  });
+
+  it("returns 'warning' at exactly the warning threshold (36h)", () => {
+    expect(getOvertimeLevel(OVERTIME_CONFIG.WARNING_THRESHOLD)).toBe("warning");
+  });
+
+  it("returns 'warning' between 36 and 46h", () => {
+    expect(getOvertimeLevel(40)).toBe("warning");
+    expect(getOvertimeLevel(46)).toBe("warning");
+  });
+
+  it("returns 'danger' above limit (> 46h)", () => {
+    expect(getOvertimeLevel(46.1)).toBe("danger");
+    expect(getOvertimeLevel(50)).toBe("danger");
+    expect(getOvertimeLevel(54)).toBe("danger");
+  });
+});
+
+describe("getOvertimeInfo", () => {
+  it("returns complete info for zero overtime", () => {
+    const info = getOvertimeInfo(100, 2026, 2); // well below 176h base
+    expect(info.overtimeHours).toBe(0);
+    expect(info.level).toBe("safe");
+    expect(info.limit).toBe(46);
+  });
+
+  it("returns warning level at threshold", () => {
+    // 176h base + 36h overtime = 212h
+    const info = getOvertimeInfo(212, 2026, 2);
+    expect(info.overtimeHours).toBe(36);
+    expect(info.level).toBe("warning");
+  });
+
+  it("returns danger level above limit", () => {
+    // 176h base + 50h overtime = 226h
+    const info = getOvertimeInfo(226, 2026, 2);
+    expect(info.overtimeHours).toBe(50);
+    expect(info.level).toBe("danger");
+  });
+});

--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { extractData, extractItems } from "@/lib/api-client";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { formatLocalDate } from "@/lib/utils/date";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -83,7 +84,7 @@ function daysInYear(year: number): number {
 }
 
 function monthStartDay(month: number, year: number): number {
-  return dayOfYear(new Date(year, month, 1).toISOString().split("T")[0], year);
+  return dayOfYear(formatLocalDate(new Date(year, month, 1)), year);
 }
 
 // ─── Gantt Bar ────────────────────────────────────────────────────────────────
@@ -91,7 +92,7 @@ function monthStartDay(month: number, year: number): number {
 function dayToDate(day: number, year: number): string {
   const d = new Date(year, 0, 1);
   d.setDate(d.getDate() + day);
-  return d.toISOString().split("T")[0];
+  return formatLocalDate(d);
 }
 
 type GanttBarProps = {

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -73,6 +73,10 @@ export default function TimesheetPage() {
         onCopyPreviousWeek={ts.copyPreviousWeek}
         onRefresh={ts.refresh}
         loading={ts.loading}
+        weekStart={ts.weekStart}
+        entries={ts.entries}
+        daysCount={ts.daysCount}
+        getDateStr={ts.getDateStr}
       />
 
       {/* Manager user filter */}

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -1,344 +1,148 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import { ChevronLeft, ChevronRight, Loader2, RefreshCw, Grid3X3, List } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { extractItems, extractData } from "@/lib/api-client";
-import { TimesheetGrid, type TaskRow } from "@/app/components/timesheet-grid";
+import { Loader2 } from "lucide-react";
+import {
+  useTimesheet,
+  TimesheetGrid,
+  TimesheetToolbar,
+  TimesheetTimer,
+  type ViewMode,
+} from "@/app/components/timesheet";
 import { TimesheetListView } from "@/app/components/timesheet-list-view";
 import { TimeSummary } from "@/app/components/time-summary";
-import { TimerWidget } from "@/app/components/timer-widget";
-import { type TimeEntry } from "@/app/components/time-entry-cell";
-import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-type User = { id: string; name: string };
-
-type StatsData = {
-  totalHours: number;
-  breakdown: { category: string; hours: number; pct: number }[];
-  taskInvestmentRate: number;
-  entryCount: number;
-};
-
-type ViewMode = "grid" | "list";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function getMondayOfWeek(d: Date): Date {
-  const copy = new Date(d);
-  const day = copy.getDay();
-  const diff = day === 0 ? -6 : 1 - day; // Monday
-  copy.setDate(copy.getDate() + diff);
-  copy.setHours(0, 0, 0, 0);
-  return copy;
-}
-
-function formatWeekLabel(monday: Date): string {
-  const friday = new Date(monday);
-  friday.setDate(friday.getDate() + 4);
-  const fmt = (d: Date) =>
-    `${d.getMonth() + 1}/${d.getDate()}`;
-  return `${monday.getFullYear()} 年　${fmt(monday)} — ${fmt(friday)}`;
-}
-
-// Fixed task rows: include a "自由工時" row for entries without a task
-const FREE_ROW: TaskRow = { taskId: null, label: "自由工時（無任務）" };
+import { PageLoading, PageError } from "@/app/components/page-states";
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 export default function TimesheetPage() {
   const { data: session } = useSession();
   const isManager = session?.user?.role === "MANAGER";
-  const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
   const [userFilter, setUserFilter] = useState("");
-  const [users, setUsers] = useState<User[]>([]);
-  const [entries, setEntries] = useState<TimeEntry[]>([]);
-  const [taskRows, setTaskRows] = useState<TaskRow[]>([FREE_ROW]);
-  const [stats, setStats] = useState<StatsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [statsLoading, setStatsLoading] = useState(false);
+  const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    // Default to list view on mobile for better readability
-    if (typeof window !== "undefined" && window.innerWidth < 640) return "list";
+    if (typeof window !== "undefined" && window.innerWidth < 768) return "list";
     return "grid";
   });
-  const [tasks, setTasks] = useState<{ id: string; title: string }[]>([]);
 
-  // Load users
+  const ts = useTimesheet(userFilter || undefined);
+
+  // Load users for manager filter
   useEffect(() => {
+    if (!isManager) return;
     fetch("/api/users")
       .then((r) => r.json())
-      .then((body) => setUsers(extractItems<User>(body)))
-      .catch(() => {});
-  }, []);
-
-  // Load tasks for timer widget task selector
-  useEffect(() => {
-    fetch("/api/tasks")
-      .then((r) => r.json())
       .then((body) => {
-        const items = extractItems<{ id: string; title: string }>(body);
-        setTasks(items);
+        const items = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [];
+        setUsers(items);
       })
       .catch(() => {});
-  }, []);
+  }, [isManager]);
 
-  // Load entries for the week
-  const loadEntries = useCallback(async () => {
-    setLoading(true);
-    setLoadError(null);
-    try {
-      const params = new URLSearchParams({
-        weekStart: weekStart.toISOString().split("T")[0],
-      });
-      if (userFilter) params.set("userId", userFilter);
-      const res = await fetch(`/api/time-entries?${params}`);
-      if (!res.ok) throw new Error("工時資料載入失敗");
-      const body = await res.json();
-      const data = extractItems<TimeEntry & { task?: { id: string; title: string } | null }>(body);
-      setEntries(data);
-
-      // Build task rows from entries + a free row
-      const seenTasks = new Map<string, string>();
-      for (const e of data) {
-        if (e.taskId && !seenTasks.has(e.taskId)) {
-          const label = (e as { task?: { title: string } | null }).task?.title ?? e.taskId;
-          seenTasks.set(e.taskId, label);
-        }
-      }
-      const rows: TaskRow[] = [
-        ...Array.from(seenTasks.entries()).map(([taskId, label]) => ({ taskId, label })),
-        FREE_ROW,
-      ];
-      setTaskRows(rows);
-    } catch (e) {
-      setLoadError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }, [weekStart, userFilter]);
-
-  useEffect(() => { loadEntries(); }, [loadEntries]);
-
-  // Load stats for the week
-  const loadStats = useCallback(async () => {
-    setStatsLoading(true);
-    try {
-      const friday = new Date(weekStart);
-      friday.setDate(friday.getDate() + 4);
-      const params = new URLSearchParams({
-        startDate: weekStart.toISOString().split("T")[0],
-        endDate: friday.toISOString().split("T")[0],
-      });
-      if (userFilter) params.set("userId", userFilter);
-      const res = await fetch(`/api/time-entries/stats?${params}`);
-      if (res.ok) { const b = await res.json(); setStats(extractData<StatsData>(b)); }
-    } finally {
-      setStatsLoading(false);
-    }
-  }, [weekStart, userFilter]);
-
-  useEffect(() => { loadStats(); }, [loadStats]);
-
-  // Cell operations
-  async function handleCellSave(
-    taskId: string | null,
-    date: string,
-    hours: number,
-    category: string,
-    description: string,
-    existingId?: string
-  ) {
-    if (existingId) {
-      const res = await fetch(`/api/time-entries/${existingId}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ date, hours, category, description }),
-      });
-      if (res.ok) {
-        const ub = await res.json(); const updated = extractData<TimeEntry>(ub);
-        setEntries((prev) => prev.map((e) => e.id === existingId ? updated : e));
-      }
-    } else {
-      const res = await fetch("/api/time-entries", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ taskId, date, hours, category, description }),
-      });
-      if (res.ok) {
-        const cb = await res.json(); const created = extractData<TimeEntry>(cb);
-        setEntries((prev) => [...prev, created]);
-        // Add task row if new task
-        if (taskId && !taskRows.find((r) => r.taskId === taskId)) {
-          setTaskRows((prev) => [
-            ...prev.filter((r) => r.taskId !== null),
-            { taskId, label: taskId },
-            FREE_ROW,
-          ]);
-        }
+  // Auto-switch to list on mobile resize
+  useEffect(() => {
+    function handleResize() {
+      if (window.innerWidth < 768 && viewMode === "grid") {
+        setViewMode("list");
       }
     }
-    // Refresh stats
-    loadStats();
-  }
-
-  async function handleCellDelete(id: string) {
-    const res = await fetch(`/api/time-entries/${id}`, { method: "DELETE" });
-    if (res.ok) {
-      setEntries((prev) => prev.filter((e) => e.id !== id));
-      loadStats();
-    }
-  }
-
-  function handleTimerChange() {
-    loadEntries();
-    loadStats();
-  }
-
-  function prevWeek() {
-    setWeekStart((d) => { const n = new Date(d); n.setDate(n.getDate() - 7); return n; });
-  }
-  function nextWeek() {
-    setWeekStart((d) => { const n = new Date(d); n.setDate(n.getDate() + 7); return n; });
-  }
-  function thisWeek() {
-    setWeekStart(getMondayOfWeek(new Date()));
-  }
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [viewMode]);
 
   return (
     <div className="flex flex-col h-full gap-4">
-      {/* Header — stacks vertically on mobile */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 flex-shrink-0">
-        <div>
-          <h1 className="text-lg sm:text-xl font-semibold tracking-tight">工時紀錄</h1>
-          <p className="text-muted-foreground text-xs sm:text-sm mt-0.5">{formatWeekLabel(weekStart)}</p>
+      {/* Timer — sticky on top */}
+      <TimesheetTimer
+        timer={ts.timer}
+        elapsed={ts.elapsed}
+        tasks={ts.tasks}
+        onStart={ts.startTimer}
+        onStop={ts.stopTimer}
+      />
+
+      {/* Toolbar */}
+      <TimesheetToolbar
+        weekRange={ts.formatWeekRange()}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        onPrevWeek={ts.prevWeek}
+        onNextWeek={ts.nextWeek}
+        onThisWeek={ts.goToThisWeek}
+        onCopyPreviousWeek={ts.copyPreviousWeek}
+        onRefresh={ts.refresh}
+        loading={ts.loading}
+      />
+
+      {/* Manager user filter */}
+      {isManager && (
+        <select
+          aria-label="篩選使用者"
+          value={userFilter}
+          onChange={(e) => setUserFilter(e.target.value)}
+          className="self-start bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+        >
+          <option value="">我的工時</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>{u.name}</option>
+          ))}
+        </select>
+      )}
+
+      {/* Content area */}
+      <div className="flex-1 flex flex-col gap-4 min-h-0">
+        {/* Stats summary */}
+        <div className="flex-shrink-0">
+          {ts.statsLoading ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              計算中...
+            </div>
+          ) : ts.stats && ts.stats.totalHours > 0 ? (
+            <TimeSummary
+              totalHours={ts.stats.totalHours}
+              breakdown={ts.stats.breakdown}
+              taskInvestmentRate={ts.stats.taskInvestmentRate}
+            />
+          ) : null}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-          {/* User filter — only visible to MANAGER */}
-          {isManager && (
-            <select
-              aria-label="篩選使用者"
-              value={userFilter}
-              onChange={(e) => setUserFilter(e.target.value)}
-              className="bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer flex-1 sm:flex-none min-w-0"
-            >
-              <option value="">我的工時</option>
-              {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
-            </select>
-          )}
-
-          {/* View toggle — grid / list */}
-          <div className="flex items-center bg-background border border-border rounded-md overflow-hidden">
-            <button
-              onClick={() => setViewMode("grid")}
-              className={cn(
-                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
-                viewMode === "grid"
-                  ? "bg-accent text-accent-foreground font-medium"
-                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-              )}
-            >
-              <Grid3X3 className="h-3.5 w-3.5" />
-              格子
-            </button>
-            <button
-              onClick={() => setViewMode("list")}
-              className={cn(
-                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
-                viewMode === "list"
-                  ? "bg-accent text-accent-foreground font-medium"
-                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-              )}
-            >
-              <List className="h-3.5 w-3.5" />
-              列表
-            </button>
-          </div>
-
-          {/* Week navigation */}
-          <div className="flex items-center gap-1 bg-background border border-border rounded-md">
-            <button onClick={prevWeek} className="p-1.5 hover:bg-accent rounded-l-md transition-colors">
-              <ChevronLeft className="h-4 w-4 text-muted-foreground" />
-            </button>
-            <button
-              onClick={thisWeek}
-              className="px-3 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              本週
-            </button>
-            <button onClick={nextWeek} className="p-1.5 hover:bg-accent rounded-r-md transition-colors">
-              <ChevronRight className="h-4 w-4 text-muted-foreground" />
-            </button>
-          </div>
-
-          <button
-            onClick={loadEntries}
-            disabled={loading}
-            className="p-1.5 rounded-md bg-background border border-border hover:bg-accent transition-colors"
-          >
-            <RefreshCw className={cn("h-4 w-4 text-muted-foreground", loading && "animate-spin")} />
-          </button>
-        </div>
-      </div>
-
-      {/* Content */}
-      <div className="flex-1 flex flex-col gap-4 min-h-0 overflow-auto">
-        {/* Timer widget + Stats summary — side by side on desktop */}
-        <div className="flex flex-col sm:flex-row gap-4">
-          <TimerWidget tasks={tasks} onTimerChange={handleTimerChange} />
-          <div className="flex-1">
-            {statsLoading ? (
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                計算中...
-              </div>
-            ) : stats && stats.totalHours > 0 ? (
-              <TimeSummary
-                totalHours={stats.totalHours}
-                breakdown={stats.breakdown}
-                taskInvestmentRate={stats.taskInvestmentRate}
-              />
-            ) : null}
-          </div>
-        </div>
-
-        {/* Grid or List view — horizontally scrollable on mobile */}
-        <div className="border border-border rounded-xl overflow-x-auto bg-card">
-          {loading ? (
+        {/* Grid or List */}
+        <div className="border border-border rounded-xl overflow-hidden bg-card">
+          {ts.loading ? (
             <PageLoading message="載入工時..." className="py-12" />
-          ) : loadError ? (
-            <PageError message={loadError} onRetry={loadEntries} className="py-12" />
+          ) : ts.loadError ? (
+            <PageError message={ts.loadError} onRetry={ts.refresh} className="py-12" />
           ) : viewMode === "grid" ? (
-            <>
-              {entries.length === 0 && (
-                <div className="text-center py-3 text-xs text-muted-foreground border-b border-border">
-                  點擊格子可輸入工時與分類。綠色 = 正常，橘色 = 超時（&gt;8h）。
-                </div>
-              )}
-              <TimesheetGrid
-                weekStart={weekStart}
-                taskRows={taskRows}
-                entries={entries}
-                onCellSave={handleCellSave}
-                onCellDelete={handleCellDelete}
-              />
-            </>
+            <TimesheetGrid
+              weekStart={ts.weekStart}
+              taskRows={ts.taskRows}
+              entries={ts.entries}
+              tasks={ts.tasks}
+              dailyTotals={ts.dailyTotals}
+              weeklyTotal={ts.weeklyTotal}
+              dayLabels={ts.dayLabels}
+              daysCount={ts.daysCount}
+              getDateStr={ts.getDateStr}
+              formatDateLabel={ts.formatDateLabel}
+              getEntriesForCell={ts.getEntriesForCell}
+              onQuickSave={ts.quickSave}
+              onFullSave={ts.saveEntry}
+              onDelete={ts.deleteEntry}
+              onAddTaskRow={ts.addTaskRow}
+            />
           ) : (
             <TimesheetListView
-              entries={entries}
-              onDelete={handleCellDelete}
+              entries={ts.entries}
+              onDelete={ts.deleteEntry}
             />
           )}
         </div>
 
-        {/* Help */}
-        <div className="text-xs text-muted-foreground/60 pb-2">
-          點擊格子可輸入工時與分類。綠色 = 正常，橘色 = 超時（&gt;8h）。
+        {/* Help text */}
+        <div className="text-xs text-muted-foreground/50 pb-2">
+          點擊格子直接輸入數字，Enter/Tab 自動儲存。雙擊可編輯分類、備註與加班標記。
         </div>
       </div>
     </div>

--- a/app/api/reports/department-timesheet/route.ts
+++ b/app/api/reports/department-timesheet/route.ts
@@ -14,6 +14,7 @@ import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { formatLocalDate } from "@/lib/utils/date";
 
 interface UserDayHours {
   [date: string]: number;
@@ -59,7 +60,7 @@ export const GET = withManager(async (req: NextRequest) => {
   for (const entry of entries) {
     const userId = entry.userId;
     const userName = (entry as unknown as { user: { name: string } }).user?.name ?? "Unknown";
-    const dateStr = new Date(entry.date).toISOString().slice(0, 10);
+    const dateStr = formatLocalDate(new Date(entry.date));
 
     if (!byUserMap.has(userId)) {
       byUserMap.set(userId, {
@@ -79,8 +80,8 @@ export const GET = withManager(async (req: NextRequest) => {
   const grandTotal = entries.reduce((sum, e) => sum + e.hours, 0);
 
   return success({
-    weekStart: start.toISOString().slice(0, 10),
-    weekEnd: end.toISOString().slice(0, 10),
+    weekStart: formatLocalDate(start),
+    weekEnd: formatLocalDate(end),
     grandTotal,
     byUser,
     entries,

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { ExportService } from "@/services/export-service";
+import { formatLocalDate } from "@/lib/utils/date";
 import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
 
 const exportService = new ExportService();
@@ -62,8 +63,8 @@ export const GET = withAuth(async (req: NextRequest) => {
     }, {} as Record<string, number>);
 
     result = exportService.exportWeeklyReport({
-      weekStart: weekStart.toISOString().split("T")[0],
-      weekEnd: weekEnd.toISOString().split("T")[0],
+      weekStart: formatLocalDate(weekStart),
+      weekEnd: formatLocalDate(weekEnd),
       completedTasks,
       totalHours,
       hoursByCategory,
@@ -187,8 +188,8 @@ export const GET = withAuth(async (req: NextRequest) => {
     }, {} as Record<string, { userId: string; name: string; total: number; planned: number; unplanned: number }>);
 
     result = exportService.exportWorkloadReport({
-      startDate: startDate.toISOString().split("T")[0],
-      endDate: endDate.toISOString().split("T")[0],
+      startDate: formatLocalDate(startDate),
+      endDate: formatLocalDate(endDate),
       totalHours,
       plannedHours,
       unplannedHours,

--- a/app/api/reports/scheduled/route.ts
+++ b/app/api/reports/scheduled/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { success } from "@/lib/api-response";
 import { withManager } from "@/lib/auth-middleware";
 import { ReportService } from "@/services/report-service";
+import { formatLocalDate } from "@/lib/utils/date";
 
 const reportService = new ReportService(prisma);
 
@@ -26,7 +27,7 @@ export const POST = withManager(async (_req: NextRequest) => {
 
   // Same-day idempotency guard: if a scheduled report notification already
   // exists for today, return early instead of regenerating.
-  const todayKey = `report-scheduled-${now.toISOString().slice(0, 10)}`;
+  const todayKey = `report-scheduled-${formatLocalDate(now)}`;
   const existingToday = await prisma.notification.count({
     where: {
       type: "TASK_CHANGED",
@@ -74,7 +75,7 @@ export const POST = withManager(async (_req: NextRequest) => {
   ].join("\n");
 
   // Create notifications for all managers
-  const weekKey = `report-${report.period.start.toISOString().slice(0, 10)}`;
+  const weekKey = `report-${formatLocalDate(report.period.start)}`;
 
   // Check for existing notifications to avoid duplicates
   const existing = await prisma.notification.findMany({

--- a/app/api/reports/timesheet-compliance/route.ts
+++ b/app/api/reports/timesheet-compliance/route.ts
@@ -16,6 +16,7 @@ import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { formatLocalDate } from "@/lib/utils/date";
 
 interface DailyEntry {
   date: string;
@@ -74,7 +75,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
   for (const [userId, { userName, entries: userEntries }] of byUser) {
     const dailyEntries: DailyEntry[] = userEntries.map((e) => ({
-      date: new Date(e.date).toISOString().slice(0, 10),
+      date: formatLocalDate(new Date(e.date)),
       hours: e.hours,
       overtime: Boolean((e as Record<string, unknown>).overtime),
       locked: Boolean((e as Record<string, unknown>).locked),
@@ -147,8 +148,8 @@ export const GET = withManager(async (req: NextRequest) => {
   }
 
   return success({
-    startDate: start.toISOString().slice(0, 10),
-    endDate: end.toISOString().slice(0, 10),
+    startDate: formatLocalDate(start),
+    endDate: formatLocalDate(end),
     users,
   });
 });

--- a/app/api/time-entries/batch/route.ts
+++ b/app/api/time-entries/batch/route.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { TimeCategory } from "@prisma/client";
 import { withAuth } from "@/lib/auth-middleware";
+import { formatLocalDate } from "@/lib/utils/date";
 import { requireAuth } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
 import { success, error } from "@/lib/api-response";
@@ -59,7 +60,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     // Build a set of existing date+taskId keys for overlap detection
     const existingKeys = new Set(
       existing.map((e) => {
-        const dateStr = new Date(e.date).toISOString().slice(0, 10);
+        const dateStr = formatLocalDate(new Date(e.date));
         return `${dateStr}:${e.taskId ?? ""}`;
       })
     );

--- a/app/api/time-entries/copy-week/route.ts
+++ b/app/api/time-entries/copy-week/route.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { formatLocalDate } from "@/lib/utils/date";
 import { validateBody } from "@/lib/validate";
 import { success } from "@/lib/api-response";
 
@@ -59,7 +60,7 @@ export const POST = withAuth(async (req: NextRequest) => {
 
   const targetKeys = new Set(
     targetEntries.map((e) => {
-      const dateStr = new Date(e.date).toISOString().slice(0, 10);
+      const dateStr = formatLocalDate(new Date(e.date));
       return `${dateStr}:${e.taskId ?? ""}`;
     })
   );
@@ -72,7 +73,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     const srcDate = new Date(entry.date);
     const tgtDate = new Date(srcDate);
     tgtDate.setDate(tgtDate.getDate() + 7);
-    const tgtDateStr = tgtDate.toISOString().slice(0, 10);
+    const tgtDateStr = formatLocalDate(tgtDate);
 
     const key = `${tgtDateStr}:${entry.taskId ?? ""}`;
     if (targetKeys.has(key)) {

--- a/app/api/time-entries/templates/[id]/route.ts
+++ b/app/api/time-entries/templates/[id]/route.ts
@@ -1,0 +1,30 @@
+/**
+ * DELETE /api/time-entries/templates/[id] — Delete a template (TS-30)
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { NotFoundError, ForbiddenError } from "@/services/errors";
+
+export const DELETE = withAuth(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+  const { id } = await context.params;
+
+  const template = await prisma.timeEntryTemplate.findUnique({ where: { id } });
+  if (!template) throw new NotFoundError(`Template not found: ${id}`);
+
+  if ((template as unknown as { userId: string }).userId !== userId) {
+    throw new ForbiddenError("只能刪除自己的模板");
+  }
+
+  await prisma.timeEntryTemplate.delete({ where: { id } });
+
+  return success({ success: true });
+});

--- a/app/components/timesheet-grid.tsx
+++ b/app/components/timesheet-grid.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { TimeEntryCell, type TimeEntry } from "./time-entry-cell";
 import { safeFixed } from "@/lib/safe-number";
+import { formatLocalDate } from "@/lib/utils/date";
 
 export type TaskRow = {
   taskId: string | null;
@@ -23,7 +24,7 @@ type TimesheetGridProps = {
 function getDateStr(weekStart: Date, dayOffset: number): string {
   const d = new Date(weekStart);
   d.setDate(d.getDate() + dayOffset);
-  return d.toISOString().split("T")[0];
+  return formatLocalDate(d);
 }
 
 function formatDateLabel(weekStart: Date, offset: number): string {

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -1,7 +1,10 @@
 export { useTimesheet } from "./use-timesheet";
+export { useTimer } from "./use-timer";
+export { useWeekNavigation } from "./use-week-navigation";
 export { TimesheetGrid } from "./timesheet-grid";
 export { TimesheetCell } from "./timesheet-cell";
 export { TimesheetToolbar } from "./timesheet-toolbar";
 export { TimesheetTimer } from "./timesheet-timer";
+export { TemplateSelector } from "./template-selector";
 export type { TimeEntry, TaskRow, TaskOption, OvertimeType, TimerState } from "./use-timesheet";
 export type { ViewMode } from "./timesheet-toolbar";

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -1,0 +1,7 @@
+export { useTimesheet } from "./use-timesheet";
+export { TimesheetGrid } from "./timesheet-grid";
+export { TimesheetCell } from "./timesheet-cell";
+export { TimesheetToolbar } from "./timesheet-toolbar";
+export { TimesheetTimer } from "./timesheet-timer";
+export type { TimeEntry, TaskRow, TaskOption, OvertimeType, TimerState } from "./use-timesheet";
+export type { ViewMode } from "./timesheet-toolbar";

--- a/app/components/timesheet/overtime-badge.tsx
+++ b/app/components/timesheet/overtime-badge.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { safeFixed } from "@/lib/safe-number";
+import { formatLocalDate } from "@/lib/utils/date";
+import {
+  OVERTIME_CONFIG,
+  getOvertimeInfo,
+  type OvertimeLevel,
+} from "@/lib/overtime";
+import { extractItems } from "@/lib/api-client";
+import { type TimeEntry } from "./use-timesheet";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type OvertimeBadgeProps = {
+  weekStart: Date;
+};
+
+type MonthlyEntry = {
+  date: string;
+  hours: number;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OvertimeBadge({ weekStart }: OvertimeBadgeProps) {
+  const [monthlyHours, setMonthlyHours] = useState(0);
+  const [dailyBreakdown, setDailyBreakdown] = useState<Record<string, number>>({});
+  const [showPopover, setShowPopover] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  // Determine the month from the weekStart (use the Monday's month)
+  const year = weekStart.getFullYear();
+  const month = weekStart.getMonth(); // 0-based
+
+  // Load monthly entries
+  const loadMonthlyData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const monthStart = new Date(year, month, 1);
+      const monthEnd = new Date(year, month + 1, 0); // last day of month
+      const params = new URLSearchParams({
+        startDate: formatLocalDate(monthStart),
+        endDate: formatLocalDate(monthEnd),
+      });
+      const res = await fetch(`/api/time-entries/stats?${params}`);
+      if (!res.ok) {
+        // Fallback: try fetching entries directly
+        const entriesRes = await fetch(
+          `/api/time-entries?weekStart=${formatLocalDate(monthStart)}&endDate=${formatLocalDate(monthEnd)}`
+        );
+        if (entriesRes.ok) {
+          const body = await entriesRes.json();
+          const entries = extractItems<MonthlyEntry>(body);
+          const total = entries.reduce((sum, e) => sum + e.hours, 0);
+          setMonthlyHours(total);
+
+          // Build daily breakdown
+          const breakdown: Record<string, number> = {};
+          for (const e of entries) {
+            const dateKey = e.date.split("T")[0];
+            breakdown[dateKey] = (breakdown[dateKey] ?? 0) + e.hours;
+          }
+          setDailyBreakdown(breakdown);
+        }
+        return;
+      }
+      const body = await res.json();
+      const data = body.data ?? body;
+      if (data?.totalHours != null) {
+        setMonthlyHours(data.totalHours);
+      }
+      // If breakdown is available, use it
+      if (data?.dailyBreakdown) {
+        setDailyBreakdown(data.dailyBreakdown);
+      }
+    } catch {
+      // Silently fail — badge shows 0
+    } finally {
+      setLoading(false);
+    }
+  }, [year, month]);
+
+  useEffect(() => {
+    loadMonthlyData();
+  }, [loadMonthlyData]);
+
+  const overtimeInfo = useMemo(
+    () => getOvertimeInfo(monthlyHours, year, month),
+    [monthlyHours, year, month]
+  );
+
+  if (loading) return null;
+
+  const badgeColors: Record<OvertimeLevel, string> = {
+    safe: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600",
+    warning: "border-amber-500/30 bg-amber-500/10 text-amber-600",
+    danger: "border-red-500/30 bg-red-500/10 text-red-500",
+  };
+
+  const monthLabel = `${year}/${String(month + 1).padStart(2, "0")}`;
+
+  function getBadgeText(): string {
+    const hours = safeFixed(overtimeInfo.overtimeHours, 1);
+    if (overtimeInfo.level === "danger") {
+      return `本月加班：${hours}h / ${OVERTIME_CONFIG.LIMIT}h（已超過法定上限）`;
+    }
+    if (overtimeInfo.level === "warning") {
+      return `本月加班：${hours}h / ${OVERTIME_CONFIG.LIMIT}h（接近上限）`;
+    }
+    return `本月加班：${hours}h`;
+  }
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={() => setShowPopover((prev) => !prev)}
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors cursor-pointer",
+          badgeColors[overtimeInfo.level]
+        )}
+        data-testid="overtime-badge"
+        data-overtime-level={overtimeInfo.level}
+      >
+        {overtimeInfo.level === "warning" && (
+          <span role="img" aria-label="warning">&#x26A0;&#xFE0F;</span>
+        )}
+        {overtimeInfo.level === "danger" && (
+          <span role="img" aria-label="alert">&#x1F6A8;</span>
+        )}
+        {getBadgeText()}
+      </button>
+
+      {/* Popover — daily overtime breakdown */}
+      {showPopover && (
+        <div
+          className="absolute top-full mt-1 right-0 z-50 w-64 bg-card border border-border rounded-lg shadow-lg p-3"
+          data-testid="overtime-popover"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-semibold text-foreground">
+              {monthLabel} 加班明細
+            </span>
+            <button
+              onClick={() => setShowPopover(false)}
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="space-y-1 max-h-48 overflow-y-auto">
+            {Object.keys(dailyBreakdown).length > 0 ? (
+              Object.entries(dailyBreakdown)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([date, hours]) => {
+                  const dailyOvertime = Math.max(0, hours - 8);
+                  if (dailyOvertime === 0) return null;
+                  return (
+                    <div key={date} className="flex justify-between text-xs">
+                      <span className="text-muted-foreground">{date}</span>
+                      <span className={cn(
+                        "tabular-nums font-medium",
+                        dailyOvertime > 0 ? "text-amber-500" : "text-foreground"
+                      )}>
+                        +{safeFixed(dailyOvertime, 1)}h
+                      </span>
+                    </div>
+                  );
+                })
+                .filter(Boolean)
+            ) : (
+              <p className="text-xs text-muted-foreground/60 text-center py-2">
+                無加班紀錄
+              </p>
+            )}
+          </div>
+
+          {/* Summary bar */}
+          <div className="mt-2 pt-2 border-t border-border/50">
+            <div className="flex justify-between text-xs">
+              <span className="text-muted-foreground">月總工時</span>
+              <span className="font-medium text-foreground tabular-nums">
+                {safeFixed(monthlyHours, 1)}h
+              </span>
+            </div>
+            <div className="flex justify-between text-xs mt-0.5">
+              <span className="text-muted-foreground">加班時數</span>
+              <span className={cn(
+                "font-semibold tabular-nums",
+                badgeColors[overtimeInfo.level].split(" ").pop()
+              )}>
+                {safeFixed(overtimeInfo.overtimeHours, 1)}h / {OVERTIME_CONFIG.LIMIT}h
+              </span>
+            </div>
+
+            {/* Progress bar */}
+            <div className="mt-1.5 h-1.5 bg-muted rounded-full overflow-hidden">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all",
+                  overtimeInfo.level === "danger" ? "bg-red-500"
+                    : overtimeInfo.level === "warning" ? "bg-amber-500"
+                      : "bg-emerald-500"
+                )}
+                style={{
+                  width: `${Math.min(100, (overtimeInfo.overtimeHours / OVERTIME_CONFIG.LIMIT) * 100)}%`,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/template-selector.tsx
+++ b/app/components/timesheet/template-selector.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { FileText, Save, ChevronDown, Trash2, X } from "lucide-react";
+import { type TimeEntry } from "./use-timesheet";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TemplateEntry = {
+  hours: number;
+  category?: string;
+  taskId?: string;
+  description?: string;
+};
+
+type Template = {
+  id: string;
+  name: string;
+  entries: string; // JSON-stringified TemplateEntry[]
+  createdAt: string;
+};
+
+type TemplateSelectorProps = {
+  weekStart: Date;
+  entries: TimeEntry[];
+  daysCount: number;
+  getDateStr: (offset: number) => string;
+  onRefresh: () => void;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function parseTemplateEntries(raw: string): TemplateEntry[] {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TemplateSelector({
+  weekStart,
+  entries,
+  daysCount,
+  getDateStr,
+  onRefresh,
+}: TemplateSelectorProps) {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveMode, setSaveMode] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [confirmTemplate, setConfirmTemplate] = useState<Template | null>(null);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Load templates
+  const loadTemplates = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/time-entries/templates");
+      if (res.ok) {
+        const body = await res.json();
+        const data = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [];
+        setTemplates(data);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) loadTemplates();
+  }, [open, loadTemplates]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setSaveMode(false);
+        setConfirmTemplate(null);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  // Clear feedback after delay
+  useEffect(() => {
+    if (!feedback) return;
+    const t = setTimeout(() => setFeedback(null), 2500);
+    return () => clearTimeout(t);
+  }, [feedback]);
+
+  // Apply template to current week (fill only empty cells)
+  async function handleApply(template: Template) {
+    setApplying(true);
+    setConfirmTemplate(null);
+    try {
+      const templateEntries = parseTemplateEntries(template.entries);
+      let totalCreated = 0;
+
+      // Apply to each day of the week
+      for (let dayOffset = 0; dayOffset < daysCount; dayOffset++) {
+        const dateStr = getDateStr(dayOffset);
+        // Get existing entries for this date
+        const existingOnDate = entries.filter(
+          (e) => e.date.split("T")[0] === dateStr
+        );
+        // Skip locked entries check
+        const hasLockedOnDate = existingOnDate.some((e) => e.locked);
+        if (hasLockedOnDate) continue;
+
+        // Only apply if the day has no existing entries (fill empty cells only)
+        if (existingOnDate.length > 0) continue;
+
+        // Apply template for this date
+        const res = await fetch(`/api/time-entries/templates/${template.id}/apply`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ date: dateStr }),
+        });
+        if (res.ok) {
+          const body = await res.json();
+          const created = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [];
+          totalCreated += created.length;
+        }
+      }
+
+      if (totalCreated > 0) {
+        setFeedback({ type: "success", msg: `已套用模板，新增 ${totalCreated} 筆記錄` });
+        onRefresh();
+      } else {
+        setFeedback({ type: "success", msg: "所有日期已有記錄，未新增任何項目" });
+      }
+    } catch {
+      setFeedback({ type: "error", msg: "套用模板失敗" });
+    } finally {
+      setApplying(false);
+      setOpen(false);
+    }
+  }
+
+  // Save current week as template
+  async function handleSave() {
+    if (!saveName.trim()) return;
+    setSaving(true);
+    try {
+      // Collect unique entry patterns from the current week (deduplicate by taskId+category)
+      const seen = new Set<string>();
+      const templateEntries: TemplateEntry[] = [];
+      for (const e of entries) {
+        if (e.locked) continue; // Don't include locked entries in template
+        const key = `${e.taskId ?? "null"}-${e.category}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        templateEntries.push({
+          hours: e.hours,
+          category: e.category,
+          taskId: e.taskId ?? undefined,
+          description: e.description ?? undefined,
+        });
+      }
+
+      if (templateEntries.length === 0) {
+        setFeedback({ type: "error", msg: "本週無可儲存的記錄" });
+        return;
+      }
+
+      const res = await fetch("/api/time-entries/templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: saveName.trim(),
+          entries: templateEntries,
+        }),
+      });
+
+      if (res.ok) {
+        setFeedback({ type: "success", msg: `模板「${saveName.trim()}」已儲存` });
+        setSaveMode(false);
+        setSaveName("");
+        loadTemplates();
+      } else {
+        const body = await res.json().catch(() => ({}));
+        setFeedback({ type: "error", msg: body?.error ?? "儲存模板失敗" });
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Delete template
+  async function handleDelete(templateId: string) {
+    const res = await fetch(`/api/time-entries/templates/${templateId}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      setTemplates((prev) => prev.filter((t) => t.id !== templateId));
+      setFeedback({ type: "success", msg: "模板已刪除" });
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative" data-testid="template-selector">
+      {/* Trigger buttons */}
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={() => {
+            setOpen(!open);
+            setSaveMode(false);
+            setConfirmTemplate(null);
+          }}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors",
+            "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
+          )}
+          data-testid="template-btn"
+        >
+          <FileText className="h-3.5 w-3.5" />
+          模板
+          <ChevronDown className={cn("h-3 w-3 transition-transform", open && "rotate-180")} />
+        </button>
+
+        <button
+          onClick={() => {
+            setOpen(true);
+            setSaveMode(true);
+            setConfirmTemplate(null);
+          }}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors",
+            "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
+          )}
+          data-testid="save-template-btn"
+        >
+          <Save className="h-3.5 w-3.5" />
+          儲存為模板
+        </button>
+      </div>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute top-full mt-1 left-0 z-50 w-72 bg-card border border-border rounded-xl shadow-2xl p-2" data-testid="template-dropdown">
+          {saveMode ? (
+            /* Save as template form */
+            <div className="space-y-2 p-1" data-testid="save-template-form">
+              <div className="text-xs font-medium text-foreground">儲存本週為模板</div>
+              <input
+                type="text"
+                value={saveName}
+                onChange={(e) => setSaveName(e.target.value)}
+                placeholder="輸入模板名稱..."
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSave();
+                  if (e.key === "Escape") { setSaveMode(false); setOpen(false); }
+                }}
+                className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                data-testid="template-name-input"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleSave}
+                  disabled={saving || !saveName.trim()}
+                  className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+                  data-testid="template-save-confirm"
+                >
+                  {saving ? "儲存中..." : "儲存"}
+                </button>
+                <button
+                  onClick={() => { setSaveMode(false); setOpen(false); }}
+                  className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
+                >
+                  取消
+                </button>
+              </div>
+            </div>
+          ) : confirmTemplate ? (
+            /* Confirmation dialog */
+            <div className="space-y-2 p-1" data-testid="template-confirm">
+              <div className="text-xs font-medium text-foreground">
+                確定要套用模板「{confirmTemplate.name}」？
+              </div>
+              <p className="text-[10px] text-muted-foreground">
+                僅填入空白日期，已有記錄的日期不受影響。鎖定的日期將被跳過。
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => handleApply(confirmTemplate)}
+                  disabled={applying}
+                  className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+                  data-testid="template-apply-confirm"
+                >
+                  {applying ? "套用中..." : "確定套用"}
+                </button>
+                <button
+                  onClick={() => setConfirmTemplate(null)}
+                  className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
+                >
+                  取消
+                </button>
+              </div>
+            </div>
+          ) : (
+            /* Template list */
+            <div className="space-y-0.5">
+              <div className="text-[10px] text-muted-foreground px-2 py-1">我的模板</div>
+              {loading ? (
+                <div className="text-xs text-muted-foreground/60 text-center py-4">載入中...</div>
+              ) : templates.length === 0 ? (
+                <div className="text-xs text-muted-foreground/60 text-center py-4">
+                  尚無模板，點擊「儲存為模板」建立
+                </div>
+              ) : (
+                templates.map((t) => {
+                  const entryCount = parseTemplateEntries(t.entries).length;
+                  return (
+                    <div
+                      key={t.id}
+                      className="flex items-center gap-1 group"
+                      data-testid={`template-item-${t.id}`}
+                    >
+                      <button
+                        onClick={() => setConfirmTemplate(t)}
+                        className="flex-1 text-left px-2.5 py-1.5 text-xs text-foreground hover:bg-accent/50 rounded-md transition-colors truncate"
+                      >
+                        <span className="font-medium">{t.name}</span>
+                        <span className="text-[10px] text-muted-foreground/60 ml-1.5">
+                          ({entryCount} 筆)
+                        </span>
+                      </button>
+                      <button
+                        onClick={() => handleDelete(t.id)}
+                        className="p-1 text-muted-foreground/40 hover:text-red-400 rounded transition-colors opacity-0 group-hover:opacity-100"
+                        title="刪除模板"
+                        data-testid={`template-delete-${t.id}`}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </button>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Feedback toast */}
+      {feedback && (
+        <div
+          className={cn(
+            "fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] px-4 py-2.5 rounded-lg shadow-lg text-sm font-medium",
+            "animate-in fade-in slide-in-from-bottom-2 duration-200",
+            feedback.type === "success"
+              ? "bg-emerald-500/10 text-emerald-500 border border-emerald-500/30"
+              : "bg-red-500/10 text-red-400 border border-red-500/30"
+          )}
+          data-testid="template-feedback"
+        >
+          {feedback.msg}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/timesheet-cell.tsx
+++ b/app/components/timesheet/timesheet-cell.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { type TimeEntry, type OvertimeType } from "./use-timesheet";
 import { safeFixed } from "@/lib/safe-number";
+import { Lock } from "lucide-react";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,8 @@ function getCatDot(cat: string) {
   return CATEGORIES.find((c) => c.value === cat)?.dot ?? "bg-slate-400";
 }
 
+const LOCKED_TOAST_MSG = "此記錄已核准鎖定，如需修改請聯繫主管";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 type TimesheetCellProps = {
@@ -47,6 +50,48 @@ type TimesheetCellProps = {
   isWeekend?: boolean;
 };
 
+// ─── Per-entry edit state ─────────────────────────────────────────────────────
+
+type EntryEditState = {
+  hours: string;
+  category: string;
+  description: string;
+  overtimeType: OvertimeType;
+  saving: boolean;
+};
+
+function initEditState(entry: TimeEntry): EntryEditState {
+  return {
+    hours: safeFixed(entry.hours, 1),
+    category: entry.category,
+    description: entry.description ?? "",
+    overtimeType: (entry.overtimeType as OvertimeType) ?? "NONE",
+    saving: false,
+  };
+}
+
+// ─── Locked Toast ─────────────────────────────────────────────────────────────
+
+function showLockedToast() {
+  // Use a lightweight toast element appended to body
+  const existing = document.getElementById("locked-toast");
+  if (existing) existing.remove();
+
+  const toast = document.createElement("div");
+  toast.id = "locked-toast";
+  toast.textContent = LOCKED_TOAST_MSG;
+  toast.style.cssText =
+    "position:fixed;bottom:24px;left:50%;transform:translateX(-50%);z-index:9999;" +
+    "background:#292524;color:#fbbf24;border:1px solid rgba(251,191,36,0.3);" +
+    "padding:8px 16px;border-radius:8px;font-size:13px;font-weight:500;" +
+    "box-shadow:0 4px 12px rgba(0,0,0,0.3);transition:opacity 0.3s;";
+  document.body.appendChild(toast);
+  setTimeout(() => {
+    toast.style.opacity = "0";
+    setTimeout(() => toast.remove(), 300);
+  }, 2500);
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function TimesheetCell({
@@ -63,18 +108,31 @@ export function TimesheetCell({
   const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
   const hasMultiple = entries.length > 1;
 
+  // Check if ALL entries are locked (cell-level locked state)
+  const allLocked = entries.length > 0 && entries.every((e) => e.locked);
+  // Check if ANY entry is locked
+  const hasLockedEntry = entries.some((e) => e.locked);
+
   const [editing, setEditing] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const cellRef = useRef<HTMLDivElement>(null);
 
-  // Expanded edit state
-  const [editHours, setEditHours] = useState("");
-  const [editCategory, setEditCategory] = useState("PLANNED_TASK");
-  const [editDescription, setEditDescription] = useState("");
-  const [editOvertimeType, setEditOvertimeType] = useState<OvertimeType>("NONE");
-  const [saving, setSaving] = useState(false);
+  // Guard against Enter+Blur double save (Item 5)
+  const savedByKeyboard = useRef(false);
+
+  // Per-entry expanded edit states (Item 7)
+  const [entryStates, setEntryStates] = useState<Map<string, EntryEditState>>(new Map());
+  // New entry form state
+  const [showNewEntry, setShowNewEntry] = useState(false);
+  const [newEntryState, setNewEntryState] = useState<EntryEditState>({
+    hours: "",
+    category: "PLANNED_TASK",
+    description: "",
+    overtimeType: "NONE",
+    saving: false,
+  });
 
   // Focus input when editing starts
   useEffect(() => {
@@ -90,6 +148,7 @@ export function TimesheetCell({
     function handler(e: MouseEvent) {
       if (cellRef.current && !cellRef.current.contains(e.target as Node)) {
         setExpanded(false);
+        setShowNewEntry(false);
       }
     }
     document.addEventListener("mousedown", handler);
@@ -99,32 +158,52 @@ export function TimesheetCell({
   // Handle click on cell — start inline editing
   const handleClick = useCallback(() => {
     if (expanded) return;
+    // Item 2: locked protection — all entries locked = no inline edit
+    if (allLocked) {
+      showLockedToast();
+      return;
+    }
     setEditing(true);
     setInputValue(entry ? safeFixed(entry.hours, 1) : "");
-  }, [entry, expanded]);
+  }, [entry, expanded, allLocked]);
 
-  // Handle double-click — open expanded editor
+  // Handle double-click — open expanded editor (Item 7: show ALL entries)
   const handleDoubleClick = useCallback(() => {
-    if (!entry) return;
+    // Allow opening expanded view even if locked (entries shown read-only)
+    if (entries.length === 0) return;
     setEditing(false);
     setExpanded(true);
-    setEditHours(safeFixed(entry.hours, 1));
-    setEditCategory(entry.category);
-    setEditDescription(entry.description ?? "");
-    setEditOvertimeType((entry.overtimeType as OvertimeType) ?? "NONE");
-  }, [entry]);
+    // Initialize per-entry edit states
+    const states = new Map<string, EntryEditState>();
+    for (const e of entries) {
+      states.set(e.id, initEditState(e));
+    }
+    setEntryStates(states);
+    setShowNewEntry(false);
+  }, [entries]);
 
   // Inline edit keyboard handler
   const handleKeyDown = useCallback(
     async (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter" || e.key === "Tab") {
         e.preventDefault();
+        // Item 5: set flag to prevent duplicate save on blur
+        savedByKeyboard.current = true;
+        setTimeout(() => { savedByKeyboard.current = false; }, 150);
         const h = parseFloat(inputValue);
         if (!isNaN(h) && h >= 0) {
           if (h === 0 && entry) {
-            await onDelete(entry.id);
+            if (entry.locked) {
+              showLockedToast();
+            } else {
+              await onDelete(entry.id);
+            }
           } else if (h > 0) {
-            await onQuickSave(taskId, date, h, entry?.id);
+            if (entry?.locked) {
+              showLockedToast();
+            } else {
+              await onQuickSave(taskId, date, h, entry?.id);
+            }
           }
         }
         setEditing(false);
@@ -145,40 +224,111 @@ export function TimesheetCell({
   );
 
   // Handle blur on inline input
+  // Item 5: skip save if already saved via keyboard (Enter/Tab)
   const handleBlur = useCallback(async () => {
+    if (savedByKeyboard.current) {
+      savedByKeyboard.current = false;
+      return;
+    }
     const h = parseFloat(inputValue);
     if (!isNaN(h) && h >= 0) {
       if (h === 0 && entry) {
-        await onDelete(entry.id);
+        if (entry.locked) {
+          showLockedToast();
+        } else {
+          await onDelete(entry.id);
+        }
       } else if (h > 0) {
-        await onQuickSave(taskId, date, h, entry?.id);
+        if (entry?.locked) {
+          showLockedToast();
+        } else {
+          await onQuickSave(taskId, date, h, entry?.id);
+        }
       }
     }
     setEditing(false);
   }, [inputValue, entry, taskId, date, onQuickSave, onDelete]);
 
-  // Expanded editor save
-  async function handleExpandedSave() {
-    const h = parseFloat(editHours);
+  // Per-entry expanded save (Item 7)
+  async function handleEntrySave(entryId: string) {
+    const state = entryStates.get(entryId);
+    if (!state) return;
+    const h = parseFloat(state.hours);
     if (isNaN(h) || h < 0) return;
-    setSaving(true);
+    setEntryStates((prev) => {
+      const next = new Map(prev);
+      next.set(entryId, { ...state, saving: true });
+      return next;
+    });
     try {
-      await onFullSave(taskId, date, h, editCategory, editDescription, editOvertimeType, entry?.id);
-      setExpanded(false);
+      await onFullSave(taskId, date, h, state.category, state.description, state.overtimeType, entryId);
     } finally {
-      setSaving(false);
+      setEntryStates((prev) => {
+        const next = new Map(prev);
+        const s = next.get(entryId);
+        if (s) next.set(entryId, { ...s, saving: false });
+        return next;
+      });
     }
   }
 
-  // Expanded editor delete
-  async function handleExpandedDelete() {
-    if (!entry) return;
-    setSaving(true);
+  // Per-entry expanded delete (Item 7)
+  async function handleEntryDelete(entryId: string) {
+    const state = entryStates.get(entryId);
+    if (!state) return;
+    setEntryStates((prev) => {
+      const next = new Map(prev);
+      next.set(entryId, { ...state, saving: true });
+      return next;
+    });
     try {
-      await onDelete(entry.id);
-      setExpanded(false);
+      await onDelete(entryId);
+      setEntryStates((prev) => {
+        const next = new Map(prev);
+        next.delete(entryId);
+        return next;
+      });
+      // If no entries left, close expanded
+      if (entryStates.size <= 1) {
+        setExpanded(false);
+      }
     } finally {
-      setSaving(false);
+      setEntryStates((prev) => {
+        const next = new Map(prev);
+        const s = next.get(entryId);
+        if (s) next.set(entryId, { ...s, saving: false });
+        return next;
+      });
+    }
+  }
+
+  // Update a single entry's edit state field
+  function updateEntryField(entryId: string, field: keyof EntryEditState, value: string) {
+    setEntryStates((prev) => {
+      const next = new Map(prev);
+      const state = next.get(entryId);
+      if (state) next.set(entryId, { ...state, [field]: value });
+      return next;
+    });
+  }
+
+  // New entry save
+  async function handleNewEntrySave() {
+    const h = parseFloat(newEntryState.hours);
+    if (isNaN(h) || h <= 0) return;
+    setNewEntryState((s) => ({ ...s, saving: true }));
+    try {
+      await onFullSave(taskId, date, h, newEntryState.category, newEntryState.description, newEntryState.overtimeType);
+      setShowNewEntry(false);
+      setNewEntryState({
+        hours: "",
+        category: "PLANNED_TASK",
+        description: "",
+        overtimeType: "NONE",
+        saving: false,
+      });
+    } finally {
+      setNewEntryState((s) => ({ ...s, saving: false }));
     }
   }
 
@@ -215,16 +365,25 @@ export function TimesheetCell({
             "w-full h-9 rounded-md border text-xs transition-all relative",
             "focus:outline-none focus:ring-2 focus:ring-ring/30",
             isWeekend && "bg-muted/20",
-            entry && totalHours > 0
+            // Item 2: locked visual — gray background
+            allLocked && "bg-muted/40 cursor-not-allowed",
+            entry && totalHours > 0 && !allLocked
               ? "font-medium border-border/60 hover:border-ring/40"
-              : "border-dashed border-border/40 text-muted-foreground/40 hover:border-ring/30 hover:text-muted-foreground hover:bg-accent/20"
+              : allLocked && totalHours > 0
+                ? "font-medium border-border/60"
+                : "border-dashed border-border/40 text-muted-foreground/40 hover:border-ring/30 hover:text-muted-foreground hover:bg-accent/20"
           )}
           data-testid="cell-button"
         >
           {entry && totalHours > 0 ? (
             <span className="flex items-center justify-center gap-1">
-              {/* Category color dot */}
-              <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", getCatDot(entry.category))} />
+              {/* Lock icon for locked entries */}
+              {allLocked ? (
+                <Lock className="w-3 h-3 text-muted-foreground/60 flex-shrink-0" />
+              ) : (
+                /* Category color dot */
+                <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", getCatDot(entry.category))} />
+              )}
               <span className="tabular-nums">{safeFixed(totalHours, 1)}</span>
               {/* Overtime indicator */}
               {hasOvertime && (
@@ -247,94 +406,224 @@ export function TimesheetCell({
         </button>
       )}
 
-      {/* ── Expanded editor (on double-click) ── */}
+      {/* ── Expanded editor (on double-click) — Item 7: multi-entry individual editing ── */}
       {expanded && (
         <div
-          className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 w-64 bg-card border border-border rounded-xl shadow-2xl p-3 space-y-2.5"
+          className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 w-72 bg-card border border-border rounded-xl shadow-2xl p-3 space-y-2"
           data-testid="cell-expanded"
         >
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">工時（小時）</label>
-            <input
-              type="number"
-              min="0"
-              max="24"
-              step="0.5"
-              autoFocus
-              value={editHours}
-              onChange={(e) => setEditHours(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleExpandedSave();
-                if (e.key === "Escape") setExpanded(false);
-              }}
-              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
+          {/* Render ALL entries individually */}
+          {entries.map((e, idx) => {
+            const state = entryStates.get(e.id);
+            if (!state) return null;
+            const isLocked = !!e.locked;
+            return (
+              <div key={e.id} data-testid={`entry-editor-${idx}`}>
+                {idx > 0 && <div className="border-t border-border/40 my-2" />}
+                {/* Locked badge */}
+                {isLocked && (
+                  <div className="flex items-center gap-1 text-[10px] text-amber-500/80 mb-1.5">
+                    <Lock className="w-3 h-3" />
+                    <span>已鎖定</span>
+                  </div>
+                )}
+                <div className="space-y-2">
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-1">工時（小時）</label>
+                    <input
+                      type="number"
+                      min="0"
+                      max="24"
+                      step="0.5"
+                      autoFocus={idx === 0}
+                      value={state.hours}
+                      onChange={(ev) => !isLocked && updateEntryField(e.id, "hours", ev.target.value)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === "Enter" && !isLocked) handleEntrySave(e.id);
+                        if (ev.key === "Escape") setExpanded(false);
+                      }}
+                      readOnly={isLocked}
+                      className={cn(
+                        "w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring",
+                        isLocked && "opacity-60 cursor-not-allowed"
+                      )}
+                    />
+                  </div>
 
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">分類</label>
-            <select
-              value={editCategory}
-              onChange={(e) => setEditCategory(e.target.value)}
-              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
-            >
-              {CATEGORIES.map((c) => (
-                <option key={c.value} value={c.value}>{c.label}</option>
-              ))}
-            </select>
-          </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-1">分類</label>
+                    <select
+                      value={state.category}
+                      onChange={(ev) => !isLocked && updateEntryField(e.id, "category", ev.target.value)}
+                      disabled={isLocked}
+                      className={cn(
+                        "w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer",
+                        isLocked && "opacity-60 cursor-not-allowed"
+                      )}
+                    >
+                      {CATEGORIES.map((c) => (
+                        <option key={c.value} value={c.value}>{c.label}</option>
+                      ))}
+                    </select>
+                  </div>
 
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">備註</label>
-            <input
-              type="text"
-              value={editDescription}
-              onChange={(e) => setEditDescription(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleExpandedSave();
-              }}
-              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-              placeholder="可選備註..."
-            />
-          </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-1">備註</label>
+                    <input
+                      type="text"
+                      value={state.description}
+                      onChange={(ev) => !isLocked && updateEntryField(e.id, "description", ev.target.value)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === "Enter" && !isLocked) handleEntrySave(e.id);
+                      }}
+                      readOnly={isLocked}
+                      className={cn(
+                        "w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring",
+                        isLocked && "opacity-60 cursor-not-allowed"
+                      )}
+                      placeholder="可選備註..."
+                    />
+                  </div>
 
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">加班類型</label>
-            <select
-              value={editOvertimeType}
-              onChange={(e) => setEditOvertimeType(e.target.value as OvertimeType)}
-              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
-            >
-              {OVERTIME_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
-          </div>
+                  <div>
+                    <label className="block text-xs text-muted-foreground mb-1">加班類型</label>
+                    <select
+                      value={state.overtimeType}
+                      onChange={(ev) => !isLocked && updateEntryField(e.id, "overtimeType", ev.target.value)}
+                      disabled={isLocked}
+                      className={cn(
+                        "w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer",
+                        isLocked && "opacity-60 cursor-not-allowed"
+                      )}
+                    >
+                      {OVERTIME_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                  </div>
 
-          <div className="flex items-center gap-2 pt-1">
-            <button
-              onClick={handleExpandedSave}
-              disabled={saving}
-              className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
-            >
-              {saving ? "儲存中..." : "儲存"}
-            </button>
-            {entry && (
+                  {/* Action buttons — hidden for locked entries */}
+                  {!isLocked && (
+                    <div className="flex items-center gap-2 pt-0.5">
+                      <button
+                        onClick={() => handleEntrySave(e.id)}
+                        disabled={state.saving}
+                        className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+                        data-testid={`entry-save-${idx}`}
+                      >
+                        {state.saving ? "儲存中..." : "儲存"}
+                      </button>
+                      <button
+                        onClick={() => handleEntryDelete(e.id)}
+                        disabled={state.saving}
+                        className="px-2.5 py-1.5 bg-red-900/30 hover:bg-red-900/50 text-red-400 text-xs rounded-md transition-colors disabled:opacity-50"
+                        data-testid={`entry-delete-${idx}`}
+                      >
+                        刪除
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+
+          {/* Divider before new entry / actions */}
+          {entries.length > 0 && <div className="border-t border-border/40 my-2" />}
+
+          {/* + 新增記錄 button */}
+          {!showNewEntry ? (
+            <div className="flex items-center gap-2">
               <button
-                onClick={handleExpandedDelete}
-                disabled={saving}
-                className="px-2.5 py-1.5 bg-red-900/30 hover:bg-red-900/50 text-red-400 text-xs rounded-md transition-colors disabled:opacity-50"
+                onClick={() => setShowNewEntry(true)}
+                className="flex-1 text-xs text-muted-foreground hover:text-foreground transition-colors py-1"
+                data-testid="add-entry-btn"
               >
-                刪除
+                + 新增記錄
               </button>
-            )}
-            <button
-              onClick={() => setExpanded(false)}
-              className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
-            >
-              取消
-            </button>
-          </div>
+              <button
+                onClick={() => setExpanded(false)}
+                className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
+              >
+                關閉
+              </button>
+            </div>
+          ) : (
+            /* New entry inline form */
+            <div className="space-y-2" data-testid="new-entry-form">
+              <div className="text-xs font-medium text-muted-foreground">新增記錄</div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">工時（小時）</label>
+                <input
+                  type="number"
+                  min="0"
+                  max="24"
+                  step="0.5"
+                  autoFocus
+                  value={newEntryState.hours}
+                  onChange={(ev) => setNewEntryState((s) => ({ ...s, hours: ev.target.value }))}
+                  onKeyDown={(ev) => {
+                    if (ev.key === "Enter") handleNewEntrySave();
+                    if (ev.key === "Escape") setShowNewEntry(false);
+                  }}
+                  className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">分類</label>
+                <select
+                  value={newEntryState.category}
+                  onChange={(ev) => setNewEntryState((s) => ({ ...s, category: ev.target.value }))}
+                  className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+                >
+                  {CATEGORIES.map((c) => (
+                    <option key={c.value} value={c.value}>{c.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">備註</label>
+                <input
+                  type="text"
+                  value={newEntryState.description}
+                  onChange={(ev) => setNewEntryState((s) => ({ ...s, description: ev.target.value }))}
+                  onKeyDown={(ev) => {
+                    if (ev.key === "Enter") handleNewEntrySave();
+                  }}
+                  className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                  placeholder="可選備註..."
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-muted-foreground mb-1">加班類型</label>
+                <select
+                  value={newEntryState.overtimeType}
+                  onChange={(ev) => setNewEntryState((s) => ({ ...s, overtimeType: ev.target.value as OvertimeType }))}
+                  className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+                >
+                  {OVERTIME_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>{o.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex items-center gap-2 pt-0.5">
+                <button
+                  onClick={handleNewEntrySave}
+                  disabled={newEntryState.saving}
+                  className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+                  data-testid="new-entry-save"
+                >
+                  {newEntryState.saving ? "儲存中..." : "新增"}
+                </button>
+                <button
+                  onClick={() => setShowNewEntry(false)}
+                  className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
+                >
+                  取消
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/app/components/timesheet/timesheet-cell.tsx
+++ b/app/components/timesheet/timesheet-cell.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { type TimeEntry, type OvertimeType } from "./use-timesheet";
+import { safeFixed } from "@/lib/safe-number";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const CATEGORIES = [
+  { value: "PLANNED_TASK", label: "原始規劃", dot: "bg-blue-500" },
+  { value: "ADDED_TASK", label: "追加任務", dot: "bg-purple-500" },
+  { value: "INCIDENT", label: "突發事件", dot: "bg-red-500" },
+  { value: "SUPPORT", label: "用戶支援", dot: "bg-orange-500" },
+  { value: "ADMIN", label: "行政庶務", dot: "bg-slate-400" },
+  { value: "LEARNING", label: "學習成長", dot: "bg-emerald-500" },
+] as const;
+
+const OVERTIME_OPTIONS: { value: OvertimeType; label: string; color: string }[] = [
+  { value: "NONE", label: "非加班", color: "" },
+  { value: "WEEKDAY", label: "平日加班", color: "bg-amber-500" },
+  { value: "HOLIDAY", label: "假日加班", color: "bg-red-500" },
+];
+
+function getCatDot(cat: string) {
+  return CATEGORIES.find((c) => c.value === cat)?.dot ?? "bg-slate-400";
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TimesheetCellProps = {
+  entries: TimeEntry[];
+  taskId: string | null;
+  date: string;
+  onQuickSave: (taskId: string | null, date: string, hours: number, existingId?: string) => Promise<void>;
+  onFullSave: (
+    taskId: string | null,
+    date: string,
+    hours: number,
+    category: string,
+    description: string,
+    overtimeType: OvertimeType,
+    existingId?: string
+  ) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  onNavigate?: (direction: "next" | "prev" | "up" | "down") => void;
+  isWeekend?: boolean;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TimesheetCell({
+  entries,
+  taskId,
+  date,
+  onQuickSave,
+  onFullSave,
+  onDelete,
+  onNavigate,
+  isWeekend,
+}: TimesheetCellProps) {
+  const entry = entries[0] ?? null;
+  const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
+  const hasMultiple = entries.length > 1;
+
+  const [editing, setEditing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const cellRef = useRef<HTMLDivElement>(null);
+
+  // Expanded edit state
+  const [editHours, setEditHours] = useState("");
+  const [editCategory, setEditCategory] = useState("PLANNED_TASK");
+  const [editDescription, setEditDescription] = useState("");
+  const [editOvertimeType, setEditOvertimeType] = useState<OvertimeType>("NONE");
+  const [saving, setSaving] = useState(false);
+
+  // Focus input when editing starts
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!expanded) return;
+    function handler(e: MouseEvent) {
+      if (cellRef.current && !cellRef.current.contains(e.target as Node)) {
+        setExpanded(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [expanded]);
+
+  // Handle click on cell — start inline editing
+  const handleClick = useCallback(() => {
+    if (expanded) return;
+    setEditing(true);
+    setInputValue(entry ? safeFixed(entry.hours, 1) : "");
+  }, [entry, expanded]);
+
+  // Handle double-click — open expanded editor
+  const handleDoubleClick = useCallback(() => {
+    if (!entry) return;
+    setEditing(false);
+    setExpanded(true);
+    setEditHours(safeFixed(entry.hours, 1));
+    setEditCategory(entry.category);
+    setEditDescription(entry.description ?? "");
+    setEditOvertimeType((entry.overtimeType as OvertimeType) ?? "NONE");
+  }, [entry]);
+
+  // Inline edit keyboard handler
+  const handleKeyDown = useCallback(
+    async (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        const h = parseFloat(inputValue);
+        if (!isNaN(h) && h >= 0) {
+          if (h === 0 && entry) {
+            await onDelete(entry.id);
+          } else if (h > 0) {
+            await onQuickSave(taskId, date, h, entry?.id);
+          }
+        }
+        setEditing(false);
+        if (e.key === "Tab") {
+          onNavigate?.(e.shiftKey ? "prev" : "next");
+        }
+      } else if (e.key === "Escape") {
+        setEditing(false);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        onNavigate?.("up");
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        onNavigate?.("down");
+      }
+    },
+    [inputValue, entry, taskId, date, onQuickSave, onDelete, onNavigate]
+  );
+
+  // Handle blur on inline input
+  const handleBlur = useCallback(async () => {
+    const h = parseFloat(inputValue);
+    if (!isNaN(h) && h >= 0) {
+      if (h === 0 && entry) {
+        await onDelete(entry.id);
+      } else if (h > 0) {
+        await onQuickSave(taskId, date, h, entry?.id);
+      }
+    }
+    setEditing(false);
+  }, [inputValue, entry, taskId, date, onQuickSave, onDelete]);
+
+  // Expanded editor save
+  async function handleExpandedSave() {
+    const h = parseFloat(editHours);
+    if (isNaN(h) || h < 0) return;
+    setSaving(true);
+    try {
+      await onFullSave(taskId, date, h, editCategory, editDescription, editOvertimeType, entry?.id);
+      setExpanded(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Expanded editor delete
+  async function handleExpandedDelete() {
+    if (!entry) return;
+    setSaving(true);
+    try {
+      await onDelete(entry.id);
+      setExpanded(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const overtimeType = (entry?.overtimeType as OvertimeType) ?? "NONE";
+  const hasOvertime = overtimeType !== "NONE";
+
+  return (
+    <div ref={cellRef} className="relative" data-testid="timesheet-cell">
+      {/* ── Inline edit mode ── */}
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="number"
+          min="0"
+          max="24"
+          step="0.5"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          className={cn(
+            "w-full h-9 text-center text-sm font-medium tabular-nums rounded-md border",
+            "bg-background border-ring/50 text-foreground",
+            "focus:outline-none focus:ring-2 focus:ring-ring/30"
+          )}
+          data-testid="cell-input"
+        />
+      ) : (
+        /* ── Display mode ── */
+        <button
+          onClick={handleClick}
+          onDoubleClick={handleDoubleClick}
+          className={cn(
+            "w-full h-9 rounded-md border text-xs transition-all relative",
+            "focus:outline-none focus:ring-2 focus:ring-ring/30",
+            isWeekend && "bg-muted/20",
+            entry && totalHours > 0
+              ? "font-medium border-border/60 hover:border-ring/40"
+              : "border-dashed border-border/40 text-muted-foreground/40 hover:border-ring/30 hover:text-muted-foreground hover:bg-accent/20"
+          )}
+          data-testid="cell-button"
+        >
+          {entry && totalHours > 0 ? (
+            <span className="flex items-center justify-center gap-1">
+              {/* Category color dot */}
+              <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", getCatDot(entry.category))} />
+              <span className="tabular-nums">{safeFixed(totalHours, 1)}</span>
+              {/* Overtime indicator */}
+              {hasOvertime && (
+                <span
+                  className={cn(
+                    "w-1.5 h-1.5 rounded-full flex-shrink-0",
+                    overtimeType === "WEEKDAY" ? "bg-amber-500" : "bg-red-500"
+                  )}
+                  title={overtimeType === "WEEKDAY" ? "平日加班" : "假日加班"}
+                />
+              )}
+              {/* Multiple entries indicator */}
+              {hasMultiple && (
+                <span className="text-[9px] text-muted-foreground/60">+{entries.length - 1}</span>
+              )}
+            </span>
+          ) : (
+            <span className="text-muted-foreground/30">—</span>
+          )}
+        </button>
+      )}
+
+      {/* ── Expanded editor (on double-click) ── */}
+      {expanded && (
+        <div
+          className="absolute top-full mt-1 left-1/2 -translate-x-1/2 z-50 w-64 bg-card border border-border rounded-xl shadow-2xl p-3 space-y-2.5"
+          data-testid="cell-expanded"
+        >
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1">工時（小時）</label>
+            <input
+              type="number"
+              min="0"
+              max="24"
+              step="0.5"
+              autoFocus
+              value={editHours}
+              onChange={(e) => setEditHours(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleExpandedSave();
+                if (e.key === "Escape") setExpanded(false);
+              }}
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1">分類</label>
+            <select
+              value={editCategory}
+              onChange={(e) => setEditCategory(e.target.value)}
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c.value} value={c.value}>{c.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1">備註</label>
+            <input
+              type="text"
+              value={editDescription}
+              onChange={(e) => setEditDescription(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleExpandedSave();
+              }}
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="可選備註..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-muted-foreground mb-1">加班類型</label>
+            <select
+              value={editOvertimeType}
+              onChange={(e) => setEditOvertimeType(e.target.value as OvertimeType)}
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+            >
+              {OVERTIME_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              onClick={handleExpandedSave}
+              disabled={saving}
+              className="flex-1 bg-accent hover:bg-accent/80 text-accent-foreground text-xs font-medium py-1.5 rounded-md transition-colors disabled:opacity-50"
+            >
+              {saving ? "儲存中..." : "儲存"}
+            </button>
+            {entry && (
+              <button
+                onClick={handleExpandedDelete}
+                disabled={saving}
+                className="px-2.5 py-1.5 bg-red-900/30 hover:bg-red-900/50 text-red-400 text-xs rounded-md transition-colors disabled:opacity-50"
+              >
+                刪除
+              </button>
+            )}
+            <button
+              onClick={() => setExpanded(false)}
+              className="px-2.5 py-1.5 text-muted-foreground hover:text-foreground text-xs rounded-md transition-colors"
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/timesheet-grid.tsx
+++ b/app/components/timesheet/timesheet-grid.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { safeFixed } from "@/lib/safe-number";
+import { TimesheetCell } from "./timesheet-cell";
+import { type TimeEntry, type TaskRow, type OvertimeType, type TaskOption } from "./use-timesheet";
+import { Plus } from "lucide-react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TimesheetGridProps = {
+  weekStart: Date;
+  taskRows: TaskRow[];
+  entries: TimeEntry[];
+  tasks: TaskOption[];
+  dailyTotals: number[];
+  weeklyTotal: number;
+  dayLabels: string[];
+  daysCount: number;
+  getDateStr: (offset: number) => string;
+  formatDateLabel: (offset: number) => string;
+  getEntriesForCell: (taskId: string | null, dateStr: string) => TimeEntry[];
+  onQuickSave: (taskId: string | null, date: string, hours: number, existingId?: string) => Promise<void>;
+  onFullSave: (
+    taskId: string | null,
+    date: string,
+    hours: number,
+    category: string,
+    description: string,
+    overtimeType: OvertimeType,
+    existingId?: string
+  ) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  onAddTaskRow: (taskId: string, label: string) => void;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TimesheetGrid({
+  taskRows,
+  entries,
+  tasks,
+  dailyTotals,
+  weeklyTotal,
+  dayLabels,
+  daysCount,
+  getDateStr,
+  formatDateLabel,
+  getEntriesForCell,
+  onQuickSave,
+  onFullSave,
+  onDelete,
+  onAddTaskRow,
+}: TimesheetGridProps) {
+  const gridRef = useRef<HTMLTableElement>(null);
+  const [showTaskSelector, setShowTaskSelector] = useState(false);
+  const [taskSearch, setTaskSearch] = useState("");
+
+  // Row totals
+  const rowTotals = taskRows.map((row) =>
+    entries
+      .filter((e) => (e.taskId ?? null) === (row.taskId ?? null))
+      .reduce((sum, e) => sum + e.hours, 0)
+  );
+
+  // Navigation callback for cells
+  const handleNavigate = useCallback(
+    (rowIdx: number, dayIdx: number, direction: "next" | "prev" | "up" | "down") => {
+      if (!gridRef.current) return;
+      let targetRow = rowIdx;
+      let targetDay = dayIdx;
+
+      switch (direction) {
+        case "next":
+          targetDay++;
+          if (targetDay >= daysCount) {
+            targetDay = 0;
+            targetRow++;
+          }
+          break;
+        case "prev":
+          targetDay--;
+          if (targetDay < 0) {
+            targetDay = daysCount - 1;
+            targetRow--;
+          }
+          break;
+        case "up":
+          targetRow--;
+          break;
+        case "down":
+          targetRow++;
+          break;
+      }
+
+      if (targetRow < 0 || targetRow >= taskRows.length) return;
+      if (targetDay < 0 || targetDay >= daysCount) return;
+
+      // Find and click the target cell button
+      const selector = `[data-row="${targetRow}"][data-day="${targetDay}"] [data-testid="cell-button"]`;
+      const btn = gridRef.current.querySelector<HTMLButtonElement>(selector);
+      btn?.click();
+    },
+    [daysCount, taskRows.length]
+  );
+
+  // Filtered tasks for add-row selector
+  const availableTaskIds = new Set(taskRows.map((r) => r.taskId).filter(Boolean));
+  const filteredTasks = tasks
+    .filter((t) => !availableTaskIds.has(t.id))
+    .filter((t) => !taskSearch || t.title.toLowerCase().includes(taskSearch.toLowerCase()));
+
+  return (
+    <div className="overflow-x-auto" data-testid="timesheet-grid">
+      <table ref={gridRef} className="w-full border-collapse text-sm">
+        {/* ── Header ── */}
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground w-48 min-w-[180px] sticky left-0 bg-card z-10">
+              任務
+            </th>
+            {dayLabels.map((day, i) => {
+              const isWeekend = i >= 5;
+              return (
+                <th
+                  key={i}
+                  className={cn(
+                    "px-1 py-2.5 text-center min-w-[72px]",
+                    isWeekend && "bg-muted/10"
+                  )}
+                >
+                  <div className={cn(
+                    "text-xs font-semibold",
+                    isWeekend ? "text-muted-foreground/60" : "text-muted-foreground"
+                  )}>
+                    週{day}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground/50 mt-0.5">
+                    {formatDateLabel(i)}
+                  </div>
+                </th>
+              );
+            })}
+            <th className="px-3 py-2.5 text-center text-xs font-medium text-muted-foreground min-w-[56px]">
+              合計
+            </th>
+          </tr>
+        </thead>
+
+        {/* ── Body ── */}
+        <tbody>
+          {taskRows.length === 0 ? (
+            <tr>
+              <td colSpan={daysCount + 2} className="text-center py-12 text-sm text-muted-foreground">
+                <div className="space-y-2">
+                  <p>本週尚無工時記錄</p>
+                  <p className="text-xs text-muted-foreground/60">點擊下方「+ 新增任務列」開始記錄</p>
+                </div>
+              </td>
+            </tr>
+          ) : (
+            taskRows.map((row, rowIdx) => (
+              <tr
+                key={row.taskId ?? `free-${rowIdx}`}
+                className="border-b border-border/40 hover:bg-accent/10 transition-colors group"
+              >
+                <td className="px-3 py-1.5 sticky left-0 bg-card group-hover:bg-accent/10 z-10">
+                  <span
+                    className="text-xs text-muted-foreground truncate block max-w-[168px]"
+                    title={row.label}
+                  >
+                    {row.taskId ? "# " : ""}
+                    {row.label}
+                  </span>
+                </td>
+                {Array.from({ length: daysCount }, (_, dayIdx) => {
+                  const dateStr = getDateStr(dayIdx);
+                  const cellEntries = getEntriesForCell(row.taskId, dateStr);
+                  const isWeekend = dayIdx >= 5;
+                  return (
+                    <td
+                      key={dayIdx}
+                      className={cn("px-1 py-1", isWeekend && "bg-muted/10")}
+                      data-row={rowIdx}
+                      data-day={dayIdx}
+                    >
+                      <TimesheetCell
+                        entries={cellEntries}
+                        taskId={row.taskId}
+                        date={dateStr}
+                        onQuickSave={onQuickSave}
+                        onFullSave={onFullSave}
+                        onDelete={onDelete}
+                        onNavigate={(dir) => handleNavigate(rowIdx, dayIdx, dir)}
+                        isWeekend={isWeekend}
+                      />
+                    </td>
+                  );
+                })}
+                <td className="px-3 py-1.5 text-center">
+                  <span
+                    className={cn(
+                      "text-xs font-medium tabular-nums",
+                      rowTotals[rowIdx] > 0 ? "text-foreground" : "text-muted-foreground/30"
+                    )}
+                  >
+                    {rowTotals[rowIdx] > 0 ? safeFixed(rowTotals[rowIdx], 1) : "—"}
+                  </span>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+
+        {/* ── Footer: daily totals ── */}
+        <tfoot>
+          <tr className="border-t border-border bg-muted/20">
+            <td className="px-3 py-2.5 sticky left-0 bg-muted/20 z-10">
+              <span className="text-xs font-semibold text-muted-foreground">每日合計</span>
+            </td>
+            {dailyTotals.map((total, i) => {
+              const isWeekend = i >= 5;
+              return (
+                <td key={i} className={cn("px-1 py-2.5 text-center", isWeekend && "bg-muted/10")}>
+                  <span
+                    className={cn(
+                      "text-xs font-semibold tabular-nums",
+                      total > 8
+                        ? "text-amber-500"
+                        : total > 0
+                          ? "text-emerald-500"
+                          : "text-muted-foreground/30"
+                    )}
+                  >
+                    {total > 0 ? safeFixed(total, 1) : "—"}
+                  </span>
+                </td>
+              );
+            })}
+            <td className="px-3 py-2.5 text-center">
+              <span className="text-xs font-bold text-foreground tabular-nums">
+                {safeFixed(weeklyTotal, 1)}
+              </span>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+
+      {/* ── Add task row button ── */}
+      <div className="px-3 py-2 border-t border-border/30">
+        {showTaskSelector ? (
+          <div className="space-y-2">
+            <input
+              type="text"
+              value={taskSearch}
+              onChange={(e) => setTaskSearch(e.target.value)}
+              placeholder="搜尋任務..."
+              autoFocus
+              className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setShowTaskSelector(false);
+                  setTaskSearch("");
+                }
+              }}
+              data-testid="task-search-input"
+            />
+            <div className="max-h-40 overflow-y-auto space-y-0.5">
+              {filteredTasks.length === 0 ? (
+                <p className="text-xs text-muted-foreground/60 py-2 text-center">無可用任務</p>
+              ) : (
+                filteredTasks.map((t) => (
+                  <button
+                    key={t.id}
+                    onClick={() => {
+                      onAddTaskRow(t.id, t.title);
+                      setShowTaskSelector(false);
+                      setTaskSearch("");
+                    }}
+                    className="w-full text-left px-2.5 py-1.5 text-xs text-foreground hover:bg-accent/50 rounded-md transition-colors truncate"
+                  >
+                    {t.title}
+                  </button>
+                ))
+              )}
+            </div>
+            <button
+              onClick={() => {
+                setShowTaskSelector(false);
+                setTaskSearch("");
+              }}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              取消
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowTaskSelector(true)}
+            className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors py-1"
+            data-testid="add-task-row-btn"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            新增任務列
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/timesheet/timesheet-timer.tsx
+++ b/app/components/timesheet/timesheet-timer.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { Play, Square, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { type TimerState, type TaskOption } from "./use-timesheet";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type TimesheetTimerProps = {
+  timer: TimerState | null;
+  elapsed: number;
+  tasks: TaskOption[];
+  onStart: (taskId: string | null) => Promise<{ ok: boolean; error: string | null }>;
+  onStop: () => Promise<{ ok: boolean; error: string | null }>;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatElapsed(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(h)}:${pad(m)}:${pad(s)}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TimesheetTimer({ timer, elapsed, tasks, onStart, onStop }: TimesheetTimerProps) {
+  const [selectedTaskId, setSelectedTaskId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isRunning = timer?.isRunning ?? false;
+
+  async function handleStart() {
+    setLoading(true);
+    setError(null);
+    const result = await onStart(selectedTaskId || null);
+    if (!result.ok) setError(result.error);
+    setLoading(false);
+  }
+
+  async function handleStop() {
+    setLoading(true);
+    setError(null);
+    const result = await onStop();
+    if (!result.ok) setError(result.error);
+    else setSelectedTaskId("");
+    setLoading(false);
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col sm:flex-row items-start sm:items-center gap-3 px-4 py-3 rounded-xl border transition-colors",
+        isRunning
+          ? "bg-emerald-500/5 border-emerald-500/20"
+          : "bg-card border-border"
+      )}
+      data-testid="timesheet-timer"
+    >
+      {/* Timer icon + display */}
+      <div className="flex items-center gap-3">
+        <Clock className={cn("h-4 w-4", isRunning ? "text-emerald-500" : "text-muted-foreground")} />
+        <div
+          className={cn(
+            "text-xl sm:text-2xl font-mono font-bold tabular-nums transition-colors",
+            isRunning ? "text-emerald-500" : "text-muted-foreground/30"
+          )}
+          data-testid="timer-display"
+        >
+          {formatElapsed(elapsed)}
+        </div>
+      </div>
+
+      {/* Task selector (when not running) */}
+      {!isRunning && (
+        <select
+          value={selectedTaskId}
+          onChange={(e) => setSelectedTaskId(e.target.value)}
+          className="bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer min-w-[160px]"
+          data-testid="timer-task-select"
+        >
+          <option value="">自由工時（無任務）</option>
+          {tasks.map((t) => (
+            <option key={t.id} value={t.id}>{t.title}</option>
+          ))}
+        </select>
+      )}
+
+      {/* Running task label */}
+      {isRunning && timer && (
+        <span className="text-xs text-muted-foreground" data-testid="timer-running-label">
+          正在計時：{timer.taskLabel}
+        </span>
+      )}
+
+      {/* Start / Stop */}
+      {isRunning ? (
+        <button
+          onClick={handleStop}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-red-900/30 hover:bg-red-900/50 text-red-400 text-xs font-medium rounded-md transition-colors disabled:opacity-50 sm:ml-auto"
+          data-testid="timer-stop-btn"
+        >
+          <Square className="h-3 w-3" />
+          停止
+        </button>
+      ) : (
+        <button
+          onClick={handleStart}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-900/30 hover:bg-emerald-900/50 text-emerald-400 text-xs font-medium rounded-md transition-colors disabled:opacity-50 sm:ml-auto"
+          data-testid="timer-start-btn"
+        >
+          <Play className="h-3 w-3" />
+          開始計時
+        </button>
+      )}
+
+      {/* Error */}
+      {error && (
+        <span className="text-xs text-red-400" data-testid="timer-error">{error}</span>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/timesheet-toolbar.tsx
+++ b/app/components/timesheet/timesheet-toolbar.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, Grid3X3, List, Copy, FileDown, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type ViewMode = "grid" | "list";
+
+type TimesheetToolbarProps = {
+  weekRange: string;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
+  onPrevWeek: () => void;
+  onNextWeek: () => void;
+  onThisWeek: () => void;
+  onCopyPreviousWeek: () => Promise<boolean>;
+  onRefresh: () => void;
+  loading?: boolean;
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function TimesheetToolbar({
+  weekRange,
+  viewMode,
+  onViewModeChange,
+  onPrevWeek,
+  onNextWeek,
+  onThisWeek,
+  onCopyPreviousWeek,
+  onRefresh,
+  loading,
+}: TimesheetToolbarProps) {
+  const [copying, setCopying] = useState(false);
+  const [copyResult, setCopyResult] = useState<"success" | "error" | null>(null);
+
+  async function handleCopy() {
+    setCopying(true);
+    setCopyResult(null);
+    try {
+      const ok = await onCopyPreviousWeek();
+      setCopyResult(ok ? "success" : "error");
+      setTimeout(() => setCopyResult(null), 2000);
+    } finally {
+      setCopying(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Row 1: Title + week range + navigation */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
+        <div>
+          <h1 className="text-lg sm:text-xl font-semibold tracking-tight">工時紀錄</h1>
+          <p className="text-muted-foreground text-xs sm:text-sm mt-0.5">{weekRange}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {/* View toggle */}
+          <div className="flex items-center bg-background border border-border rounded-md overflow-hidden">
+            <button
+              onClick={() => onViewModeChange("grid")}
+              className={cn(
+                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
+                viewMode === "grid"
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+              data-testid="view-grid-btn"
+            >
+              <Grid3X3 className="h-3.5 w-3.5" />
+              格子
+            </button>
+            <button
+              onClick={() => onViewModeChange("list")}
+              className={cn(
+                "flex items-center gap-1 px-2.5 py-1.5 text-xs transition-colors",
+                viewMode === "list"
+                  ? "bg-accent text-accent-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+              )}
+              data-testid="view-list-btn"
+            >
+              <List className="h-3.5 w-3.5" />
+              列表
+            </button>
+          </div>
+
+          {/* Week navigation */}
+          <div className="flex items-center gap-0.5 bg-background border border-border rounded-md">
+            <button
+              onClick={onPrevWeek}
+              className="p-1.5 hover:bg-accent rounded-l-md transition-colors"
+              data-testid="prev-week-btn"
+            >
+              <ChevronLeft className="h-4 w-4 text-muted-foreground" />
+            </button>
+            <button
+              onClick={onThisWeek}
+              className="px-3 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              data-testid="this-week-btn"
+            >
+              本週
+            </button>
+            <button
+              onClick={onNextWeek}
+              className="p-1.5 hover:bg-accent rounded-r-md transition-colors"
+              data-testid="next-week-btn"
+            >
+              <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            </button>
+          </div>
+
+          {/* Refresh */}
+          <button
+            onClick={onRefresh}
+            disabled={loading}
+            className="p-1.5 rounded-md bg-background border border-border hover:bg-accent transition-colors"
+            data-testid="refresh-btn"
+          >
+            <RefreshCw className={cn("h-4 w-4 text-muted-foreground", loading && "animate-spin")} />
+          </button>
+        </div>
+      </div>
+
+      {/* Row 2: Quick actions */}
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={handleCopy}
+          disabled={copying}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors",
+            copyResult === "success"
+              ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-500"
+              : copyResult === "error"
+                ? "border-red-500/30 bg-red-500/10 text-red-400"
+                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50",
+            copying && "opacity-50"
+          )}
+          data-testid="copy-week-btn"
+        >
+          <Copy className="h-3.5 w-3.5" />
+          {copyResult === "success" ? "已複製" : copyResult === "error" ? "複製失敗" : "複製上週"}
+        </button>
+
+        {/* Color legend */}
+        <div className="flex items-center gap-3 ml-auto text-[10px] text-muted-foreground/50">
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-emerald-500" /> 正常
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-amber-500" /> 超時/平日OT
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-red-500" /> 假日OT
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export type { ViewMode };

--- a/app/components/timesheet/timesheet-toolbar.tsx
+++ b/app/components/timesheet/timesheet-toolbar.tsx
@@ -3,6 +3,9 @@
 import { useState } from "react";
 import { ChevronLeft, ChevronRight, Grid3X3, List, Copy, FileDown, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { TemplateSelector } from "./template-selector";
+import { OvertimeBadge } from "./overtime-badge";
+import { type TimeEntry } from "./use-timesheet";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -18,6 +21,11 @@ type TimesheetToolbarProps = {
   onCopyPreviousWeek: () => Promise<boolean>;
   onRefresh: () => void;
   loading?: boolean;
+  // Template props (Item 6)
+  weekStart?: Date;
+  entries?: TimeEntry[];
+  daysCount?: number;
+  getDateStr?: (offset: number) => string;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -32,6 +40,10 @@ export function TimesheetToolbar({
   onCopyPreviousWeek,
   onRefresh,
   loading,
+  weekStart,
+  entries,
+  daysCount,
+  getDateStr,
 }: TimesheetToolbarProps) {
   const [copying, setCopying] = useState(false);
   const [copyResult, setCopyResult] = useState<"success" | "error" | null>(null);
@@ -144,6 +156,20 @@ export function TimesheetToolbar({
           <Copy className="h-3.5 w-3.5" />
           {copyResult === "success" ? "已複製" : copyResult === "error" ? "複製失敗" : "複製上週"}
         </button>
+
+        {/* Template selector (Item 6) */}
+        {weekStart && entries && daysCount && getDateStr && (
+          <TemplateSelector
+            weekStart={weekStart}
+            entries={entries}
+            daysCount={daysCount}
+            getDateStr={getDateStr}
+            onRefresh={onRefresh}
+          />
+        )}
+
+        {/* Overtime badge (Item 9) */}
+        {weekStart && <OvertimeBadge weekStart={weekStart} />}
 
         {/* Color legend */}
         <div className="flex items-center gap-3 ml-auto text-[10px] text-muted-foreground/50">

--- a/app/components/timesheet/use-timer.ts
+++ b/app/components/timesheet/use-timer.ts
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { extractData } from "@/lib/api-client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type TimerState = {
+  isRunning: boolean;
+  taskId: string | null;
+  taskLabel: string;
+  startTime: number | null; // epoch ms
+  entryId: string | null;
+};
+
+// ─── localStorage persistence ────────────────────────────────────────────────
+
+const TIMER_STORAGE_KEY = "titan-timer-state";
+
+function loadTimerState(): TimerState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(TIMER_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as TimerState;
+  } catch {
+    return null;
+  }
+}
+
+function saveTimerState(state: TimerState | null) {
+  if (typeof window === "undefined") return;
+  if (state) {
+    localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(state));
+  } else {
+    localStorage.removeItem(TIMER_STORAGE_KEY);
+  }
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useTimer() {
+  const [timer, setTimer] = useState<TimerState | null>(() => loadTimerState());
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Persist timer state
+  useEffect(() => {
+    saveTimerState(timer);
+  }, [timer]);
+
+  // Tick timer
+  useEffect(() => {
+    if (timer?.isRunning && timer.startTime) {
+      setElapsed(Math.floor((Date.now() - timer.startTime) / 1000));
+      intervalRef.current = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - timer.startTime!) / 1000));
+      }, 1000);
+    } else {
+      setElapsed(0);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [timer]);
+
+  // Restore timer from server on mount
+  useEffect(() => {
+    fetch("/api/time-entries/running")
+      .then((r) => r.json())
+      .then((body) => {
+        const data = extractData<{
+          id: string;
+          taskId: string | null;
+          startTime: string;
+          task?: { title: string } | null;
+        } | null>(body);
+        if (data?.startTime) {
+          setTimer({
+            isRunning: true,
+            taskId: data.taskId,
+            taskLabel: data.task?.title ?? "自由工時",
+            startTime: new Date(data.startTime).getTime(),
+            entryId: data.id,
+          });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // Start timer
+  const startTimer = useCallback(async (taskId: string | null) => {
+    try {
+      const res = await fetch("/api/time-entries/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId: taskId || undefined }),
+      });
+      if (res.status === 409) return { ok: false, error: "已有計時器在運行中" };
+      if (!res.ok) return { ok: false, error: "啟動計時器失敗" };
+      const body = await res.json();
+      const entry = extractData<{
+        id: string;
+        taskId: string | null;
+        startTime: string;
+        task?: { title: string } | null;
+      }>(body);
+      const taskLabel = entry.task?.title ?? "自由工時";
+      setTimer({
+        isRunning: true,
+        taskId: entry.taskId,
+        taskLabel,
+        startTime: new Date(entry.startTime).getTime(),
+        entryId: entry.id,
+      });
+      return { ok: true, error: null };
+    } catch {
+      return { ok: false, error: "啟動計時器失敗" };
+    }
+  }, []);
+
+  // Stop timer — returns { ok, error }; caller should refresh entries after success
+  const stopTimer = useCallback(async () => {
+    try {
+      const res = await fetch("/api/time-entries/stop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) return { ok: false, error: "停止計時器失敗" };
+      setTimer(null);
+      return { ok: true, error: null };
+    } catch {
+      return { ok: false, error: "停止計時器失敗" };
+    }
+  }, []);
+
+  // Reset timer (clear without API call)
+  const resetTimer = useCallback(() => {
+    setTimer(null);
+  }, []);
+
+  return {
+    timer,
+    elapsed,
+    startTimer,
+    stopTimer,
+    resetTimer,
+  };
+}

--- a/app/components/timesheet/use-timesheet.ts
+++ b/app/components/timesheet/use-timesheet.ts
@@ -1,0 +1,481 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { extractItems, extractData } from "@/lib/api-client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type OvertimeType = "NONE" | "WEEKDAY" | "HOLIDAY";
+
+export type TimeEntry = {
+  id: string;
+  taskId: string | null;
+  date: string;
+  hours: number;
+  startTime?: string | null;
+  endTime?: string | null;
+  isRunning?: boolean;
+  overtime?: boolean;
+  overtimeType?: OvertimeType;
+  category: string;
+  description: string | null;
+  sortOrder?: number;
+  task?: { id: string; title: string; category?: string } | null;
+};
+
+export type TaskOption = {
+  id: string;
+  title: string;
+};
+
+export type TaskRow = {
+  taskId: string | null;
+  label: string;
+};
+
+export type TimerState = {
+  isRunning: boolean;
+  taskId: string | null;
+  taskLabel: string;
+  startTime: number | null; // epoch ms
+  entryId: string | null;
+};
+
+type StatsData = {
+  totalHours: number;
+  breakdown: { category: string; hours: number; pct: number }[];
+  taskInvestmentRate: number;
+  entryCount: number;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getMondayOfWeek(d: Date): Date {
+  const copy = new Date(d);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+export function getSundayOfWeek(monday: Date): Date {
+  const sunday = new Date(monday);
+  sunday.setDate(sunday.getDate() + 6);
+  return sunday;
+}
+
+export function formatWeekRange(monday: Date): string {
+  const sunday = getSundayOfWeek(monday);
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+  return `${fmt(monday)} — ${fmt(sunday)}`;
+}
+
+export function getDateStr(weekStart: Date, dayOffset: number): string {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + dayOffset);
+  return d.toISOString().split("T")[0];
+}
+
+export function formatDateLabel(weekStart: Date, offset: number): string {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + offset);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+const DAYS_COUNT = 7;
+const DAY_LABELS = ["一", "二", "三", "四", "五", "六", "日"];
+
+const FREE_ROW: TaskRow = { taskId: null, label: "自由工時（無任務）" };
+
+const TIMER_STORAGE_KEY = "titan-timer-state";
+
+function loadTimerState(): TimerState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(TIMER_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as TimerState;
+  } catch {
+    return null;
+  }
+}
+
+function saveTimerState(state: TimerState | null) {
+  if (typeof window === "undefined") return;
+  if (state) {
+    localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(state));
+  } else {
+    localStorage.removeItem(TIMER_STORAGE_KEY);
+  }
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useTimesheet(userFilter?: string) {
+  // Week navigation
+  const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
+
+  // Data
+  const [entries, setEntries] = useState<TimeEntry[]>([]);
+  const [taskRows, setTaskRows] = useState<TaskRow[]>([FREE_ROW]);
+  const [tasks, setTasks] = useState<TaskOption[]>([]);
+  const [stats, setStats] = useState<StatsData | null>(null);
+
+  // Loading states
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+
+  // Timer
+  const [timer, setTimer] = useState<TimerState | null>(() => loadTimerState());
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Persist timer state
+  useEffect(() => {
+    saveTimerState(timer);
+  }, [timer]);
+
+  // Tick timer
+  useEffect(() => {
+    if (timer?.isRunning && timer.startTime) {
+      setElapsed(Math.floor((Date.now() - timer.startTime) / 1000));
+      intervalRef.current = setInterval(() => {
+        setElapsed(Math.floor((Date.now() - timer.startTime!) / 1000));
+      }, 1000);
+    } else {
+      setElapsed(0);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [timer]);
+
+  // Load tasks
+  useEffect(() => {
+    fetch("/api/tasks")
+      .then((r) => r.json())
+      .then((body) => setTasks(extractItems<TaskOption>(body)))
+      .catch(() => {});
+  }, []);
+
+  // Load entries for the week
+  const loadEntries = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const params = new URLSearchParams({
+        weekStart: weekStart.toISOString().split("T")[0],
+      });
+      if (userFilter) params.set("userId", userFilter);
+      const res = await fetch(`/api/time-entries?${params}`);
+      if (!res.ok) throw new Error("工時資料載入失敗");
+      const body = await res.json();
+      const data = extractItems<TimeEntry>(body);
+      setEntries(data);
+
+      // Build task rows from entries
+      const seenTasks = new Map<string, string>();
+      for (const e of data) {
+        if (e.taskId && !seenTasks.has(e.taskId)) {
+          const label = e.task?.title ?? e.taskId;
+          seenTasks.set(e.taskId, label);
+        }
+      }
+      const rows: TaskRow[] = [
+        ...Array.from(seenTasks.entries()).map(([taskId, label]) => ({ taskId, label })),
+        FREE_ROW,
+      ];
+      setTaskRows(rows);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [weekStart, userFilter]);
+
+  useEffect(() => {
+    loadEntries();
+  }, [loadEntries]);
+
+  // Load stats
+  const loadStats = useCallback(async () => {
+    setStatsLoading(true);
+    try {
+      const sunday = getSundayOfWeek(weekStart);
+      const params = new URLSearchParams({
+        startDate: weekStart.toISOString().split("T")[0],
+        endDate: sunday.toISOString().split("T")[0],
+      });
+      if (userFilter) params.set("userId", userFilter);
+      const res = await fetch(`/api/time-entries/stats?${params}`);
+      if (res.ok) {
+        const b = await res.json();
+        setStats(extractData<StatsData>(b));
+      }
+    } finally {
+      setStatsLoading(false);
+    }
+  }, [weekStart, userFilter]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  // ─── CRUD ───────────────────────────────────────────────────────────────────
+
+  async function saveEntry(
+    taskId: string | null,
+    date: string,
+    hours: number,
+    category: string,
+    description: string,
+    overtimeType: OvertimeType,
+    existingId?: string
+  ) {
+    const payload = {
+      taskId,
+      date,
+      hours,
+      category,
+      description,
+      overtimeType,
+      overtime: overtimeType !== "NONE",
+    };
+
+    if (existingId) {
+      const res = await fetch(`/api/time-entries/${existingId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        const ub = await res.json();
+        const updated = extractData<TimeEntry>(ub);
+        setEntries((prev) => prev.map((e) => (e.id === existingId ? updated : e)));
+      }
+    } else {
+      const res = await fetch("/api/time-entries", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        const cb = await res.json();
+        const created = extractData<TimeEntry>(cb);
+        setEntries((prev) => [...prev, created]);
+        // Add task row if new
+        if (taskId && !taskRows.find((r) => r.taskId === taskId)) {
+          const taskLabel = tasks.find((t) => t.id === taskId)?.title ?? taskId;
+          setTaskRows((prev) => [
+            ...prev.filter((r) => r.taskId !== null),
+            { taskId, label: taskLabel },
+            FREE_ROW,
+          ]);
+        }
+      }
+    }
+    loadStats();
+  }
+
+  async function deleteEntry(id: string) {
+    const res = await fetch(`/api/time-entries/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      setEntries((prev) => prev.filter((e) => e.id !== id));
+      loadStats();
+    }
+  }
+
+  // Quick save: just hours (for inline cell editing)
+  async function quickSave(
+    taskId: string | null,
+    date: string,
+    hours: number,
+    existingId?: string
+  ) {
+    await saveEntry(taskId, date, hours, "PLANNED_TASK", "", "NONE", existingId);
+  }
+
+  // ─── Week Navigation ────────────────────────────────────────────────────────
+
+  function prevWeek() {
+    setWeekStart((d) => {
+      const n = new Date(d);
+      n.setDate(n.getDate() - 7);
+      return n;
+    });
+  }
+
+  function nextWeek() {
+    setWeekStart((d) => {
+      const n = new Date(d);
+      n.setDate(n.getDate() + 7);
+      return n;
+    });
+  }
+
+  function goToThisWeek() {
+    setWeekStart(getMondayOfWeek(new Date()));
+  }
+
+  // ─── Copy Previous Week ─────────────────────────────────────────────────────
+
+  async function copyPreviousWeek() {
+    const prevMonday = new Date(weekStart);
+    prevMonday.setDate(prevMonday.getDate() - 7);
+    const res = await fetch("/api/time-entries/copy-week", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sourceWeekStart: prevMonday.toISOString().split("T")[0],
+        targetWeekStart: weekStart.toISOString().split("T")[0],
+      }),
+    });
+    if (res.ok) {
+      await loadEntries();
+      loadStats();
+    }
+    return res.ok;
+  }
+
+  // ─── Timer ──────────────────────────────────────────────────────────────────
+
+  async function startTimer(taskId: string | null) {
+    try {
+      const res = await fetch("/api/time-entries/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ taskId: taskId || undefined }),
+      });
+      if (res.status === 409) return { ok: false, error: "已有計時器在運行中" };
+      if (!res.ok) return { ok: false, error: "啟動計時器失敗" };
+      const body = await res.json();
+      const entry = extractData<{ id: string; taskId: string | null; startTime: string; task?: { title: string } | null }>(body);
+      const taskLabel = entry.task?.title ?? "自由工時";
+      setTimer({
+        isRunning: true,
+        taskId: entry.taskId,
+        taskLabel,
+        startTime: new Date(entry.startTime).getTime(),
+        entryId: entry.id,
+      });
+      return { ok: true, error: null };
+    } catch {
+      return { ok: false, error: "啟動計時器失敗" };
+    }
+  }
+
+  async function stopTimer() {
+    try {
+      const res = await fetch("/api/time-entries/stop", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) return { ok: false, error: "停止計時器失敗" };
+      setTimer(null);
+      await loadEntries();
+      loadStats();
+      return { ok: true, error: null };
+    } catch {
+      return { ok: false, error: "停止計時器失敗" };
+    }
+  }
+
+  // Restore timer from server on mount
+  useEffect(() => {
+    fetch("/api/time-entries/running")
+      .then((r) => r.json())
+      .then((body) => {
+        const data = extractData<{ id: string; taskId: string | null; startTime: string; task?: { title: string } | null } | null>(body);
+        if (data?.startTime) {
+          setTimer({
+            isRunning: true,
+            taskId: data.taskId,
+            taskLabel: data.task?.title ?? "自由工時",
+            startTime: new Date(data.startTime).getTime(),
+            entryId: data.id,
+          });
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  // ─── Computed ───────────────────────────────────────────────────────────────
+
+  // Daily totals (7 days Mon-Sun)
+  const dailyTotals = Array.from({ length: DAYS_COUNT }, (_, i) => {
+    const dateStr = getDateStr(weekStart, i);
+    return entries
+      .filter((e) => e.date.split("T")[0] === dateStr)
+      .reduce((sum, e) => sum + e.hours, 0);
+  });
+
+  const weeklyTotal = entries.reduce((sum, e) => sum + e.hours, 0);
+
+  // Get entries for a specific cell
+  function getEntriesForCell(taskId: string | null, dateStr: string): TimeEntry[] {
+    return entries.filter(
+      (e) => (e.taskId ?? null) === (taskId ?? null) && e.date.split("T")[0] === dateStr
+    );
+  }
+
+  // Add a new empty task row
+  function addTaskRow(taskId: string, label: string) {
+    if (taskRows.find((r) => r.taskId === taskId)) return;
+    setTaskRows((prev) => [
+      ...prev.filter((r) => r.taskId !== null),
+      { taskId, label },
+      FREE_ROW,
+    ]);
+  }
+
+  return {
+    // Week
+    weekStart,
+    prevWeek,
+    nextWeek,
+    goToThisWeek,
+    formatWeekRange: () => formatWeekRange(weekStart),
+
+    // Data
+    entries,
+    taskRows,
+    tasks,
+    stats,
+
+    // Loading
+    loading,
+    loadError,
+    statsLoading,
+    refresh: loadEntries,
+
+    // CRUD
+    saveEntry,
+    deleteEntry,
+    quickSave,
+    copyPreviousWeek,
+
+    // Task rows
+    addTaskRow,
+
+    // Timer
+    timer,
+    elapsed,
+    startTimer,
+    stopTimer,
+
+    // Computed
+    dailyTotals,
+    weeklyTotal,
+    getEntriesForCell,
+
+    // Constants
+    dayLabels: DAY_LABELS,
+    daysCount: DAYS_COUNT,
+    getDateStr: (offset: number) => getDateStr(weekStart, offset),
+    formatDateLabel: (offset: number) => formatDateLabel(weekStart, offset),
+  };
+}

--- a/app/components/timesheet/use-timesheet.ts
+++ b/app/components/timesheet/use-timesheet.ts
@@ -1,7 +1,16 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { extractItems, extractData } from "@/lib/api-client";
+import { formatLocalDate } from "@/lib/utils/date";
+
+// Re-export from extracted hooks for backward compatibility
+export { getMondayOfWeek, getSundayOfWeek, formatWeekRange, getDateStr, formatDateLabel } from "./use-week-navigation";
+export { type TimerState } from "./use-timer";
+
+// Import extracted hooks
+import { useTimer } from "./use-timer";
+import { useWeekNavigation, getSundayOfWeek } from "./use-week-navigation";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -20,6 +29,7 @@ export type TimeEntry = {
   category: string;
   description: string | null;
   sortOrder?: number;
+  locked?: boolean;
   task?: { id: string; title: string; category?: string } | null;
 };
 
@@ -33,14 +43,6 @@ export type TaskRow = {
   label: string;
 };
 
-export type TimerState = {
-  isRunning: boolean;
-  taskId: string | null;
-  taskLabel: string;
-  startTime: number | null; // epoch ms
-  entryId: string | null;
-};
-
 type StatsData = {
   totalHours: number;
   breakdown: { category: string; hours: number; pct: number }[];
@@ -48,74 +50,16 @@ type StatsData = {
   entryCount: number;
 };
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-export function getMondayOfWeek(d: Date): Date {
-  const copy = new Date(d);
-  const day = copy.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  copy.setDate(copy.getDate() + diff);
-  copy.setHours(0, 0, 0, 0);
-  return copy;
-}
-
-export function getSundayOfWeek(monday: Date): Date {
-  const sunday = new Date(monday);
-  sunday.setDate(sunday.getDate() + 6);
-  return sunday;
-}
-
-export function formatWeekRange(monday: Date): string {
-  const sunday = getSundayOfWeek(monday);
-  const fmt = (d: Date) =>
-    `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
-  return `${fmt(monday)} — ${fmt(sunday)}`;
-}
-
-export function getDateStr(weekStart: Date, dayOffset: number): string {
-  const d = new Date(weekStart);
-  d.setDate(d.getDate() + dayOffset);
-  return d.toISOString().split("T")[0];
-}
-
-export function formatDateLabel(weekStart: Date, offset: number): string {
-  const d = new Date(weekStart);
-  d.setDate(d.getDate() + offset);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
-
-const DAYS_COUNT = 7;
-const DAY_LABELS = ["一", "二", "三", "四", "五", "六", "日"];
+// ─── Constants ────────────────────────────────────────────────────────────────
 
 const FREE_ROW: TaskRow = { taskId: null, label: "自由工時（無任務）" };
 
-const TIMER_STORAGE_KEY = "titan-timer-state";
-
-function loadTimerState(): TimerState | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = localStorage.getItem(TIMER_STORAGE_KEY);
-    if (!raw) return null;
-    return JSON.parse(raw) as TimerState;
-  } catch {
-    return null;
-  }
-}
-
-function saveTimerState(state: TimerState | null) {
-  if (typeof window === "undefined") return;
-  if (state) {
-    localStorage.setItem(TIMER_STORAGE_KEY, JSON.stringify(state));
-  } else {
-    localStorage.removeItem(TIMER_STORAGE_KEY);
-  }
-}
-
-// ─── Hook ─────────────────────────────────────────────────────────────────────
+// ─── Hook (facade) ───────────────────────────────────────────────────────────
 
 export function useTimesheet(userFilter?: string) {
-  // Week navigation
-  const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
+  // Compose extracted hooks
+  const week = useWeekNavigation();
+  const timerHook = useTimer();
 
   // Data
   const [entries, setEntries] = useState<TimeEntry[]>([]);
@@ -127,31 +71,6 @@ export function useTimesheet(userFilter?: string) {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [statsLoading, setStatsLoading] = useState(false);
-
-  // Timer
-  const [timer, setTimer] = useState<TimerState | null>(() => loadTimerState());
-  const [elapsed, setElapsed] = useState(0);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  // Persist timer state
-  useEffect(() => {
-    saveTimerState(timer);
-  }, [timer]);
-
-  // Tick timer
-  useEffect(() => {
-    if (timer?.isRunning && timer.startTime) {
-      setElapsed(Math.floor((Date.now() - timer.startTime) / 1000));
-      intervalRef.current = setInterval(() => {
-        setElapsed(Math.floor((Date.now() - timer.startTime!) / 1000));
-      }, 1000);
-    } else {
-      setElapsed(0);
-    }
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [timer]);
 
   // Load tasks
   useEffect(() => {
@@ -167,7 +86,7 @@ export function useTimesheet(userFilter?: string) {
     setLoadError(null);
     try {
       const params = new URLSearchParams({
-        weekStart: weekStart.toISOString().split("T")[0],
+        weekStart: formatLocalDate(week.weekStart),
       });
       if (userFilter) params.set("userId", userFilter);
       const res = await fetch(`/api/time-entries?${params}`);
@@ -194,7 +113,7 @@ export function useTimesheet(userFilter?: string) {
     } finally {
       setLoading(false);
     }
-  }, [weekStart, userFilter]);
+  }, [week.weekStart, userFilter]);
 
   useEffect(() => {
     loadEntries();
@@ -204,10 +123,10 @@ export function useTimesheet(userFilter?: string) {
   const loadStats = useCallback(async () => {
     setStatsLoading(true);
     try {
-      const sunday = getSundayOfWeek(weekStart);
+      const sunday = getSundayOfWeek(week.weekStart);
       const params = new URLSearchParams({
-        startDate: weekStart.toISOString().split("T")[0],
-        endDate: sunday.toISOString().split("T")[0],
+        startDate: formatLocalDate(week.weekStart),
+        endDate: formatLocalDate(sunday),
       });
       if (userFilter) params.set("userId", userFilter);
       const res = await fetch(`/api/time-entries/stats?${params}`);
@@ -218,7 +137,7 @@ export function useTimesheet(userFilter?: string) {
     } finally {
       setStatsLoading(false);
     }
-  }, [weekStart, userFilter]);
+  }, [week.weekStart, userFilter]);
 
   useEffect(() => {
     loadStats();
@@ -298,39 +217,17 @@ export function useTimesheet(userFilter?: string) {
     await saveEntry(taskId, date, hours, "PLANNED_TASK", "", "NONE", existingId);
   }
 
-  // ─── Week Navigation ────────────────────────────────────────────────────────
-
-  function prevWeek() {
-    setWeekStart((d) => {
-      const n = new Date(d);
-      n.setDate(n.getDate() - 7);
-      return n;
-    });
-  }
-
-  function nextWeek() {
-    setWeekStart((d) => {
-      const n = new Date(d);
-      n.setDate(n.getDate() + 7);
-      return n;
-    });
-  }
-
-  function goToThisWeek() {
-    setWeekStart(getMondayOfWeek(new Date()));
-  }
-
   // ─── Copy Previous Week ─────────────────────────────────────────────────────
 
   async function copyPreviousWeek() {
-    const prevMonday = new Date(weekStart);
+    const prevMonday = new Date(week.weekStart);
     prevMonday.setDate(prevMonday.getDate() - 7);
     const res = await fetch("/api/time-entries/copy-week", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        sourceWeekStart: prevMonday.toISOString().split("T")[0],
-        targetWeekStart: weekStart.toISOString().split("T")[0],
+        sourceWeekStart: formatLocalDate(prevMonday),
+        targetWeekStart: formatLocalDate(week.weekStart),
       }),
     });
     if (res.ok) {
@@ -340,74 +237,26 @@ export function useTimesheet(userFilter?: string) {
     return res.ok;
   }
 
-  // ─── Timer ──────────────────────────────────────────────────────────────────
+  // ─── Timer wrappers (preserve original interface) ───────────────────────────
 
   async function startTimer(taskId: string | null) {
-    try {
-      const res = await fetch("/api/time-entries/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ taskId: taskId || undefined }),
-      });
-      if (res.status === 409) return { ok: false, error: "已有計時器在運行中" };
-      if (!res.ok) return { ok: false, error: "啟動計時器失敗" };
-      const body = await res.json();
-      const entry = extractData<{ id: string; taskId: string | null; startTime: string; task?: { title: string } | null }>(body);
-      const taskLabel = entry.task?.title ?? "自由工時";
-      setTimer({
-        isRunning: true,
-        taskId: entry.taskId,
-        taskLabel,
-        startTime: new Date(entry.startTime).getTime(),
-        entryId: entry.id,
-      });
-      return { ok: true, error: null };
-    } catch {
-      return { ok: false, error: "啟動計時器失敗" };
-    }
+    return await timerHook.startTimer(taskId);
   }
 
   async function stopTimer() {
-    try {
-      const res = await fetch("/api/time-entries/stop", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      if (!res.ok) return { ok: false, error: "停止計時器失敗" };
-      setTimer(null);
+    const result = await timerHook.stopTimer();
+    if (result.ok) {
       await loadEntries();
       loadStats();
-      return { ok: true, error: null };
-    } catch {
-      return { ok: false, error: "停止計時器失敗" };
     }
+    return result;
   }
-
-  // Restore timer from server on mount
-  useEffect(() => {
-    fetch("/api/time-entries/running")
-      .then((r) => r.json())
-      .then((body) => {
-        const data = extractData<{ id: string; taskId: string | null; startTime: string; task?: { title: string } | null } | null>(body);
-        if (data?.startTime) {
-          setTimer({
-            isRunning: true,
-            taskId: data.taskId,
-            taskLabel: data.task?.title ?? "自由工時",
-            startTime: new Date(data.startTime).getTime(),
-            entryId: data.id,
-          });
-        }
-      })
-      .catch(() => {});
-  }, []);
 
   // ─── Computed ───────────────────────────────────────────────────────────────
 
   // Daily totals (7 days Mon-Sun)
-  const dailyTotals = Array.from({ length: DAYS_COUNT }, (_, i) => {
-    const dateStr = getDateStr(weekStart, i);
+  const dailyTotals = Array.from({ length: week.daysCount }, (_, i) => {
+    const dateStr = week.getDateStr(i);
     return entries
       .filter((e) => e.date.split("T")[0] === dateStr)
       .reduce((sum, e) => sum + e.hours, 0);
@@ -433,12 +282,12 @@ export function useTimesheet(userFilter?: string) {
   }
 
   return {
-    // Week
-    weekStart,
-    prevWeek,
-    nextWeek,
-    goToThisWeek,
-    formatWeekRange: () => formatWeekRange(weekStart),
+    // Week (from useWeekNavigation)
+    weekStart: week.weekStart,
+    prevWeek: week.goToPrevWeek,
+    nextWeek: week.goToNextWeek,
+    goToThisWeek: week.goToToday,
+    formatWeekRange: week.formatWeekRange,
 
     // Data
     entries,
@@ -461,9 +310,9 @@ export function useTimesheet(userFilter?: string) {
     // Task rows
     addTaskRow,
 
-    // Timer
-    timer,
-    elapsed,
+    // Timer (from useTimer)
+    timer: timerHook.timer,
+    elapsed: timerHook.elapsed,
     startTimer,
     stopTimer,
 
@@ -472,10 +321,10 @@ export function useTimesheet(userFilter?: string) {
     weeklyTotal,
     getEntriesForCell,
 
-    // Constants
-    dayLabels: DAY_LABELS,
-    daysCount: DAYS_COUNT,
-    getDateStr: (offset: number) => getDateStr(weekStart, offset),
-    formatDateLabel: (offset: number) => formatDateLabel(weekStart, offset),
+    // Constants (from useWeekNavigation)
+    dayLabels: week.dayLabels,
+    daysCount: week.daysCount,
+    getDateStr: week.getDateStr,
+    formatDateLabel: week.formatDateLabel,
   };
 }

--- a/app/components/timesheet/use-week-navigation.ts
+++ b/app/components/timesheet/use-week-navigation.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { formatLocalDate } from "@/lib/utils/date";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function getMondayOfWeek(d: Date): Date {
+  const copy = new Date(d);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+export function getSundayOfWeek(monday: Date): Date {
+  const sunday = new Date(monday);
+  sunday.setDate(sunday.getDate() + 6);
+  return sunday;
+}
+
+export function formatWeekRange(monday: Date): string {
+  const sunday = getSundayOfWeek(monday);
+  const fmt = (d: Date) =>
+    `${d.getFullYear()}/${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+  return `${fmt(monday)} — ${fmt(sunday)}`;
+}
+
+export function getDateStr(weekStart: Date, dayOffset: number): string {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + dayOffset);
+  return formatLocalDate(d);
+}
+
+export function formatDateLabel(weekStart: Date, offset: number): string {
+  const d = new Date(weekStart);
+  d.setDate(d.getDate() + offset);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const DAYS_COUNT = 7;
+export const DAY_LABELS = ["一", "二", "三", "四", "五", "六", "日"];
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useWeekNavigation() {
+  const [weekStart, setWeekStart] = useState<Date>(() => getMondayOfWeek(new Date()));
+
+  const goToPrevWeek = useCallback(() => {
+    setWeekStart((d) => {
+      const n = new Date(d);
+      n.setDate(n.getDate() - 7);
+      return n;
+    });
+  }, []);
+
+  const goToNextWeek = useCallback(() => {
+    setWeekStart((d) => {
+      const n = new Date(d);
+      n.setDate(n.getDate() + 7);
+      return n;
+    });
+  }, []);
+
+  const goToToday = useCallback(() => {
+    setWeekStart(getMondayOfWeek(new Date()));
+  }, []);
+
+  const weekEnd = useMemo(() => getSundayOfWeek(weekStart), [weekStart]);
+
+  return {
+    weekStart,
+    weekEnd,
+    goToPrevWeek,
+    goToNextWeek,
+    goToToday,
+    formatWeekRange: () => formatWeekRange(weekStart),
+    getDateStr: (offset: number) => getDateStr(weekStart, offset),
+    formatDateLabel: (offset: number) => formatDateLabel(weekStart, offset),
+    getWeekDays: () => Array.from({ length: DAYS_COUNT }, (_, i) => getDateStr(weekStart, i)),
+    dayLabels: DAY_LABELS,
+    daysCount: DAYS_COUNT,
+  };
+}

--- a/lib/overtime.ts
+++ b/lib/overtime.ts
@@ -1,0 +1,93 @@
+/**
+ * 月加班時數計算與警示門檻
+ *
+ * 台灣勞基法：
+ * - 每月加班上限 46 小時（一般情況）
+ * - 特殊情況上限 54 小時（需勞資會議同意）
+ * - 此模組計算當月加班時數並判定警示等級
+ */
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+export const OVERTIME_CONFIG = {
+  /** 黃色警告門檻（時） */
+  WARNING_THRESHOLD: 36,
+  /** 法定上限（時） */
+  LIMIT: 46,
+  /** 特殊上限（時），需勞資會議同意 */
+  SPECIAL_LIMIT: 54,
+} as const;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type OvertimeLevel = "safe" | "warning" | "danger";
+
+export type OvertimeInfo = {
+  /** 當月加班時數 */
+  overtimeHours: number;
+  /** 警示等級 */
+  level: OvertimeLevel;
+  /** 法定上限 */
+  limit: number;
+};
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * 計算指定月份的工作天數（排除週六日）
+ */
+export function getWorkingDaysInMonth(year: number, month: number): number {
+  // month is 0-based (0 = January)
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  let workingDays = 0;
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dayOfWeek = new Date(year, month, day).getDay();
+    if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+      workingDays++;
+    }
+  }
+  return workingDays;
+}
+
+/**
+ * 計算當月加班時數
+ *
+ * 加班時數 = 月總工時 - 基準工時（工作天數 x 8）
+ * 如果結果 < 0 則為 0（尚未超過正常工時）
+ */
+export function calculateMonthlyOvertime(
+  totalMonthlyHours: number,
+  year: number,
+  month: number,
+): number {
+  const workingDays = getWorkingDaysInMonth(year, month);
+  const baseHours = workingDays * 8;
+  const overtime = totalMonthlyHours - baseHours;
+  return Math.max(0, overtime);
+}
+
+/**
+ * 取得加班警示等級
+ */
+export function getOvertimeLevel(overtimeHours: number): OvertimeLevel {
+  if (overtimeHours > OVERTIME_CONFIG.LIMIT) return "danger";
+  if (overtimeHours >= OVERTIME_CONFIG.WARNING_THRESHOLD) return "warning";
+  return "safe";
+}
+
+/**
+ * 計算完整的加班資訊
+ */
+export function getOvertimeInfo(
+  totalMonthlyHours: number,
+  year: number,
+  month: number,
+): OvertimeInfo {
+  const overtimeHours = calculateMonthlyOvertime(totalMonthlyHours, year, month);
+  const level = getOvertimeLevel(overtimeHours);
+  return {
+    overtimeHours,
+    level,
+    limit: OVERTIME_CONFIG.LIMIT,
+  };
+}

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,17 @@
+/**
+ * 本地時區日期工具
+ *
+ * 不要用 toISOString() — 它會轉 UTC，在 UTC+8 凌晨時段會偏移一天。
+ * 例如 2026-03-24T00:30:00+08:00 → toISOString() 會回傳 "2026-03-23T16:30:00Z"
+ * 取 split("T")[0] 後會得到 "2026-03-23"，比本地日期少一天。
+ */
+
+/**
+ * 格式化為 YYYY-MM-DD（本地時區）
+ */
+export function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -14,3 +14,4 @@
 
 export { safeFixed, safePct, safeNum } from "@/lib/safe-number";
 export { getClientIp } from "@/lib/get-client-ip";
+export { formatLocalDate } from "@/lib/utils/date";

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,11 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.0",
+        "@swc/core": "1.15.21",
+        "@swc/jest": "0.2.39",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "14.6.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
@@ -1827,6 +1830,19 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.3.0.tgz",
+      "integrity": "sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
     },
     "node_modules/@jest/diff-sequences": {
       "version": "30.3.0",
@@ -3747,6 +3763,286 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/core": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
+      "integrity": "sha512-fkk7NJcBscrR3/F8jiqlMptRHP650NxqDnspBMrRe5d8xOoCy9MLL5kOBLFXjFLfMo3KQQHhk+/jUULOMlR1uQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.21",
+        "@swc/core-darwin-x64": "1.15.21",
+        "@swc/core-linux-arm-gnueabihf": "1.15.21",
+        "@swc/core-linux-arm64-gnu": "1.15.21",
+        "@swc/core-linux-arm64-musl": "1.15.21",
+        "@swc/core-linux-ppc64-gnu": "1.15.21",
+        "@swc/core-linux-s390x-gnu": "1.15.21",
+        "@swc/core-linux-x64-gnu": "1.15.21",
+        "@swc/core-linux-x64-musl": "1.15.21",
+        "@swc/core-win32-arm64-msvc": "1.15.21",
+        "@swc/core-win32-ia32-msvc": "1.15.21",
+        "@swc/core-win32-x64-msvc": "1.15.21"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.21.tgz",
+      "integrity": "sha512-SA8SFg9dp0qKRH8goWsax6bptFE2EdmPf2YRAQW9WoHGf3XKM1bX0nd5UdwxmC5hXsBUZAYf7xSciCler6/oyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.21.tgz",
+      "integrity": "sha512-//fOVntgowz9+V90lVsNCtyyrtbHp3jWH6Rch7MXHXbcvbLmbCTmssl5DeedUWLLGiAAW1wksBdqdGYOTjaNLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.21.tgz",
+      "integrity": "sha512-meNI4Sh6h9h8DvIfEc0l5URabYMSuNvyisLmG6vnoYAS43s8ON3NJR8sDHvdP7NJTrLe0q/x2XCn6yL/BeHcZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.21.tgz",
+      "integrity": "sha512-QrXlNQnHeXqU2EzLlnsPoWEh8/GtNJLvfMiPsDhk+ht6Xv8+vhvZ5YZ/BokNWSIZiWPKLAqR0M7T92YF5tmD3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.21.tgz",
+      "integrity": "sha512-8/yGCMO333ultDaMQivE5CjO6oXDPeeg1IV4sphojPkb0Pv0i6zvcRIkgp60xDB+UxLr6VgHgt+BBgqS959E9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.21.tgz",
+      "integrity": "sha512-ucW0HzPx0s1dgRvcvuLSPSA/2Kk/VYTv9st8qe1Kc22Gu0Q0rH9+6TcBTmMuNIp0Xs4BPr1uBttmbO1wEGI49Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.21.tgz",
+      "integrity": "sha512-ulTnOGc5I7YRObE/9NreAhQg94QkiR5qNhhcUZ1iFAYjzg/JGAi1ch+s/Ixe61pMIr8bfVrF0NOaB0f8wjaAfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.21.tgz",
+      "integrity": "sha512-D0RokxtM+cPvSqJIKR6uja4hbD+scI9ezo95mBhfSyLUs9wnPPl26sLp1ZPR/EXRdYm3F3S6RUtVi+8QXhT24Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.21.tgz",
+      "integrity": "sha512-nER8u7VeRfmU6fMDzl1NQAbbB/G7O2avmvCOwIul1uGkZ2/acbPH+DCL9h5+0yd/coNcxMBTL6NGepIew+7C2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.21.tgz",
+      "integrity": "sha512-+/AgNBnjYugUA8C0Do4YzymgvnGbztv7j8HKSQLvR/DQgZPoXQ2B3PqB2mTtGh/X5DhlJWiqnunN35JUgWcAeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.21.tgz",
+      "integrity": "sha512-IkSZj8PX/N4HcaFhMQtzmkV8YSnuNoJ0E6OvMwFiOfejPhiKXvl7CdDsn1f4/emYEIDO3fpgZW9DTaCRMDxaDA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.21",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.21.tgz",
+      "integrity": "sha512-zUyWso7OOENB6e1N1hNuNn8vbvLsTdKQ5WKLgt/JcBNfJhKy/6jmBmqI3GXk/MyvQKd5SLvP7A0F36p7TeDqvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/jest": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^30.0.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3860,6 +4156,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -7874,6 +8184,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -45,8 +45,11 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.0",
+    "@swc/core": "1.15.21",
+    "@swc/jest": "0.2.39",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "14.6.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -432,6 +432,12 @@ enum TimeCategory {
   LEARNING
 }
 
+enum OvertimeType {
+  NONE      // 非加班
+  WEEKDAY   // 平日加班
+  HOLIDAY   // 假日加班（國定假日/週末）
+}
+
 model TimeEntry {
   id          String       @id @default(cuid())
   taskId      String?
@@ -448,13 +454,17 @@ model TimeEntry {
   endTime   DateTime?
 
   // TS-03: 加班標記
-  overtime Boolean @default(false)
+  overtime     Boolean      @default(false)   // 保留，遷移期間使用
+  overtimeType OvertimeType @default(NONE)    // 新欄位：加班類型
 
   // TS-04: 覆核鎖定
   locked Boolean @default(false)
 
   // TS-05: 計時器運行狀態
   isRunning Boolean @default(false)
+
+  // TS-06: 排序（同日同任務多筆排序）
+  sortOrder Int @default(0)
 
   task Task? @relation(fields: [taskId], references: [id])
   user User  @relation(fields: [userId], references: [id])
@@ -463,6 +473,7 @@ model TimeEntry {
   @@index([userId])
   @@index([date])
   @@index([userId, isRunning])
+  @@index([userId, date])
   @@map("time_entries")
 }
 
@@ -474,14 +485,30 @@ model TimeEntryTemplate {
   id        String   @id @default(cuid())
   name      String
   userId    String
-  entries   String   // JSON array of { hours, category, taskId?, description? }
+  entries   String   // JSON array (保留向下相容)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  user User @relation(fields: [userId], references: [id])
+  items TimeEntryTemplateItem[]
+  user  User @relation(fields: [userId], references: [id])
 
   @@index([userId])
   @@map("time_entry_templates")
+}
+
+model TimeEntryTemplateItem {
+  id          String       @id @default(cuid())
+  templateId  String
+  taskId      String?
+  hours       Float
+  category    TimeCategory @default(PLANNED_TASK)
+  description String?
+  sortOrder   Int          @default(0)
+
+  template TimeEntryTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  @@index([templateId])
+  @@map("time_entry_template_items")
 }
 
 // ═══════════════════════════════════════

--- a/services/export-service.ts
+++ b/services/export-service.ts
@@ -1,4 +1,5 @@
 import ExcelJS from "exceljs";
+import { formatLocalDate } from "@/lib/utils/date";
 
 export interface ExportColumn {
   header: string;
@@ -106,7 +107,7 @@ ${bodyRows}
       id: t.id,
       title: t.title,
       assignee: t.primaryAssignee?.name ?? "",
-      completedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString().split("T")[0] : String(t.updatedAt),
+      completedAt: t.updatedAt instanceof Date ? formatLocalDate(t.updatedAt) : String(t.updatedAt),
     }));
 
     return {
@@ -143,7 +144,7 @@ ${bodyRows}
       title: t.title,
       status: t.status,
       priority: t.priority,
-      dueDate: t.dueDate instanceof Date ? t.dueDate.toISOString().split("T")[0] : (t.dueDate ?? ""),
+      dueDate: t.dueDate instanceof Date ? formatLocalDate(t.dueDate) : (t.dueDate ?? ""),
     }));
 
     const monthStr = String(input.month).padStart(2, "0");

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { formatLocalDate } from "@/lib/utils/date";
 
 const DAYS_AHEAD = 7;
 
@@ -239,7 +240,7 @@ export class NotificationService {
     if (now.getDay() !== 5) return [];
 
     const { weekStart, weekEnd } = this.getWeekBounds(now);
-    const weekKey = `${weekStart.toISOString().slice(0, 10)}`;
+    const weekKey = `${formatLocalDate(weekStart)}`;
 
     // Get all active engineers
     const engineers = await this.prisma.user.findMany({
@@ -305,7 +306,7 @@ export class NotificationService {
     const todayEnd = new Date(now);
     todayEnd.setHours(23, 59, 59, 999);
 
-    const todayKey = todayStart.toISOString().slice(0, 10);
+    const todayKey = formatLocalDate(todayStart);
 
     // Get all active users (engineers + managers)
     const activeUsers = await this.prisma.user.findMany({
@@ -408,13 +409,13 @@ export class NotificationService {
     // Group hours by userId and date
     const hoursByUserDate: Record<string, Record<string, number>> = {};
     for (const entry of entries) {
-      const dateStr = new Date(entry.date).toISOString().slice(0, 10);
+      const dateStr = formatLocalDate(new Date(entry.date));
       if (!hoursByUserDate[entry.userId]) hoursByUserDate[entry.userId] = {};
       hoursByUserDate[entry.userId][dateStr] =
         (hoursByUserDate[entry.userId][dateStr] ?? 0) + entry.hours;
     }
 
-    const todayKey = now.toISOString().slice(0, 10);
+    const todayKey = formatLocalDate(now);
     const result: NotificationInput[] = [];
 
     for (const eng of engineers) {
@@ -424,7 +425,7 @@ export class NotificationService {
       let consecutive = 0;
       let maxConsecutive = 0;
       for (const wd of workDays) {
-        const dateStr = wd.toISOString().slice(0, 10);
+        const dateStr = formatLocalDate(wd);
         const dayHours = userDays[dateStr] ?? 0;
         if (dayHours < DAILY_THRESHOLD) {
           consecutive++;

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import { calculateAchievement, calculateAvgAchievement } from "@/lib/kpi-calculator";
+import { formatLocalDate } from "@/lib/utils/date";
 
 // ── Filter types ────────────────────────────────────────────────────────────
 
@@ -481,7 +482,7 @@ export class ReportService {
 
     const byDateMap = changes.reduce(
       (acc, c) => {
-        const dateKey = c.changedAt.toISOString().slice(0, 10);
+        const dateKey = formatLocalDate(c.changedAt);
         if (!acc[dateKey]) {
           acc[dateKey] = {
             date: dateKey,


### PR DESCRIPTION
## Summary
- **Data model**: Added `OvertimeType` enum (`NONE`/`WEEKDAY`/`HOLIDAY`), `overtimeType` and `sortOrder` fields to `TimeEntry`, `TimeEntryTemplateItem` model, and `userId+date` composite index
- **New Clockify-style grid**: 7-day weekly spreadsheet (Mon-Sun) with inline cell editing — click cell, type hours, Tab/Enter to save. Double-click for expanded editor (category, description, overtime type)
- **Timer redesign**: Sticky timer bar with task selector, localStorage persistence across page refreshes, auto-sync with server running state
- **Architecture**: `useTimesheet` custom hook centralizes all week navigation, CRUD, timer, and computed state. New components under `app/components/timesheet/`

## Changes
| File | Change |
|------|--------|
| `prisma/schema.prisma` | `OvertimeType` enum, `overtimeType`/`sortOrder` on TimeEntry, `TimeEntryTemplateItem` model, new index |
| `app/components/timesheet/use-timesheet.ts` | Custom hook: week state, entries CRUD, timer, copy-week, computed totals |
| `app/components/timesheet/timesheet-grid.tsx` | 7-day grid with task rows, daily totals, add-task-row selector |
| `app/components/timesheet/timesheet-cell.tsx` | Inline editable cell: click→type→Enter. Double-click→expanded editor |
| `app/components/timesheet/timesheet-toolbar.tsx` | Week navigation, view toggle, copy-previous-week, color legend |
| `app/components/timesheet/timesheet-timer.tsx` | Timer with task selector, start/stop, elapsed display |
| `app/(app)/timesheet/page.tsx` | Rewritten to compose new components via `useTimesheet` hook |
| `__tests__/components/timesheet-redesign.test.tsx` | 31 new tests covering grid, cell, toolbar, timer |

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] 31 new tests pass (`npx jest __tests__/components/timesheet-redesign.test.tsx`)
- [x] All 185 existing component tests still pass
- [ ] Manual: verify grid renders correctly in browser
- [ ] Manual: test inline editing (click cell → type → Enter/Tab)
- [ ] Manual: test timer start/stop with localStorage persistence
- [ ] Manual: verify mobile auto-switches to list view at < 768px
- [ ] Run `npx prisma db push` or create migration before deploying

Closes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)