### PR TITLE
feat(admin): AD-1 user CRUD with search, filters, protections

### DIFF
--- a/__tests__/api/user-crud-enhanced.test.ts
+++ b/__tests__/api/user-crud-enhanced.test.ts
@@ -1,0 +1,136 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * User CRUD Enhancement tests — Issue #800 (AD-1)
+ */
+
+const mockAuthFn = jest.fn();
+jest.mock("@/auth", () => ({ auth: (...args: unknown[]) => mockAuthFn(...args) }));
+
+const mockUserFindMany = jest.fn().mockResolvedValue([]);
+const mockUserFindUnique = jest.fn();
+const mockUserCount = jest.fn();
+const mockUserUpdate = jest.fn();
+const mockUserCreate = jest.fn();
+const mockTaskFindMany = jest.fn().mockResolvedValue([]);
+const mockAuditCreate = jest.fn().mockResolvedValue({});
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findMany: (...args: unknown[]) => mockUserFindMany(...args),
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      count: (...args: unknown[]) => mockUserCount(...args),
+      update: (...args: unknown[]) => mockUserUpdate(...args),
+      create: (...args: unknown[]) => mockUserCreate(...args),
+    },
+    task: { findMany: (...args: unknown[]) => mockTaskFindMany(...args) },
+    auditLog: { create: (...args: unknown[]) => mockAuditCreate(...args) },
+  },
+}));
+
+jest.mock("@/lib/rate-limiter", () => ({
+  createApiRateLimiter: () => ({}), checkRateLimit: jest.fn(),
+  createLoginRateLimiter: () => ({}),
+  RateLimitError: class extends Error { retryAfter = 60; },
+}));
+jest.mock("@/lib/csrf", () => ({ validateCsrf: jest.fn(), CsrfError: class extends Error {} }));
+jest.mock("@/lib/logger", () => ({ logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() } }));
+jest.mock("@/lib/request-logger", () => ({ requestLogger: (_req: unknown, fn: () => unknown) => fn() }));
+
+import { UserService } from "@/services/user-service";
+import { ValidationError } from "@/services/errors";
+
+describe("UserService.listUsers search", () => {
+  const prisma = require("@/lib/prisma").prisma;
+  const svc = new UserService(prisma);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should pass search filter to where clause", async () => {
+    mockUserFindMany.mockResolvedValueOnce([]);
+    await svc.listUsers({ search: "alice" });
+    const call = mockUserFindMany.mock.calls[0][0];
+    expect(call.where.OR).toBeDefined();
+    expect(call.where.OR).toEqual([
+      { name: { contains: "alice", mode: "insensitive" } },
+      { email: { contains: "alice", mode: "insensitive" } },
+    ]);
+  });
+
+  it("should pass role filter", async () => {
+    mockUserFindMany.mockResolvedValueOnce([]);
+    await svc.listUsers({ role: "MANAGER" });
+    expect(mockUserFindMany.mock.calls[0][0].where.role).toBe("MANAGER");
+  });
+});
+
+describe("UserService.suspendUser protections", () => {
+  const prisma = require("@/lib/prisma").prisma;
+  const svc = new UserService(prisma);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should prevent disabling last MANAGER", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({ id: "u1", role: "MANAGER", isActive: true });
+    mockUserCount.mockResolvedValueOnce(1); // only 1 active manager
+
+    await expect(svc.suspendUser("u1")).rejects.toThrow("無法停用最後一位管理員帳號");
+  });
+
+  it("should allow disabling MANAGER when others exist", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({ id: "u1", role: "MANAGER", isActive: true });
+    mockUserCount.mockResolvedValueOnce(2); // 2 active managers
+    mockUserUpdate.mockResolvedValueOnce({ id: "u1", isActive: false, name: "A", email: "a@b.com", role: "MANAGER" });
+
+    const result = await svc.suspendUser("u1");
+    expect(result.isActive).toBe(false);
+  });
+
+  it("should allow disabling ENGINEER without restriction", async () => {
+    mockUserFindUnique.mockResolvedValueOnce({ id: "u2", role: "ENGINEER", isActive: true });
+    mockUserUpdate.mockResolvedValueOnce({ id: "u2", isActive: false, name: "B", email: "b@b.com", role: "ENGINEER" });
+
+    const result = await svc.suspendUser("u2");
+    expect(result.isActive).toBe(false);
+  });
+});
+
+describe("UserService.getPendingTasks", () => {
+  const prisma = require("@/lib/prisma").prisma;
+  const svc = new UserService(prisma);
+
+  it("should query pending tasks for user", async () => {
+    mockTaskFindMany.mockResolvedValueOnce([
+      { id: "t1", title: "Task 1", status: "IN_PROGRESS", dueDate: null },
+    ]);
+    const tasks = await svc.getPendingTasks("u1");
+    expect(tasks).toHaveLength(1);
+    expect(mockTaskFindMany.mock.calls[0][0].where.primaryAssigneeId).toBe("u1");
+  });
+});
+
+describe("GET /api/users with search", () => {
+  const { NextRequest } = require("next/server");
+  let GET: Function;
+
+  beforeAll(async () => {
+    const mod = await import("@/app/api/users/route");
+    GET = mod.GET;
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should pass search param to service", async () => {
+    mockAuthFn.mockResolvedValue({ user: { id: "u1", role: "MANAGER" }, expires: "2099-01-01" });
+    mockUserFindMany.mockResolvedValueOnce([]);
+
+    const req = new NextRequest("http://localhost/api/users?search=alice&role=ENGINEER");
+    await GET(req);
+
+    const call = mockUserFindMany.mock.calls[0][0];
+    expect(call.where.OR).toBeDefined();
+    expect(call.where.role).toBe("ENGINEER");
+  });
+});

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -15,8 +15,10 @@ const auditService = new AuditService(prisma);
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const includeSuspended = searchParams.get("includeSuspended") === "true";
+  const search = searchParams.get("search") ?? undefined;
+  const role = searchParams.get("role") ?? undefined;
 
