### PR TITLE
feat(timesheet): 快速填報模板 — 預覽、重命名 (T-3)

### DIFF
--- a/__tests__/api/time-entry-templates.test.ts
+++ b/__tests__/api/time-entry-templates.test.ts
@@ -1,0 +1,257 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Time entry templates — Fixes #833 (T-3)
+ *
+ * Tests:
+ *   - POST creates template with items (max 10 limit)
+ *   - GET returns templates with items
+ *   - PATCH edits template name
+ *   - DELETE removes template
+ *   - POST apply creates entries, skips existing
+ *   - User isolation (can't access others' templates)
+ */
+
+import { createMockRequest } from "../utils/test-utils";
+
+const mockTimeEntryTemplate = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  count: jest.fn(),
+};
+const mockTimeEntry = {
+  findMany: jest.fn(),
+  create: jest.fn(),
+};
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    timeEntryTemplate: mockTimeEntryTemplate,
+    timeEntry: mockTimeEntry,
+  },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+jest.mock("@/lib/logger", () => ({ logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() } }));
+jest.mock("@/lib/request-logger", () => ({ requestLogger: (_req: unknown, fn: () => unknown) => fn() }));
+jest.mock("@/lib/csrf", () => ({ validateCsrf: jest.fn(), CsrfError: class extends Error {} }));
+jest.mock("@/lib/rate-limiter", () => ({
+  createApiRateLimiter: jest.fn(() => ({})),
+  checkRateLimit: jest.fn(),
+  RateLimitError: class extends Error { retryAfter = 60; },
+}));
+jest.mock("@/auth", () => ({ auth: jest.fn() }));
+
+const SESSION = { user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" }, expires: "2099" };
+const OTHER_SESSION = { user: { id: "u2", name: "Other", email: "o@e.com", role: "ENGINEER" }, expires: "2099" };
+
+describe("POST /api/time-entries/templates — create", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("creates template with items and enforces max 10", async () => {
+    mockTimeEntryTemplate.count.mockResolvedValue(0);
+    mockTimeEntryTemplate.create.mockResolvedValue({
+      id: "tpl1",
+      name: "My Template",
+      userId: "u1",
+      entries: "[]",
+      items: [{ id: "i1", hours: 8, category: "PLANNED_TASK", sortOrder: 0 }],
+    });
+
+    const { POST } = await import("@/app/api/time-entries/templates/route");
+    const res = await POST(createMockRequest("/api/time-entries/templates", {
+      method: "POST",
+      body: { name: "My Template", entries: [{ hours: 8, category: "PLANNED_TASK" }] },
+    }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.data.name).toBe("My Template");
+  });
+
+  it("rejects when user has 10 templates", async () => {
+    mockTimeEntryTemplate.count.mockResolvedValue(10);
+
+    const { POST } = await import("@/app/api/time-entries/templates/route");
+    const res = await POST(createMockRequest("/api/time-entries/templates", {
+      method: "POST",
+      body: { name: "Overflow", entries: [{ hours: 4 }] },
+    }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("10");
+  });
+});
+
+describe("GET /api/time-entries/templates — list", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("returns templates with items for current user only", async () => {
+    mockTimeEntryTemplate.findMany.mockResolvedValue([
+      { id: "tpl1", name: "T1", userId: "u1", items: [{ id: "i1", hours: 8 }] },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/templates/route");
+    const res = await GET(createMockRequest("/api/time-entries/templates"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].items).toHaveLength(1);
+
+    // Verify userId filter
+    expect(mockTimeEntryTemplate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "u1" } })
+    );
+  });
+});
+
+describe("PATCH /api/time-entries/templates/[id] — rename", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("renames own template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({ id: "tpl1", userId: "u1", name: "Old" });
+    mockTimeEntryTemplate.update.mockResolvedValue({
+      id: "tpl1", userId: "u1", name: "New Name", items: [],
+    });
+
+    const { PATCH } = await import("@/app/api/time-entries/templates/[id]/route");
+    const context = { params: Promise.resolve({ id: "tpl1" }) };
+    const res = await PATCH(
+      createMockRequest("/api/time-entries/templates/tpl1", { method: "PATCH", body: { name: "New Name" } }),
+      context,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.name).toBe("New Name");
+  });
+
+  it("rejects renaming another user's template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({ id: "tpl2", userId: "u2", name: "Other" });
+
+    const { PATCH } = await import("@/app/api/time-entries/templates/[id]/route");
+    const context = { params: Promise.resolve({ id: "tpl2" }) };
+    const res = await PATCH(
+      createMockRequest("/api/time-entries/templates/tpl2", { method: "PATCH", body: { name: "Hijack" } }),
+      context,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for non-existent template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/time-entries/templates/[id]/route");
+    const context = { params: Promise.resolve({ id: "nope" }) };
+    const res = await PATCH(
+      createMockRequest("/api/time-entries/templates/nope", { method: "PATCH", body: { name: "X" } }),
+      context,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/time-entries/templates/[id]", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("deletes own template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({ id: "tpl1", userId: "u1" });
+    mockTimeEntryTemplate.delete.mockResolvedValue({});
+
+    const { DELETE } = await import("@/app/api/time-entries/templates/[id]/route");
+    const context = { params: Promise.resolve({ id: "tpl1" }) };
+    const res = await DELETE(
+      createMockRequest("/api/time-entries/templates/tpl1", { method: "DELETE" }),
+      context,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects deleting another user's template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({ id: "tpl2", userId: "u2" });
+
+    const { DELETE } = await import("@/app/api/time-entries/templates/[id]/route");
+    const context = { params: Promise.resolve({ id: "tpl2" }) };
+    const res = await DELETE(
+      createMockRequest("/api/time-entries/templates/tpl2", { method: "DELETE" }),
+      context,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/time-entries/templates/[id]/apply", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("applies template, skipping existing tasks on date", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({
+      id: "tpl1",
+      userId: "u1",
+      entries: JSON.stringify([
+        { hours: 8, category: "PLANNED_TASK", taskId: "t1" },
+        { hours: 2, category: "ADMIN", taskId: "t2" },
+      ]),
+    });
+    // t1 already exists on that date
+    mockTimeEntry.findMany.mockResolvedValue([{ taskId: "t1" }]);
+    mockTimeEntry.create.mockResolvedValue({ id: "new1", taskId: "t2", hours: 2 });
+
+    const { POST } = await import("@/app/api/time-entries/templates/[id]/apply/route");
+    const context = { params: Promise.resolve({ id: "tpl1" }) };
+    const res = await POST(
+      createMockRequest("/api/time-entries/templates/tpl1/apply", { method: "POST", body: { date: "2026-03-26" } }),
+      context,
+    );
+    expect(res.status).toBe(201);
+    // Only t2 should have been created (t1 was skipped)
+    expect(mockTimeEntry.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects applying another user's template", async () => {
+    mockTimeEntryTemplate.findUnique.mockResolvedValue({ id: "tpl2", userId: "u2", entries: "[]" });
+
+    const { POST } = await import("@/app/api/time-entries/templates/[id]/apply/route");
+    const context = { params: Promise.resolve({ id: "tpl2" }) };
+    const res = await POST(
+      createMockRequest("/api/time-entries/templates/tpl2/apply", { method: "POST", body: { date: "2026-03-26" } }),
+      context,
+    );
+    expect(res.status).toBe(403);
+  });
+});

--- a/app/api/time-entries/templates/[id]/route.ts
+++ b/app/api/time-entries/templates/[id]/route.ts
@@ -1,13 +1,67 @@
 /**
- * DELETE /api/time-entries/templates/[id] — Delete a template (TS-30)
+ * GET / PATCH / DELETE /api/time-entries/templates/[id] — Template CRUD (TS-30, Issue #833)
  */
 
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
 import { success } from "@/lib/api-response";
 import { NotFoundError, ForbiddenError } from "@/services/errors";
+
+const updateTemplateSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+/** GET — template detail with items (Issue #833) */
+export const GET = withAuth(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+  const { id } = await context.params;
+
+  const template = await prisma.timeEntryTemplate.findUnique({
+    where: { id },
+    include: { items: { orderBy: { sortOrder: "asc" } } },
+  });
+  if (!template) throw new NotFoundError(`Template not found: ${id}`);
+  if ((template as unknown as { userId: string }).userId !== userId) {
+    throw new ForbiddenError("只能查看自己的模板");
+  }
+
+  return success(template);
+});
+
+/** PATCH — edit template name (Issue #833) */
+export const PATCH = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+  const { id } = await context.params;
+
+  const template = await prisma.timeEntryTemplate.findUnique({ where: { id } });
+  if (!template) throw new NotFoundError(`Template not found: ${id}`);
+  if ((template as unknown as { userId: string }).userId !== userId) {
+    throw new ForbiddenError("只能編輯自己的模板");
+  }
+
+  const raw = await req.json();
+  const { name } = validateBody(updateTemplateSchema, raw);
+
+  const updated = await prisma.timeEntryTemplate.update({
+    where: { id },
+    data: { name },
+    include: { items: { orderBy: { sortOrder: "asc" } } },
+  });
+
+  return success(updated);
+});
 
 export const DELETE = withAuth(async (
   _req: NextRequest,

--- a/app/api/time-entries/templates/route.ts
+++ b/app/api/time-entries/templates/route.ts
@@ -33,6 +33,11 @@ export const GET = withAuth(async (_req: NextRequest) => {
   const templates = await prisma.timeEntryTemplate.findMany({
     where: { userId: session.user.id },
     orderBy: { createdAt: "desc" },
+    include: {
+      items: {
+        orderBy: { sortOrder: "asc" },
+      },
+    },
   });
 
   return success(templates);
@@ -56,6 +61,18 @@ export const POST = withAuth(async (req: NextRequest) => {
       name,
       userId,
       entries: JSON.stringify(entries),
+      items: {
+        create: entries.map((e, idx) => ({
+          taskId: e.taskId || null,
+          hours: e.hours,
+          category: e.category ?? "PLANNED_TASK",
+          description: e.description || null,
+          sortOrder: idx,
+        })),
+      },
+    },
+    include: {
+      items: { orderBy: { sortOrder: "asc" } },
     },
   });
 

--- a/app/components/timesheet/template-selector.tsx
+++ b/app/components/timesheet/template-selector.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
-import { FileText, Save, ChevronDown, Trash2, X } from "lucide-react";
+import { FileText, Save, ChevronDown, Trash2, X, Pencil, Check } from "lucide-react";
 import { type TimeEntry } from "./use-timesheet";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -14,11 +14,30 @@ type TemplateEntry = {
   description?: string;
 };
 
+type TemplateItem = {
+  id: string;
+  hours: number;
+  category: string;
+  taskId?: string | null;
+  description?: string | null;
+  sortOrder: number;
+};
+
 type Template = {
   id: string;
   name: string;
   entries: string; // JSON-stringified TemplateEntry[]
+  items?: TemplateItem[];
   createdAt: string;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  PLANNED_TASK: "原始規劃",
+  ADDED_TASK: "追加任務",
+  INCIDENT: "突發事件",
+  SUPPORT: "用戶支援",
+  ADMIN: "行政庶務",
+  LEARNING: "學習成長",
 };
 
 type TemplateSelectorProps = {
@@ -57,6 +76,8 @@ export function TemplateSelector({
   const [saveName, setSaveName] = useState("");
   const [confirmTemplate, setConfirmTemplate] = useState<Template | null>(null);
   const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
   const ref = useRef<HTMLDivElement>(null);
 
   // Load templates
@@ -197,6 +218,22 @@ export function TemplateSelector({
     }
   }
 
+  // Rename template (Issue #833)
+  async function handleRename(templateId: string) {
+    if (!editName.trim()) return;
+    const res = await fetch(`/api/time-entries/templates/${templateId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: editName.trim() }),
+    });
+    if (res.ok) {
+      setTemplates((prev) => prev.map((t) => t.id === templateId ? { ...t, name: editName.trim() } : t));
+      setFeedback({ type: "success", msg: "模板名稱已更新" });
+    }
+    setEditingId(null);
+    setEditName("");
+  }
+
   // Delete template
   async function handleDelete(templateId: string) {
     const res = await fetch(`/api/time-entries/templates/${templateId}`, {
@@ -284,10 +321,25 @@ export function TemplateSelector({
               </div>
             </div>
           ) : confirmTemplate ? (
-            /* Confirmation dialog */
+            /* Confirmation with preview (Issue #833) */
             <div className="space-y-2 p-1" data-testid="template-confirm">
               <div className="text-xs font-medium text-foreground">
-                確定要套用模板「{confirmTemplate.name}」？
+                套用模板「{confirmTemplate.name}」— 預覽
+              </div>
+              {/* Preview items */}
+              <div className="max-h-40 overflow-y-auto space-y-1 border border-border/50 rounded-md p-1.5" data-testid="template-preview">
+                {(() => {
+                  const items = confirmTemplate.items && confirmTemplate.items.length > 0
+                    ? confirmTemplate.items
+                    : parseTemplateEntries(confirmTemplate.entries).map((e, i) => ({ ...e, id: String(i), sortOrder: i, taskId: e.taskId ?? null, description: e.description ?? null, category: e.category ?? "PLANNED_TASK" }));
+                  return items.map((item) => (
+                    <div key={item.id ?? item.sortOrder} className="flex items-center gap-2 text-[11px] text-foreground px-1.5 py-1 rounded bg-muted/30">
+                      <span className="text-muted-foreground w-12 flex-shrink-0">{item.hours}h</span>
+                      <span className="flex-1 truncate">{CATEGORY_LABELS[item.category] ?? item.category}</span>
+                      {item.description && <span className="text-muted-foreground/60 truncate max-w-[80px]">{item.description}</span>}
+                    </div>
+                  ));
+                })()}
               </div>
               <p className="text-[10px] text-muted-foreground">
                 僅填入空白日期，已有記錄的日期不受影響。鎖定的日期將被跳過。
@@ -321,30 +373,59 @@ export function TemplateSelector({
                 </div>
               ) : (
                 templates.map((t) => {
-                  const entryCount = parseTemplateEntries(t.entries).length;
+                  const entryCount = t.items?.length ?? parseTemplateEntries(t.entries).length;
+                  const isEditing = editingId === t.id;
                   return (
                     <div
                       key={t.id}
                       className="flex items-center gap-1 group"
                       data-testid={`template-item-${t.id}`}
                     >
-                      <button
-                        onClick={() => setConfirmTemplate(t)}
-                        className="flex-1 text-left px-2.5 py-1.5 text-xs text-foreground hover:bg-accent/50 rounded-md transition-colors truncate"
-                      >
-                        <span className="font-medium">{t.name}</span>
-                        <span className="text-[10px] text-muted-foreground/60 ml-1.5">
-                          ({entryCount} 筆)
-                        </span>
-                      </button>
-                      <button
-                        onClick={() => handleDelete(t.id)}
-                        className="p-1 text-muted-foreground/40 hover:text-red-400 rounded transition-colors opacity-0 group-hover:opacity-100"
-                        title="刪除模板"
-                        data-testid={`template-delete-${t.id}`}
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </button>
+                      {isEditing ? (
+                        <div className="flex-1 flex items-center gap-1 px-1.5">
+                          <input
+                            type="text"
+                            value={editName}
+                            onChange={(e) => setEditName(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === "Enter") handleRename(t.id); if (e.key === "Escape") setEditingId(null); }}
+                            autoFocus
+                            className="flex-1 bg-background border border-border rounded px-1.5 py-0.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                            data-testid={`template-rename-input-${t.id}`}
+                          />
+                          <button onClick={() => handleRename(t.id)} className="p-0.5 text-emerald-500 hover:text-emerald-400"><Check className="h-3 w-3" /></button>
+                          <button onClick={() => setEditingId(null)} className="p-0.5 text-muted-foreground hover:text-foreground"><X className="h-3 w-3" /></button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setConfirmTemplate(t)}
+                          className="flex-1 text-left px-2.5 py-1.5 text-xs text-foreground hover:bg-accent/50 rounded-md transition-colors truncate"
+                        >
+                          <span className="font-medium">{t.name}</span>
+                          <span className="text-[10px] text-muted-foreground/60 ml-1.5">
+                            ({entryCount} 筆)
+                          </span>
+                        </button>
+                      )}
+                      {!isEditing && (
+                        <>
+                          <button
+                            onClick={() => { setEditingId(t.id); setEditName(t.name); }}
+                            className="p-1 text-muted-foreground/40 hover:text-blue-400 rounded transition-colors opacity-0 group-hover:opacity-100"
+                            title="編輯名稱"
+                            data-testid={`template-edit-${t.id}`}
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(t.id)}
+                            className="p-1 text-muted-foreground/40 hover:text-red-400 rounded transition-colors opacity-0 group-hover:opacity-100"
+                            title="刪除模板"
+                            data-testid={`template-delete-${t.id}`}
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        </>
+                      )}
                     </div>
                   );
                 })


### PR DESCRIPTION
## Summary
- POST `/api/time-entries/templates` 同步建立 `TimeEntryTemplateItem` 記錄
- GET 模板列表包含 items 詳情（供前端預覽）
- 新增 PATCH `/api/time-entries/templates/[id]` 重命名 API
- 新增 GET `/api/time-entries/templates/[id]` 詳情 API
- `TemplateSelector` 套用前顯示預覽清單（AC: 確認後才寫入）
- 模板列表支援 inline 重命名（pencil icon）
- 使用者隔離：所有操作驗證 userId 歸屬

## QA 自審報告
- [x] `tsc --noEmit`: 0 new errors
- [x] `jest time-entry-templates.test.ts`: 10/10 pass
- [x] AC 驗證：儲存/套用/預覽/刪除/重命名/10個上限/使用者隔離
- [x] 套用前顯示預覽，確認後才寫入

## Test plan
- [ ] 建立模板並確認 items 正確儲存
- [ ] 套用模板到有既有記錄的日期，確認跳過邏輯
- [ ] 嘗試超過 10 個模板被拒絕
- [ ] 確認無法操作他人模板

Fixes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)