### PR TITLE
feat(timesheet): Phase 2 — Manager Monthly View + approval workflow

### DIFF
--- a/__tests__/api/timesheet-approval.test.ts
+++ b/__tests__/api/timesheet-approval.test.ts
@@ -1,0 +1,544 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API tests: Phase 2 Timesheet Approval — Issue #853
+ *
+ * Tests for:
+ *   - POST /api/time-entries/approve (batch approve)
+ *   - POST /api/time-entries/reject (batch reject)
+ *   - GET /api/time-entries/monthly (monthly view)
+ *   - GET /api/time-entries/monthly-summary (summary stats)
+ *   - PUT /api/time-entries/[id] auto-reset REJECTED → PENDING
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+
+const mockTransaction = jest.fn();
+const mockTimeEntry = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  update: jest.fn(),
+  updateMany: jest.fn(),
+};
+const mockTimesheetApproval = {
+  createMany: jest.fn(),
+};
+const mockAuditLog = { create: jest.fn() };
+const mockUser = { findMany: jest.fn() };
+const mockNotification = { createMany: jest.fn() };
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    timeEntry: mockTimeEntry,
+    timesheetApproval: mockTimesheetApproval,
+    auditLog: mockAuditLog,
+    user: mockUser,
+    notification: mockNotification,
+    $transaction: (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        timeEntry: mockTimeEntry,
+        timesheetApproval: mockTimesheetApproval,
+        auditLog: mockAuditLog,
+        notification: mockNotification,
+      }),
+  },
+}));
+
+// ── Auth mock ────────────────────────────────────────────────────────────────
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION_ENGINEER = {
+  user: { id: "u1", name: "Engineer", email: "e@t.com", role: "ENGINEER" },
+  expires: "2099",
+};
+
+const SESSION_MANAGER = {
+  user: { id: "m1", name: "Manager", email: "m@t.com", role: "MANAGER" },
+  expires: "2099",
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PENDING_ENTRY = {
+  id: "entry-1",
+  userId: "u1",
+  hours: 8,
+  date: new Date("2026-03-02"),
+  category: "PLANNED_TASK",
+  isRunning: false,
+  locked: false,
+  approvalStatus: "PENDING",
+};
+
+const REJECTED_ENTRY = {
+  id: "entry-2",
+  userId: "u1",
+  hours: 4,
+  date: new Date("2026-03-03"),
+  category: "PLANNED_TASK",
+  isRunning: false,
+  locked: false,
+  approvalStatus: "REJECTED",
+};
+
+const RUNNING_ENTRY = {
+  id: "entry-3",
+  userId: "u1",
+  hours: 0,
+  date: new Date("2026-03-04"),
+  category: "PLANNED_TASK",
+  isRunning: true,
+  locked: false,
+  approvalStatus: "PENDING",
+};
+
+const SELF_ENTRY = {
+  id: "entry-4",
+  userId: "m1", // same as manager
+  hours: 6,
+  date: new Date("2026-03-05"),
+  category: "PLANNED_TASK",
+  isRunning: false,
+  locked: false,
+  approvalStatus: "PENDING",
+};
+
+const APPROVED_ENTRY = {
+  id: "entry-5",
+  userId: "u1",
+  hours: 8,
+  date: new Date("2026-03-06"),
+  category: "PLANNED_TASK",
+  isRunning: false,
+  locked: true,
+  approvalStatus: "APPROVED",
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST /api/time-entries/approve
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/time-entries/approve", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test("approve PENDING entries succeeds", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([PENDING_ENTRY]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 1 });
+    mockTimesheetApproval.createMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-1"] },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.approved).toBe(1);
+    expect(mockTimeEntry.updateMany).toHaveBeenCalled();
+  });
+
+  test("approve REJECTED entries succeeds", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([REJECTED_ENTRY]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 1 });
+    mockTimesheetApproval.createMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-2"] },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.approved).toBe(1);
+  });
+
+  test("self-approval blocked with 403", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([SELF_ENTRY]);
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-4"] },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  test("isRunning entries excluded from approval", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([RUNNING_ENTRY]);
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-3"] },
+      })
+    );
+
+    // No eligible entries → 400
+    expect(res.status).toBe(400);
+  });
+
+  test("approve empty entryIds returns validation error", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: [] },
+      })
+    );
+
+    // Zod validation error
+    expect(res.status).toBe(400);
+  });
+
+  test("approve already-approved entry is skipped (idempotent)", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([APPROVED_ENTRY]);
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-5"] },
+      })
+    );
+
+    // Already approved → no eligible → 400
+    expect(res.status).toBe(400);
+  });
+
+  test("approve creates AuditLog records", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([PENDING_ENTRY]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 1 });
+    mockTimesheetApproval.createMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-1"] },
+      })
+    );
+
+    expect(mockAuditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          action: "BATCH_APPROVE_TIME_ENTRIES",
+        }),
+      })
+    );
+  });
+
+  test("non-manager gets 403", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { POST } = await import("@/app/api/time-entries/approve/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/approve", {
+        method: "POST",
+        body: { entryIds: ["entry-1"] },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST /api/time-entries/reject
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/time-entries/reject", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test("reject with reason succeeds", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([PENDING_ENTRY]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 1 });
+    mockTimesheetApproval.createMany.mockResolvedValue({ count: 1 });
+    mockNotification.createMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: ["entry-1"], reason: "時數不正確" },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.rejected).toBe(1);
+  });
+
+  test("reject sets locked=false", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockTimeEntry.findMany.mockResolvedValue([APPROVED_ENTRY]);
+    mockTimeEntry.updateMany.mockResolvedValue({ count: 1 });
+    mockTimesheetApproval.createMany.mockResolvedValue({ count: 1 });
+    mockNotification.createMany.mockResolvedValue({ count: 1 });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: ["entry-5"], reason: "需要修正" },
+      })
+    );
+
+    expect(mockTimeEntry.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ locked: false, approvalStatus: "REJECTED" }),
+      })
+    );
+  });
+
+  test("reject requires reason (empty string fails)", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: ["entry-1"], reason: "" },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("reject without reason field fails", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: ["entry-1"] },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("reject empty entryIds returns validation error", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: [], reason: "理由" },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("non-manager gets 403", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { POST } = await import("@/app/api/time-entries/reject/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/reject", {
+        method: "POST",
+        body: { entryIds: ["entry-1"], reason: "理由" },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/time-entries/monthly
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/time-entries/monthly", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test("returns correct structure for a month", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockUser.findMany.mockResolvedValue([
+      { id: "u1", name: "Engineer", email: "e@t.com" },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      {
+        ...PENDING_ENTRY,
+        task: { id: "t1", title: "Task 1", category: "PLANNED" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/monthly/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/monthly", {
+        searchParams: { month: "2026-03" },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.month).toBe("2026-03");
+    expect(body.data.daysInMonth).toBe(31);
+    expect(body.data.members).toHaveLength(1);
+    expect(body.data.members[0].userId).toBe("u1");
+  });
+
+  test("invalid month param returns error", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { GET } = await import("@/app/api/time-entries/monthly/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/monthly", {
+        searchParams: { month: "invalid" },
+      })
+    );
+
+    // Should not be 200 with valid data
+    const body = await res.json();
+    expect(body.data.error).toBeDefined();
+  });
+
+  test("non-manager gets 403", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { GET } = await import("@/app/api/time-entries/monthly/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/monthly", {
+        searchParams: { month: "2026-03" },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/time-entries/monthly-summary
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/time-entries/monthly-summary", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test("summary calculates overtime correctly", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockUser.findMany.mockResolvedValue([
+      { id: "u1", name: "Engineer" },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      { ...PENDING_ENTRY, overtimeType: "WEEKDAY", hours: 2 },
+      { ...PENDING_ENTRY, id: "entry-1b", overtimeType: "HOLIDAY", hours: 4 },
+      { ...PENDING_ENTRY, id: "entry-1c", overtimeType: "NONE", hours: 8 },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/monthly-summary/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/monthly-summary", {
+        searchParams: { month: "2026-03" },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.teamOvertime.weekday).toBe(2);
+    expect(body.data.teamOvertime.holiday).toBe(4);
+    expect(body.data.teamOvertime.total).toBe(6);
+    expect(body.data.members[0].totalHours).toBe(14);
+  });
+
+  test("non-manager gets 403", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+
+    const { GET } = await import("@/app/api/time-entries/monthly-summary/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/monthly-summary", {
+        searchParams: { month: "2026-03" },
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PUT /api/time-entries/[id] — auto-reset REJECTED → PENDING
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("PUT /api/time-entries/[id] — auto-reset REJECTED → PENDING", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  test("editing REJECTED entry auto-resets to PENDING", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ENGINEER);
+    const rejectedEntry = {
+      ...REJECTED_ENTRY,
+      userId: "u1",
+      description: "old",
+      taskId: null,
+    };
+    mockTimeEntry.findUnique.mockResolvedValue(rejectedEntry);
+    mockTimeEntry.update.mockResolvedValue({
+      ...rejectedEntry,
+      hours: 6,
+      approvalStatus: "PENDING",
+    });
+    mockAuditLog.create.mockResolvedValue({});
+
+    const { PUT } = await import("@/app/api/time-entries/[id]/route");
+    const res = await PUT(
+      createMockRequest("/api/time-entries/entry-2", {
+        method: "PUT",
+        body: { hours: 6 },
+      }),
+      { params: Promise.resolve({ id: "entry-2" }) }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockTimeEntry.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ approvalStatus: "PENDING" }),
+      })
+    );
+  });
+});

