### PR TITLE
feat(activity): AF-1 activity_log infrastructure

### DIFF
--- a/__tests__/api/activity-log.test.ts
+++ b/__tests__/api/activity-log.test.ts
@@ -1,0 +1,357 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Activity Log API + Service tests — Issue #802 (AF-1)
+ *
+ * Tests the unified activity_log infrastructure including:
+ * - ActivityLogger service (logActivity function)
+ * - Action/Module enums
+ * - GET /api/activity endpoint with pagination/filtering
+ * - Append-only constraint (no UPDATE/DELETE)
+ * - Metadata JSONB support
+ */
+
+import { NextRequest } from "next/server";
+
+// ── Auth mock (manual for node env) ──────────────────────────────────────
+const mockAuthFn = jest.fn();
+jest.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockAuthFn(...args),
+}));
+
+// ── Prisma mock ─────────────────────────────────────────────────────────
+const mockAuditCreate = jest.fn().mockResolvedValue({
+  id: "act-1",
+  userId: "user-1",
+  action: "CREATE",
+  module: "KANBAN",
+  resourceType: "Task",
+  resourceId: "task-1",
+  metadata: { before: null, after: { title: "New Task" } },
+  ipAddress: "127.0.0.1",
+  userAgent: "Mozilla/5.0",
+  createdAt: new Date(),
+});
+
+const mockAuditFindMany = jest.fn().mockResolvedValue([
+  {
+    id: "act-1",
+    userId: "user-1",
+    action: "CREATE",
+    module: "KANBAN",
+    resourceType: "Task",
+    resourceId: "task-1",
+    metadata: null,
+    detail: null,
+    ipAddress: "127.0.0.1",
+    userAgent: null,
+    createdAt: new Date("2026-03-01"),
+  },
+]);
+
+const mockAuditCount = jest.fn().mockResolvedValue(1);
+
+const mockTaskActivityFindMany = jest.fn().mockResolvedValue([
+  {
+    id: "ta-1",
+    taskId: "task-1",
+    userId: "user-1",
+    action: "STATUS_CHANGE",
+    detail: { from: "TODO", to: "IN_PROGRESS" },
+    createdAt: new Date("2026-03-02"),
+    user: { id: "user-1", name: "Test User" },
+    task: { id: "task-1", title: "Test Task" },
+  },
+]);
+
+const mockTaskActivityCount = jest.fn().mockResolvedValue(1);
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    auditLog: {
+      create: (...args: unknown[]) => mockAuditCreate(...args),
+      findMany: (...args: unknown[]) => mockAuditFindMany(...args),
+      count: (...args: unknown[]) => mockAuditCount(...args),
+    },
+    taskActivity: {
+      findMany: (...args: unknown[]) => mockTaskActivityFindMany(...args),
+      count: (...args: unknown[]) => mockTaskActivityCount(...args),
+    },
+  },
+}));
+
+// ── Rate limiter mock ────────────────────────────────────────────────────
+jest.mock("@/lib/rate-limiter", () => ({
+  createApiRateLimiter: () => ({}),
+  checkRateLimit: jest.fn(),
+  createLoginRateLimiter: () => ({}),
+  RateLimitError: class extends Error {
+    retryAfter = 60;
+  },
+}));
+
+// ── CSRF mock ────────────────────────────────────────────────────────────
+jest.mock("@/lib/csrf", () => ({
+  validateCsrf: jest.fn(),
+  CsrfError: class extends Error {},
+}));
+
+// ── Logger mock ──────────────────────────────────────────────────────────
+jest.mock("@/lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock("@/lib/request-logger", () => ({
+  requestLogger: (_req: unknown, fn: () => unknown) => fn(),
+}));
+
+// ═════════════════════════════════════════════════════════════════════════
+// ActivityLogger service tests
+// ═════════════════════════════════════════════════════════════════════════
+
+describe("ActivityLogger service", () => {
+  let logActivity: typeof import("@/services/activity-logger").logActivity;
+  let ActivityAction: typeof import("@/services/activity-logger").ActivityAction;
+  let ActivityModule: typeof import("@/services/activity-logger").ActivityModule;
+
+  beforeAll(async () => {
+    const mod = await import("@/services/activity-logger");
+    logActivity = mod.logActivity;
+    ActivityAction = mod.ActivityAction;
+    ActivityModule = mod.ActivityModule;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should write all required fields via logActivity()", async () => {
+    await logActivity({
+      userId: "user-1",
+      action: ActivityAction.CREATE,
+      module: ActivityModule.KANBAN,
+      targetType: "Task",
+      targetId: "task-1",
+      metadata: { before: null, after: { title: "New Task" } },
+      ipAddress: "127.0.0.1",
+      userAgent: "Mozilla/5.0",
+    });
+
+    expect(mockAuditCreate).toHaveBeenCalledTimes(1);
+    const arg = mockAuditCreate.mock.calls[0][0];
+    expect(arg.data).toMatchObject({
+      userId: "user-1",
+      action: "CREATE",
+      module: "KANBAN",
+      resourceType: "Task",
+      resourceId: "task-1",
+      ipAddress: "127.0.0.1",
+      userAgent: "Mozilla/5.0",
+    });
+    expect(arg.data.metadata).toBeDefined();
+  });
+
+  it("should handle null optional fields", async () => {
+    await logActivity({
+      userId: null,
+      action: ActivityAction.LOGIN,
+      module: ActivityModule.AUTH,
+    });
+
+    const arg = mockAuditCreate.mock.calls[0][0];
+    expect(arg.data.userId).toBeNull();
+    expect(arg.data.resourceId).toBeNull();
+    // Prisma.JsonNull is a special sentinel object, not literal null
+    expect(arg.data.metadata).toBeDefined();
+  });
+
+  it("should expose all required action types", () => {
+    const requiredActions = [
+      "CREATE", "UPDATE", "DELETE", "LOGIN", "LOGOUT", "STATUS_CHANGE",
+    ];
+    for (const action of requiredActions) {
+      expect(Object.values(ActivityAction)).toContain(action);
+    }
+  });
+
+  it("should expose all required module types", () => {
+    const requiredModules = [
+      "AUTH", "KANBAN", "TIMESHEET", "KPI", "ADMIN", "GANTT", "PLAN", "SETTINGS",
+    ];
+    for (const mod of requiredModules) {
+      expect(Object.values(ActivityModule)).toContain(mod);
+    }
+  });
+
+  it("should store before/after diff in metadata", async () => {
+    const diff = {
+      before: { status: "TODO" },
+      after: { status: "IN_PROGRESS" },
+    };
+
+    await logActivity({
+      userId: "user-1",
+      action: ActivityAction.STATUS_CHANGE,
+      module: ActivityModule.KANBAN,
+      targetType: "Task",
+      targetId: "task-1",
+      metadata: diff,
+    });
+
+    const arg = mockAuditCreate.mock.calls[0][0];
+    expect(arg.data.metadata).toEqual(diff);
+  });
+
+  it("should not throw when prisma.create fails (fire-and-forget)", async () => {
+    mockAuditCreate.mockRejectedValueOnce(new Error("DB connection lost"));
+
+    await expect(
+      logActivity({
+        userId: "user-1",
+        action: ActivityAction.CREATE,
+        module: ActivityModule.KANBAN,
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// queryActivityLogs service tests
+// ═════════════════════════════════════════════════════════════════════════
+
+describe("queryActivityLogs service", () => {
+  let queryActivityLogs: typeof import("@/services/activity-logger").queryActivityLogs;
+
+  beforeAll(async () => {
+    const mod = await import("@/services/activity-logger");
+    queryActivityLogs = mod.queryActivityLogs;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return paginated results with total count", async () => {
+    const result = await queryActivityLogs({ page: 1, limit: 20 });
+
+    expect(result.items).toBeDefined();
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("should apply module filter to where clause", async () => {
+    await queryActivityLogs({ module: "AUTH" });
+
+    const call = mockAuditFindMany.mock.calls[0][0];
+    expect(call.where.module).toBe("AUTH");
+  });
+
+  it("should apply userId filter", async () => {
+    await queryActivityLogs({ userId: "user-2" });
+
+    const call = mockAuditFindMany.mock.calls[0][0];
+    expect(call.where.userId).toBe("user-2");
+  });
+
+  it("should cap limit at 100", async () => {
+    await queryActivityLogs({ limit: 500 });
+
+    const call = mockAuditFindMany.mock.calls[0][0];
+    expect(call.take).toBe(100);
+  });
+
+  it("should default page to 1 and limit to 20", async () => {
+    await queryActivityLogs({});
+
+    const call = mockAuditFindMany.mock.calls[0][0];
+    expect(call.skip).toBe(0);
+    expect(call.take).toBe(20);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// GET /api/activity endpoint tests
+// ═════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/activity", () => {
+  let GET: (req: NextRequest) => Promise<Response>;
+
+  beforeAll(async () => {
+    const mod = await import("@/app/api/activity/route");
+    GET = mod.GET as unknown as (req: NextRequest) => Promise<Response>;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 401 for unauthenticated requests", async () => {
+    mockAuthFn.mockResolvedValueOnce(null);
+    const req = new NextRequest("http://localhost/api/activity");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("should return merged activity feed for MANAGER", async () => {
+    mockAuthFn.mockResolvedValue({
+      user: { id: "user-1", role: "MANAGER" },
+      expires: "2099-01-01",
+    });
+
+    const req = new NextRequest("http://localhost/api/activity?page=1&limit=20");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toBeDefined();
+    expect(Array.isArray(body.data.items)).toBe(true);
+  });
+
+  it("should support module filter param", async () => {
+    mockAuthFn.mockResolvedValue({
+      user: { id: "user-1", role: "MANAGER" },
+      expires: "2099-01-01",
+    });
+
+    const req = new NextRequest("http://localhost/api/activity?module=AUTH");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    expect(mockAuditFindMany).toHaveBeenCalled();
+    const auditCall = mockAuditFindMany.mock.calls[0][0];
+    expect(auditCall.where.module).toBe("AUTH");
+  });
+
+  it("should force ENGINEER to see only own logs", async () => {
+    mockAuthFn.mockResolvedValue({
+      user: { id: "eng-1", role: "ENGINEER" },
+      expires: "2099-01-01",
+    });
+
+    const req = new NextRequest("http://localhost/api/activity?userId=other-user");
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    // ENGINEER should have userId forced to own
+    const auditCall = mockAuditFindMany.mock.calls[0][0];
+    expect(auditCall.where.userId).toBe("eng-1");
+    const taskCall = mockTaskActivityFindMany.mock.calls[0][0];
+    expect(taskCall.where.userId).toBe("eng-1");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// Append-only constraint: no UPDATE/DELETE API
+// ═════════════════════════════════════════════════════════════════════════
+
+describe("Activity log append-only", () => {
+  it("should NOT export PUT, PATCH, or DELETE handlers", async () => {
+    const mod = await import("@/app/api/activity/route");
+    expect((mod as Record<string, unknown>).PUT).toBeUndefined();
+    expect((mod as Record<string, unknown>).PATCH).toBeUndefined();
+    expect((mod as Record<string, unknown>).DELETE).toBeUndefined();
+  });
+});

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -1,36 +1,70 @@
+/**
+ * Activity Log API — Issue #802 (AF-1)
+ *
+ * GET /api/activity — unified activity feed with filtering and RBAC.
+ * Merges TaskActivity + AuditLog, sorted by timestamp descending.
+ * Append-only: no PUT, PATCH, or DELETE handlers exported.
+ *
+ * Access: MANAGER sees all; ENGINEER forced to own logs only.
+ */
+
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { success } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 
 interface ActivityItem {
   id: string;
   source: "task_activity" | "audit_log";
   action: string;
+  module: string | null;
   userId: string | null;
   userName: string | null;
   resourceType: string;
   resourceId: string | null;
   resourceName: string | null;
+  metadata: unknown;
   detail: unknown;
+  ipAddress: string | null;
+  userAgent: string | null;
   createdAt: Date;
 }
 
-/**
- * GET /api/activity
- * Returns a merged, paginated feed of TaskActivity + AuditLog entries,
- * sorted by timestamp descending.
- */
 export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
   const { searchParams } = new URL(req.url);
   const { page, limit, skip } = parsePagination(searchParams);
+
+  // Filters
+  const actionFilter = searchParams.get("action") ?? undefined;
+  const moduleFilter = searchParams.get("module") ?? undefined;
+  const resourceTypeFilter = searchParams.get("resourceType") ?? undefined;
+
+  // ENGINEER can only see own logs
+  let userIdFilter = searchParams.get("userId") ?? undefined;
+  if (session.user.role === "ENGINEER") {
+    userIdFilter = session.user.id;
+  }
+
+  // Build where clauses
+  const auditWhere: Record<string, unknown> = {};
+  if (userIdFilter) auditWhere.userId = userIdFilter;
+  if (actionFilter) auditWhere.action = actionFilter;
+  if (moduleFilter) auditWhere.module = moduleFilter;
+  if (resourceTypeFilter) auditWhere.resourceType = resourceTypeFilter;
+
+  const taskActivityWhere: Record<string, unknown> = {};
+  if (userIdFilter) taskActivityWhere.userId = userIdFilter;
+  if (actionFilter) taskActivityWhere.action = actionFilter;
 
   // Fetch both sources in parallel
   const [taskActivities, auditLogs, taskActivityCount, auditLogCount] = await Promise.all([
     prisma.taskActivity.findMany({
+      where: taskActivityWhere,
       orderBy: { createdAt: "desc" },
-      take: limit * 2, // over-fetch to merge
+      take: limit * 2,
       skip: 0,
       include: {
         user: { select: { id: true, name: true } },
@@ -38,12 +72,13 @@ export const GET = withAuth(async (req: NextRequest) => {
       },
     }),
     prisma.auditLog.findMany({
+      where: auditWhere,
       orderBy: { createdAt: "desc" },
       take: limit * 2,
       skip: 0,
     }),
-    prisma.taskActivity.count(),
-    prisma.auditLog.count(),
+    prisma.taskActivity.count({ where: taskActivityWhere }),
+    prisma.auditLog.count({ where: auditWhere }),
   ]);
 
   // Normalize TaskActivity
@@ -51,26 +86,34 @@ export const GET = withAuth(async (req: NextRequest) => {
     id: a.id,
     source: "task_activity" as const,
     action: a.action,
+    module: "KANBAN",
     userId: a.userId,
     userName: a.user.name,
     resourceType: "Task",
     resourceId: a.taskId,
     resourceName: a.task.title,
+    metadata: a.detail,
     detail: a.detail,
+    ipAddress: null,
+    userAgent: null,
     createdAt: a.createdAt,
   }));
 
-  // Normalize AuditLog
+  // Normalize AuditLog (with new Issue #802 fields)
   const fromAuditLogs: ActivityItem[] = auditLogs.map((l) => ({
     id: l.id,
     source: "audit_log" as const,
     action: l.action,
+    module: l.module,
     userId: l.userId,
-    userName: null, // AuditLog does not join user
+    userName: null,
     resourceType: l.resourceType,
     resourceId: l.resourceId,
     resourceName: null,
+    metadata: l.metadata,
     detail: l.detail,
+    ipAddress: l.ipAddress,
+    userAgent: l.userAgent,
     createdAt: l.createdAt,
   }));
 
@@ -85,6 +128,11 @@ export const GET = withAuth(async (req: NextRequest) => {
 
   return success({
     items: paginated,
+    total,
+    page,
+    limit,
     pagination: buildPaginationMeta(total, { page, limit, skip }),
   });
 });
+
+// Append-only: no PUT, PATCH, DELETE exported (audit requirement — Issue #802)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -683,14 +683,19 @@ model TaskTemplate {
 model AuditLog {
   id           String   @id @default(cuid())
   userId       String?  // null for unauthenticated events (e.g. login failures)
-  action       String   // e.g. DELETE_TASK, ROLE_CHANGE, PASSWORD_CHANGE, LOGIN_FAILURE
+  action       String   // e.g. CREATE, UPDATE, DELETE, LOGIN, LOGOUT, STATUS_CHANGE
+  module       String   @default("AUTH") // AUTH, KANBAN, TIMESHEET, KPI, ADMIN, GANTT, PLAN, SETTINGS
   resourceType String   // e.g. Task, User, Auth
   resourceId   String?  // nullable for non-resource events
-  detail       String?  // human-readable or JSON-serialised description
+  metadata     Json?    // JSONB — before/after diff, extra context (Issue #802)
+  detail       String?  // human-readable description (backward compat)
   ipAddress    String?
+  userAgent    String?  // browser/client user-agent string (Issue #802)
   createdAt    DateTime @default(now())
 
   @@index([userId])
+  @@index([module])
+  @@index([createdAt])
   @@index([resourceType, resourceId])
   @@map("audit_logs")
 }

--- a/services/activity-logger.ts
+++ b/services/activity-logger.ts
@@ -1,0 +1,139 @@
+/**
+ * Unified Activity Logger — Issue #802 (AF-1)
+ *
+ * Event-sourcing-style activity log that serves both:
+ *   - 團隊動態牆 (team activity feed)
+ *   - 稽核日誌 (audit log for compliance)
+ *
+ * All modules call logActivity() to record operations.
+ * Activity logs are append-only — no update or delete.
+ *
+ * Uses the existing AuditLog model (extended with module, userAgent, metadata fields).
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { logger } from "@/lib/logger";
+
+// ── Action types ─────────────────────────────────────────────────────────
+
+export const ActivityAction = {
+  CREATE: "CREATE",
+  UPDATE: "UPDATE",
+  DELETE: "DELETE",
+  LOGIN: "LOGIN",
+  LOGOUT: "LOGOUT",
+  STATUS_CHANGE: "STATUS_CHANGE",
+  LOGIN_FAILURE: "LOGIN_FAILURE",
+  PASSWORD_CHANGE: "PASSWORD_CHANGE",
+  ROLE_CHANGE: "ROLE_CHANGE",
+  ACCOUNT_LOCK: "ACCOUNT_LOCK",
+  ACCOUNT_UNLOCK: "ACCOUNT_UNLOCK",
+  SESSION_TIMEOUT: "SESSION_TIMEOUT",
+  PERMISSION_GRANT: "PERMISSION_GRANT",
+  PERMISSION_REVOKE: "PERMISSION_REVOKE",
+  EXPORT: "EXPORT",
+  IMPORT: "IMPORT",
+} as const;
+
+export type ActivityActionType = (typeof ActivityAction)[keyof typeof ActivityAction];
+
+// ── Module types ─────────────────────────────────────────────────────────
+
+export const ActivityModule = {
+  AUTH: "AUTH",
+  KANBAN: "KANBAN",
+  TIMESHEET: "TIMESHEET",
+  KPI: "KPI",
+  ADMIN: "ADMIN",
+  GANTT: "GANTT",
+  PLAN: "PLAN",
+  SETTINGS: "SETTINGS",
+  KNOWLEDGE: "KNOWLEDGE",
+  REPORT: "REPORT",
+  NOTIFICATION: "NOTIFICATION",
+} as const;
+
+export type ActivityModuleType = (typeof ActivityModule)[keyof typeof ActivityModule];
+
+// ── Input type ───────────────────────────────────────────────────────────
+
+export interface LogActivityInput {
+  userId: string | null;
+  action: ActivityActionType | string;
+  module: ActivityModuleType | string;
+  targetType?: string;
+  targetId?: string;
+  metadata?: Record<string, unknown> | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+// ── Core function ────────────────────────────────────────────────────────
+
+/**
+ * Record an activity log entry. Append-only — never update or delete.
+ *
+ * This is the single entry point for all modules to record operations.
+ * Failures are logged but never thrown to avoid blocking business logic.
+ */
+export async function logActivity(input: LogActivityInput): Promise<void> {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId: input.userId ?? null,
+        action: input.action,
+        module: input.module,
+        resourceType: input.targetType ?? "unknown",
+        resourceId: input.targetId ?? null,
+        metadata: input.metadata
+          ? (input.metadata as Prisma.InputJsonValue)
+          : Prisma.JsonNull,
+        detail: input.metadata ? JSON.stringify(input.metadata) : null,
+        ipAddress: input.ipAddress ?? null,
+        userAgent: input.userAgent ?? null,
+      },
+    });
+  } catch (err) {
+    // Fire-and-forget: never let logging failure break business logic
+    logger.error(
+      { err, action: input.action, module: input.module },
+      "[activity-logger] Failed to write activity log"
+    );
+  }
+}
+
+/**
+ * Query activity logs with pagination and filtering.
+ * Used by GET /api/activity endpoint.
+ */
+export async function queryActivityLogs(params: {
+  userId?: string;
+  action?: string;
+  module?: string;
+  resourceType?: string;
+  page?: number;
+  limit?: number;
+}): Promise<{ items: unknown[]; total: number; page: number; limit: number }> {
+  const page = Math.max(1, params.page ?? 1);
+  const limit = Math.min(100, Math.max(1, params.limit ?? 20));
+  const skip = (page - 1) * limit;
+
+  const where: Record<string, unknown> = {};
+  if (params.userId) where.userId = params.userId;
+  if (params.action) where.action = params.action;
+  if (params.module) where.module = params.module;
+  if (params.resourceType) where.resourceType = params.resourceType;
+
+  const [items, total] = await Promise.all([
+    prisma.auditLog.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: limit,
+    }),
+    prisma.auditLog.count({ where }),
+  ]);
+
+  return { items, total, page, limit };
+}


### PR DESCRIPTION
## Summary
- 擴展 AuditLog model：新增 `module`、`metadata` (JSONB)、`userAgent` 欄位及 `module`/`createdAt` 索引
- 建立 `ActivityLogger` 服務：統一 `logActivity()` 函式、Action/Module 類型枚舉
- 強化 GET /api/activity：支援 module/action/userId/resourceType 篩選及 RBAC（ENGINEER 僅可見自己的日誌）
- Append-only：不匯出 PUT/PATCH/DELETE（稽核需求）

## QA Review
- [x] `npx tsc --noEmit` — 0 new errors
- [x] `npx jest --passWithNoTests` — 145 suites, 1881 passed, 6 skipped
- [x] 16 new tests covering: logActivity fields, null handling, enums, JSONB metadata, fire-and-forget error handling, pagination, module filter, RBAC enforcement, append-only constraint
- [x] Backward compatible: existing AuditService callers unaffected (new fields have defaults)
- [x] No secrets committed
- [x] Security: ENGINEER forced to own userId in queries

Closes #802

🤖 Generated with [Claude Code](https://claude.com/claude-code)