### PR TITLE
feat(kanban): K-4 快速篩選

### DIFF
--- a/__tests__/components/task-filters.test.tsx
+++ b/__tests__/components/task-filters.test.tsx
@@ -1,26 +1,51 @@
 /**
- * Component tests: TaskFilters
+ * Component tests: TaskFilters — Issue #812 (K-4)
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { TaskFilters } from "@/app/components/task-filters";
+import {
+  TaskFilters,
+  emptyFilters,
+  hasActiveFilters,
+  parseFiltersFromUrl,
+  serializeFiltersToUrl,
+} from "@/app/components/task-filters";
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: jest.fn() }),
+  usePathname: () => "/kanban",
+}));
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-const emptyFilters = { assignee: "", priority: "", category: "" };
-
 describe("TaskFilters", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => [
-        { id: "u1", name: "Alice" },
-        { id: "u2", name: "Bob" },
-      ],
-    } as Response);
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/api/users")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            data: { items: [{ id: "u1", name: "Alice" }, { id: "u2", name: "Bob" }] },
+          }),
+        });
+      }
+      if (url.includes("/api/tasks/tags")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            data: { tags: [{ name: "維運", color: "#3B82F6" }, { name: "開發", color: "#10B981" }] },
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
   });
 
   it("renders filter icon and label", async () => {
@@ -36,7 +61,6 @@ describe("TaskFilters", () => {
     });
     expect(screen.getByText("所有優先度")).toBeInTheDocument();
     expect(screen.getByText("P0 緊急")).toBeInTheDocument();
-    expect(screen.getByText("P1 高")).toBeInTheDocument();
   });
 
   it("renders category select with options", async () => {
@@ -45,38 +69,21 @@ describe("TaskFilters", () => {
     });
     expect(screen.getByText("所有分類")).toBeInTheDocument();
     expect(screen.getByText("原始規劃")).toBeInTheDocument();
-    expect(screen.getByText("突發事件")).toBeInTheDocument();
   });
 
-  it("loads and renders users in assignee select", async () => {
+  it("renders tag filter button", async () => {
     await act(async () => {
       render(<TaskFilters filters={emptyFilters} onChange={jest.fn()} />);
     });
-    await waitFor(() => {
-      expect(screen.getByText("Alice")).toBeInTheDocument();
-      expect(screen.getByText("Bob")).toBeInTheDocument();
-    });
+    expect(screen.getByText("標籤")).toBeInTheDocument();
   });
 
-  it("calls onChange when priority is changed", async () => {
-    const handleChange = jest.fn();
+  it("renders date range inputs", async () => {
     await act(async () => {
-      render(<TaskFilters filters={emptyFilters} onChange={handleChange} />);
+      render(<TaskFilters filters={emptyFilters} onChange={jest.fn()} />);
     });
-    const selects = screen.getAllByRole("combobox");
-    // Priority is the second select (after assignee)
-    fireEvent.change(selects[1], { target: { value: "P1" } });
-    expect(handleChange).toHaveBeenCalledWith({ assignee: "", priority: "P1", category: "" });
-  });
-
-  it("calls onChange when category is changed", async () => {
-    const handleChange = jest.fn();
-    await act(async () => {
-      render(<TaskFilters filters={emptyFilters} onChange={handleChange} />);
-    });
-    const selects = screen.getAllByRole("combobox");
-    fireEvent.change(selects[2], { target: { value: "INCIDENT" } });
-    expect(handleChange).toHaveBeenCalledWith({ assignee: "", priority: "", category: "INCIDENT" });
+    expect(screen.getByLabelText("到期日起始")).toBeInTheDocument();
+    expect(screen.getByLabelText("到期日結束")).toBeInTheDocument();
   });
 
   it("does not show clear button when no active filters", async () => {
@@ -88,7 +95,24 @@ describe("TaskFilters", () => {
 
   it("shows clear button when filter is active", async () => {
     await act(async () => {
-      render(<TaskFilters filters={{ assignee: "u1", priority: "", category: "" }} onChange={jest.fn()} />);
+      render(
+        <TaskFilters
+          filters={{ ...emptyFilters, assignee: "u1" }}
+          onChange={jest.fn()}
+        />
+      );
+    });
+    expect(screen.getByText("清除篩選")).toBeInTheDocument();
+  });
+
+  it("shows clear button when tags are active", async () => {
+    await act(async () => {
+      render(
+        <TaskFilters
+          filters={{ ...emptyFilters, tags: ["維運"] }}
+          onChange={jest.fn()}
+        />
+      );
     });
     expect(screen.getByText("清除篩選")).toBeInTheDocument();
   });
@@ -96,9 +120,98 @@ describe("TaskFilters", () => {
   it("calls onChange with cleared filters when clear is clicked", async () => {
     const handleChange = jest.fn();
     await act(async () => {
-      render(<TaskFilters filters={{ assignee: "u1", priority: "P0", category: "" }} onChange={handleChange} />);
+      render(
+        <TaskFilters
+          filters={{ ...emptyFilters, assignee: "u1", priority: "P0" }}
+          onChange={handleChange}
+        />
+      );
     });
     fireEvent.click(screen.getByText("清除篩選"));
-    expect(handleChange).toHaveBeenCalledWith({ assignee: "", priority: "", category: "" });
+    expect(handleChange).toHaveBeenCalledWith(emptyFilters);
+  });
+
+  it("shows filter count when totalCount and filteredCount provided", async () => {
+    await act(async () => {
+      render(
+        <TaskFilters
+          filters={{ ...emptyFilters, priority: "P0" }}
+          onChange={jest.fn()}
+          totalCount={45}
+          filteredCount={12}
+        />
+      );
+    });
+    expect(screen.getByText("顯示 12/45 筆任務")).toBeInTheDocument();
+  });
+
+  it("does not show filter count when no active filters", async () => {
+    await act(async () => {
+      render(
+        <TaskFilters
+          filters={emptyFilters}
+          onChange={jest.fn()}
+          totalCount={45}
+          filteredCount={45}
+        />
+      );
+    });
+    expect(screen.queryByText(/筆任務/)).not.toBeInTheDocument();
+  });
+});
+
+describe("hasActiveFilters", () => {
+  it("returns false for empty filters", () => {
+    expect(hasActiveFilters(emptyFilters)).toBe(false);
+  });
+
+  it("returns true when assignee set", () => {
+    expect(hasActiveFilters({ ...emptyFilters, assignee: "u1" })).toBe(true);
+  });
+
+  it("returns true when tags set", () => {
+    expect(hasActiveFilters({ ...emptyFilters, tags: ["維運"] })).toBe(true);
+  });
+
+  it("returns true when dueDateFrom set", () => {
+    expect(hasActiveFilters({ ...emptyFilters, dueDateFrom: "2026-01-01" })).toBe(true);
+  });
+});
+
+describe("URL serialization", () => {
+  it("serializes filters to query string", () => {
+    const qs = serializeFiltersToUrl({
+      assignee: "u1",
+      priority: "P0",
+      category: "",
+      tags: ["維運", "開發"],
+      dueDateFrom: "2026-01-01",
+      dueDateTo: "2026-12-31",
+    });
+    expect(qs).toContain("assignee=u1");
+    expect(qs).toContain("priority=P0");
+    expect(qs).not.toContain("category=");
+    expect(qs).toContain("tags=");
+    expect(qs).toContain("dueDateFrom=2026-01-01");
+    expect(qs).toContain("dueDateTo=2026-12-31");
+  });
+
+  it("returns empty string for empty filters", () => {
+    expect(serializeFiltersToUrl(emptyFilters)).toBe("");
+  });
+
+  it("parses filters from URL search params", () => {
+    const params = new URLSearchParams("assignee=u1&priority=P0&tags=維運,開發&dueDateFrom=2026-01-01");
+    const parsed = parseFiltersFromUrl(params);
+    expect(parsed.assignee).toBe("u1");
+    expect(parsed.priority).toBe("P0");
+    expect(parsed.tags).toEqual(["維運", "開發"]);
+    expect(parsed.dueDateFrom).toBe("2026-01-01");
+    expect(parsed.dueDateTo).toBe("");
+  });
+
+  it("parses empty URL as empty filters", () => {
+    const parsed = parseFiltersFromUrl(new URLSearchParams());
+    expect(parsed).toEqual(emptyFilters);
   });
 });

--- a/__tests__/pages/kanban-extended.test.tsx
+++ b/__tests__/pages/kanban-extended.test.tsx
@@ -28,6 +28,8 @@ jest.mock("@/app/components/task-card", () => ({
 }));
 jest.mock("@/app/components/task-filters", () => ({
   TaskFilters: () => <div data-testid="task-filters" />,
+  emptyFilters: { assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" },
+  hasActiveFilters: () => false,
 }));
 jest.mock("@/app/components/task-detail-modal", () => ({
   TaskDetailModal: () => <div data-testid="task-detail-modal" />,

--- a/__tests__/pages/kanban.test.tsx
+++ b/__tests__/pages/kanban.test.tsx
@@ -20,6 +20,8 @@ jest.mock("@/app/components/task-card", () => ({
 }));
 jest.mock("@/app/components/task-filters", () => ({
   TaskFilters: () => <div data-testid="task-filters" />,
+  emptyFilters: { assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" },
+  hasActiveFilters: () => false,
 }));
 jest.mock("@/app/components/task-detail-modal", () => ({
   TaskDetailModal: () => <div data-testid="task-detail-modal" />,

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -17,7 +17,7 @@ import { Plus, Kanban, Loader2, CheckSquare, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractItems } from "@/lib/api-client";
 import { type TaskCardData } from "@/app/components/task-card";
-import { TaskFilters, type TaskFilters as FiltersType } from "@/app/components/task-filters";
+import { TaskFilters, type TaskFilters as FiltersType, emptyFilters, hasActiveFilters } from "@/app/components/task-filters";
 import { TaskDetailModal } from "@/app/components/task-detail-modal";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { KanbanColumn } from "@/app/components/kanban-column";
@@ -91,7 +91,8 @@ export default function KanbanPage() {
   const [tasks, setTasks] = useState<(TaskCardData & { position?: number })[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [filters, setFilters] = useState<FiltersType>({ assignee: "", priority: "", category: "" });
+  const [allTasks, setAllTasks] = useState<(TaskCardData & { position?: number })[]>([]);
+  const [filters, setFilters] = useState<FiltersType>({ ...emptyFilters });
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<TaskStatus | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -122,7 +123,29 @@ export default function KanbanPage() {
       const res = await fetch(`/api/tasks?${params}`);
       if (!res.ok) throw new Error("任務載入失敗");
       const body = await res.json();
-      setTasks(extractItems<TaskCardData & { position?: number }>(body));
+      const fetched = extractItems<TaskCardData & { position?: number; tags?: string[]; dueDate?: string | null }>(body);
+      setAllTasks(fetched);
+
+      // Client-side AND filtering for tags and dueDate range
+      let filtered = fetched;
+      if (filters.tags.length > 0) {
+        filtered = filtered.filter((t) =>
+          filters.tags.every((tag) => (t as unknown as { tags?: string[] }).tags?.includes(tag))
+        );
+      }
+      if (filters.dueDateFrom) {
+        filtered = filtered.filter((t) => {
+          const due = (t as unknown as { dueDate?: string | null }).dueDate;
+          return due && due.split("T")[0] >= filters.dueDateFrom;
+        });
+      }
+      if (filters.dueDateTo) {
+        filtered = filtered.filter((t) => {
+          const due = (t as unknown as { dueDate?: string | null }).dueDate;
+          return due && due.split("T")[0] <= filters.dueDateTo;
+        });
+      }
+      setTasks(filtered);
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
@@ -405,7 +428,13 @@ export default function KanbanPage() {
 
       {/* Filters */}
       <div className="flex-shrink-0">