-  const users = await userService.listUsers({ includeSuspended });
+  const users = await userService.listUsers({ includeSuspended, search, role });
   return success(users);
 });
 

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -8,6 +8,7 @@ export interface ListUsersFilter {
   role?: Role | string;
   isActive?: boolean;
   includeSuspended?: boolean;
+  search?: string; // Issue #800: search by name or email
 }
 
 export interface CreateUserInput {
@@ -43,6 +44,14 @@ export class UserService {
     // unless caller explicitly opts in with includeSuspended
     if (!filter.includeSuspended) {
       where.isActive = true;
+    }
+
+    // Issue #800: search by name or email
+    if (filter.search) {
+      where.OR = [
+        { name: { contains: filter.search, mode: "insensitive" } },
+        { email: { contains: filter.search, mode: "insensitive" } },
+      ];
     }
 
     return this.prisma.user.findMany({
@@ -191,9 +200,33 @@ export class UserService {
     return updated;
   }
 
+  /**
+   * Get pending tasks for a user (Issue #800: show on suspend).
+   */
+  async getPendingTasks(userId: string) {
+    return this.prisma.task.findMany({
+      where: {
+        primaryAssigneeId: userId,
+        status: { in: ["BACKLOG", "TODO", "IN_PROGRESS", "REVIEW"] },
+      },
+      select: { id: true, title: true, status: true, dueDate: true },
+      orderBy: { dueDate: "asc" },
+    });
+  }
+
   async suspendUser(id: string) {
     const existing = await this.prisma.user.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`User not found: ${id}`);
+
+    // Issue #800: prevent disabling the last active MANAGER
+    if (existing.role === "MANAGER") {
+      const activeManagerCount = await this.prisma.user.count({
+        where: { role: "MANAGER", isActive: true },
+      });
+      if (activeManagerCount <= 1) {
+        throw new ValidationError("無法停用最後一位管理員帳號");
+      }
+    }
 
     const updated = await this.prisma.user.update({
       where: { id },


### PR DESCRIPTION
## Summary
- 使用者列表支援 name/email 搜尋（case-insensitive）及角色篩選
- 禁止停用最後一位 MANAGER 帳號
- 新增 getPendingTasks() 方法供停用前顯示待辦清單

## QA Review
- [x] `npx tsc --noEmit` — 0 new errors
- [x] 7 new tests: search filter, role filter, last manager protection, pending tasks
- [x] Backward compatible: existing API callers unchanged
- [x] No secrets committed

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)