### PR TITLE
feat(dashboard): D-1 首頁「我的待辦」清單 #807

### DIFF
--- a/__tests__/api/my-todo-list.test.ts
+++ b/__tests__/api/my-todo-list.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * My Todo List — Issue #807 (D-1)
+ *
+ * Tests the GET /api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW endpoint
+ * used by the dashboard "我的待辦" component.
+ */
+
+import { NextRequest } from "next/server";
+
+// ── Auth mock ─────────────────────────────────────────────────────────
+const mockAuthFn = jest.fn();
+jest.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockAuthFn(...args),
+}));
+
+// ── Prisma mock ─────────────────────────────────────────────────────
+const mockTaskFindMany = jest.fn();
+const mockTaskCount = jest.fn();
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: {
+      findMany: (...args: unknown[]) => mockTaskFindMany(...args),
+      count: (...args: unknown[]) => mockTaskCount(...args),
+    },
+  },
+}));
+
+// ── Import route handler after mocks ────────────────────────────────
+import { GET } from "@/app/api/tasks/route";
+
+function makeRequest(url: string) {
+  return new NextRequest(new URL(url, "http://localhost:3000"));
+}
+
+const NOW = new Date("2026-03-26T10:00:00+08:00");
+
+const TASKS = [
+  {
+    id: "t1",
+    title: "逾期任務",
+    status: "TODO",
+    priority: "P0",
+    dueDate: new Date("2026-03-20"),
+    tags: ["urgent"],
+    primaryAssignee: { id: "u1", name: "王小明", avatar: null },
+    backupAssignee: null,
+    creator: { id: "u1", name: "王小明" },
+    monthlyGoal: null,
+    subTasks: [],
+    deliverables: [],
+    incidentRecord: null,
+    _count: { subTasks: 0, comments: 0 },
+  },
+  {
+    id: "t2",
+    title: "今天截止",
+    status: "IN_PROGRESS",
+    priority: "P1",
+    dueDate: new Date("2026-03-26"),
+    tags: [],
+    primaryAssignee: { id: "u1", name: "王小明", avatar: null },
+    backupAssignee: null,
+    creator: { id: "u1", name: "王小明" },
+    monthlyGoal: null,
+    subTasks: [],
+    deliverables: [],
+    incidentRecord: null,
+    _count: { subTasks: 0, comments: 0 },
+  },
+  {
+    id: "t3",
+    title: "無截止日任務",
+    status: "REVIEW",
+    priority: "P2",
+    dueDate: null,
+    tags: ["feature"],
+    primaryAssignee: { id: "u1", name: "王小明", avatar: null },
+    backupAssignee: null,
+    creator: { id: "u1", name: "王小明" },
+    monthlyGoal: null,
+    subTasks: [],
+    deliverables: [],
+    incidentRecord: null,
+    _count: { subTasks: 0, comments: 0 },
+  },
+];
+
+describe("GET /api/tasks (my todos — D-1)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthFn.mockResolvedValue({
+      user: { id: "u1", name: "王小明", email: "wang@test.com", role: "ENGINEER" },
+      expires: "2099-01-01",
+    });
+    mockTaskFindMany.mockResolvedValue(TASKS);
+    mockTaskCount.mockResolvedValue(TASKS.length);
+  });
+
+  it("returns tasks assigned to current user with statuses TODO, IN_PROGRESS, REVIEW", async () => {
+    const req = makeRequest("/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW&limit=50");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toHaveLength(3);
+    expect(body.data.items[0].id).toBe("t1");
+    expect(body.data.items[1].id).toBe("t2");
+    expect(body.data.items[2].id).toBe("t3");
+  });
+
+  it("does not include DONE tasks", async () => {
+    const req = makeRequest("/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW");
+    await GET(req);
+
+    // Verify the Prisma call filters for the correct statuses
+    const callArgs = mockTaskFindMany.mock.calls[0][0];
+    const statusFilter = callArgs.where.status;
+    expect(statusFilter).toEqual({ in: ["TODO", "IN_PROGRESS", "REVIEW"] });
+  });
+
+  it("resolves assignee=me to the session user id", async () => {
+    const req = makeRequest("/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW");
+    await GET(req);
+
+    const callArgs = mockTaskFindMany.mock.calls[0][0];
+    expect(callArgs.where.OR).toEqual([
+      { primaryAssigneeId: "u1" },
+      { backupAssigneeId: "u1" },
+    ]);
+  });
+
+  it("returns empty array with pagination when no tasks", async () => {
+    mockTaskFindMany.mockResolvedValue([]);
+    mockTaskCount.mockResolvedValue(0);
+
+    const req = makeRequest("/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.data.items).toEqual([]);
+    expect(body.data.pagination.total).toBe(0);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    mockAuthFn.mockResolvedValue(null);
+
+    const req = makeRequest("/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW");
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { Target, ClipboardList, Clock, BarChart3, Users, CalendarClock, AlertTriangle } from "lucide-react";
+import { MyTodoList } from "@/app/components/my-todo-list";
 import { safeFixed, safePct } from "@/lib/safe-number";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
@@ -703,10 +704,10 @@ export default function DashboardPage() {
         <EngineerDashboard />
       )}
 
-      {/* ── Today's Tasks Card (both views) ── */}
+      {/* ── My Todo List (both views, Issue #807) ── */}
       {status !== "loading" && (
         <div className="mt-8">
-          <TodayTasksCard />
+          <MyTodoList />
         </div>
       )}
 

--- a/app/components/my-todo-list.tsx
+++ b/app/components/my-todo-list.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { ClipboardList, AlertTriangle, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
+import { PageEmpty, PageError, SkeletonBar } from "@/app/components/page-states";
+import { formatDate } from "@/lib/format";
+import { TaskDetailModal } from "@/app/components/task-detail-modal";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface TodoTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  dueDate: string | null;
+  tags: string[];
+  primaryAssignee?: { id: string; name: string; avatar?: string | null } | null;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const STATUS_BADGE: Record<string, { label: string; className: string }> = {
+  BACKLOG: { label: "待排", className: "bg-muted text-muted-foreground" },
+  TODO: { label: "待辦", className: "bg-blue-500/10 text-blue-500" },
+  IN_PROGRESS: { label: "進行中", className: "bg-yellow-500/10 text-yellow-500" },
+  REVIEW: { label: "待審核", className: "bg-purple-500/10 text-purple-500" },
+};
+
+const PRIORITY_DOT: Record<string, string> = {
+  P0: "bg-danger",
+  P1: "bg-warning",
+  P2: "bg-yellow-400",
+  P3: "bg-muted-foreground",
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function dueCountdownText(dueDate: string): { text: string; urgent: boolean } {
+  const now = new Date();
+  const due = new Date(dueDate);
+  const diffMs = due.getTime() - now.getTime();
+  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays < 0) return { text: `逾期 ${Math.abs(diffDays)} 天`, urgent: true };
+  if (diffDays === 0) return { text: "今天截止", urgent: true };
+  if (diffDays === 1) return { text: "明天截止", urgent: true };
+  if (diffDays <= 3) return { text: `${diffDays} 天後截止`, urgent: true };
+  return { text: `${diffDays} 天後截止`, urgent: false };
+}
+
+// ── Skeleton ───────────────────────────────────────────────────────────────
+
+function TodoListSkeleton() {
+  return (
+    <div className="bg-card rounded-xl shadow-card p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <SkeletonBar className="h-4 w-4" />
+        <SkeletonBar className="h-4 w-24" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 p-3">
+            <SkeletonBar className="w-2 h-2 rounded-full" />
+            <SkeletonBar className="flex-1 h-4" />
+            <SkeletonBar className="w-12 h-4" />
+            <SkeletonBar className="w-16 h-4" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+interface MyTodoListProps {
+  /** 最多顯示幾筆，0 = 不限 */
+  maxItems?: number;
+}
+
+export function MyTodoList({ maxItems = 0 }: MyTodoListProps) {
+  const [tasks, setTasks] = useState<TodoTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const fetchTodos = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        "/api/tasks?assignee=me&status=TODO,IN_PROGRESS,REVIEW&limit=50"
+      );
+      if (!res.ok) throw new Error("無法載入待辦任務");
+      const body = await res.json();
+      const all: TodoTask[] = extractItems<TodoTask>(body);
+
+      // Sort by dueDate ascending; null dueDate goes last
+      const withDue = all
+        .filter((t) => t.dueDate)
+        .sort(
+          (a, b) =>
+            new Date(a.dueDate!).getTime() - new Date(b.dueDate!).getTime()
+        );
+      const withoutDue = all.filter((t) => !t.dueDate);
+      const sorted = [...withDue, ...withoutDue];
+
+      setTasks(maxItems > 0 ? sorted.slice(0, maxItems) : sorted);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [maxItems]);
+
+  useEffect(() => {
+    fetchTodos();
+  }, [fetchTodos]);
+
+  if (loading) return <TodoListSkeleton />;
+  if (error) return <PageError message={error} onRetry={fetchTodos} className="py-8" />;
+  if (tasks.length === 0) {
+    return (
+      <div className="bg-card rounded-xl shadow-card p-5">
+        <PageEmpty
+          icon={<ClipboardList className="h-8 w-8" />}
+          title="沒有待辦任務"
+          description="目前沒有指派給您的未完成任務，做得好！"
+          className="py-8"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-card rounded-xl shadow-card p-5">
+        <h2 className="text-sm font-medium mb-4 flex items-center gap-2">
+          <ClipboardList className="h-4 w-4 text-primary" />
+          我的待辦
+          <span className="text-xs text-muted-foreground font-normal">
+            （共 {tasks.length} 項）
+          </span>
+        </h2>
+        <div className="space-y-1">
+          {tasks.map((t) => {
+            const countdown = t.dueDate ? dueCountdownText(t.dueDate) : null;
+            const badge = STATUS_BADGE[t.status];
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setSelectedTaskId(t.id)}
+                className="w-full flex items-center gap-3 p-3 rounded-lg hover:bg-accent/60 transition-colors text-left group"
+              >
+                {/* Priority dot */}
+                <span
+                  className={cn(
+                    "w-2 h-2 rounded-full flex-shrink-0",
+                    PRIORITY_DOT[t.priority] ?? "bg-muted-foreground"
+                  )}
+                />
+
+                {/* Title */}
+                <span className="flex-1 text-sm text-foreground truncate">
+                  {t.title}
+                </span>
+
+                {/* Tags */}
+                {t.tags?.length > 0 && (
+                  <div className="hidden sm:flex items-center gap-1 flex-shrink-0">
+                    {t.tags.slice(0, 2).map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[10px] px-1.5 py-0.5 rounded bg-accent text-muted-foreground"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                {/* Status badge */}
+                {badge && (
+                  <span
+                    className={cn(
+                      "text-[10px] font-medium px-1.5 py-0.5 rounded flex-shrink-0",
+                      badge.className
+                    )}
+                  >
+                    {badge.label}
+                  </span>
+                )}
+
+                {/* Due date countdown */}
+                {countdown ? (
+                  <span
+                    className={cn(
+                      "text-[11px] tabular-nums flex-shrink-0 flex items-center gap-1",
+                      countdown.urgent
+                        ? "text-danger font-medium"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {countdown.urgent && (
+                      <AlertTriangle className="h-3 w-3" />
+                    )}
+                    {countdown.text}
+                  </span>
+                ) : (
+                  <span className="text-[11px] text-muted-foreground flex-shrink-0">
+                    無截止日
+                  </span>
+                )}
+
+                {/* Arrow */}
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/40 group-hover:text-muted-foreground flex-shrink-0 transition-colors" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Task Detail Modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdated={fetchTodos}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- 新增 `MyTodoList` 元件，顯示指派給當前使用者的所有未完成任務（TODO, IN_PROGRESS, REVIEW）
- 按到期日升序排列（最緊急在上），null 到期日排最後
- 每筆任務顯示：優先級標記、標題、標籤、狀態 badge、到期倒數
- 點擊任務開啟 `TaskDetailModal`
- 空狀態友善提示、Skeleton loading
- 整合至 Dashboard 主頁，取代原 `TodayTasksCard`

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 新增錯誤
- [x] `npx jest __tests__/api/my-todo-list.test.ts` — 5/5 pass
- [x] AC 全部滿足：未完成任務篩選、到期日排序、標題/狀態/到期日/標籤顯示、點擊開啟詳情、空狀態、skeleton
- [x] Edge cases：null dueDate 排最後、無任務空狀態、未認證 401
- [x] 安全：透過 `withAuth` + `requireAuth` 保護 API
- [x] UI 文字全部繁體中文

## Test plan
- [ ] 登入 ENGINEER 帳號，儀表板應顯示「我的待辦」清單
- [ ] 確認只顯示 TODO/IN_PROGRESS/REVIEW 狀態的任務
- [ ] 確認按到期日排序（最近在上）
- [ ] 點擊任務確認開啟詳情 modal
- [ ] 無任務時確認顯示「沒有待辦任務」

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)