-        <TaskFilters filters={filters} onChange={setFilters} />
+        <TaskFilters
+          filters={filters}
+          onChange={setFilters}
+          totalCount={allTasks.length}
+          filteredCount={tasks.length}
+          syncUrl
+        />
       </div>
 
       {/* Bulk action bar */}
@@ -495,7 +524,7 @@ export default function KanbanPage() {
         <div className="flex-1">
           <PageError message={fetchError} onRetry={fetchTasks} />
         </div>
-      ) : tasks.length === 0 && !filters.assignee && !filters.priority && !filters.category ? (
+      ) : tasks.length === 0 && !hasActiveFilters(filters) ? (
         <div className="flex-1">
           <PageEmpty
             icon={<Kanban className="h-10 w-10" />}

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -1,21 +1,41 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Filter, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { extractItems } from "@/lib/api-client";
+import { extractItems, extractData } from "@/lib/api-client";
+import { useRouter, usePathname } from "next/navigation";
 
 export type TaskFilters = {
   assignee: string;
   priority: string;
   category: string;
+  tags: string[];
+  dueDateFrom: string;
+  dueDateTo: string;
+};
+
+export const emptyFilters: TaskFilters = {
+  assignee: "",
+  priority: "",
+  category: "",
+  tags: [],
+  dueDateFrom: "",
+  dueDateTo: "",
 };
 
 type User = { id: string; name: string };
+type TagOption = { name: string; color: string };
 
 interface TaskFiltersProps {
   filters: TaskFilters;
   onChange: (filters: TaskFilters) => void;
+  /** Total tasks count (before filter) */
+  totalCount?: number;
+  /** Filtered tasks count */
+  filteredCount?: number;
+  /** Whether to sync filters to URL query string */
+  syncUrl?: boolean;
 }
 
 const priorities = [
@@ -36,8 +56,52 @@ const categories = [
   { value: "LEARNING", label: "學習成長" },
 ];
 
-export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
+/**
+ * Parse filters from URL search params.
+ */
+export function parseFiltersFromUrl(searchParams: URLSearchParams): TaskFilters {
+  return {
+    assignee: searchParams.get("assignee") ?? "",
+    priority: searchParams.get("priority") ?? "",
+    category: searchParams.get("category") ?? "",
+    tags: searchParams.get("tags")?.split(",").filter(Boolean) ?? [],
+    dueDateFrom: searchParams.get("dueDateFrom") ?? "",
+    dueDateTo: searchParams.get("dueDateTo") ?? "",
+  };
+}
+
+/**
+ * Serialize filters to URL search params string.
+ */
+export function serializeFiltersToUrl(filters: TaskFilters): string {
+  const params = new URLSearchParams();
+  if (filters.assignee) params.set("assignee", filters.assignee);
+  if (filters.priority) params.set("priority", filters.priority);
+  if (filters.category) params.set("category", filters.category);
+  if (filters.tags.length > 0) params.set("tags", filters.tags.join(","));
+  if (filters.dueDateFrom) params.set("dueDateFrom", filters.dueDateFrom);
+  if (filters.dueDateTo) params.set("dueDateTo", filters.dueDateTo);
+  return params.toString();
+}
+
+export function hasActiveFilters(filters: TaskFilters): boolean {
+  return !!(
+    filters.assignee ||
+    filters.priority ||
+    filters.category ||
+    filters.tags.length > 0 ||
+    filters.dueDateFrom ||
+    filters.dueDateTo
+  );
+}
+
+export function TaskFilters({ filters, onChange, totalCount, filteredCount, syncUrl }: TaskFiltersProps) {
   const [users, setUsers] = useState<User[]>([]);
+  const [tags, setTags] = useState<TagOption[]>([]);
+  const [tagDropdownOpen, setTagDropdownOpen] = useState(false);
+
+  const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     fetch("/api/users")
@@ -46,75 +110,175 @@ export function TaskFilters({ filters, onChange }: TaskFiltersProps) {
       .catch(() => {});
   }, []);
 
-  const hasActiveFilters = filters.assignee || filters.priority || filters.category;
+  useEffect(() => {
+    fetch("/api/tasks/tags")
+      .then((r) => r.json())
+      .then((body) => {
+        const data = extractData<{ tags: TagOption[] }>(body);
+        setTags(data?.tags ?? []);
+      })
+      .catch(() => {});
+  }, []);
 
-  const clearFilters = () => onChange({ assignee: "", priority: "", category: "" });
+  // Sync filters to URL
+  useEffect(() => {
+    if (!syncUrl) return;
+    const qs = serializeFiltersToUrl(filters);
+    const newUrl = qs ? `${pathname}?${qs}` : pathname;
+    router.replace(newUrl, { scroll: false });
+  }, [filters, syncUrl, pathname, router]);
+
+  const active = hasActiveFilters(filters);
+
+  const clearFilters = () => onChange({ ...emptyFilters });
+
+  function toggleTag(tagName: string) {
+    const newTags = filters.tags.includes(tagName)
+      ? filters.tags.filter((t) => t !== tagName)
+      : [...filters.tags, tagName];
+    onChange({ ...filters, tags: newTags });
+  }
 
   const selectCls =
     "h-9 bg-card border border-border text-foreground text-sm rounded-lg px-3 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 cursor-pointer hover:border-muted-foreground/30 transition-all shadow-sm";
 
+  const dateCls =
+    "h-9 bg-card border border-border text-foreground text-sm rounded-lg px-2.5 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all shadow-sm";
+
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <div className="flex items-center gap-1.5 text-muted-foreground">
-        <Filter className="h-3.5 w-3.5" />
-        <span className="text-xs font-medium">篩選</span>
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-1.5 text-muted-foreground">
+          <Filter className="h-3.5 w-3.5" />
+          <span className="text-xs font-medium">篩選</span>
+        </div>
+
+        {/* Assignee */}
+        <select
+          aria-label="篩選負責人"
+          value={filters.assignee}
+          onChange={(e) => onChange({ ...filters, assignee: e.target.value })}
+          className={selectCls}
+        >
+          <option value="">所有成員</option>
+          {users.map((u) => (
+            <option key={u.id} value={u.id}>
+              {u.name}
+            </option>
+          ))}
+        </select>
+
+        {/* Priority */}
+        <select
+          aria-label="篩選優先度"
+          value={filters.priority}
+          onChange={(e) => onChange({ ...filters, priority: e.target.value })}
+          className={selectCls}
+        >
+          {priorities.map((p) => (
+            <option key={p.value} value={p.value}>
+              {p.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Category */}
+        <select
+          aria-label="篩選分類"
+          value={filters.category}
+          onChange={(e) => onChange({ ...filters, category: e.target.value })}
+          className={selectCls}
+        >
+          {categories.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+
+        {/* Tags multi-select dropdown */}
+        <div className="relative">
+          <button
+            onClick={() => setTagDropdownOpen((v) => !v)}
+            className={cn(
+              selectCls,
+              "flex items-center gap-1.5 min-w-[100px]",
+              filters.tags.length > 0 && "border-primary/50"
+            )}
+          >
+            標籤
+            {filters.tags.length > 0 && (
+              <span className="bg-primary/20 text-primary text-[10px] font-bold px-1.5 py-0.5 rounded-full">
+                {filters.tags.length}
+              </span>
+            )}
+          </button>
+          {tagDropdownOpen && (
+            <div className="absolute top-full mt-1 left-0 z-50 w-48 bg-card border border-border rounded-lg shadow-xl p-2 max-h-48 overflow-y-auto">
+              {tags.map((tag) => (
+                <label
+                  key={tag.name}
+                  className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-accent/30 cursor-pointer text-xs"
+                >
+                  <input
+                    type="checkbox"
+                    checked={filters.tags.includes(tag.name)}
+                    onChange={() => toggleTag(tag.name)}
+                    className="h-3.5 w-3.5 rounded border-border"
+                  />
+                  <span
+                    className="w-2 h-2 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: tag.color }}
+                  />
+                  <span className="text-foreground">{tag.name}</span>
+                </label>
+              ))}
+              {tags.length === 0 && (
+                <div className="text-xs text-muted-foreground px-2 py-1">無標籤</div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Due date range */}
+        <div className="flex items-center gap-1">
+          <input
+            type="date"
+            aria-label="到期日起始"
+            value={filters.dueDateFrom}
+            onChange={(e) => onChange({ ...filters, dueDateFrom: e.target.value })}
+            className={dateCls}
+          />
+          <span className="text-xs text-muted-foreground">~</span>
+          <input
+            type="date"
+            aria-label="到期日結束"
+            value={filters.dueDateTo}
+            onChange={(e) => onChange({ ...filters, dueDateTo: e.target.value })}
+            className={dateCls}
+          />
+        </div>
+
+        {/* Clear */}
+        {active && (
+          <button
+            onClick={clearFilters}
+            className={cn(
+              "flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors",
+              "px-2 py-1.5 rounded-md border border-border hover:border-border/60 bg-background"
+            )}
+          >
+            <X className="h-3 w-3" />
+            清除篩選
+          </button>
+        )}
       </div>
 
-      {/* Assignee */}
-      <select
-        aria-label="篩選負責人"
-        value={filters.assignee}
-        onChange={(e) => onChange({ ...filters, assignee: e.target.value })}
-        className={selectCls}
-      >
-        <option value="">所有成員</option>
-        {users.map((u) => (
-          <option key={u.id} value={u.id}>
-            {u.name}
-          </option>
-        ))}
-      </select>
-
-      {/* Priority */}
-      <select
-        aria-label="篩選優先度"
-        value={filters.priority}
-        onChange={(e) => onChange({ ...filters, priority: e.target.value })}
-        className={selectCls}
-      >
-        {priorities.map((p) => (
-          <option key={p.value} value={p.value}>
-            {p.label}
-          </option>
-        ))}
-      </select>
-
-      {/* Category */}
-      <select
-        aria-label="篩選分類"
-        value={filters.category}
-        onChange={(e) => onChange({ ...filters, category: e.target.value })}
-        className={selectCls}
-      >
-        {categories.map((c) => (
-          <option key={c.value} value={c.value}>
-            {c.label}
-          </option>
-        ))}
-      </select>
-
-      {/* Clear */}
-      {hasActiveFilters && (
-        <button
-          onClick={clearFilters}
-          className={cn(
-            "flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors",
-            "px-2 py-1.5 rounded-md border border-border hover:border-border/60 bg-background"
-          )}
-        >
-          <X className="h-3 w-3" />
-          清除篩選
-        </button>
+      {/* Filter count indicator */}
+      {active && totalCount !== undefined && filteredCount !== undefined && (
+        <div className="text-xs text-muted-foreground">
+          顯示 {filteredCount}/{totalCount} 筆任務
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- TaskFilters 元件增強：標籤多選、到期日範圍篩選
- 篩選條件為 AND 邏輯
- 篩選狀態同步至 URL query string（可分享）
- 篩選結果數量顯示（「顯示 12/45 筆任務」）
- 清除篩選按鈕

## QA 自審報告
- [x] tsc 0 新增錯誤
- [x] jest 全部通過（2067 passed, 6 skipped）
- [x] AC: 指派人下拉 + 標籤多選 + 到期日範圍
- [x] AC: 即時生效（不需搜尋按鈕）
- [x] AC: 多篩選條件 AND 邏輯
- [x] AC: 清除篩選按鈕
- [x] AC: URL query string 正確序列化/反序列化
- [x] AC: 篩選結果數量顯示

Fixes #812