### PR TITLE
feat(activity): AF-2 動態時間軸 UI #810

### DIFF
--- a/__tests__/api/activity-timeline.test.ts
+++ b/__tests__/api/activity-timeline.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Activity Timeline — Issue #810 (AF-2)
+ *
+ * Tests the activity formatter and date grouping utilities.
+ */
+
+import {
+  formatActivityDescription,
+  getDateGroupLabel,
+} from "@/lib/utils/activity-formatter";
+
+describe("formatActivityDescription (AF-2)", () => {
+  it("formats a CREATE action with resource name", () => {
+    const result = formatActivityDescription({
+      action: "CREATE",
+      userName: "王小明",
+      resourceType: "Task",
+      resourceName: "修復登入 bug",
+      detail: null,
+      metadata: null,
+    });
+    expect(result).toBe("王小明 建立了任務『修復登入 bug』");
+  });
+
+  it("formats a STATUS_CHANGE with from/to details", () => {
+    const result = formatActivityDescription({
+      action: "STATUS_CHANGE",
+      userName: "王小明",
+      resourceType: "Task",
+      resourceName: "修復登入 bug",
+      detail: { from: "IN_PROGRESS", to: "REVIEW" },
+      metadata: null,
+    });
+    expect(result).toBe("王小明 將任務『修復登入 bug』狀態從 進行中 改為 待審核");
+  });
+
+  it("formats a STATUS_CHANGED with status-only detail", () => {
+    const result = formatActivityDescription({
+      action: "STATUS_CHANGED",
+      userName: "李大華",
+      resourceType: "Task",
+      resourceName: "部署 v2",
+      detail: { status: "DONE" },
+      metadata: null,
+    });
+    expect(result).toBe("李大華 將任務『部署 v2』狀態改為 已完成");
+  });
+
+  it("handles null userName gracefully", () => {
+    const result = formatActivityDescription({
+      action: "DELETE",
+      userName: null,
+      resourceType: "Document",
+      resourceName: "舊文件",
+      detail: null,
+      metadata: null,
+    });
+    expect(result).toBe("系統 刪除了文件『舊文件』");
+  });
+
+  it("handles unknown action labels", () => {
+    const result = formatActivityDescription({
+      action: "CUSTOM_ACTION",
+      userName: "張三",
+      resourceType: "Task",
+      resourceName: null,
+      detail: null,
+      metadata: null,
+    });
+    expect(result).toBe("張三 CUSTOM_ACTION任務");
+  });
+
+  it("handles unknown resource types", () => {
+    const result = formatActivityDescription({
+      action: "UPDATE",
+      userName: "張三",
+      resourceType: "CustomResource",
+      resourceName: "test",
+      detail: null,
+      metadata: null,
+    });
+    expect(result).toBe("張三 更新了CustomResource『test』");
+  });
+});
+
+describe("getDateGroupLabel (AF-2)", () => {
+  const realDate = Date;
+
+  function mockDate(isoDate: string) {
+    const fixed = new realDate(isoDate);
+    jest.spyOn(globalThis, "Date").mockImplementation((...args: unknown[]) => {
+      if (args.length === 0) return fixed;
+      // @ts-expect-error spread constructor
+      return new realDate(...args);
+    });
+    (globalThis.Date as unknown as typeof realDate).now = () => fixed.getTime();
+    (globalThis.Date as unknown as typeof realDate).parse = realDate.parse;
+    (globalThis.Date as unknown as typeof realDate).UTC = realDate.UTC;
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns '今天' for today's date", () => {
+    // Now = 2026-03-26 14:00 Taipei
+    mockDate("2026-03-26T06:00:00.000Z");
+    expect(getDateGroupLabel("2026-03-26T04:00:00.000Z")).toBe("今天");
+  });
+
+  it("returns '昨天' for yesterday's date", () => {
+    mockDate("2026-03-26T06:00:00.000Z");
+    expect(getDateGroupLabel("2026-03-25T04:00:00.000Z")).toBe("昨天");
+  });
+
+  it("returns 'N 天前' for dates within a week", () => {
+    mockDate("2026-03-26T06:00:00.000Z");
+    expect(getDateGroupLabel("2026-03-23T04:00:00.000Z")).toBe("3 天前");
+  });
+
+  it("returns formatted date for dates older than a week", () => {
+    mockDate("2026-03-26T06:00:00.000Z");
+    const result = getDateGroupLabel("2026-03-10T04:00:00.000Z");
+    // Should contain month and day in Chinese locale
+    expect(result).toMatch(/3月10日/);
+  });
+});

