### PR TITLE
feat(auth): AU-2 password strength validation

### DIFF
--- a/__tests__/api/password-validation.test.ts
+++ b/__tests__/api/password-validation.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Password Strength Validation tests — Issue #796 (AU-2)
+ */
+
+describe("password-policy enhanced", () => {
+  let validatePassword: typeof import("@/lib/password-policy").validatePassword;
+  let validatePasswordWithEmail: typeof import("@/lib/password-policy").validatePasswordWithEmail;
+  let getPasswordStrength: typeof import("@/lib/password-policy").getPasswordStrength;
+  let isPasswordValid: typeof import("@/lib/password-policy").isPasswordValid;
+
+  beforeAll(async () => {
+    const mod = await import("@/lib/password-policy");
+    validatePassword = mod.validatePassword;
+    validatePasswordWithEmail = mod.validatePasswordWithEmail;
+    getPasswordStrength = mod.getPasswordStrength;
+    isPasswordValid = mod.isPasswordValid;
+  });
+
+  describe("basic rules", () => {
+    it("accepts valid strong password", () => {
+      expect(validatePassword("Titan@2026!x")).toEqual([]);
+    });
+
+    it("rejects short password", () => {
+      const failures = validatePassword("Short1!");
+      expect(failures.length).toBeGreaterThan(0);
+    });
+
+    it("rejects password without uppercase", () => {
+      const failures = validatePassword("alllowercase1!x");
+      expect(failures).toContain("至少 1 個大寫英文字母");
+    });
+
+    it("rejects password without lowercase", () => {
+      const failures = validatePassword("ALLUPPERCASE1!X");
+      expect(failures).toContain("至少 1 個小寫英文字母");
+    });
+
+    it("rejects password without digit", () => {
+      const failures = validatePassword("NoDigitsHere!!");
+      expect(failures).toContain("至少 1 個數字");
+    });
+
+    it("rejects password without special char", () => {
+      const failures = validatePassword("NoSpecial12345a");
+      expect(failures).toContain("至少 1 個特殊字元");
+    });
+
+    it("boundary: exactly 12 chars valid password passes", () => {
+      expect(validatePassword("Abcdef1234!@")).toEqual([]);
+    });
+  });
+
+  describe("common password blacklist", () => {
+    it("rejects common password", () => {
+      const failures = validatePassword("Password123!");
+      expect(failures).toContain("此密碼過於常見，請選擇更安全的密碼");
+    });
+
+    it("accepts non-common password", () => {
+      expect(validatePassword("Unique@Passw0rd!")).toEqual([]);
+    });
+  });
+
+  describe("email local part check", () => {
+    it("rejects password containing email local part", () => {
+      const failures = validatePasswordWithEmail("Alice@12345!", "alice@example.com");
+      expect(failures).toContain("密碼不可包含您的帳號名稱");
+    });
+
+    it("case-insensitive email check", () => {
+      const failures = validatePasswordWithEmail("ALICE@12345!", "alice@example.com");
+      expect(failures).toContain("密碼不可包含您的帳號名稱");
+    });
+
+    it("accepts password not containing email", () => {
+      const failures = validatePasswordWithEmail("Str0ng!Pass@x", "bob@example.com");
+      expect(failures).toEqual([]);
+    });
+
+    it("skips short local parts (< 3 chars)", () => {
+      const failures = validatePasswordWithEmail("Ab@12345678!", "ab@example.com");
+      expect(failures).not.toContain("密碼不可包含您的帳號名稱");
+    });
+  });
+
+  describe("password strength score", () => {
+    it("returns 弱 for weak password", () => {
+      const s = getPasswordStrength("abc");
+      expect(s.label).toBe("弱");
+      expect(s.score).toBe(1);
+    });
+
+    it("returns 中 for medium password", () => {
+      const s = getPasswordStrength("Abcdef1234");
+      expect(s.label).toBe("中");
+    });
+
+    it("returns 強 for strong password", () => {
+      const s = getPasswordStrength("Titan@2026!x");
+      expect(s.label).toBe("強");
+    });
+
+    it("returns passedRules and totalRules", () => {
+      const s = getPasswordStrength("Titan@2026!x");
+      expect(s.passedRules).toBe(5);
+      expect(s.totalRules).toBe(5);
+    });
+  });
+
+  describe("isPasswordValid backward compat", () => {
+    it("returns true for valid password", () => {
+      expect(isPasswordValid("Titan@2026!x")).toBe(true);
+    });
+    it("returns false for weak password", () => {
+      expect(isPasswordValid("weak")).toBe(false);
+    });
+  });
+});
+
+describe("shared password validator (Zod)", () => {
+  let passwordSchema: typeof import("@/validators/shared/password").passwordSchema;
+
+  beforeAll(async () => {
+    const mod = await import("@/validators/shared/password");
+    passwordSchema = mod.passwordSchema;
+  });
+
+  it("accepts valid password", () => {
+    expect(passwordSchema.safeParse("Titan@2026!x").success).toBe(true);
+  });
+
+  it("rejects short password", () => {
+    expect(passwordSchema.safeParse("Short1!").success).toBe(false);
+  });
+});

