### PR TITLE
fix(knowledge): 中文搜尋無結果修正

### DIFF
--- a/__tests__/api/document-search-chinese.test.ts
+++ b/__tests__/api/document-search-chinese.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD tests for Issue #830: Chinese search in knowledge base
+ *
+ * Verifies that the document search API handles Chinese keywords
+ * by falling back to ILIKE when full-text search returns no results.
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// Mock prisma
+const mockQueryRaw = jest.fn();
+const mockFindMany = jest.fn();
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    $queryRaw: (...args: unknown[]) => mockQueryRaw(...args),
+    document: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
+  },
+}));
+
+// Mock auth
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION = {
+  user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" },
+  expires: "2099",
+};
+
+describe("GET /api/documents/search", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+  });
+
+  it("returns results for Chinese query when FTS returns empty but ILIKE matches", async () => {
+    // Full-text search returns nothing for Chinese
+    mockQueryRaw.mockResolvedValue([]);
+    // ILIKE fallback finds the document
+    mockFindMany.mockResolvedValue([
+      { id: "doc-1", title: "資安政策", slug: "security-policy", parentId: null, content: "資安政策內容..." },
+    ]);
+
+    const { GET } = await import("@/app/api/documents/search/route");
+    const req = createMockRequest("/api/documents/search", {
+      searchParams: { q: "資安" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.length).toBeGreaterThan(0);
+    expect(body.data[0].title).toBe("資安政策");
+  });
+
+  it("returns empty array for empty query", async () => {
+    const { GET } = await import("@/app/api/documents/search/route");
+    const req = createMockRequest("/api/documents/search", {
+      searchParams: { q: "" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual([]);
+  });
+
+  it("returns FTS results for English query when available", async () => {
+    mockQueryRaw.mockResolvedValue([
+      { id: "doc-2", title: "QA Automation", slug: "qa-auto", parentId: null, snippet: "QA test doc" },
+    ]);
+
+    const { GET } = await import("@/app/api/documents/search/route");
+    const req = createMockRequest("/api/documents/search", {
+      searchParams: { q: "QA" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.length).toBeGreaterThan(0);
+  });
+});

--- a/app/api/documents/search/route.ts
+++ b/app/api/documents/search/route.ts
@@ -3,15 +3,22 @@ import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 
+type SearchResult = {
+  id: string;
+  title: string;
+  slug: string;
+  parentId: string | null;
+  snippet: string;
+};
+
 export const GET = withAuth(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const q = searchParams.get("q")?.trim();
   if (!q) return success([]);
 
-  const results = await prisma.$queryRaw<
-    { id: string; title: string; slug: string; parentId: string | null; snippet: string }[]
-  >`
+  // Try PostgreSQL full-text search first (works well for English/space-delimited text)
+  const ftsResults = await prisma.$queryRaw<SearchResult[]>`
     SELECT
       id,
       title,
@@ -24,5 +31,38 @@ export const GET = withAuth(async (req: NextRequest) => {
     LIMIT 20
   `;
 
-  return success(results);
+  // If FTS returned results, use them
+  if (ftsResults.length > 0) {
+    return success(ftsResults);
+  }
+
+  // Fallback: ILIKE search for CJK text (Chinese/Japanese/Korean)
+  // PostgreSQL full-text search with 'simple' config tokenizes by whitespace,
+  // which doesn't work for CJK languages where words aren't space-separated.
+  const likeResults = await prisma.document.findMany({
+    where: {
+      OR: [
+        { title: { contains: q, mode: "insensitive" } },
+        { content: { contains: q, mode: "insensitive" } },
+      ],
+    },
+    select: {
+      id: true,
+      title: true,
+      slug: true,
+      parentId: true,
+      content: true,
+    },
+    take: 20,
+  });
+
+  const mapped: SearchResult[] = likeResults.map((doc) => ({
+    id: doc.id,
+    title: doc.title,
+    slug: doc.slug,
+    parentId: doc.parentId,
+    snippet: doc.content.substring(0, 200),
+  }));
+
+  return success(mapped);
 });


### PR DESCRIPTION
## Summary
- PostgreSQL `to_tsvector('simple', ...)` 以空白分詞，無法處理中文（CJK 語系無空白分隔）
- 新增 ILIKE fallback：當 FTS 回傳空結果時，改用 Prisma `contains` (case-insensitive) 搜尋 title 和 content
- 英文搜尋行為不變（仍優先使用 FTS 排序）

## QA Review
- [x] **AC 驗證**: 搜尋「資安」可找到「資安政策」文件
- [x] **TypeScript**: `npx tsc --noEmit` — 0 errors
- [x] **Tests**: 144 suites passed, 0 failed
- [x] **邊界案例**: 空查詢 → 空陣列、英文查詢 → FTS 結果、中文查詢 → ILIKE fallback
- [x] **效能**: ILIKE 只在 FTS 無結果時觸發，不影響正常英文搜尋效能
- [x] **向後相容**: 英文搜尋邏輯完全不變
- [x] **安全性**: 使用 Prisma parameterized query，無 SQL injection 風險

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)