--- a/app/(app)/activity/page.tsx
+++ b/app/(app)/activity/page.tsx
@@ -1,196 +1,32 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Activity, Loader2, ChevronLeft, ChevronRight } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { extractData } from "@/lib/api-client";
-import { PageError, PageEmpty, ListSkeleton } from "@/app/components/page-states";
-import { formatRelative } from "@/lib/format";
+/**
+ * Activity Page — Issue #810 (AF-2)
+ *
+ * Refactored to use ActivityTimeline component with:
+ * - Time-descending display (newest first)
+ * - Human-readable event descriptions
+ * - User avatars
+ * - Date group separators (今天、昨天、更早)
+ * - Infinite scroll (loads 50 per page)
+ * - Skeleton loading + retry on error
+ */
 
-interface ActivityItem {
-  id: string;
-  source: "task_activity" | "audit_log";
-  action: string;
-  userId: string | null;
-  userName: string | null;
-  resourceType: string;
-  resourceId: string | null;
-  resourceName: string | null;
-  detail: unknown;
-  createdAt: string;
-}
-
-interface PaginationMeta {
-  page: number;
-  limit: number;
-  total: number;
-  totalPages: number;
-}
-
-const ACTION_LABELS: Record<string, string> = {
-  CREATE: "建立",
-  UPDATE: "更新",
-  DELETE: "刪除",
-  STATUS_CHANGE: "變更狀態",
-  COMMENT: "留言",
-  ASSIGN: "指派",
-  POST_TASKS: "建立任務",
-  PATCH_TASKS: "更新任務",
-  DELETE_TASK: "刪除任務",
-  ROLE_CHANGE: "角色變更",
-  PASSWORD_CHANGE: "密碼變更",
-  LOGIN_FAILURE: "登入失敗",
-};
-
-function getActionLabel(action: string): string {
-  return ACTION_LABELS[action] ?? action;
-}
-
-const SOURCE_BADGE: Record<string, { label: string; className: string }> = {
-  task_activity: { label: "任務", className: "bg-blue-500/10 text-blue-500" },
-  audit_log: { label: "系統", className: "bg-amber-500/10 text-amber-500" },
-};
+import { ActivityTimeline } from "@/app/components/activity-timeline";
 
 export default function ActivityPage() {
-  const [items, setItems] = useState<ActivityItem[]>([]);
-  const [pagination, setPagination] = useState<PaginationMeta | null>(null);
-  const [page, setPage] = useState(1);
-  const [loading, setLoading] = useState(true);
-  const [fetchError, setFetchError] = useState<string | null>(null);
-
-  const fetchActivity = useCallback(async () => {
-    setLoading(true);
-    setFetchError(null);
-    try {
-      const res = await fetch(`/api/activity?page=${page}&limit=30`);
-      if (!res.ok) throw new Error("活動紀錄載入失敗");
-      const body = await res.json();
-      const data = extractData<{ items: ActivityItem[]; pagination: PaginationMeta }>(body);
-      setItems(data?.items ?? []);
-      setPagination(data?.pagination ?? null);
-    } catch (e) {
-      setFetchError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }, [page]);
-
-  useEffect(() => {
-    fetchActivity();
-  }, [fetchActivity]);
-
   return (
     <div className="flex flex-col h-full gap-4">
       {/* Header */}
       <div className="flex-shrink-0">
         <h1 className="text-xl font-semibold tracking-tight">團隊動態</h1>
         <p className="text-muted-foreground text-sm mt-0.5">
-          查看團隊成員的最新操作紀錄
+          查看團隊成員的最新操作紀錄，按時間倒序排列
         </p>
       </div>
 
-      {/* Content */}
-      {loading ? (
-        <ListSkeleton rows={8} />
-      ) : fetchError ? (
-        <PageError message={fetchError} onRetry={fetchActivity} />
-      ) : items.length === 0 ? (
-        <PageEmpty
-          icon={<Activity className="h-10 w-10" />}
-          title="尚無活動紀錄"
-          description="系統尚未記錄任何操作"
-        />
-      ) : (
-        <>
-          {/* Activity list */}
-          <div className="flex-1 overflow-y-auto space-y-1">
-            {items.map((item) => {
-              const badge = SOURCE_BADGE[item.source];
-              return (
-                <div
-                  key={`${item.source}-${item.id}`}
-                  className="flex items-start gap-3 px-4 py-3 rounded-lg hover:bg-accent/50 transition-colors"
-                >
-                  {/* Timeline dot */}
-                  <div className="mt-1.5 h-2 w-2 rounded-full bg-muted-foreground/40 flex-shrink-0" />
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      {/* Who */}
-                      <span className="text-sm font-medium text-foreground">
-                        {item.userName ?? "系統"}
-                      </span>
-
-                      {/* Action */}
-                      <span className="text-sm text-muted-foreground">
-                        {getActionLabel(item.action)}
-                      </span>
-
-                      {/* Resource */}
-                      {item.resourceName && (
-                        <span className="text-sm font-medium text-foreground truncate max-w-[200px]">
-                          {item.resourceName}
-                        </span>
-                      )}
-
-                      {/* Source badge */}
-                      {badge && (
-                        <span
-                          className={cn(
-                            "text-[10px] font-medium px-1.5 py-0.5 rounded",
-                            badge.className
-                          )}
-                        >
-                          {badge.label}
-                        </span>
-                      )}
-                    </div>
-
-                    {/* Detail */}
-                    {typeof item.detail === "string" && item.detail && (
-                      <p className="text-xs text-muted-foreground mt-0.5 truncate">
-                        {item.detail}
-                      </p>
-                    )}
-
-                    {/* Timestamp */}
-                    <p className="text-xs text-muted-foreground/60 mt-0.5">
-                      {formatRelative(item.createdAt)}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Pagination */}
-          {pagination && pagination.totalPages > 1 && (
-            <div className="flex-shrink-0 flex items-center justify-between px-4 py-2 border-t border-border">
-              <p className="text-xs text-muted-foreground">
-                共 {pagination.total} 筆，第 {pagination.page}/{pagination.totalPages} 頁
-              </p>
-              <div className="flex items-center gap-1">
-                <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page <= 1}
-                  className="p-1 rounded hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                  aria-label="上一頁"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </button>
-                <button
-                  onClick={() => setPage((p) => Math.min(pagination.totalPages, p + 1))}
-                  disabled={page >= pagination.totalPages}
-                  className="p-1 rounded hover:bg-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                  aria-label="下一頁"
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              </div>
-            </div>
-          )}
-        </>
-      )}
+      {/* Timeline content */}
+      <ActivityTimeline />
     </div>
   );
 }

--- a/app/components/activity-item.tsx
+++ b/app/components/activity-item.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { formatRelative, formatDateTime } from "@/lib/format";
+import { formatActivityDescription } from "@/lib/utils/activity-formatter";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ActivityItemData {
+  id: string;
+  source: "task_activity" | "audit_log";
+  action: string;
+  userId: string | null;
+  userName: string | null;
+  resourceType: string;
+  resourceId: string | null;
+  resourceName: string | null;
+  detail: unknown;
+  metadata: unknown;
+  createdAt: string;
+}
+
+// ── Source Badge ────────────────────────────────────────────────────────────
+
+const SOURCE_BADGE: Record<string, { label: string; className: string }> = {
+  task_activity: { label: "任務", className: "bg-blue-500/10 text-blue-500" },
+  audit_log: { label: "系統", className: "bg-amber-500/10 text-amber-500" },
+};
+
+// ── Avatar ─────────────────────────────────────────────────────────────────
+
+function UserAvatar({ name }: { name: string }) {
+  const initial = name.charAt(0).toUpperCase();
+  // Generate a consistent color from the name
+  const colors = [
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-purple-500",
+    "bg-orange-500",
+    "bg-pink-500",
+    "bg-teal-500",
+  ];
+  const colorIdx = name.split("").reduce((acc, c) => acc + c.charCodeAt(0), 0) % colors.length;
+
+  return (
+    <div
+      className={cn(
+        "h-8 w-8 rounded-full flex items-center justify-center text-xs font-medium text-white flex-shrink-0",
+        colors[colorIdx]
+      )}
+    >
+      {initial}
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+interface ActivityItemProps {
+  item: ActivityItemData;
+}
+
+export function ActivityItem({ item }: ActivityItemProps) {
+  const badge = SOURCE_BADGE[item.source];
+  const description = formatActivityDescription({
+    action: item.action,
+    userName: item.userName,
+    resourceType: item.resourceType,
+    resourceName: item.resourceName,
+    detail: item.detail,
+    metadata: item.metadata,
+  });
+
+  const userName = item.userName ?? "系統";
+
+  return (
+    <div className="flex items-start gap-3 px-4 py-3 hover:bg-accent/30 transition-colors rounded-lg">
+      {/* Avatar */}
+      <UserAvatar name={userName} />
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {/* Description */}
+        <p className="text-sm text-foreground leading-relaxed">
+          {description}
+        </p>
+
+        {/* Detail string (if any) */}
+        {typeof item.detail === "string" && item.detail && (
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">
+            {item.detail}
+          </p>
+        )}
+
+        {/* Footer: timestamp + source badge */}
+        <div className="flex items-center gap-2 mt-1">
+          <span
+            className="text-[11px] text-muted-foreground/60 cursor-help"
+            title={formatDateTime(item.createdAt)}
+          >
+            {formatRelative(item.createdAt)}
+          </span>
+          {badge && (
+            <span
+              className={cn(
+                "text-[10px] font-medium px-1.5 py-0.5 rounded",
+                badge.className
+              )}
+            >
+              {badge.label}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/activity-timeline.tsx
+++ b/app/components/activity-timeline.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Activity, Loader2, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { extractData } from "@/lib/api-client";
+import { PageEmpty, ListSkeleton } from "@/app/components/page-states";
+import { ActivityItem, type ActivityItemData } from "@/app/components/activity-item";
+import { getDateGroupLabel } from "@/lib/utils/activity-formatter";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+interface ActivityResponse {
+  items: ActivityItemData[];
+  pagination: PaginationMeta;
+}
+
+// ── Date Group Separator ───────────────────────────────────────────────────
+
+function DateGroupHeader({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-2">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 50;
+
+export function ActivityTimeline() {
+  const [items, setItems] = useState<ActivityItemData[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchPage = useCallback(
+    async (pageNum: number, append: boolean) => {
+      if (append) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
+      setFetchError(null);
+
+      try {
+        const res = await fetch(
+          `/api/activity?page=${pageNum}&limit=${PAGE_SIZE}`
+        );
+        if (!res.ok) throw new Error("活動紀錄載入失敗");
+        const body = await res.json();
+        const data = extractData<ActivityResponse>(body);
+        const newItems = data?.items ?? [];
+        const pagination = data?.pagination;
+
+        if (append) {
+          setItems((prev) => {
+            // Deduplicate by composite key (source + id)
+            const existingKeys = new Set(
+              prev.map((it) => `${it.source}-${it.id}`)
+            );
+            const unique = newItems.filter(
+              (it) => !existingKeys.has(`${it.source}-${it.id}`)
+            );
+            return [...prev, ...unique];
+          });
+        } else {
+          setItems(newItems);
+        }
+
+        const totalPages = pagination?.totalPages ?? 1;
+        setHasMore(pageNum < totalPages);
+      } catch (e) {
+        setFetchError(e instanceof Error ? e.message : "載入失敗");
+      } finally {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+    },
+    []
+  );
+
+  // Initial load
+  useEffect(() => {
+    fetchPage(1, false);
+  }, [fetchPage]);
+
+  // Infinite scroll: observe sentinel
+  useEffect(() => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+    }
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry?.isIntersecting && hasMore && !loadingMore && !loading) {
+          const nextPage = page + 1;
+          setPage(nextPage);
+          fetchPage(nextPage, true);
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    if (sentinelRef.current) {
+      observerRef.current.observe(sentinelRef.current);
+    }
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [hasMore, loadingMore, loading, page, fetchPage]);
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  if (loading && items.length === 0) {
+    return <ListSkeleton rows={8} />;
+  }
+
+  if (fetchError && items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-20">
+        <p className="text-sm text-muted-foreground">{fetchError}</p>
+        <button
+          onClick={() => {
+            setPage(1);
+            fetchPage(1, false);
+          }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-card hover:bg-accent text-foreground rounded-lg border border-border shadow-sm hover:shadow transition-all"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          重試
+        </button>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <PageEmpty
+        icon={<Activity className="h-10 w-10" />}
+        title="尚無活動紀錄"
+        description="系統尚未記錄任何操作，當團隊開始使用後將自動紀錄"
+      />
+    );
+  }
+
+  // Group items by date
+  const grouped: { label: string; items: ActivityItemData[] }[] = [];
+  let currentLabel = "";
+
+  for (const item of items) {
+    const label = getDateGroupLabel(item.createdAt);
+    if (label !== currentLabel) {
+      currentLabel = label;
+      grouped.push({ label, items: [item] });
+    } else {
+      grouped[grouped.length - 1].items.push(item);
+    }
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {grouped.map((group) => (
+        <div key={group.label}>
+          <DateGroupHeader label={group.label} />
+          <div className="space-y-0.5">
+            {group.items.map((item) => (
+              <ActivityItem
+                key={`${item.source}-${item.id}`}
+                item={item}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {/* Loading more indicator */}
+      {loadingMore && (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-primary" />
+          <span className="ml-2 text-xs text-muted-foreground">載入更多...</span>
+        </div>
+      )}
+
+      {/* Error during load more */}
+      {fetchError && items.length > 0 && (
+        <div className="flex items-center justify-center py-4">
+          <button
+            onClick={() => fetchPage(page, true)}
+            className="flex items-center gap-2 px-3 py-1.5 text-xs font-medium bg-card hover:bg-accent text-foreground rounded-lg border border-border"
+          >
+            <RefreshCw className="h-3 w-3" />
+            載入失敗，點擊重試
+          </button>
+        </div>
+      )}
+
+      {/* Infinite scroll sentinel */}
+      {hasMore && !loadingMore && !fetchError && (
+        <div ref={sentinelRef} className="h-4" />
+      )}
+
+      {/* End of list */}
+      {!hasMore && items.length > 0 && (
+        <div className="flex items-center justify-center py-6">
+          <span className="text-xs text-muted-foreground/50">— 已載入全部紀錄 —</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/utils/activity-formatter.ts
+++ b/lib/utils/activity-formatter.ts
@@ -1,0 +1,132 @@
+/**
+ * Activity event description formatter — Issue #810 (AF-2)
+ *
+ * Converts raw activity log entries into human-readable Chinese descriptions.
+ * Example: "王小明 將任務『修復登入 bug』狀態從 進行中 改為 待審核"
+ */
+
+// ── Action → Label mapping ─────────────────────────────────────────────────
+
+const ACTION_LABELS: Record<string, string> = {
+  CREATE: "建立了",
+  UPDATE: "更新了",
+  DELETE: "刪除了",
+  STATUS_CHANGE: "變更了狀態",
+  STATUS_CHANGED: "變更了狀態",
+  COMMENT: "留言於",
+  ASSIGN: "指派了",
+  POST_TASKS: "建立了任務",
+  PATCH_TASKS: "更新了任務",
+  DELETE_TASK: "刪除了任務",
+  ROLE_CHANGE: "變更了角色",
+  PASSWORD_CHANGE: "變更了密碼",
+  LOGIN_FAILURE: "登入失敗",
+  LOGIN: "登入了系統",
+  LOGOUT: "登出了系統",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  BACKLOG: "待排",
+  TODO: "待辦",
+  IN_PROGRESS: "進行中",
+  REVIEW: "待審核",
+  DONE: "已完成",
+};
+
+const RESOURCE_LABELS: Record<string, string> = {
+  Task: "任務",
+  User: "使用者",
+  Document: "文件",
+  AnnualPlan: "年度計畫",
+  MonthlyGoal: "月目標",
+  KPI: "KPI",
+  TimeEntry: "工時紀錄",
+};
+
+// ── Formatter ──────────────────────────────────────────────────────────────
+
+interface ActivityData {
+  action: string;
+  userName: string | null;
+  resourceType: string;
+  resourceName: string | null;
+  detail: unknown;
+  metadata: unknown;
+}
+
+/**
+ * Format an activity event into a human-readable description.
+ */
+export function formatActivityDescription(item: ActivityData): string {
+  const who = item.userName ?? "系統";
+  const actionLabel = ACTION_LABELS[item.action] ?? item.action;
+  const resourceLabel = RESOURCE_LABELS[item.resourceType] ?? item.resourceType;
+  const resourceName = item.resourceName ? `『${item.resourceName}』` : "";
+
+  // Special handling for status changes with detail
+  if (
+    (item.action === "STATUS_CHANGE" || item.action === "STATUS_CHANGED") &&
+    item.detail &&
+    typeof item.detail === "object"
+  ) {
+    const d = item.detail as Record<string, unknown>;
+    const from = d.from || d.oldStatus;
+    const to = d.to || d.status || d.newStatus;
+
+    if (from && to) {
+      const fromLabel = STATUS_LABELS[from as string] ?? from;
+      const toLabel = STATUS_LABELS[to as string] ?? to;
+      return `${who} 將${resourceLabel}${resourceName}狀態從 ${fromLabel} 改為 ${toLabel}`;
+    }
+
+    if (to) {
+      const toLabel = STATUS_LABELS[to as string] ?? to;
+      return `${who} 將${resourceLabel}${resourceName}狀態改為 ${toLabel}`;
+    }
+  }
+
+  // Generic format
+  return `${who} ${actionLabel}${resourceLabel}${resourceName}`;
+}
+
+/**
+ * Group activity items by date label (今天、昨天、更早).
+ * Uses Asia/Taipei timezone.
+ */
+export function getDateGroupLabel(dateStr: string | Date): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+
+  // Get dates in Asia/Taipei
+  const dateTaipei = new Date(
+    date.toLocaleString("en-US", { timeZone: "Asia/Taipei" })
+  );
+  const nowTaipei = new Date(
+    now.toLocaleString("en-US", { timeZone: "Asia/Taipei" })
+  );
+
+  const dateDay = new Date(
+    dateTaipei.getFullYear(),
+    dateTaipei.getMonth(),
+    dateTaipei.getDate()
+  );
+  const today = new Date(
+    nowTaipei.getFullYear(),
+    nowTaipei.getMonth(),
+    nowTaipei.getDate()
+  );
+
+  const diffDays = Math.floor(
+    (today.getTime() - dateDay.getTime()) / (1000 * 60 * 60 * 24)
+  );
+
+  if (diffDays === 0) return "今天";
+  if (diffDays === 1) return "昨天";
+  if (diffDays <= 7) return `${diffDays} 天前`;
+
+  return date.toLocaleDateString("zh-TW", {
+    month: "long",
+    day: "numeric",
+    timeZone: "Asia/Taipei",
+  });
+}


### PR DESCRIPTION
## Summary
- 重構活動頁面，新增 3 個元件：`ActivityTimeline`、`ActivityItem`、`activity-formatter`
- 時間倒序顯示（最新在上），按日期分組（今天、昨天、N 天前、具體日期）
- Infinite scroll：預設載入 50 筆，滾動到底部自動載入更多（IntersectionObserver）
- 每筆事件顯示：使用者頭像/姓名、友善可讀描述、相對時間（hover 顯示完整時間）
- 事件描述中文化（如「王小明 將任務『修復 bug』狀態從 進行中 改為 待審核」）
- Skeleton loading、網路錯誤 retry 按鈕、空狀態提示

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 新增錯誤（pre-existing: task-detail-modal.tsx、subtask-validators.ts）
- [x] `npx jest __tests__/api/activity-timeline.test.ts` — 10/10 pass
- [x] AC 全部滿足：時間倒序、頭像/姓名/描述/相對時間、日期分組、infinite scroll、skeleton、retry
- [x] Edge cases：null userName → 顯示「系統」、未知 action 直接顯示原文、重複項目去重
- [x] 時區：Asia/Taipei 日期分組正確
- [x] 效能：IntersectionObserver 避免不必要渲染
- [x] UI 文字全部繁體中文

## Test plan
- [ ] 開啟動態頁面，確認最新事件在最上方
- [ ] 確認日期分組標籤正確（今天、昨天、更早）
- [ ] 滾動到底部確認自動載入更多
- [ ] hover 時間確認顯示完整日期時間
- [ ] 斷網後確認顯示 retry 按鈕

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)