--- a/app/components/password-strength-indicator.tsx
+++ b/app/components/password-strength-indicator.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Password Strength Indicator — Issue #796 (AU-2)
+ *
+ * Displays real-time password strength feedback (弱/中/強)
+ * and lists which rules are satisfied/unsatisfied.
+ */
+
+import { useMemo } from "react";
+import {
+  PASSWORD_RULES,
+  getPasswordStrength,
+} from "@/lib/password-policy";
+
+interface PasswordStrengthIndicatorProps {
+  password: string;
+  email?: string;
+}
+
+export function PasswordStrengthIndicator({
+  password,
+  email,
+}: PasswordStrengthIndicatorProps) {
+  const strength = useMemo(() => getPasswordStrength(password), [password]);
+
+  const emailLocalPart = email?.split("@")[0]?.toLowerCase();
+  const containsEmail =
+    emailLocalPart &&
+    emailLocalPart.length >= 3 &&
+    password.toLowerCase().includes(emailLocalPart);
+
+  if (!password) return null;
+
+  const colorMap = {
+    弱: "bg-red-500",
+    中: "bg-yellow-500",
+    強: "bg-green-500",
+  };
+
+  const widthMap = {
+    弱: "w-1/3",
+    中: "w-2/3",
+    強: "w-full",
+  };
+
+  return (
+    <div className="mt-2 space-y-2">
+      {/* Strength bar */}
+      <div className="flex items-center gap-2">
+        <div className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${colorMap[strength.label]} ${widthMap[strength.label]}`}
+          />
+        </div>
+        <span className="text-xs font-medium min-w-[2rem]">
+          {strength.label}
+        </span>
+      </div>
+
+      {/* Rule checklist */}
+      <ul className="text-xs space-y-0.5">
+        {PASSWORD_RULES.map((rule, i) => {
+          const passed = rule.regex.test(password);
+          return (
+            <li key={i} className={passed ? "text-green-600" : "text-gray-400"}>
+              {passed ? "✓" : "○"} {rule.message}
+            </li>
+          );
+        })}
+        {containsEmail && (
+          <li className="text-red-500">✗ 密碼不可包含您的帳號名稱</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/lib/password-policy.ts
+++ b/lib/password-policy.ts
@@ -1,5 +1,5 @@
 /**
- * Password policy constants and validation — Issue #180
+ * Password policy constants and validation — Issue #180, enhanced #796 (AU-2)
  *
  * 金管會資安管理辦法 + ISO 27001 A.9.4.3:
  *   - 最少 12 字元
@@ -7,6 +7,8 @@
  *   - 至少 1 小寫英文
  *   - 至少 1 數字
  *   - 至少 1 特殊字元
+ *   - 不可包含使用者帳號名稱 (Issue #796)
+ *   - 不可為常見弱密碼 (Issue #796)
  */
 
 export const PASSWORD_MIN_LENGTH = 12;
@@ -22,14 +24,47 @@ export const PASSWORD_RULES = [
 export const PASSWORD_POLICY_DESCRIPTION =
   "密碼須至少 12 字元，包含大寫、小寫、數字及特殊字元";
 
+/** Common weak passwords blacklist — Issue #796 */
+const COMMON_PASSWORDS = new Set([
+  "password123!", "Password123!", "P@ssword1234", "Qwerty12345!",
+  "Admin@123456", "Welcome@1234", "Changeme123!", "Letmein@1234",
+  "123456789Ab!", "Abc@12345678", "Password!234", "Titan@123456",
+  "Test@1234567", "Default@1234",
+]);
+
 /**
  * Validates a password against the full policy.
  * Returns an array of failed rule messages (empty = valid).
  */
 export function validatePassword(password: string): string[] {
-  return PASSWORD_RULES.filter((rule) => !rule.regex.test(password)).map(
-    (rule) => rule.message
+  const failures: string[] = PASSWORD_RULES.filter((rule) => !rule.regex.test(password)).map(
+    (rule) => rule.message as string
   );
+
+  // Check common passwords blacklist
+  if (COMMON_PASSWORDS.has(password)) {
+    failures.push("此密碼過於常見，請選擇更安全的密碼");
+  }
+
+  return failures;
+}
+
+/**
+ * Validate password with email context (Issue #796).
+ * Checks all rules + email local part inclusion.
+ */
+export function validatePasswordWithEmail(password: string, email: string): string[] {
+  const failures = validatePassword(password);
+
+  // Check if password contains email local part
+  if (email) {
+    const localPart = email.split("@")[0]?.toLowerCase();
+    if (localPart && localPart.length >= 3 && password.toLowerCase().includes(localPart)) {
+      failures.push("密碼不可包含您的帳號名稱");
+    }
+  }
+
+  return failures;
 }
 
 /**
@@ -37,4 +72,40 @@ export function validatePassword(password: string): string[] {
  */
 export function isPasswordValid(password: string): boolean {
   return validatePassword(password).length === 0;
+}
+
+/**
+ * Compute password strength score (0-4) for frontend indicator.
+ * 0 = very weak, 1 = weak, 2 = fair, 3 = strong, 4 = very strong
+ */
+export function getPasswordStrength(password: string): {
+  score: number;
+  label: "弱" | "中" | "強";
+  passedRules: number;
+  totalRules: number;
+} {
+  const passedRules = PASSWORD_RULES.filter((rule) => rule.regex.test(password)).length;
+  const totalRules = PASSWORD_RULES.length;
+
+  let score: number;
+  let label: "弱" | "中" | "強";
+
+  if (passedRules <= 2) {
+    score = 1;
+    label = "弱";
+  } else if (passedRules <= 4) {
+    score = 2;
+    label = "中";
+  } else {
+    score = 3;
+    label = "強";
+  }
+
+  // Extra point for length > 16
+  if (password.length >= 16 && passedRules === totalRules) {
+    score = 4;
+    label = "強";
+  }
+
+  return { score, label, passedRules, totalRules };
 }

--- a/validators/shared/password.ts
+++ b/validators/shared/password.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared password validation schema — Issue #796 (AU-2)
+ *
+ * Used by both frontend and backend. Exports a Zod schema
+ * and a context-aware validator that checks email inclusion.
+ */
+
+import { z } from "zod";
+import {
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_RULES,
+  PASSWORD_POLICY_DESCRIPTION,
+  validatePasswordWithEmail,
+} from "@/lib/password-policy";
+
+/**
+ * Basic password schema (no email context).
+ * For forms where email is not available.
+ */
+export const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, `密碼至少 ${PASSWORD_MIN_LENGTH} 個字元`)
+  .refine(
+    (pw) => PASSWORD_RULES.every((rule) => rule.regex.test(pw)),
+    { message: PASSWORD_POLICY_DESCRIPTION }
+  );
+
+/**
+ * Password + email validation (with email local part check).
+ * Use this in registration/change-password forms.
+ */
+export const passwordWithEmailSchema = z.object({
+  password: z.string().min(PASSWORD_MIN_LENGTH),
+  email: z.string().email(),
+}).refine(
+  (data) => validatePasswordWithEmail(data.password, data.email).length === 0,
+  {
+    message: "密碼不符合安全規則",
+    path: ["password"],
+  }
+);
+
+export type PasswordInput = z.infer<typeof passwordSchema>;


### PR DESCRIPTION
## Summary
- 增強密碼驗證：email local part 檢查、常見弱密碼黑名單
- 密碼強度評分（弱/中/強）供前端即時顯示
- 建立 `validators/shared/password.ts` 前後端共用
- 新增 `PasswordStrengthIndicator` 前端元件

## QA Review
- [x] `npx tsc --noEmit` — 0 new errors
- [x] 21 new tests: basic rules, blacklist, email check, strength scoring, boundary values
- [x] Backward compatible: isPasswordValid() unchanged
- [x] Unicode handling: email local part check is case-insensitive
- [x] No secrets committed

Closes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)