--- a/__tests__/components/monthly-grid.test.tsx
+++ b/__tests__/components/monthly-grid.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Frontend tests: Monthly Grid + Approval — Issue #853
+ */
+import React from "react";
+import { render, screen, fireEvent } from "../utils/test-utils";
+import { MonthlyGrid, MonthlyMobileList } from "@/app/components/timesheet/monthly-grid";
+import type { MonthlyMember } from "@/app/components/timesheet/use-monthly-timesheet";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeMember(overrides?: Partial<MonthlyMember>): MonthlyMember {
+  return {
+    userId: "u1",
+    name: "測試工程師",
+    email: "test@example.com",
+    days: {},
+    ...overrides,
+  };
+}
+
+function makeMemberWithDays(): MonthlyMember {
+  return makeMember({
+    days: {
+      "2026-03-02": {
+        totalHours: 8,
+        approvalStatus: "APPROVED",
+        entries: [
+          {
+            id: "e1",
+            taskId: "t1",
+            date: "2026-03-02",
+            hours: 8,
+            category: "PLANNED_TASK",
+            description: null,
+            overtimeType: "NONE",
+            approvalStatus: "APPROVED",
+            isRunning: false,
+            locked: true,
+            task: { id: "t1", title: "Task 1" },
+          },
+        ],
+      },
+      "2026-03-03": {
+        totalHours: 10,
+        approvalStatus: "PENDING",
+        entries: [
+          {
+            id: "e2",
+            taskId: "t1",
+            date: "2026-03-03",
+            hours: 10,
+            category: "PLANNED_TASK",
+            description: null,
+            overtimeType: "WEEKDAY",
+            approvalStatus: "PENDING",
+            isRunning: false,
+            locked: false,
+            task: { id: "t1", title: "Task 1" },
+          },
+        ],
+      },
+      "2026-03-04": {
+        totalHours: 12,
+        approvalStatus: "REJECTED",
+        entries: [
+          {
+            id: "e3",
+            taskId: "t1",
+            date: "2026-03-04",
+            hours: 12,
+            category: "PLANNED_TASK",
+            description: null,
+            overtimeType: "WEEKDAY",
+            approvalStatus: "REJECTED",
+            isRunning: false,
+            locked: false,
+            task: { id: "t1", title: "Task 1" },
+          },
+        ],
+      },
+    },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MonthlyGrid
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("MonthlyGrid", () => {
+  const defaultProps = {
+    daysInMonth: 31,
+    month: "2026-03",
+    expandedCell: null,
+    onCellClick: jest.fn(),
+    onMemberClick: jest.fn(),
+  };
+
+  test("renders correct number of cells (member row × days)", () => {
+    const members = [makeMember()];
+    const { container } = render(
+      <MonthlyGrid {...defaultProps} members={members} />
+    );
+    // 1 member row, each with 31 day cells + 1 total cell = 32 td
+    const tds = container.querySelectorAll("tbody td");
+    // 31 cells + 1 total + 1 name = 33
+    expect(tds.length).toBe(33);
+  });
+
+  test("empty month shows all gray/dash cells", () => {
+    const members = [makeMember()];
+    render(<MonthlyGrid {...defaultProps} members={members} />);
+    // All cells should show "—" for zero hours
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBe(31); // 31 days
+  });
+
+  test("color coding: ≤8h shows green, >8h shows yellow, >10h shows red", () => {
+    const member = makeMemberWithDays();
+    const { container } = render(
+      <MonthlyGrid {...defaultProps} members={[member]} />
+    );
+
+    // Find cell with "8.0" (should have green class)
+    const cells = container.querySelectorAll("td");
+    const cellTexts = Array.from(cells).map((c) => c.textContent);
+    expect(cellTexts.some((t) => t?.includes("8.0"))).toBe(true);
+    expect(cellTexts.some((t) => t?.includes("10.0"))).toBe(true);
+    expect(cellTexts.some((t) => t?.includes("12.0"))).toBe(true);
+  });
+
+  test("cell click calls onCellClick with userId and date", () => {
+    const member = makeMemberWithDays();
+    const onCellClick = jest.fn();
+    const { container } = render(
+      <MonthlyGrid {...defaultProps} members={[member]} onCellClick={onCellClick} />
+    );
+
+    // Click the first data cell (day 1)
+    const firstDataCell = container.querySelectorAll("tbody td")[1]; // skip name cell
+    fireEvent.click(firstDataCell);
+    expect(onCellClick).toHaveBeenCalledWith("u1", "2026-03-01");
+  });
+
+  test("weekend cells (day 1=Sunday, day 7=Saturday) have background class", () => {
+    // March 2026: day 1 is Sunday, day 7 is Saturday
+    const members = [makeMember()];
+    const { container } = render(
+      <MonthlyGrid {...defaultProps} members={members} />
+    );
+
+    // Header: day 1 (Sunday) should have muted/50 class
+    const headerCells = container.querySelectorAll("thead th");
+    // headerCells[0] is "成員", [1] is day 1 (Sunday)
+    expect(headerCells[1].className).toContain("bg-muted/50");
+  });
+
+  test("approval status icon ✓ for APPROVED, ✗ for REJECTED", () => {
+    const member = makeMemberWithDays();
+    render(<MonthlyGrid {...defaultProps} members={[member]} />);
+
+    expect(screen.getByText("✓")).toBeTruthy();
+    expect(screen.getByText("✗")).toBeTruthy();
+  });
+
+  test("expanded cell gets ring-2 highlight", () => {
+    const member = makeMemberWithDays();
+    const { container } = render(
+      <MonthlyGrid
+        {...defaultProps}
+        members={[member]}
+        expandedCell={{ userId: "u1", date: "2026-03-02" }}
+      />
+    );
+
+    const cells = container.querySelectorAll("tbody td");
+    const expandedCells = Array.from(cells).filter((c) =>
+      c.className.includes("ring-2")
+    );
+    expect(expandedCells.length).toBe(1);
+  });
+
+  test("no members shows empty state message", () => {
+    render(<MonthlyGrid {...defaultProps} members={[]} />);
+    expect(screen.getByText("本月無工時資料")).toBeTruthy();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MonthlyMobileList (mobile view)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("MonthlyMobileList", () => {
+  test("renders member cards with name and total hours", () => {
+    const member = makeMemberWithDays();
+    render(
+      <MonthlyMobileList
+        members={[member]}
+        month="2026-03"
+        onMemberClick={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("測試工程師")).toBeTruthy();
+    expect(screen.getByText("30.0h")).toBeTruthy(); // 8 + 10 + 12
+  });
+});

--- a/__tests__/pages/timesheet-enhanced.test.tsx
+++ b/__tests__/pages/timesheet-enhanced.test.tsx
@@ -10,6 +10,11 @@ import "@testing-library/jest-dom";
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => "/timesheet",
+}));
+
 const mockUseSession = jest.fn();
 jest.mock("next-auth/react", () => ({
   useSession: (...args: unknown[]) => mockUseSession(...args),

--- a/__tests__/pages/timesheet-extended.test.tsx
+++ b/__tests__/pages/timesheet-extended.test.tsx
@@ -15,6 +15,11 @@ import React from "react";
 import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => "/timesheet",
+}));
+
 const mockUseSession = jest.fn();
 jest.mock("next-auth/react", () => ({
   useSession: (...args: unknown[]) => mockUseSession(...args),

--- a/__tests__/pages/timesheet.test.tsx
+++ b/__tests__/pages/timesheet.test.tsx
@@ -5,6 +5,11 @@ import React from "react";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => "/timesheet",
+}));
+
 jest.mock("next-auth/react", () => ({
   useSession: jest.fn(() => ({
     data: { user: { id: "u1", name: "Alice", role: "MEMBER" }, expires: "2099" },

--- a/app/(app)/timesheet/monthly/page.tsx
+++ b/app/(app)/timesheet/monthly/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Download,
+  ArrowLeft,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useMonthlyTimesheet } from "@/app/components/timesheet/use-monthly-timesheet";
+import { MonthlyGrid, MonthlyMobileList } from "@/app/components/timesheet/monthly-grid";
+import { MonthlyDayDetail } from "@/app/components/timesheet/monthly-day-detail";
+import { ApprovalPanel } from "@/app/components/timesheet/approval-panel";
+import { MonthlySummary } from "@/app/components/timesheet/monthly-summary";
+import { PageLoading, PageError } from "@/app/components/page-states";
+
+export default function MonthlyTimesheetPage() {
+  const { data: session, status: sessionStatus } = useSession();
+  const router = useRouter();
+  const isManager = session?.user?.role === "MANAGER";
+  const [isMobile, setIsMobile] = useState(false);
+
+  // RBAC guard
+  useEffect(() => {
+    if (sessionStatus === "authenticated" && !isManager) {
+      router.replace("/timesheet");
+    }
+  }, [sessionStatus, isManager, router]);
+
+  // Mobile detection
+  useEffect(() => {
+    function check() {
+      setIsMobile(window.innerWidth < 768);
+    }
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  const ts = useMonthlyTimesheet();
+
+  // Find expanded cell data
+  const expandedMember = ts.expandedCell
+    ? ts.data?.members.find((m) => m.userId === ts.expandedCell!.userId)
+    : null;
+  const expandedEntries = expandedMember && ts.expandedCell
+    ? expandedMember.days[ts.expandedCell.date]?.entries ?? []
+    : [];
+
+  // Get filtered entry IDs for a member (need to pass to ApprovalPanel)
+  const getFilteredEntryIds = useCallback(
+    (userId: string): string[] => {
+      if (!ts.data) return [];
+      const member = ts.data.members.find((m) => m.userId === userId);
+      if (!member) return [];
+      const ids: string[] = [];
+      for (const day of Object.values(member.days)) {
+        for (const entry of day.entries) {
+          if (ts.statusFilter === "all" || entry.approvalStatus === ts.statusFilter) {
+            if (!entry.isRunning) {
+              ids.push(entry.id);
+            }
+          }
+        }
+      }
+      return ids;
+    },
+    [ts.data, ts.statusFilter]
+  );
+
+  function handleMemberClick(userId: string) {
+    // Navigate to weekly timesheet filtered by this user
+    router.push(`/timesheet?userId=${userId}`);
+  }
+
+  function handleCellClick(userId: string, date: string) {
+    if (ts.expandedCell?.userId === userId && ts.expandedCell?.date === date) {
+      ts.setExpandedCell(null);
+    } else {
+      ts.setExpandedCell({ userId, date });
+    }
+  }
+
+  if (sessionStatus === "loading") {
+    return <PageLoading message="載入中..." />;
+  }
+
+  if (!isManager) {
+    return null;
+  }
+
+  // Format month display
+  const [yearStr, monthStr] = ts.month.split("-");
+  const monthDisplay = `${yearStr} 年 ${parseInt(monthStr, 10)} 月`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => router.push("/timesheet")}
+            className="p-1.5 rounded-md hover:bg-muted transition-colors"
+            title="回到週報"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <h1 className="text-lg font-semibold">月報審核</h1>
+        </div>
+
+        {/* Month navigation */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={ts.prevMonth}
+            className="p-1.5 rounded-md hover:bg-muted transition-colors"
+            aria-label="上個月"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <span className="text-sm font-medium min-w-[120px] text-center">{monthDisplay}</span>
+          <button
+            onClick={ts.nextMonth}
+            className="p-1.5 rounded-md hover:bg-muted transition-colors"
+            aria-label="下個月"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+          <button
+            onClick={ts.goToThisMonth}
+            className="px-2.5 py-1 text-xs rounded-md border border-border hover:bg-muted transition-colors"
+          >
+            <Calendar className="h-3 w-3 inline mr-1" />
+            本月
+          </button>
+          <button
+            onClick={ts.exportCSV}
+            disabled={!ts.data}
+            className="px-2.5 py-1 text-xs rounded-md border border-border hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            <Download className="h-3 w-3 inline mr-1" />
+            匯出 CSV
+          </button>
+        </div>
+      </div>
+
+      {/* Summary */}
+      {ts.summary && !ts.summaryLoading && (
+        <MonthlySummary summary={ts.summary} />
+      )}
+
+      {/* Main content */}
+      <div className="flex flex-col lg:flex-row gap-4">
+        {/* Grid area */}
+        <div className="flex-1 min-w-0">
+          <div className="border border-border rounded-xl overflow-hidden bg-card">
+            {ts.loading ? (
+              <PageLoading message="載入月報..." className="py-12" />
+            ) : ts.error ? (
+              <PageError message={ts.error} onRetry={ts.refresh} className="py-12" />
+            ) : ts.data ? (
+              isMobile ? (
+                <div className="p-3">
+                  <MonthlyMobileList
+                    members={ts.data.members}
+                    month={ts.data.month}
+                    onMemberClick={handleMemberClick}
+                  />
+                </div>
+              ) : (
+                <MonthlyGrid
+                  members={ts.data.members}
+                  daysInMonth={ts.data.daysInMonth}
+                  month={ts.data.month}
+                  expandedCell={ts.expandedCell}
+                  onCellClick={handleCellClick}
+                  onMemberClick={handleMemberClick}
+                />
+              )
+            ) : null}
+          </div>
+
+          {/* Expanded day detail */}
+          {ts.expandedCell && expandedMember && (
+            <div className="mt-3">
+              <MonthlyDayDetail
+                memberName={expandedMember.name}
+                date={ts.expandedCell.date}
+                entries={expandedEntries}
+                selectedEntryIds={ts.selectedEntryIds}
+                onToggleEntry={ts.toggleEntrySelection}
+                onClose={() => ts.setExpandedCell(null)}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Approval panel (sidebar on desktop, below on mobile) */}
+        {ts.data && (
+          <div className="lg:w-[280px] flex-shrink-0">
+            <ApprovalPanel
+              members={ts.data.members}
+              selectedCount={ts.selectedEntryIds.size}
+              filteredCount={ts.filteredCount}
+              statusFilter={ts.statusFilter}
+              onStatusFilterChange={ts.setStatusFilter}
+              onSelectAll={ts.selectAll}
+              onClearSelection={ts.clearSelection}
+              onToggleMember={ts.toggleMemberSelection}
+              selectedEntryIds={ts.selectedEntryIds}
+              getFilteredEntryIds={getFilteredEntryIds}
+              onApprove={ts.batchApprove}
+              onReject={ts.batchReject}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Help text */}
+      <div className="text-xs text-muted-foreground/50 pb-2">
+        點擊格子查看當日工時詳情。勾選工時記錄後可批次核准或駁回。成員名稱可點擊跳轉至週報。
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
-import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Loader2, CalendarDays } from "lucide-react";
 import {
   useTimesheet,
   TimesheetGrid,
@@ -18,6 +19,7 @@ import { PageLoading, PageError } from "@/app/components/page-states";
 
 export default function TimesheetPage() {
   const { data: session } = useSession();
+  const router = useRouter();
   const isManager = session?.user?.role === "MANAGER";
   const [userFilter, setUserFilter] = useState("");
   const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
@@ -79,9 +81,17 @@ export default function TimesheetPage() {
         getDateStr={ts.getDateStr}
       />
 
-      {/* Manager user filter */}
+      {/* Manager actions */}
       {isManager && (
-        <select
+        <div className="flex items-center gap-3 flex-wrap">
+          <button
+            onClick={() => router.push("/timesheet/monthly")}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors"
+          >
+            <CalendarDays className="h-4 w-4" />
+            月報
+          </button>
+          <select
           aria-label="篩選使用者"
           value={userFilter}
           onChange={(e) => setUserFilter(e.target.value)}
@@ -92,6 +102,7 @@ export default function TimesheetPage() {
             <option key={u.id} value={u.id}>{u.name}</option>
           ))}
         </select>
+        </div>
       )}
 
       {/* Content area */}

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -48,6 +48,11 @@ export const PUT = withAuth(async (
   if (category !== undefined) updates.category = category as TimeCategory;
   if (description !== undefined) updates.description = description || null;
 
+  // Phase 2: Auto-reset REJECTED → PENDING on edit
+  if ((existing as Record<string, unknown>).approvalStatus === "REJECTED") {
+    updates.approvalStatus = "PENDING";
+  }
+
   const entry = await prisma.timeEntry.update({
     where: { id },
     data: updates,

--- a/app/api/time-entries/approve/route.ts
+++ b/app/api/time-entries/approve/route.ts
@@ -1,0 +1,96 @@
+/**
+ * POST /api/time-entries/approve
+ *
+ * Batch approve time entries. MANAGER only — Issue #851 (Phase 2).
+ *
+ * P0 checks:
+ *   - No self-approval (reviewer === entry.userId → 403)
+ *   - Exclude isRunning entries
+ *   - Only PENDING/REJECTED → APPROVED
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { ForbiddenError } from "@/services/errors";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success, error } from "@/lib/api-response";
+
+const approveSchema = z.object({
+  entryIds: z.array(z.string()).min(1, "至少需選擇一筆工時記錄"),
+});
+
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireRole("MANAGER");
+  const reviewerId = session.user.id;
+
+  const raw = await req.json();
+  const { entryIds } = validateBody(approveSchema, raw);
+
+  // Fetch all target entries
+  const entries = await prisma.timeEntry.findMany({
+    where: { id: { in: entryIds } },
+  });
+
+  // P0: Block self-approval
+  const selfEntries = entries.filter((e) => e.userId === reviewerId);
+  if (selfEntries.length > 0) {
+    throw new ForbiddenError("不可審核自己的工時記錄");
+  }
+
+  // Filter: exclude isRunning, only PENDING/REJECTED
+  const eligible = entries.filter(
+    (e) =>
+      !e.isRunning &&
+      ((e as Record<string, unknown>).approvalStatus === "PENDING" ||
+        (e as Record<string, unknown>).approvalStatus === "REJECTED")
+  );
+
+  if (eligible.length === 0) {
+    return error("NoEligibleEntries", "沒有符合核准條件的工時記錄", 400);
+  }
+
+  const eligibleIds = eligible.map((e) => e.id);
+
+  // Transaction: update entries + create approval records + audit log
+  await prisma.$transaction(async (tx) => {
+    // Batch update entries
+    await tx.timeEntry.updateMany({
+      where: { id: { in: eligibleIds } },
+      data: {
+        locked: true,
+        approvalStatus: "APPROVED",
+      },
+    });
+
+    // Create approval records
+    await tx.timesheetApproval.createMany({
+      data: eligibleIds.map((entryId) => ({
+        timeEntryId: entryId,
+        reviewerId,
+        status: "APPROVED" as const,
+      })),
+    });
+
+    // Audit log
+    await tx.auditLog.create({
+      data: {
+        userId: reviewerId,
+        action: "BATCH_APPROVE_TIME_ENTRIES",
+        resourceType: "TimeEntry",
+        detail: JSON.stringify({
+          entryIds: eligibleIds,
+          count: eligibleIds.length,
+        }),
+      },
+    });
+  });
+
+  return success({
+    approved: eligibleIds.length,
+    skipped: entries.length - eligible.length,
+    entryIds: eligibleIds,
+  });
+});

--- a/app/api/time-entries/monthly-summary/route.ts
+++ b/app/api/time-entries/monthly-summary/route.ts
@@ -1,0 +1,165 @@
+/**
+ * GET /api/time-entries/monthly-summary?month=2026-03
+ *
+ * Returns monthly summary statistics for managers.
+ * MANAGER only — Issue #851 (Phase 2).
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+const monthParamSchema = z.string().regex(/^\d{4}-\d{2}$/, "格式須為 YYYY-MM");
+
+/**
+ * Count workdays (Mon–Fri) in a given month.
+ */
+function countWorkdays(year: number, month: number): number {
+  const lastDay = new Date(year, month, 0).getDate();
+  let count = 0;
+  for (let d = 1; d <= lastDay; d++) {
+    const dow = new Date(year, month - 1, d).getDay();
+    if (dow !== 0 && dow !== 6) count++;
+  }
+  return count;
+}
+
+/**
+ * Check if a date is a weekend (Saturday or Sunday).
+ */
+function isWeekend(date: Date): boolean {
+  const dow = date.getDay();
+  return dow === 0 || dow === 6;
+}
+
+export const GET = withManager(async (req: NextRequest) => {
+  await requireRole("MANAGER");
+
+  const { searchParams } = new URL(req.url);
+  const monthRaw = searchParams.get("month");
+
+  const monthResult = monthParamSchema.safeParse(monthRaw);
+  if (!monthResult.success) {
+    return success({ error: "month 參數格式須為 YYYY-MM" }, 400) as never;
+  }
+  const month = monthResult.data;
+
+  const [yearStr, monthStr] = month.split("-");
+  const year = parseInt(yearStr, 10);
+  const mon = parseInt(monthStr, 10);
+  const startDate = new Date(year, mon - 1, 1);
+  const endDate = new Date(year, mon, 0);
+
+  const workdays = countWorkdays(year, mon);
+  const daysInMonth = endDate.getDate();
+
+  // Get all active users
+  const users = await prisma.user.findMany({
+    where: { isActive: true },
+    select: { id: true, name: true },
+    orderBy: { name: "asc" },
+  });
+
+  // Get all time entries for the month
+  const entries = await prisma.timeEntry.findMany({
+    where: {
+      date: { gte: startDate, lte: endDate },
+    },
+  });
+
+  // Per-member stats
+  const memberStats = users.map((user) => {
+    const userEntries = entries.filter((e) => e.userId === user.id);
+
+    // Total hours
+    const totalHours = userEntries.reduce((sum, e) => sum + e.hours, 0);
+
+    // Overtime breakdown
+    const weekdayOvertime = userEntries
+      .filter((e) => e.overtimeType === "WEEKDAY")
+      .reduce((sum, e) => sum + e.hours, 0);
+    const holidayOvertime = userEntries
+      .filter((e) => e.overtimeType === "HOLIDAY")
+      .reduce((sum, e) => sum + e.hours, 0);
+
+    // Days with entries
+    const datesWithEntries = new Set(
+      userEntries.map((e) => e.date.toISOString().split("T")[0])
+    );
+
+    // Missing workdays (no entries filed)
+    const missingDays: string[] = [];
+    for (let d = 1; d <= daysInMonth; d++) {
+      const date = new Date(year, mon - 1, d);
+      if (isWeekend(date)) continue;
+      const dateStr = date.toISOString().split("T")[0];
+      if (!datesWithEntries.has(dateStr)) {
+        missingDays.push(dateStr);
+      }
+    }
+
+    // Approval status counts
+    const pending = userEntries.filter(
+      (e) => (e as Record<string, unknown>).approvalStatus === "PENDING"
+    ).length;
+    const approved = userEntries.filter(
+      (e) => (e as Record<string, unknown>).approvalStatus === "APPROVED"
+    ).length;
+    const rejected = userEntries.filter(
+      (e) => (e as Record<string, unknown>).approvalStatus === "REJECTED"
+    ).length;
+
+    return {
+      userId: user.id,
+      name: user.name,
+      totalHours,
+      expectedHours: workdays * 8,
+      weekdayOvertime,
+      holidayOvertime,
+      totalOvertime: weekdayOvertime + holidayOvertime,
+      missingDays,
+      missingDayCount: missingDays.length,
+      approval: { pending, approved, rejected, total: userEntries.length },
+    };
+  });
+
+  // Team totals
+  const teamOvertime = {
+    weekday: memberStats.reduce((sum, m) => sum + m.weekdayOvertime, 0),
+    holiday: memberStats.reduce((sum, m) => sum + m.holidayOvertime, 0),
+    total: memberStats.reduce((sum, m) => sum + m.totalOvertime, 0),
+  };
+
+  // Overtime ranking (desc by total overtime)
+  const overtimeRanking = [...memberStats]
+    .filter((m) => m.totalOvertime > 0)
+    .sort((a, b) => b.totalOvertime - a.totalOvertime)
+    .map((m, i) => ({
+      rank: i + 1,
+      userId: m.userId,
+      name: m.name,
+      totalOvertime: m.totalOvertime,
+    }));
+
+  // Approval progress
+  const approvalProgress = {
+    pending: memberStats.reduce((sum, m) => sum + m.approval.pending, 0),
+    approved: memberStats.reduce((sum, m) => sum + m.approval.approved, 0),
+    rejected: memberStats.reduce((sum, m) => sum + m.approval.rejected, 0),
+    total: memberStats.reduce((sum, m) => sum + m.approval.total, 0),
+  };
+
+  return success({
+    month,
+    workdays,
+    daysInMonth,
+    expectedHoursPerMember: workdays * 8,
+    teamOvertime,
+    overtimeRanking,
+    approvalProgress,
+    members: memberStats,
+  });
+});

--- a/app/api/time-entries/monthly/route.ts
+++ b/app/api/time-entries/monthly/route.ts
@@ -1,0 +1,101 @@
+/**
+ * GET /api/time-entries/monthly?month=2026-03
+ *
+ * Returns all team members' time entries for the specified month.
+ * MANAGER only — Issue #851 (Phase 2).
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { validateBody } from "@/lib/validate";
+
+const monthParamSchema = z.string().regex(/^\d{4}-\d{2}$/, "格式須為 YYYY-MM");
+
+export const GET = withManager(async (req: NextRequest) => {
+  await requireRole("MANAGER");
+
+  const { searchParams } = new URL(req.url);
+  const monthRaw = searchParams.get("month");
+
+  // Validate month param
+  const monthResult = monthParamSchema.safeParse(monthRaw);
+  if (!monthResult.success) {
+    return success({ error: "month 參數格式須為 YYYY-MM" }, 400) as never;
+  }
+  const month = monthResult.data;
+
+  // Calculate date range for the month
+  const [yearStr, monthStr] = month.split("-");
+  const year = parseInt(yearStr, 10);
+  const mon = parseInt(monthStr, 10);
+  const startDate = new Date(year, mon - 1, 1);
+  const endDate = new Date(year, mon, 0); // last day of month
+
+  // Get all active users
+  const users = await prisma.user.findMany({
+    where: { isActive: true },
+    select: { id: true, name: true, email: true },
+    orderBy: { name: "asc" },
+  });
+
+  // Get all time entries for the month (all users)
+  const entries = await prisma.timeEntry.findMany({
+    where: {
+      date: { gte: startDate, lte: endDate },
+    },
+    include: {
+      task: { select: { id: true, title: true, category: true } },
+    },
+    orderBy: [{ date: "asc" }, { createdAt: "asc" }],
+  });
+
+  // Group entries by userId → date
+  const members = users.map((user) => {
+    const userEntries = entries.filter((e) => e.userId === user.id);
+    const days: Record<string, {
+      totalHours: number;
+      entries: typeof entries;
+      approvalStatus: string;
+    }> = {};
+
+    for (const entry of userEntries) {
+      // Use local date string from the Date object
+      const dateKey = entry.date.toISOString().split("T")[0];
+      if (!days[dateKey]) {
+        days[dateKey] = { totalHours: 0, entries: [], approvalStatus: "PENDING" };
+      }
+      days[dateKey].totalHours += entry.hours;
+      days[dateKey].entries.push(entry);
+    }
+
+    // Determine day-level approval status:
+    // ALL approved → APPROVED, ANY rejected → REJECTED, otherwise PENDING
+    for (const [, day] of Object.entries(days)) {
+      const statuses = day.entries.map((e) => (e as Record<string, unknown>).approvalStatus as string);
+      if (statuses.length > 0 && statuses.every((s) => s === "APPROVED")) {
+        day.approvalStatus = "APPROVED";
+      } else if (statuses.some((s) => s === "REJECTED")) {
+        day.approvalStatus = "REJECTED";
+      } else {
+        day.approvalStatus = "PENDING";
+      }
+    }
+
+    return {
+      userId: user.id,
+      name: user.name,
+      email: user.email,
+      days,
+    };
+  });
+
+  return success({
+    month,
+    daysInMonth: endDate.getDate(),
+    members,
+  });
+});

--- a/app/api/time-entries/reject/route.ts
+++ b/app/api/time-entries/reject/route.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/time-entries/reject
+ *
+ * Batch reject time entries. MANAGER only — Issue #851 (Phase 2).
+ *
+ * - reason is required (zod validation)
+ * - Sets locked=false, approvalStatus=REJECTED
+ * - Creates TimesheetApproval records
+ * - Creates Notification for affected users
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireRole } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success, error } from "@/lib/api-response";
+
+const rejectSchema = z.object({
+  entryIds: z.array(z.string()).min(1, "至少需選擇一筆工時記錄"),
+  reason: z.string().min(1, "駁回理由為必填"),
+});
+
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireRole("MANAGER");
+  const reviewerId = session.user.id;
+
+  const raw = await req.json();
+  const { entryIds, reason } = validateBody(rejectSchema, raw);
+
+  // Fetch all target entries
+  const entries = await prisma.timeEntry.findMany({
+    where: { id: { in: entryIds } },
+  });
+
+  // Filter: only PENDING/APPROVED entries can be rejected
+  const eligible = entries.filter(
+    (e) =>
+      (e as Record<string, unknown>).approvalStatus === "PENDING" ||
+      (e as Record<string, unknown>).approvalStatus === "APPROVED"
+  );
+
+  if (eligible.length === 0) {
+    return error("NoEligibleEntries", "沒有符合駁回條件的工時記錄", 400);
+  }
+
+  const eligibleIds = eligible.map((e) => e.id);
+
+  // Collect unique affected user IDs for notifications
+  const affectedUserIds = [...new Set(eligible.map((e) => e.userId))];
+
+  // Transaction: update entries + create approval records + notifications + audit log
+  await prisma.$transaction(async (tx) => {
+    // Batch update entries
+    await tx.timeEntry.updateMany({
+      where: { id: { in: eligibleIds } },
+      data: {
+        locked: false,
+        approvalStatus: "REJECTED",
+      },
+    });
+
+    // Create approval records
+    await tx.timesheetApproval.createMany({
+      data: eligibleIds.map((entryId) => ({
+        timeEntryId: entryId,
+        reviewerId,
+        status: "REJECTED" as const,
+        reason,
+      })),
+    });
+
+    // Create notifications for affected users
+    await tx.notification.createMany({
+      data: affectedUserIds.map((userId) => ({
+        userId,
+        type: "TIMESHEET_REJECTED" as const,
+        title: "工時被駁回",
+        body: `主管駁回了您的工時記錄，理由：${reason}`,
+        relatedType: "TimeEntry",
+      })),
+    });
+
+    // Audit log
+    await tx.auditLog.create({
+      data: {
+        userId: reviewerId,
+        action: "BATCH_REJECT_TIME_ENTRIES",
+        resourceType: "TimeEntry",
+        detail: JSON.stringify({
+          entryIds: eligibleIds,
+          count: eligibleIds.length,
+          reason,
+          affectedUserIds,
+        }),
+      },
+    });
+  });
+
+  return success({
+    rejected: eligibleIds.length,
+    skipped: entries.length - eligible.length,
+    entryIds: eligibleIds,
+  });
+});

--- a/app/components/timesheet/approval-panel.tsx
+++ b/app/components/timesheet/approval-panel.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Check, X, Filter } from "lucide-react";
+import type { MonthlyMember } from "./use-monthly-timesheet";
+
+type StatusFilter = "all" | "PENDING" | "APPROVED" | "REJECTED";
+
+type ApprovalPanelProps = {
+  members: MonthlyMember[];
+  selectedCount: number;
+  filteredCount: number;
+  statusFilter: StatusFilter;
+  onStatusFilterChange: (filter: StatusFilter) => void;
+  onSelectAll: () => void;
+  onClearSelection: () => void;
+  onToggleMember: (userId: string) => void;
+  selectedEntryIds: Set<string>;
+  getFilteredEntryIds: (userId: string) => string[];
+  onApprove: () => Promise<Response | undefined>;
+  onReject: (reason: string) => Promise<Response | undefined>;
+};
+
+const FILTER_OPTIONS: { value: StatusFilter; label: string }[] = [
+  { value: "PENDING", label: "待審核" },
+  { value: "REJECTED", label: "已駁回" },
+  { value: "APPROVED", label: "已核准" },
+  { value: "all", label: "全部" },
+];
+
+export function ApprovalPanel({
+  members,
+  selectedCount,
+  filteredCount,
+  statusFilter,
+  onStatusFilterChange,
+  onSelectAll,
+  onClearSelection,
+  onToggleMember,
+  selectedEntryIds,
+  getFilteredEntryIds,
+  onApprove,
+  onReject,
+}: ApprovalPanelProps) {
+  const [showRejectDialog, setShowRejectDialog] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+  const [actionLoading, setActionLoading] = useState(false);
+
+  async function handleApprove() {
+    setActionLoading(true);
+    try {
+      await onApprove();
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleReject() {
+    if (!rejectReason.trim()) return;
+    setActionLoading(true);
+    try {
+      await onReject(rejectReason);
+      setRejectReason("");
+      setShowRejectDialog(false);
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  return (
+    <div className="border border-border rounded-lg bg-card p-4 space-y-4">
+      <h3 className="text-sm font-semibold flex items-center gap-2">
+        <Filter className="h-4 w-4" />
+        審核面板
+      </h3>
+
+      {/* Status filter */}
+      <div className="flex gap-1 flex-wrap">
+        {FILTER_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => onStatusFilterChange(opt.value)}
+            className={cn(
+              "px-2.5 py-1 rounded text-xs transition-colors",
+              statusFilter === opt.value
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted hover:bg-muted/80 text-muted-foreground"
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Member checkboxes */}
+      <div className="space-y-1 max-h-[200px] overflow-y-auto">
+        {members.map((member) => {
+          const memberIds = getFilteredEntryIds(member.userId);
+          const allSelected = memberIds.length > 0 && memberIds.every((id) => selectedEntryIds.has(id));
+          const someSelected = memberIds.some((id) => selectedEntryIds.has(id));
+
+          return (
+            <label
+              key={member.userId}
+              className="flex items-center gap-2 px-2 py-1 rounded hover:bg-muted/50 cursor-pointer text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={allSelected}
+                ref={(el) => { if (el) el.indeterminate = someSelected && !allSelected; }}
+                onChange={() => onToggleMember(member.userId)}
+                disabled={memberIds.length === 0}
+                className="rounded border-border"
+              />
+              <span className={memberIds.length === 0 ? "text-muted-foreground" : ""}>
+                {member.name}
+              </span>
+              <span className="text-xs text-muted-foreground ml-auto">
+                {memberIds.length} 筆
+              </span>
+            </label>
+          );
+        })}
+      </div>
+
+      {/* Select all / clear */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">
+          {filteredCount} 筆符合條件，已選 {selectedCount} 筆
+        </span>
+        <div className="flex gap-2">
+          <button onClick={onSelectAll} className="text-primary hover:underline">
+            全選
+          </button>
+          <button onClick={onClearSelection} className="text-muted-foreground hover:underline">
+            清除
+          </button>
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          onClick={handleApprove}
+          disabled={selectedCount === 0 || actionLoading}
+          className={cn(
+            "flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+            "bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          <Check className="h-4 w-4" />
+          核准 ({selectedCount})
+        </button>
+        <button
+          onClick={() => setShowRejectDialog(true)}
+          disabled={selectedCount === 0 || actionLoading}
+          className={cn(
+            "flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+            "bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          <X className="h-4 w-4" />
+          駁回 ({selectedCount})
+        </button>
+      </div>
+
+      {/* Reject reason dialog */}
+      {showRejectDialog && (
+        <div className="border border-red-200 dark:border-red-800 rounded-md p-3 bg-red-50 dark:bg-red-950/30 space-y-2">
+          <label className="text-xs font-medium text-red-800 dark:text-red-200">
+            駁回理由（必填）
+          </label>
+          <textarea
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            placeholder="請輸入駁回理由..."
+            className="w-full px-2 py-1.5 text-sm border border-border rounded bg-background resize-none"
+            rows={3}
+            autoFocus
+          />
+          <div className="flex gap-2 justify-end">
+            <button
+              onClick={() => { setShowRejectDialog(false); setRejectReason(""); }}
+              className="px-3 py-1 text-xs rounded bg-muted hover:bg-muted/80"
+            >
+              取消
+            </button>
+            <button
+              onClick={handleReject}
+              disabled={!rejectReason.trim() || actionLoading}
+              className="px-3 py-1 text-xs rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+            >
+              確認駁回
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/monthly-day-detail.tsx
+++ b/app/components/timesheet/monthly-day-detail.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+import type { MonthlyEntry, ApprovalStatus } from "./use-monthly-timesheet";
+
+type MonthlyDayDetailProps = {
+  memberName: string;
+  date: string;
+  entries: MonthlyEntry[];
+  selectedEntryIds: Set<string>;
+  onToggleEntry: (entryId: string) => void;
+  onClose: () => void;
+};
+
+const STATUS_LABELS: Record<ApprovalStatus, string> = {
+  PENDING: "待審核",
+  APPROVED: "已核准",
+  REJECTED: "已駁回",
+};
+
+const STATUS_COLORS: Record<ApprovalStatus, string> = {
+  PENDING: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-200",
+  APPROVED: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-200",
+  REJECTED: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-200",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  PLANNED_TASK: "計畫任務",
+  ADDED_TASK: "追加任務",
+  INCIDENT: "事件處理",
+  SUPPORT: "技術支援",
+  ADMIN: "行政庶務",
+  LEARNING: "學習進修",
+};
+
+export function MonthlyDayDetail({
+  memberName,
+  date,
+  entries,
+  selectedEntryIds,
+  onToggleEntry,
+  onClose,
+}: MonthlyDayDetailProps) {
+  const totalHours = entries.reduce((sum, e) => sum + e.hours, 0);
+
+  return (
+    <div className="border border-border rounded-lg bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h4 className="text-sm font-semibold">{memberName}</h4>
+          <p className="text-xs text-muted-foreground">{date} — {totalHours.toFixed(1)} 小時</p>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 rounded hover:bg-muted transition-colors"
+          aria-label="關閉"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">當日無工時記錄</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry) => (
+            <div
+              key={entry.id}
+              className={cn(
+                "flex items-start gap-2 p-2 rounded border border-border/50 text-xs",
+                entry.isRunning && "opacity-50"
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={selectedEntryIds.has(entry.id)}
+                onChange={() => onToggleEntry(entry.id)}
+                disabled={entry.isRunning}
+                className="mt-0.5 rounded border-border"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-mono font-semibold">{entry.hours.toFixed(1)}h</span>
+                  <span className={cn("px-1.5 py-0.5 rounded text-[10px]", STATUS_COLORS[entry.approvalStatus])}>
+                    {STATUS_LABELS[entry.approvalStatus]}
+                  </span>
+                  {entry.isRunning && (
+                    <span className="px-1.5 py-0.5 rounded bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200 text-[10px]">
+                      計時中
+                    </span>
+                  )}
+                </div>
+                <div className="text-muted-foreground mt-0.5">
+                  {CATEGORY_LABELS[entry.category] || entry.category}
+                  {entry.task && <> — {entry.task.title}</>}
+                </div>
+                {entry.description && (
+                  <div className="text-muted-foreground/70 mt-0.5 truncate">{entry.description}</div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/monthly-grid.tsx
+++ b/app/components/timesheet/monthly-grid.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { MonthlyMember, ApprovalStatus } from "./use-monthly-timesheet";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type MonthlyGridProps = {
+  members: MonthlyMember[];
+  daysInMonth: number;
+  month: string; // YYYY-MM
+  expandedCell: { userId: string; date: string } | null;
+  onCellClick: (userId: string, date: string) => void;
+  onMemberClick?: (userId: string) => void;
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const DAY_NAMES = ["日", "一", "二", "三", "四", "五", "六"];
+
+function isWeekend(year: number, month: number, day: number): boolean {
+  const dow = new Date(year, month - 1, day).getDay();
+  return dow === 0 || dow === 6;
+}
+
+function getHoursColor(hours: number): string {
+  if (hours === 0) return "bg-muted/30 text-muted-foreground/50";
+  if (hours <= 8) return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200";
+  if (hours <= 10) return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-200";
+  return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200";
+}
+
+function getApprovalIcon(status: ApprovalStatus): string {
+  switch (status) {
+    case "APPROVED": return "✓";
+    case "REJECTED": return "✗";
+    default: return "";
+  }
+}
+
+function getApprovalIconColor(status: ApprovalStatus): string {
+  switch (status) {
+    case "APPROVED": return "text-green-600 dark:text-green-400";
+    case "REJECTED": return "text-red-600 dark:text-red-400";
+    default: return "";
+  }
+}
+
+// ─── Components ──────────────────────────────────────────────────────────────
+
+function MonthlyGridHeader({ daysInMonth, month }: { daysInMonth: number; month: string }) {
+  const [yearStr, monthStr] = month.split("-");
+  const year = parseInt(yearStr, 10);
+  const mon = parseInt(monthStr, 10);
+
+  return (
+    <tr className="border-b border-border">
+      <th className="sticky left-0 z-10 bg-card px-3 py-2 text-left text-xs font-medium text-muted-foreground min-w-[100px]">
+        成員
+      </th>
+      {Array.from({ length: daysInMonth }, (_, i) => {
+        const day = i + 1;
+        const dow = new Date(year, mon - 1, day).getDay();
+        const weekend = isWeekend(year, mon, day);
+        return (
+          <th
+            key={day}
+            className={cn(
+              "px-1 py-1 text-center text-xs font-normal min-w-[36px]",
+              weekend && "bg-muted/50"
+            )}
+          >
+            <div className="font-medium">{day}</div>
+            <div className="text-muted-foreground/70 text-[10px]">{DAY_NAMES[dow]}</div>
+          </th>
+        );
+      })}
+      <th className="px-2 py-2 text-center text-xs font-medium text-muted-foreground min-w-[50px]">
+        合計
+      </th>
+    </tr>
+  );
+}
+
+function MonthlyCell({
+  hours,
+  approvalStatus,
+  isWeekendDay,
+  isExpanded,
+  onClick,
+}: {
+  hours: number;
+  approvalStatus: ApprovalStatus;
+  isWeekendDay: boolean;
+  isExpanded: boolean;
+  onClick: () => void;
+}) {
+  const icon = getApprovalIcon(approvalStatus);
+  const iconColor = getApprovalIconColor(approvalStatus);
+
+  return (
+    <td
+      className={cn(
+        "px-1 py-1 text-center cursor-pointer transition-colors hover:ring-1 hover:ring-primary/50",
+        isWeekendDay && "bg-muted/30",
+        isExpanded && "ring-2 ring-primary",
+        hours === 0 ? "text-muted-foreground/30" : getHoursColor(hours)
+      )}
+      onClick={onClick}
+    >
+      <div className="text-xs font-mono leading-tight">
+        {hours > 0 ? hours.toFixed(1) : "—"}
+      </div>
+      {icon && (
+        <div className={cn("text-[9px] leading-none", iconColor)}>{icon}</div>
+      )}
+    </td>
+  );
+}
+
+function MonthlyGridRow({
+  member,
+  daysInMonth,
+  month,
+  expandedCell,
+  onCellClick,
+  onMemberClick,
+}: {
+  member: MonthlyMember;
+  daysInMonth: number;
+  month: string;
+  expandedCell: { userId: string; date: string } | null;
+  onCellClick: (userId: string, date: string) => void;
+  onMemberClick?: (userId: string) => void;
+}) {
+  const [yearStr, monthStr] = month.split("-");
+  const year = parseInt(yearStr, 10);
+  const mon = parseInt(monthStr, 10);
+
+  let totalHours = 0;
+
+  const cells = Array.from({ length: daysInMonth }, (_, i) => {
+    const day = i + 1;
+    const dateStr = `${yearStr}-${monthStr}-${String(day).padStart(2, "0")}`;
+    const dayData = member.days[dateStr];
+    const hours = dayData?.totalHours ?? 0;
+    const status: ApprovalStatus = (dayData?.approvalStatus as ApprovalStatus) ?? "PENDING";
+    totalHours += hours;
+
+    return (
+      <MonthlyCell
+        key={day}
+        hours={hours}
+        approvalStatus={status}
+        isWeekendDay={isWeekend(year, mon, day)}
+        isExpanded={expandedCell?.userId === member.userId && expandedCell?.date === dateStr}
+        onClick={() => onCellClick(member.userId, dateStr)}
+      />
+    );
+  });
+
+  return (
+    <tr className="border-b border-border/50 hover:bg-muted/20">
+      <td className="sticky left-0 z-10 bg-card px-3 py-2 text-sm font-medium min-w-[100px]">
+        <button
+          className="text-left hover:text-primary hover:underline transition-colors"
+          onClick={() => onMemberClick?.(member.userId)}
+          title={`查看 ${member.name} 的週報`}
+        >
+          {member.name}
+        </button>
+      </td>
+      {cells}
+      <td className="px-2 py-2 text-center text-xs font-mono font-semibold">
+        {totalHours.toFixed(1)}
+      </td>
+    </tr>
+  );
+}
+
+// ─── Main Grid ───────────────────────────────────────────────────────────────
+
+export function MonthlyGrid({
+  members,
+  daysInMonth,
+  month,
+  expandedCell,
+  onCellClick,
+  onMemberClick,
+}: MonthlyGridProps) {
+  if (members.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        本月無工時資料
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <MonthlyGridHeader daysInMonth={daysInMonth} month={month} />
+        </thead>
+        <tbody>
+          {members.map((member) => (
+            <MonthlyGridRow
+              key={member.userId}
+              member={member}
+              daysInMonth={daysInMonth}
+              month={month}
+              expandedCell={expandedCell}
+              onCellClick={onCellClick}
+              onMemberClick={onMemberClick}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Mobile List View ────────────────────────────────────────────────────────
+
+export function MonthlyMobileList({
+  members,
+  month,
+  onMemberClick,
+}: {
+  members: MonthlyMember[];
+  month: string;
+  onMemberClick?: (userId: string) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      {members.map((member) => {
+        let totalHours = 0;
+        let approvedCount = 0;
+        let pendingCount = 0;
+        let rejectedCount = 0;
+
+        for (const day of Object.values(member.days)) {
+          totalHours += day.totalHours;
+          for (const entry of day.entries) {
+            if (entry.approvalStatus === "APPROVED") approvedCount++;
+            else if (entry.approvalStatus === "REJECTED") rejectedCount++;
+            else pendingCount++;
+          }
+        }
+
+        return (
+          <div
+            key={member.userId}
+            className="border border-border rounded-lg p-3 bg-card"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <button
+                className="font-medium text-sm hover:text-primary hover:underline"
+                onClick={() => onMemberClick?.(member.userId)}
+              >
+                {member.name}
+              </button>
+              <span className="text-sm font-mono font-semibold">
+                {totalHours.toFixed(1)}h
+              </span>
+            </div>
+            <div className="flex gap-3 text-xs text-muted-foreground">
+              <span>{month}</span>
+              {pendingCount > 0 && <span className="text-yellow-600">待審 {pendingCount}</span>}
+              {approvedCount > 0 && <span className="text-green-600">已核 {approvedCount}</span>}
+              {rejectedCount > 0 && <span className="text-red-600">駁回 {rejectedCount}</span>}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/timesheet/monthly-summary.tsx
+++ b/app/components/timesheet/monthly-summary.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Clock, AlertTriangle, TrendingUp, CheckCircle2 } from "lucide-react";
+import type { MonthlySummaryData } from "./use-monthly-timesheet";
+
+type MonthlySummaryProps = {
+  summary: MonthlySummaryData;
+};
+
+function StatCard({
+  title,
+  icon,
+  children,
+  className,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("border border-border rounded-lg bg-card p-3", className)}>
+      <div className="flex items-center gap-2 mb-2 text-sm font-medium">
+        {icon}
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function MonthlySummary({ summary }: MonthlySummaryProps) {
+  const { teamOvertime, overtimeRanking, approvalProgress, members } = summary;
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+      {/* Team Overtime */}
+      <StatCard title="團隊加班" icon={<Clock className="h-4 w-4 text-orange-500" />}>
+        <div className="space-y-1 text-xs">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">平日加班</span>
+            <span className="font-mono">{teamOvertime.weekday.toFixed(1)}h</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">假日加班</span>
+            <span className="font-mono">{teamOvertime.holiday.toFixed(1)}h</span>
+          </div>
+          <div className="flex justify-between font-semibold border-t border-border pt-1">
+            <span>總計</span>
+            <span className="font-mono">{teamOvertime.total.toFixed(1)}h</span>
+          </div>
+        </div>
+      </StatCard>
+
+      {/* Overtime Ranking */}
+      <StatCard title="加班排名" icon={<TrendingUp className="h-4 w-4 text-blue-500" />}>
+        {overtimeRanking.length === 0 ? (
+          <p className="text-xs text-muted-foreground">本月無加班記錄</p>
+        ) : (
+          <div className="space-y-1 text-xs">
+            {overtimeRanking.slice(0, 5).map((r) => (
+              <div key={r.userId} className="flex justify-between">
+                <span className="text-muted-foreground">
+                  #{r.rank} {r.name}
+                </span>
+                <span className="font-mono">{r.totalOvertime.toFixed(1)}h</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </StatCard>
+
+      {/* Missing Days */}
+      <StatCard title="缺填工時" icon={<AlertTriangle className="h-4 w-4 text-yellow-500" />}>
+        <div className="space-y-1 text-xs">
+          {members.filter((m) => m.missingDayCount > 0).length === 0 ? (
+            <p className="text-muted-foreground">全員已填寫完畢</p>
+          ) : (
+            members
+              .filter((m) => m.missingDayCount > 0)
+              .sort((a, b) => b.missingDayCount - a.missingDayCount)
+              .slice(0, 5)
+              .map((m) => (
+                <div key={m.userId} className="flex justify-between">
+                  <span className="text-muted-foreground">{m.name}</span>
+                  <span className="font-mono text-yellow-600">{m.missingDayCount} 天</span>
+                </div>
+              ))
+          )}
+        </div>
+      </StatCard>
+
+      {/* Approval Progress */}
+      <StatCard title="審核進度" icon={<CheckCircle2 className="h-4 w-4 text-green-500" />}>
+        <div className="space-y-1 text-xs">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">待審核</span>
+            <span className="font-mono text-yellow-600">{approvalProgress.pending}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">已核准</span>
+            <span className="font-mono text-green-600">{approvalProgress.approved}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">已駁回</span>
+            <span className="font-mono text-red-600">{approvalProgress.rejected}</span>
+          </div>
+          {approvalProgress.total > 0 && (
+            <div className="pt-1 border-t border-border">
+              <div className="flex h-2 rounded-full overflow-hidden bg-muted">
+                <div
+                  className="bg-green-500"
+                  style={{ width: `${(approvalProgress.approved / approvalProgress.total) * 100}%` }}
+                />
+                <div
+                  className="bg-red-500"
+                  style={{ width: `${(approvalProgress.rejected / approvalProgress.total) * 100}%` }}
+                />
+              </div>
+              <div className="text-center text-muted-foreground mt-1">
+                {Math.round((approvalProgress.approved / approvalProgress.total) * 100)}% 完成
+              </div>
+            </div>
+          )}
+        </div>
+      </StatCard>
+
+      {/* Expected Hours Baseline */}
+      {members.length > 0 && (
+        <div className="md:col-span-2 lg:col-span-4">
+          <StatCard title="應填工時 baseline" icon={<Clock className="h-4 w-4 text-muted-foreground" />}>
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2 text-xs">
+              {members.map((m) => {
+                const pct = m.expectedHours > 0 ? (m.totalHours / m.expectedHours) * 100 : 0;
+                return (
+                  <div key={m.userId} className="flex items-center justify-between gap-1">
+                    <span className="text-muted-foreground truncate">{m.name}</span>
+                    <span className={cn(
+                      "font-mono whitespace-nowrap",
+                      pct >= 100 ? "text-green-600" : pct >= 80 ? "text-yellow-600" : "text-red-600"
+                    )}>
+                      {m.totalHours.toFixed(0)}/{m.expectedHours}h
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </StatCard>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/use-monthly-timesheet.ts
+++ b/app/components/timesheet/use-monthly-timesheet.ts
@@ -1,0 +1,347 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { extractData } from "@/lib/api-client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type ApprovalStatus = "PENDING" | "APPROVED" | "REJECTED";
+
+export type MonthlyEntry = {
+  id: string;
+  taskId: string | null;
+  date: string;
+  hours: number;
+  category: string;
+  description: string | null;
+  overtimeType: string;
+  approvalStatus: ApprovalStatus;
+  isRunning: boolean;
+  locked: boolean;
+  task?: { id: string; title: string; category?: string } | null;
+};
+
+export type MonthlyDay = {
+  totalHours: number;
+  entries: MonthlyEntry[];
+  approvalStatus: ApprovalStatus;
+};
+
+export type MonthlyMember = {
+  userId: string;
+  name: string;
+  email: string;
+  days: Record<string, MonthlyDay>;
+};
+
+export type MonthlyData = {
+  month: string;
+  daysInMonth: number;
+  members: MonthlyMember[];
+};
+
+export type MemberStat = {
+  userId: string;
+  name: string;
+  totalHours: number;
+  expectedHours: number;
+  weekdayOvertime: number;
+  holidayOvertime: number;
+  totalOvertime: number;
+  missingDays: string[];
+  missingDayCount: number;
+  approval: { pending: number; approved: number; rejected: number; total: number };
+};
+
+export type MonthlySummaryData = {
+  month: string;
+  workdays: number;
+  daysInMonth: number;
+  expectedHoursPerMember: number;
+  teamOvertime: { weekday: number; holiday: number; total: number };
+  overtimeRanking: { rank: number; userId: string; name: string; totalOvertime: number }[];
+  approvalProgress: { pending: number; approved: number; rejected: number; total: number };
+  members: MemberStat[];
+};
+
+type StatusFilter = "all" | "PENDING" | "APPROVED" | "REJECTED";
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useMonthlyTimesheet() {
+  // Month navigation
+  const [month, setMonth] = useState(() => {
+    const now = new Date();
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  });
+
+  // Data
+  const [data, setData] = useState<MonthlyData | null>(null);
+  const [summary, setSummary] = useState<MonthlySummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Selection
+  const [selectedEntryIds, setSelectedEntryIds] = useState<Set<string>>(new Set());
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("PENDING");
+
+  // Expanded cell
+  const [expandedCell, setExpandedCell] = useState<{
+    userId: string;
+    date: string;
+  } | null>(null);
+
+  // ─── Fetch ──────────────────────────────────────────────────────────────────
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/time-entries/monthly?month=${month}`);
+      if (!res.ok) throw new Error("月報資料載入失敗");
+      const body = await res.json();
+      setData(extractData<MonthlyData>(body));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [month]);
+
+  const loadSummary = useCallback(async () => {
+    setSummaryLoading(true);
+    try {
+      const res = await fetch(`/api/time-entries/monthly-summary?month=${month}`);
+      if (res.ok) {
+        const body = await res.json();
+        setSummary(extractData<MonthlySummaryData>(body));
+      }
+    } finally {
+      setSummaryLoading(false);
+    }
+  }, [month]);
+
+  useEffect(() => {
+    loadData();
+    loadSummary();
+  }, [loadData, loadSummary]);
+
+  // ─── Month Navigation ──────────────────────────────────────────────────────
+
+  function prevMonth() {
+    setMonth((prev) => {
+      const [y, m] = prev.split("-").map(Number);
+      const d = new Date(y, m - 2, 1);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    });
+    setSelectedEntryIds(new Set());
+    setExpandedCell(null);
+  }
+
+  function nextMonth() {
+    setMonth((prev) => {
+      const [y, m] = prev.split("-").map(Number);
+      const d = new Date(y, m, 1);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    });
+    setSelectedEntryIds(new Set());
+    setExpandedCell(null);
+  }
+
+  function goToThisMonth() {
+    const now = new Date();
+    setMonth(`${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`);
+    setSelectedEntryIds(new Set());
+    setExpandedCell(null);
+  }
+
+  // ─── Selection ─────────────────────────────────────────────────────────────
+
+  /** Get all entry IDs matching current filters for a member */
+  function getFilteredEntryIds(userId: string): string[] {
+    if (!data) return [];
+    const member = data.members.find((m) => m.userId === userId);
+    if (!member) return [];
+
+    const ids: string[] = [];
+    for (const day of Object.values(member.days)) {
+      for (const entry of day.entries) {
+        if (statusFilter === "all" || entry.approvalStatus === statusFilter) {
+          if (!entry.isRunning) {
+            ids.push(entry.id);
+          }
+        }
+      }
+    }
+    return ids;
+  }
+
+  function toggleMemberSelection(userId: string) {
+    const memberIds = getFilteredEntryIds(userId);
+    setSelectedEntryIds((prev) => {
+      const next = new Set(prev);
+      const allSelected = memberIds.every((id) => next.has(id));
+      if (allSelected) {
+        memberIds.forEach((id) => next.delete(id));
+      } else {
+        memberIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+  }
+
+  function toggleEntrySelection(entryId: string) {
+    setSelectedEntryIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(entryId)) {
+        next.delete(entryId);
+      } else {
+        next.add(entryId);
+      }
+      return next;
+    });
+  }
+
+  function selectAll() {
+    if (!data) return;
+    const allIds: string[] = [];
+    for (const member of data.members) {
+      allIds.push(...getFilteredEntryIds(member.userId));
+    }
+    setSelectedEntryIds(new Set(allIds));
+  }
+
+  function clearSelection() {
+    setSelectedEntryIds(new Set());
+  }
+
+  // ─── Filtered count ────────────────────────────────────────────────────────
+
+  const filteredCount = useMemo(() => {
+    if (!data) return 0;
+    let count = 0;
+    for (const member of data.members) {
+      count += getFilteredEntryIds(member.userId).length;
+    }
+    return count;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, statusFilter]);
+
+  // ─── Batch Actions ─────────────────────────────────────────────────────────
+
+  async function batchApprove() {
+    if (selectedEntryIds.size === 0) return;
+    const res = await fetch("/api/time-entries/approve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entryIds: Array.from(selectedEntryIds) }),
+    });
+    if (res.ok) {
+      setSelectedEntryIds(new Set());
+      await Promise.all([loadData(), loadSummary()]);
+    }
+    return res;
+  }
+
+  async function batchReject(reason: string) {
+    if (selectedEntryIds.size === 0 || !reason.trim()) return;
+    const res = await fetch("/api/time-entries/reject", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        entryIds: Array.from(selectedEntryIds),
+        reason: reason.trim(),
+      }),
+    });
+    if (res.ok) {
+      setSelectedEntryIds(new Set());
+      await Promise.all([loadData(), loadSummary()]);
+    }
+    return res;
+  }
+
+  // ─── CSV Export ────────────────────────────────────────────────────────────
+
+  function exportCSV() {
+    if (!data) return;
+
+    const headers = ["成員", "日期", "時數", "分類", "加班類型", "審核狀態", "任務", "說明"];
+    const rows: string[][] = [];
+
+    for (const member of data.members) {
+      for (const [date, day] of Object.entries(member.days)) {
+        for (const entry of day.entries) {
+          rows.push([
+            member.name,
+            date,
+            String(entry.hours),
+            entry.category,
+            entry.overtimeType || "NONE",
+            entry.approvalStatus,
+            entry.task?.title || "",
+            entry.description || "",
+          ]);
+        }
+      }
+    }
+
+    const csvContent = [
+      headers.map(escapeCSV).join(","),
+      ...rows.map((row) => row.map(escapeCSV).join(",")),
+    ].join("\n");
+
+    // BOM for Excel compatibility with Chinese characters
+    const blob = new Blob(["\uFEFF" + csvContent], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `工時月報_${data.month}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return {
+    // Month
+    month,
+    prevMonth,
+    nextMonth,
+    goToThisMonth,
+
+    // Data
+    data,
+    summary,
+    loading,
+    summaryLoading,
+    error,
+    refresh: () => { loadData(); loadSummary(); },
+
+    // Selection
+    selectedEntryIds,
+    statusFilter,
+    setStatusFilter: setStatusFilter as (f: StatusFilter) => void,
+    toggleMemberSelection,
+    toggleEntrySelection,
+    selectAll,
+    clearSelection,
+    filteredCount,
+
+    // Expanded cell
+    expandedCell,
+    setExpandedCell,
+
+    // Actions
+    batchApprove,
+    batchReject,
+    exportCSV,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function escapeCSV(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/prisma/migrations/0005_add_timesheet_approval/migration.sql
+++ b/prisma/migrations/0005_add_timesheet_approval/migration.sql
@@ -1,0 +1,34 @@
+-- Phase 2: Timesheet Approval Schema
+-- Issue #850: TimesheetApproval model + TimeEntry.approvalStatus
+
+-- 1. Create TimesheetApprovalStatus enum
+CREATE TYPE "TimesheetApprovalStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- 2. Add approvalStatus to time_entries
+ALTER TABLE "time_entries" ADD COLUMN "approvalStatus" "TimesheetApprovalStatus" NOT NULL DEFAULT 'PENDING';
+
+-- 3. Migrate existing locked=true entries to APPROVED
+UPDATE "time_entries" SET "approvalStatus" = 'APPROVED' WHERE "locked" = true;
+
+-- 4. Create timesheet_approvals table
+CREATE TABLE "timesheet_approvals" (
+    "id" TEXT NOT NULL,
+    "timeEntryId" TEXT NOT NULL,
+    "reviewerId" TEXT NOT NULL,
+    "status" "TimesheetApprovalStatus" NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "timesheet_approvals_pkey" PRIMARY KEY ("id")
+);
+
+-- 5. Create indexes
+CREATE INDEX "timesheet_approvals_timeEntryId_idx" ON "timesheet_approvals"("timeEntryId");
+CREATE INDEX "timesheet_approvals_reviewerId_idx" ON "timesheet_approvals"("reviewerId");
+
+-- 6. Add foreign keys
+ALTER TABLE "timesheet_approvals" ADD CONSTRAINT "timesheet_approvals_timeEntryId_fkey" FOREIGN KEY ("timeEntryId") REFERENCES "time_entries"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "timesheet_approvals" ADD CONSTRAINT "timesheet_approvals_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- 7. Add TIMESHEET_REJECTED to NotificationType enum
+ALTER TYPE "NotificationType" ADD VALUE 'TIMESHEET_REJECTED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
   approvalRequests         ApprovalRequest[]    @relation("ApprovalRequester")
   approvalReviews          ApprovalRequest[]    @relation("ApprovalApprover")
   timeEntryTemplates       TimeEntryTemplate[]
+  timesheetReviews         TimesheetApproval[]  @relation("TimesheetReviewer")
 
   @@map("users")
 }
@@ -438,6 +439,13 @@ enum OvertimeType {
   HOLIDAY   // 假日加班（國定假日/週末）
 }
 
+// Phase 2: 工時審核狀態
+enum TimesheetApprovalStatus {
+  PENDING
+  APPROVED
+  REJECTED
+}
+
 model TimeEntry {
   id          String       @id @default(cuid())
   taskId      String?
@@ -460,6 +468,12 @@ model TimeEntry {
   // TS-04: 覆核鎖定
   locked Boolean @default(false)
 
+  // Phase 2: 審核狀態
+  approvalStatus TimesheetApprovalStatus @default(PENDING)
+
+  // Phase 2: 審核歷程
+  approvals TimesheetApproval[]
+
   // TS-05: 計時器運行狀態
   isRunning Boolean @default(false)
 
@@ -475,6 +489,27 @@ model TimeEntry {
   @@index([userId, isRunning])
   @@index([userId, date])
   @@map("time_entries")
+}
+
+// ═══════════════════════════════════════
+// 工時審核 (Phase 2)
+// ═══════════════════════════════════════
+
+/// 審核歷程 — 每次核准/駁回記錄一筆，保留完整歷史
+model TimesheetApproval {
+  id          String                   @id @default(cuid())
+  timeEntryId String
+  reviewerId  String
+  status      TimesheetApprovalStatus
+  reason      String?                  // 駁回理由
+  createdAt   DateTime                 @default(now())
+
+  timeEntry TimeEntry @relation(fields: [timeEntryId], references: [id], onDelete: Cascade)
+  reviewer  User      @relation("TimesheetReviewer", fields: [reviewerId], references: [id])
+
+  @@index([timeEntryId])
+  @@index([reviewerId])
+  @@map("timesheet_approvals")
 }
 
 // ═══════════════════════════════════════
@@ -524,6 +559,7 @@ enum NotificationType {
   BACKUP_ACTIVATED
   TASK_CHANGED
   TIMESHEET_REMINDER
+  TIMESHEET_REJECTED    // Phase 2: 工時被駁回通知
 }
 
 model Notification {

--- a/validators/shared/enums.ts
+++ b/validators/shared/enums.ts
@@ -58,6 +58,14 @@ export const TimeCategoryEnum = z.enum([
   "LEARNING",
 ]);
 
+// ── Timesheet Approval ─────────────────────────────────────────────────────
+
+export const TimesheetApprovalStatusEnum = z.enum([
+  "PENDING",
+  "APPROVED",
+  "REJECTED",
+]);
+
 // ── User ────────────────────────────────────────────────────────────────────
 
 export const RoleEnum = z.enum(["MANAGER", "ENGINEER"]);
@@ -70,4 +78,5 @@ export type TaskCategory = z.infer<typeof TaskCategoryEnum>;
 export type GoalStatus = z.infer<typeof GoalStatusEnum>;
 export type KpiStatus = z.infer<typeof KpiStatusEnum>;
 export type TimeCategory = z.infer<typeof TimeCategoryEnum>;
+export type TimesheetApprovalStatus = z.infer<typeof TimesheetApprovalStatusEnum>;
 export type Role = z.infer<typeof RoleEnum>;


### PR DESCRIPTION
## Summary
- Implements complete monthly timesheet view for managers with batch approve/reject workflow
- New Prisma schema: `TimesheetApproval` model, `TimesheetApprovalStatus` enum, `TimeEntry.approvalStatus` field
- 4 new API endpoints + 1 modified endpoint with full RBAC, Zod validation, `$transaction`, audit logging
- Frontend: monthly grid (color-coded cells), approval panel, summary cards, CSV export, mobile responsive

## Changes

### Schema (#850)
- `TimesheetApprovalStatus` enum (`PENDING`, `APPROVED`, `REJECTED`)
- `TimesheetApproval` model with reviewer relation
- `TimeEntry.approvalStatus` default `PENDING`
- Migration: `locked=true` entries auto-set to `APPROVED`

### APIs (#851)
- `GET /api/time-entries/monthly` — team monthly data (MANAGER only)
- `POST /api/time-entries/approve` — batch approve (blocks self-approval, excludes isRunning)
- `POST /api/time-entries/reject` — batch reject (reason required, sends notifications)
- `GET /api/time-entries/monthly-summary` — overtime/missing/approval stats
- `PUT /api/time-entries/[id]` — auto-reset `REJECTED` to `PENDING` on edit

### Frontend (#852)
- `/timesheet/monthly` page with RBAC guard
- Monthly grid: 31-day columns, color-coded (green/yellow/red/gray), approval icons
- Day detail panel with entry-level checkbox selection
- Approval panel: status filter, member checkboxes, batch approve/reject with reason dialog
- Summary cards: overtime breakdown, ranking, missing days, approval progress bar
- CSV export (BOM for Excel Chinese support)
- Mobile: switches to list view at `<768px`
- Weekly page: added "月報" navigation button for managers

### Tests (#853)
- 20 API tests: approve/reject flows, self-approval block, RBAC, validation, audit log
- 9 frontend tests: grid rendering, color coding, cell click, approval icons, mobile view

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 29/29 tests passing (`npx jest --passWithNoTests`)
- [ ] Manual: login as MANAGER, navigate to /timesheet/monthly
- [ ] Manual: approve/reject entries, verify notifications
- [ ] Manual: edit rejected entry, verify auto-reset to PENDING
- [ ] Manual: CSV export opens correctly in Excel

Closes #850
Closes #851
Closes #852
Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)