### PR TITLE
feat(dashboard): D-3 逾期任務警示 #809

### DIFF
--- a/__tests__/api/overdue-warnings.test.ts
+++ b/__tests__/api/overdue-warnings.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Overdue Task Warnings — Issue #809 (D-3)
+ *
+ * Tests the overdue detection logic and API usage.
+ * Overdue = dueDate 23:59:59 (Asia/Taipei) has passed AND status !== DONE.
+ */
+
+import { isOverdue, overdueDays } from "@/lib/utils/overdue";
+
+describe("isOverdue (D-3)", () => {
+  // Use a fixed "now" for tests
+  const realDate = Date;
+
+  function mockDate(isoDate: string) {
+    const fixed = new realDate(isoDate);
+    jest.spyOn(globalThis, "Date").mockImplementation((...args: unknown[]) => {
+      if (args.length === 0) return fixed;
+      // @ts-expect-error spread constructor
+      return new realDate(...args);
+    });
+    // Preserve static methods
+    (globalThis.Date as unknown as typeof realDate).now = () => fixed.getTime();
+    (globalThis.Date as unknown as typeof realDate).parse = realDate.parse;
+    (globalThis.Date as unknown as typeof realDate).UTC = realDate.UTC;
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns false when dueDate is null", () => {
+    expect(isOverdue(null, "TODO")).toBe(false);
+  });
+
+  it("returns false when dueDate is undefined", () => {
+    expect(isOverdue(undefined, "TODO")).toBe(false);
+  });
+
+  it("returns false when status is DONE even if past due", () => {
+    // Now = 2026-03-27 10:00 Taipei
+    mockDate("2026-03-27T02:00:00.000Z"); // 10:00 Taipei
+    expect(isOverdue("2026-03-25T00:00:00.000Z", "DONE")).toBe(false);
+  });
+
+  it("returns true when dueDate has passed and status is not DONE", () => {
+    // Now = 2026-03-27 10:00 Taipei, due = 2026-03-25
+    mockDate("2026-03-27T02:00:00.000Z"); // 10:00 Taipei
+    expect(isOverdue("2026-03-25T00:00:00.000Z", "TODO")).toBe(true);
+    expect(isOverdue("2026-03-25T00:00:00.000Z", "IN_PROGRESS")).toBe(true);
+  });
+
+  it("returns false when due date is today and day has not ended in Asia/Taipei", () => {
+    // Now = 2026-03-26 10:00 Taipei (still before 23:59:59)
+    // Due = 2026-03-26
+    mockDate("2026-03-26T02:00:00.000Z"); // 10:00 Taipei
+    expect(isOverdue("2026-03-26T00:00:00.000Z", "TODO")).toBe(false);
+  });
+
+  it("returns true when due date has ended in Asia/Taipei (past 23:59:59)", () => {
+    // Now = 2026-03-27 00:30 Taipei = 2026-03-26 16:30 UTC
+    // Due = 2026-03-26 (23:59:59 Taipei = 15:59:59 UTC, which is < 16:30 UTC)
+    mockDate("2026-03-26T16:30:00.000Z"); // 00:30 next day Taipei
+    expect(isOverdue("2026-03-26T00:00:00.000Z", "TODO")).toBe(true);
+  });
+
+  it("returns false for tasks with no dueDate", () => {
+    mockDate("2026-03-27T02:00:00.000Z");
+    expect(isOverdue(null, "IN_PROGRESS")).toBe(false);
+  });
+});
+
+describe("overdueDays (D-3)", () => {
+  const realDate = Date;
+
+  function mockDate(isoDate: string) {
+    const fixed = new realDate(isoDate);
+    jest.spyOn(globalThis, "Date").mockImplementation((...args: unknown[]) => {
+      if (args.length === 0) return fixed;
+      // @ts-expect-error spread constructor
+      return new realDate(...args);
+    });
+    (globalThis.Date as unknown as typeof realDate).now = () => fixed.getTime();
+    (globalThis.Date as unknown as typeof realDate).parse = realDate.parse;
+    (globalThis.Date as unknown as typeof realDate).UTC = realDate.UTC;
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns 0 when not overdue", () => {
+    mockDate("2026-03-26T02:00:00.000Z");
+    expect(overdueDays("2026-03-26T00:00:00.000Z", "TODO")).toBe(0);
+    expect(overdueDays(null, "TODO")).toBe(0);
+    expect(overdueDays("2026-03-20T00:00:00.000Z", "DONE")).toBe(0);
+  });
+
+  it("calculates correct overdue days", () => {
+    // Now = 2026-03-28 10:00 Taipei, due = 2026-03-25
+    // Overdue by 3 days
+    mockDate("2026-03-28T02:00:00.000Z");
+    expect(overdueDays("2026-03-25T00:00:00.000Z", "TODO")).toBe(3);
+  });
+
+  it("returns 1 for task due yesterday", () => {
+    // Now = 2026-03-27 10:00 Taipei, due = 2026-03-26
+    mockDate("2026-03-27T02:00:00.000Z");
+    expect(overdueDays("2026-03-26T00:00:00.000Z", "IN_PROGRESS")).toBe(1);
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { Target, ClipboardList, Clock, BarChart3, Users, CalendarClock, AlertTriangle } from "lucide-react";
+import { OverdueAlert } from "@/app/components/overdue-alert";
 import { safeFixed, safePct } from "@/lib/safe-number";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
@@ -694,6 +695,13 @@ export default function DashboardPage() {
           {isManager ? "主管視角 — 團隊整體狀況" : "工程師視角 — 我的工作狀況"}
         </p>
       </div>
+
+      {/* ── Overdue Alert (Issue #809, top of dashboard) ── */}
+      {status !== "loading" && (
+        <div className="mb-6">
+          <OverdueAlert />
+        </div>
+      )}
 
       {status === "loading" ? (
         <PageLoading />

--- a/app/components/overdue-alert.tsx
+++ b/app/components/overdue-alert.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { AlertTriangle, ChevronRight, Bell } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
+import { SkeletonBar, PageError } from "@/app/components/page-states";
+import { TaskDetailModal } from "@/app/components/task-detail-modal";
+import { isOverdue, overdueDays } from "@/lib/utils/overdue";
+import { useSession } from "next-auth/react";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface OverdueTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  dueDate: string | null;
+  primaryAssignee?: { id: string; name: string; avatar?: string | null } | null;
+}
+
+// ── Skeleton ───────────────────────────────────────────────────────────────
+
+function OverdueSkeleton() {
+  return (
+    <div className="border border-danger/30 bg-danger/5 rounded-xl p-5">
+      <div className="flex items-center gap-2 mb-3">
+        <SkeletonBar className="h-4 w-4" />
+        <SkeletonBar className="h-4 w-24" />
+        <SkeletonBar className="h-5 w-5 rounded-full" />
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 p-2">
+            <SkeletonBar className="flex-1 h-4" />
+            <SkeletonBar className="w-20 h-4" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function OverdueAlert() {
+  const { data: session } = useSession();
+  const isManager = session?.user?.role === "MANAGER" || session?.user?.role === "ADMIN";
+
+  const [tasks, setTasks] = useState<OverdueTask[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const fetchOverdue = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // Manager sees all team tasks; Engineer sees own only
+      const assigneeParam = isManager ? "" : "assignee=me&";
+      const res = await fetch(
+        `/api/tasks?${assigneeParam}status=BACKLOG,TODO,IN_PROGRESS,REVIEW&limit=100`
+      );
+      if (!res.ok) throw new Error("無法載入逾期任務");
+      const body = await res.json();
+      const all: OverdueTask[] = extractItems<OverdueTask>(body);
+
+      // Filter to overdue only, sort by overdue days descending
+      const overdue = all
+        .filter((t) => isOverdue(t.dueDate, t.status))
+        .sort((a, b) => overdueDays(b.dueDate, b.status) - overdueDays(a.dueDate, a.status));
+
+      setTasks(overdue);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [isManager]);
+
+  useEffect(() => {
+    fetchOverdue();
+  }, [fetchOverdue]);
+
+  if (loading) return <OverdueSkeleton />;
+  if (error) return <PageError message={error} onRetry={fetchOverdue} className="py-4" />;
+  if (tasks.length === 0) return null; // No overdue = no alert shown
+
+  return (
+    <>
+      <div className="border border-danger/30 bg-danger/5 rounded-xl p-5">
+        {/* Header with overdue count badge */}
+        <div className="flex items-center gap-2 mb-4">
+          <AlertTriangle className="h-4 w-4 text-danger" />
+          <h2 className="text-sm font-medium text-danger">逾期任務警示</h2>
+          <span className="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-danger text-white text-[11px] font-bold">
+            {tasks.length}
+          </span>
+          {isManager && (
+            <span className="text-[10px] text-muted-foreground ml-1">（團隊全部）</span>
+          )}
+        </div>
+
+        {/* Overdue task list — sorted by overdue days desc */}
+        <div className="space-y-1">
+          {tasks.map((t) => {
+            const days = overdueDays(t.dueDate, t.status);
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setSelectedTaskId(t.id)}
+                className="w-full flex items-center gap-3 p-2.5 rounded-lg bg-danger/5 hover:bg-danger/10 transition-colors text-left group"
+              >
+                {/* Overdue days */}
+                <span className="text-xs font-bold text-danger tabular-nums flex-shrink-0 w-16">
+                  逾期 {days} 天
+                </span>
+
+                {/* Title */}
+                <span className="flex-1 text-sm text-foreground truncate">
+                  {t.title}
+                </span>
+
+                {/* Assignee (for Manager view) */}
+                {isManager && t.primaryAssignee && (
+                  <span className="text-[11px] text-muted-foreground flex-shrink-0">
+                    {t.primaryAssignee.name}
+                  </span>
+                )}
+
+                {/* Due date */}
+                <span className="text-[11px] text-danger tabular-nums flex-shrink-0">
+                  {t.dueDate
+                    ? new Date(t.dueDate).toLocaleDateString("zh-TW", {
+                        month: "numeric",
+                        day: "numeric",
+                      })
+                    : ""}
+                </span>
+
+                <ChevronRight className="h-3.5 w-3.5 text-danger/40 group-hover:text-danger flex-shrink-0 transition-colors" />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Task Detail Modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdated={fetchOverdue}
+        />
+      )}
+    </>
+  );
+}

--- a/lib/utils/overdue.ts
+++ b/lib/utils/overdue.ts
@@ -1,0 +1,62 @@
+/**
+ * Overdue task utilities — Issue #809 (D-3)
+ *
+ * Overdue definition: dueDate 23:59:59 (Asia/Taipei) has passed,
+ * and the task status is NOT "DONE".
+ *
+ * Asia/Taipei is always UTC+8 (no DST).
+ */
+
+/**
+ * Check if a task is overdue based on its dueDate and status.
+ * A task is overdue when:
+ * - dueDate is not null
+ * - Current time > dueDate 23:59:59 in Asia/Taipei (UTC+8)
+ * - Status is not DONE
+ */
+export function isOverdue(
+  dueDate: string | Date | null | undefined,
+  status: string
+): boolean {
+  if (!dueDate) return false;
+  if (status === "DONE") return false;
+
+  const due = new Date(dueDate);
+  if (isNaN(due.getTime())) return false;
+
+  // Get end of day in Asia/Taipei (UTC+8)
+  // Set due date to 23:59:59.999 in Taipei time, then convert to UTC
+  const taipeiStr = due.toLocaleDateString("en-US", { timeZone: "Asia/Taipei" });
+  const taipeiDay = new Date(taipeiStr);
+  taipeiDay.setHours(23, 59, 59, 999);
+
+  // Convert back to UTC by subtracting UTC+8 offset
+  const endOfDayUtc = new Date(taipeiDay.getTime() - 8 * 60 * 60 * 1000);
+
+  return new Date() > endOfDayUtc;
+}
+
+/**
+ * Calculate the number of overdue days (in Asia/Taipei timezone).
+ * Returns 0 if not overdue.
+ */
+export function overdueDays(
+  dueDate: string | Date | null | undefined,
+  status: string
+): number {
+  if (!isOverdue(dueDate, status)) return 0;
+
+  const due = new Date(dueDate!);
+  const now = new Date();
+
+  // Get today's date in Asia/Taipei
+  const nowTaipeiStr = now.toLocaleDateString("en-US", { timeZone: "Asia/Taipei" });
+  const nowTaipei = new Date(nowTaipeiStr);
+
+  // Get due date in Asia/Taipei
+  const dueTaipeiStr = due.toLocaleDateString("en-US", { timeZone: "Asia/Taipei" });
+  const dueTaipei = new Date(dueTaipeiStr);
+
+  const diffMs = nowTaipei.getTime() - dueTaipei.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}


### PR DESCRIPTION
## Summary
- 新增 `lib/utils/overdue.ts`：逾期判定邏輯（Asia/Taipei 23:59:59 過後 + 狀態非完成）
- 新增 `OverdueAlert` 元件：紅色警示區塊 + 逾期數量 badge
- 逾期清單按逾期天數降序排列（逾期最久的在最上面）
- Manager 看團隊所有逾期任務，Engineer 看個人
- 點擊任務開啟詳情 modal
- 整合至 Dashboard 頂部（最醒目位置）

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 新增錯誤
- [x] `npx jest __tests__/api/overdue-warnings.test.ts` — 10/10 pass
- [x] AC 全部滿足：紅色標示、逾期定義正確、badge 數字、逾期天數排序、Manager 團隊視圖
- [x] Edge cases：null dueDate 不算逾期、DONE 狀態不算逾期、當天 23:59:59 前不算逾期
- [x] 時區：Asia/Taipei UTC+8 正確處理（含邊界測試）
- [x] 安全：透過 `withAuth` 保護 API
- [x] UI 文字全部繁體中文

## Test plan
- [ ] 建立一個已過期的任務，確認儀表板頂部出現紅色逾期警示
- [ ] 確認逾期天數計算正確
- [ ] 確認當天截止的任務在 23:59:59 前不會標記為逾期
- [ ] DONE 狀態的任務即使過期也不應出現
- [ ] Manager 可看到所有成員的逾期任務

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)