### PR TITLE
feat(kpi): KP-2 KPI 填報介面

### DIFF
--- a/__mocks__/prisma.ts
+++ b/__mocks__/prisma.ts
@@ -27,6 +27,7 @@ export const mockPrisma = {
   taskActivity: createMockModel(),
   taskChange: createMockModel(),
   kPITaskLink: createMockModel(),
+  kPIAchievement: createMockModel(),
   milestone: createMockModel(),
   subTask: createMockModel(),
   taskAttachment: createMockModel(),

--- a/__tests__/api/kpi-achievement.test.ts
+++ b/__tests__/api/kpi-achievement.test.ts
@@ -1,0 +1,199 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API route tests: /api/kpi/[id]/achievement
+ * Issue #822: KP-2 KPI 填報介面
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+const mockKPI = { findUnique: jest.fn(), update: jest.fn() };
+const mockKPIAchievement = {
+  findMany: jest.fn(),
+  upsert: jest.fn(),
+};
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: { kPI: mockKPI, kPIAchievement: mockKPIAchievement },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+
+const ENGINEER = { user: { id: "eng1", name: "Engineer", email: "eng@test.com", role: "ENGINEER" }, expires: "2099" };
+const ADMIN = { user: { id: "admin1", name: "Admin", email: "admin@test.com", role: "ADMIN" }, expires: "2099" };
+const CREATOR = { user: { id: "creator1", name: "Creator", email: "c@test.com", role: "MANAGER" }, expires: "2099" };
+
+const MOCK_KPI_ACTIVE = {
+  id: "kpi-1",
+  status: "ACTIVE",
+  minValue: 0,
+  maxValue: 100,
+  createdBy: "creator1",
+};
+
+const MOCK_ACHIEVEMENT = {
+  id: "ach-1",
+  kpiId: "kpi-1",
+  period: "2026-01",
+  actualValue: 85,
+  note: "Good",
+  reportedBy: "creator1",
+};
+
+describe("GET /api/kpi/[id]/achievement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(ENGINEER);
+    mockKPI.findUnique.mockResolvedValue(MOCK_KPI_ACTIVE);
+    mockKPIAchievement.findMany.mockResolvedValue([MOCK_ACHIEVEMENT]);
+  });
+
+  it("returns achievement history", async () => {
+    const { GET } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await GET(
+      createMockRequest("/api/kpi/kpi-1/achievement"),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].period).toBe("2026-01");
+  });
+
+  it("returns 404 for non-existent KPI", async () => {
+    mockKPI.findUnique.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await GET(
+      createMockRequest("/api/kpi/x/achievement"),
+      { params: Promise.resolve({ id: "x" }) }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await GET(
+      createMockRequest("/api/kpi/kpi-1/achievement"),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/kpi/[id]/achievement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(CREATOR);
+    mockKPI.findUnique.mockResolvedValue(MOCK_KPI_ACTIVE);
+    mockKPIAchievement.upsert.mockResolvedValue(MOCK_ACHIEVEMENT);
+    mockKPIAchievement.findMany.mockResolvedValue([MOCK_ACHIEVEMENT]);
+    mockKPI.update.mockResolvedValue({});
+  });
+
+  it("creates achievement as KPI creator", async () => {
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 85, note: "Good" },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(201);
+    expect(mockKPIAchievement.upsert).toHaveBeenCalled();
+  });
+
+  it("creates achievement as Admin (non-creator)", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN);
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 85 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 403 for non-creator non-admin", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER);
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 85 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects reporting on non-ACTIVE KPI", async () => {
+    mockKPI.findUnique.mockResolvedValue({ ...MOCK_KPI_ACTIVE, status: "DRAFT" });
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 85 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects value below minValue", async () => {
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: -5 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects value above maxValue", async () => {
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 150 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects empty period", async () => {
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    const res = await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "", actualValue: 85 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("updates KPI actual value after reporting", async () => {
+    const { POST } = await import("@/app/api/kpi/[id]/achievement/route");
+    await POST(
+      createMockRequest("/api/kpi/kpi-1/achievement", {
+        method: "POST",
+        body: { period: "2026-01", actualValue: 85 },
+      }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(mockKPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "kpi-1" },
+        data: { actual: 85 },
+      })
+    );
+  });
+});

--- a/__tests__/api/kpi.test.ts
+++ b/__tests__/api/kpi.test.ts
@@ -3,27 +3,46 @@
  */
 /**
  * API route tests: /api/kpi and /api/kpi/[id]
+ * Enhanced for Sprint 7 KP-1 (#821): new fields, filters, weight validation
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockKPI = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn() };
+const mockKPI = {
+  findMany: jest.fn(),
+  findUnique: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  count: jest.fn(),
+  aggregate: jest.fn(),
+};
+const mockKPITaskLink = { deleteMany: jest.fn() };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { kPI: mockKPI } }));
+jest.mock("@/lib/prisma", () => ({
+  prisma: { kPI: mockKPI, kPITaskLink: mockKPITaskLink },
+}));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
 
-const MEMBER = { user: { id: "u1", name: "Test", email: "t@e.com", role: "MEMBER" }, expires: "2099" };
+const ENGINEER = { user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" }, expires: "2099" };
 const MANAGER = { user: { id: "mgr", name: "Mgr", email: "m@e.com", role: "MANAGER" }, expires: "2099" };
 
 const MOCK_KPI = {
   id: "kpi-1",
-  year: 2024,
+  year: 2026,
   code: "KPI-01",
   title: "Revenue Growth",
+  description: null,
+  measureMethod: "Monthly revenue tracking",
   target: 100,
   actual: 80,
-  weight: 1,
+  weight: 10,
+  frequency: "MONTHLY",
+  minValue: 0,
+  maxValue: 100,
+  unit: "%",
+  visibility: "ALL",
+  status: "ACTIVE",
   autoCalc: false,
   taskLinks: [],
   deliverables: [],
@@ -33,16 +52,18 @@ const MOCK_KPI = {
 describe("GET /api/kpi", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(ENGINEER);
     mockKPI.findMany.mockResolvedValue([MOCK_KPI]);
+    mockKPI.count.mockResolvedValue(1);
   });
 
-  it("returns kpi list when authenticated", async () => {
+  it("returns paginated kpi list when authenticated", async () => {
     const { GET } = await import("@/app/api/kpi/route");
     const res = await GET(createMockRequest("/api/kpi"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("kpi-1");
+    expect(body.data.items[0].id).toBe("kpi-1");
+    expect(body.data.total).toBe(1);
   });
 
   it("returns 401 when no session", async () => {
@@ -55,7 +76,64 @@ describe("GET /api/kpi", () => {
   it("filters by year", async () => {
     const { GET } = await import("@/app/api/kpi/route");
     await GET(createMockRequest("/api/kpi", { searchParams: { year: "2023" } }));
-    expect(mockKPI.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { year: 2023 } }));
+    expect(mockKPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ year: 2023 }),
+      })
+    );
+  });
+
+  it("filters by status", async () => {
+    const { GET } = await import("@/app/api/kpi/route");
+    await GET(createMockRequest("/api/kpi", { searchParams: { status: "DRAFT" } }));
+    expect(mockKPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ status: "DRAFT" }),
+      })
+    );
+  });
+
+  it("filters by frequency", async () => {
+    const { GET } = await import("@/app/api/kpi/route");
+    await GET(createMockRequest("/api/kpi", { searchParams: { frequency: "QUARTERLY" } }));
+    expect(mockKPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ frequency: "QUARTERLY" }),
+      })
+    );
+  });
+
+  it("supports search by title/code", async () => {
+    const { GET } = await import("@/app/api/kpi/route");
+    await GET(createMockRequest("/api/kpi", { searchParams: { search: "revenue" } }));
+    expect(mockKPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            expect.objectContaining({ title: expect.objectContaining({ contains: "revenue" }) }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it("ENGINEER only sees ALL-visibility KPIs", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER);
+    const { GET } = await import("@/app/api/kpi/route");
+    await GET(createMockRequest("/api/kpi"));
+    expect(mockKPI.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ visibility: "ALL" }),
+      })
+    );
+  });
+
+  it("MANAGER sees all KPIs (no visibility filter)", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER);
+    const { GET } = await import("@/app/api/kpi/route");
+    await GET(createMockRequest("/api/kpi"));
+    const callArgs = mockKPI.findMany.mock.calls[0][0];
+    expect(callArgs.where.visibility).toBeUndefined();
   });
 
   it("returns 500 on database error", async () => {
@@ -71,30 +149,54 @@ describe("POST /api/kpi", () => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MANAGER);
     mockKPI.create.mockResolvedValue(MOCK_KPI);
+    mockKPI.aggregate.mockResolvedValue({ _sum: { weight: 0 } });
   });
 
-  it("creates KPI as manager", async () => {
+  it("creates KPI with new fields as manager", async () => {
     const { POST } = await import("@/app/api/kpi/route");
     const res = await POST(createMockRequest("/api/kpi", {
       method: "POST",
-      body: { year: 2024, code: "KPI-01", title: "Revenue Growth", target: 100 },
+      body: {
+        year: 2026, code: "KPI-01", title: "Revenue Growth", target: 100,
+        weight: 10, frequency: "MONTHLY", minValue: 0, maxValue: 100,
+        unit: "%", visibility: "ALL", measureMethod: "Monthly tracking",
+      },
     }));
     expect(res.status).toBe(201);
+    expect(mockKPI.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          frequency: "MONTHLY",
+          visibility: "ALL",
+          measureMethod: "Monthly tracking",
+        }),
+      })
+    );
   });
 
   it("returns 403 for non-manager", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(ENGINEER);
     const { POST } = await import("@/app/api/kpi/route");
     const res = await POST(createMockRequest("/api/kpi", {
       method: "POST",
-      body: { year: 2024, code: "KPI-01", title: "Revenue Growth", target: 100 },
+      body: { year: 2026, code: "KPI-01", title: "Revenue Growth", target: 100 },
     }));
     expect(res.status).toBe(403);
   });
 
   it("returns 400 when required fields missing", async () => {
     const { POST } = await import("@/app/api/kpi/route");
-    const res = await POST(createMockRequest("/api/kpi", { method: "POST", body: { year: 2024 } }));
+    const res = await POST(createMockRequest("/api/kpi", { method: "POST", body: { year: 2026 } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects when weight total would exceed 100%", async () => {
+    mockKPI.aggregate.mockResolvedValue({ _sum: { weight: 95 } });
+    const { POST } = await import("@/app/api/kpi/route");
+    const res = await POST(createMockRequest("/api/kpi", {
+      method: "POST",
+      body: { year: 2026, code: "KPI-99", title: "Over Weight", target: 100, weight: 10 },
+    }));
     expect(res.status).toBe(400);
   });
 
@@ -103,7 +205,7 @@ describe("POST /api/kpi", () => {
     const { POST } = await import("@/app/api/kpi/route");
     const res = await POST(createMockRequest("/api/kpi", {
       method: "POST",
-      body: { year: 2024, code: "KPI-01", title: "Revenue Growth", target: 100 },
+      body: { year: 2026, code: "KPI-01", title: "Revenue Growth", target: 100 },
     }));
     expect(res.status).toBe(401);
   });
@@ -112,11 +214,11 @@ describe("POST /api/kpi", () => {
 describe("GET /api/kpi/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(ENGINEER);
     mockKPI.findUnique.mockResolvedValue(MOCK_KPI);
   });
 
-  it("returns kpi by id", async () => {
+  it("returns kpi by id with new fields", async () => {
     const { GET } = await import("@/app/api/kpi/[id]/route");
     const res = await GET(createMockRequest("/api/kpi/kpi-1"), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(200);
@@ -143,7 +245,9 @@ describe("PUT /api/kpi/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MANAGER);
+    mockKPI.findUnique.mockResolvedValue(MOCK_KPI);
     mockKPI.update.mockResolvedValue({ ...MOCK_KPI, actual: 90 });
+    mockKPI.aggregate.mockResolvedValue({ _sum: { weight: 10 } });
   });
 
   it("updates KPI as manager", async () => {
@@ -152,8 +256,28 @@ describe("PUT /api/kpi/[id]", () => {
     expect(res.status).toBe(200);
   });
 
+  it("rejects invalid status transition (ACTIVE -> DRAFT)", async () => {
+    const { PUT } = await import("@/app/api/kpi/[id]/route");
+    const res = await PUT(
+      createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { status: "DRAFT" } }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("allows valid status transition (DRAFT -> ACTIVE)", async () => {
+    mockKPI.findUnique.mockResolvedValue({ ...MOCK_KPI, status: "DRAFT" });
+    mockKPI.update.mockResolvedValue({ ...MOCK_KPI, status: "ACTIVE" });
+    const { PUT } = await import("@/app/api/kpi/[id]/route");
+    const res = await PUT(
+      createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { status: "ACTIVE" } }),
+      { params: Promise.resolve({ id: "kpi-1" }) }
+    );
+    expect(res.status).toBe(200);
+  });
+
   it("returns 403 for non-manager", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(ENGINEER);
     const { PUT } = await import("@/app/api/kpi/[id]/route");
     const res = await PUT(createMockRequest("/api/kpi/kpi-1", { method: "PUT", body: { actual: 90 } }), { params: Promise.resolve({ id: "kpi-1" }) });
     expect(res.status).toBe(403);

--- a/__tests__/api/password-expiry.test.ts
+++ b/__tests__/api/password-expiry.test.ts
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * TDD: Password expiry enforcement — Fixes #834 (AU-5)
+ *
+ * Tests:
+ *   - isPasswordExpired: 90 days boundary
+ *   - daysUntilExpiry: countdown calculation
+ *   - Change-password API: rejects last 5 passwords
+ *   - Change-password API: updates passwordChangedAt
+ *   - Session includes passwordChangedAt for client warning
+ */
+
+describe("password-expiry module", () => {
+  // Use direct import since there's no prisma dependency
+  const { isPasswordExpired, daysUntilExpiry, PASSWORD_MAX_AGE_DAYS } = require("@/lib/password-expiry");
+
+  it("returns true when passwordChangedAt is null", () => {
+    expect(isPasswordExpired(null)).toBe(true);
+  });
+
+  it("returns false when password changed today", () => {
+    expect(isPasswordExpired(new Date())).toBe(false);
+  });
+
+  it("returns true when password changed exactly 90 days ago + 1ms", () => {
+    const expired = new Date(Date.now() - PASSWORD_MAX_AGE_DAYS * 24 * 60 * 60 * 1000 - 1);
+    expect(isPasswordExpired(expired)).toBe(true);
+  });
+
+  it("returns false when password changed 89 days ago", () => {
+    const notExpired = new Date(Date.now() - 89 * 24 * 60 * 60 * 1000);
+    expect(isPasswordExpired(notExpired)).toBe(false);
+  });
+
+  it("daysUntilExpiry returns 0 when null", () => {
+    expect(daysUntilExpiry(null)).toBe(0);
+  });
+
+  it("daysUntilExpiry returns correct countdown", () => {
+    // Changed 83 days ago → 7 days until expiry
+    const changedAt = new Date(Date.now() - 83 * 24 * 60 * 60 * 1000);
+    expect(daysUntilExpiry(changedAt)).toBe(7);
+  });
+
+  it("daysUntilExpiry returns 0 when expired", () => {
+    const expired = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000);
+    expect(daysUntilExpiry(expired)).toBe(0);
+  });
+
+  it("daysUntilExpiry returns 90 when changed just now", () => {
+    const justNow = new Date();
+    expect(daysUntilExpiry(justNow)).toBe(90);
+  });
+});
+
+describe("POST /api/auth/change-password — password history", () => {
+  const mockUser = { findUnique: jest.fn(), update: jest.fn() };
+  const mockPasswordHistory = { findMany: jest.fn(), create: jest.fn() };
+  const mockTransaction = jest.fn();
+  const mockAuditLog = { create: jest.fn() };
+
+  jest.mock("@/lib/prisma", () => ({
+    prisma: {
+      user: mockUser,
+      passwordHistory: mockPasswordHistory,
+      auditLog: mockAuditLog,
+      $transaction: (...args: unknown[]) => mockTransaction(...args),
+    },
+  }));
+
+  const mockCompare = jest.fn();
+  const mockHash = jest.fn();
+  jest.mock("bcryptjs", () => ({
+    compare: (...a: unknown[]) => mockCompare(...a),
+    hash: (...a: unknown[]) => mockHash(...a),
+  }));
+
+  jest.mock("next-auth", () => ({
+    getServerSession: jest.fn(),
+  }));
+
+  jest.mock("@/lib/logger", () => ({ logger: { info: jest.fn(), error: jest.fn() } }));
+  jest.mock("@/auth", () => ({ auth: jest.fn() }));
+
+  const { createMockRequest } = require("../utils/test-utils");
+
+  const SESSION = { user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" }, expires: "2099" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(SESSION);
+  });
+
+  it("rejects if new password matches one of last 5 passwords", async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: "u1",
+      password: "$2a$12$current",
+      passwordChangedAt: new Date(),
+    });
+    // Current password check passes
+    mockCompare.mockImplementation(async (input: string, hash: string) => {
+      if (hash === "$2a$12$current") return true; // current password check
+      if (hash === "$2a$12$old3") return true; // matches old password #3
+      return false;
+    });
+    mockPasswordHistory.findMany.mockResolvedValue([
+      { hash: "$2a$12$old1" },
+      { hash: "$2a$12$old2" },
+      { hash: "$2a$12$old3" },
+      { hash: "$2a$12$old4" },
+      { hash: "$2a$12$old5" },
+    ]);
+
+    const req = createMockRequest("/api/auth/change-password", {
+      method: "POST",
+      body: { currentPassword: "Current1!", newPassword: "MatchesOld3!" },
+    });
+
+    const { POST } = await import("@/app/api/auth/change-password/route");
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.message).toContain("5");
+  });
+
+  it("updates passwordChangedAt and records to PasswordHistory on success", async () => {
+    mockUser.findUnique.mockResolvedValue({
+      id: "u1",
+      password: "$2a$12$current",
+      passwordChangedAt: new Date(),
+    });
+    mockCompare.mockResolvedValue(false);
+    // First call is current password check (true), rest are history checks (false)
+    mockCompare
+      .mockResolvedValueOnce(true) // current password ok
+      .mockResolvedValue(false); // no history match
+    mockPasswordHistory.findMany.mockResolvedValue([]);
+    mockHash.mockResolvedValue("$2a$12$newHash");
+    mockTransaction.mockResolvedValue([]);
+
+    const req = createMockRequest("/api/auth/change-password", {
+      method: "POST",
+      body: { currentPassword: "Current@1234", newPassword: "NewSecure@123" },
+    });
+
+    const { POST } = await import("@/app/api/auth/change-password/route");
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Verify transaction was called (creates password history + updates user)
+    expect(mockTransaction).toHaveBeenCalled();
+    const txCalls = mockTransaction.mock.calls[0][0];
+    expect(txCalls).toHaveLength(2); // passwordHistory.create + user.update
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { auth } = require("@/auth");
+    auth.mockResolvedValue(null);
+
+    const req = createMockRequest("/api/auth/change-password", {
+      method: "POST",
+      body: { currentPassword: "x", newPassword: "y" },
+    });
+
+    const { POST } = await import("@/app/api/auth/change-password/route");
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import { Target, Plus, Unlink, ChevronDown, ChevronRight } from "lucide-react";
+import { Target, Plus, Unlink, ChevronDown, ChevronRight, Search, Filter } from "lucide-react";
 import { z } from "zod";
 import { cn } from "@/lib/utils";
-import { extractItems, extractData } from "@/lib/api-client";
+import { extractData } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { FormError, FormBanner } from "@/app/components/form-error";
-import { safeFixed, safePct } from "@/lib/safe-number";
+import { safePct } from "@/lib/safe-number";
 import { calculateAchievement } from "@/lib/kpi-calculator";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -31,9 +31,15 @@ interface KPI {
   code: string;
   title: string;
   description?: string | null;
+  measureMethod?: string | null;
   target: number;
   actual: number;
   weight: number;
+  frequency: string;
+  minValue?: number | null;
+  maxValue?: number | null;
+  unit?: string | null;
+  visibility: string;
   status: string;
   autoCalc: boolean;
   taskLinks: KPITaskLink[];
@@ -58,16 +64,27 @@ function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: strin
 }
 
 const STATUS_LABEL: Record<string, string> = {
-  ON_TRACK: "進行中",
-  AT_RISK: "風險",
-  BEHIND: "落後",
+  DRAFT: "草稿",
+  ACTIVE: "啟用",
   ACHIEVED: "達成",
+  MISSED: "未達",
+  CANCELLED: "停用",
 };
 const STATUS_COLOR: Record<string, string> = {
-  ON_TRACK: "text-success bg-success/10",
-  AT_RISK: "text-yellow-400 bg-warning/10",
-  BEHIND: "text-danger bg-danger/10",
+  DRAFT: "text-muted-foreground bg-muted",
+  ACTIVE: "text-success bg-success/10",
   ACHIEVED: "text-blue-400 bg-blue-500/10",
+  MISSED: "text-danger bg-danger/10",
+  CANCELLED: "text-muted-foreground bg-muted/50",
+};
+const FREQUENCY_LABEL: Record<string, string> = {
+  MONTHLY: "月報",
+  QUARTERLY: "季報",
+  YEARLY: "年報",
+};
+const VISIBILITY_LABEL: Record<string, string> = {
+  ALL: "全員可見",
+  MANAGER: "僅管理者",
 };
 const TASK_STATUS_LABEL: Record<string, string> = {
   TODO: "待辦",
@@ -83,12 +100,18 @@ const createKpiFormSchema = z.object({
   code: z.string().min(1, "代碼為必填"),
   title: z.string().min(1, "名稱為必填"),
   description: z.string().optional(),
+  measureMethod: z.string().optional(),
   target: z.number().nonnegative("目標值不得為負數"),
-  weight: z.number().positive("權重必須大於 0"),
+  weight: z.number().min(0, "權重不得為負").max(100, "權重不得超過 100"),
+  frequency: z.enum(["MONTHLY", "QUARTERLY", "YEARLY"]),
+  minValue: z.number().optional(),
+  maxValue: z.number().optional(),
+  unit: z.string().optional(),
+  visibility: z.enum(["ALL", "MANAGER"]),
   autoCalc: z.boolean(),
 });
 
-type KpiFormErrors = Partial<Record<keyof z.infer<typeof createKpiFormSchema>, string>>;
+type KpiFormErrors = Partial<Record<string, string>>;
 
 // ── Create KPI Form ────────────────────────────────────────────────────────
 
@@ -104,28 +127,40 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
     code: "",
     title: "",
     description: "",
+    measureMethod: "",
     target: "",
     weight: "1",
+    frequency: "MONTHLY",
+    minValue: "",
+    maxValue: "",
+    unit: "",
+    visibility: "ALL",
     autoCalc: false,
   });
   const [submitting, setSubmitting] = useState(false);
   const [bannerError, setBannerError] = useState("");
   const [fieldErrors, setFieldErrors] = useState<KpiFormErrors>({});
 
-  function validate(): z.infer<typeof createKpiFormSchema> | null {
+  function validate() {
     const result = createKpiFormSchema.safeParse({
       year: parseInt(form.year) || 0,
       code: form.code,
       title: form.title,
       description: form.description || undefined,
+      measureMethod: form.measureMethod || undefined,
       target: parseFloat(form.target),
       weight: parseFloat(form.weight),
+      frequency: form.frequency,
+      minValue: form.minValue ? parseFloat(form.minValue) : undefined,
+      maxValue: form.maxValue ? parseFloat(form.maxValue) : undefined,
+      unit: form.unit || undefined,
+      visibility: form.visibility,
       autoCalc: form.autoCalc,
     });
     if (!result.success) {
       const errs: KpiFormErrors = {};
       for (const issue of result.error.issues) {
-        const field = issue.path[0] as keyof KpiFormErrors;
+        const field = issue.path[0] as string;
         if (field && !errs[field]) errs[field] = issue.message;
       }
       setFieldErrors(errs);
@@ -149,7 +184,7 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
       });
       if (!res.ok) {
         const errBody = await res.json().catch(() => ({}));
-        setBannerError(errBody?.error ?? errBody?.message ?? "建立失敗");
+        setBannerError(errBody?.message ?? errBody?.error ?? "建立失敗");
         return;
       }
       const body = await res.json();
@@ -200,6 +235,16 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
           />
           <FormError message={fieldErrors.title} />
         </div>
+        <div className="col-span-2 space-y-1">
+          <label className="text-xs text-muted-foreground">衡量方式</label>
+          <input
+            type="text"
+            placeholder="如：每月客訴件數"
+            value={form.measureMethod}
+            onChange={(e) => setForm((f) => ({ ...f, measureMethod: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
         <div className="space-y-1">
           <label className="text-xs text-muted-foreground">目標值 *</label>
           <input
@@ -213,7 +258,7 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
           <FormError message={fieldErrors.target} />
         </div>
         <div className="space-y-1">
-          <label className="text-xs text-muted-foreground">權重</label>
+          <label className="text-xs text-muted-foreground">權重 (%)</label>
           <input
             type="number"
             step="0.1"
@@ -223,6 +268,63 @@ function CreateKPIForm({ onCreated, onCancel }: CreateFormProps) {
               fieldErrors.weight ? "border-red-500" : "border-border")}
           />
           <FormError message={fieldErrors.weight} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">最小值</label>
+          <input
+            type="number"
+            placeholder="0"
+            value={form.minValue}
+            onChange={(e) => setForm((f) => ({ ...f, minValue: e.target.value }))}
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.minValue ? "border-red-500" : "border-border")}
+          />
+          <FormError message={fieldErrors.minValue} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">最大值</label>
+          <input
+            type="number"
+            placeholder="100"
+            value={form.maxValue}
+            onChange={(e) => setForm((f) => ({ ...f, maxValue: e.target.value }))}
+            className={cn("w-full bg-accent border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary",
+              fieldErrors.maxValue ? "border-red-500" : "border-border")}
+          />
+          <FormError message={fieldErrors.maxValue} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">單位</label>
+          <input
+            type="text"
+            placeholder="如 %、次、小時"
+            value={form.unit}
+            onChange={(e) => setForm((f) => ({ ...f, unit: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">填報頻率</label>
+          <select
+            value={form.frequency}
+            onChange={(e) => setForm((f) => ({ ...f, frequency: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="MONTHLY">月報</option>
+            <option value="QUARTERLY">季報</option>
+            <option value="YEARLY">年報</option>
+          </select>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs text-muted-foreground">可視權限</label>
+          <select
+            value={form.visibility}
+            onChange={(e) => setForm((f) => ({ ...f, visibility: e.target.value }))}
+            className="w-full bg-accent border border-border rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="ALL">全員可見</option>
+            <option value="MANAGER">僅 Manager + Admin</option>
+          </select>
         </div>
         <div className="col-span-2 space-y-1">
           <label className="text-xs text-muted-foreground">說明</label>
@@ -274,9 +376,10 @@ interface KPICardProps {
   isManager: boolean;
   onUnlink: (kpiId: string, taskId: string) => Promise<void>;
   onRefresh: () => void;
+  onStatusChange: (kpiId: string, newStatus: string) => Promise<void>;
 }
 
-function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
+function KPICard({ kpi, isManager, onUnlink, onStatusChange }: KPICardProps) {
   const [expanded, setExpanded] = useState(false);
   const rate = achievementRate(kpi);
 
@@ -304,20 +407,29 @@ function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
               <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
             )}
             <div className="min-w-0">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs font-mono text-muted-foreground">{kpi.code}</span>
-                {kpi.status && (
-                  <span
-                    className={cn(
-                      "text-[10px] px-1.5 py-0.5 rounded-full font-medium",
-                      STATUS_COLOR[kpi.status] ?? "text-muted-foreground bg-accent"
-                    )}
-                  >
-                    {STATUS_LABEL[kpi.status] ?? kpi.status}
+                <span
+                  className={cn(
+                    "text-[10px] px-1.5 py-0.5 rounded-full font-medium",
+                    STATUS_COLOR[kpi.status] ?? "text-muted-foreground bg-accent"
+                  )}
+                >
+                  {STATUS_LABEL[kpi.status] ?? kpi.status}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {FREQUENCY_LABEL[kpi.frequency] ?? kpi.frequency}
+                </span>
+                {kpi.visibility === "MANAGER" && (
+                  <span className="text-[10px] text-amber-500 bg-amber-500/10 px-1.5 py-0.5 rounded-full">
+                    {VISIBILITY_LABEL.MANAGER}
                   </span>
                 )}
               </div>
               <p className="text-sm font-medium text-foreground mt-0.5">{kpi.title}</p>
+              {kpi.measureMethod && (
+                <p className="text-xs text-muted-foreground mt-0.5">衡量: {kpi.measureMethod}</p>
+              )}
               {kpi.description && (
                 <p className="text-xs text-muted-foreground mt-0.5 truncate">{kpi.description}</p>
               )}
@@ -326,7 +438,7 @@ function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
           <div className="text-right flex-shrink-0">
             <p className="text-lg font-semibold tabular-nums">{safePct(rate, 0)}%</p>
             <p className="text-[10px] text-muted-foreground tabular-nums">
-              {kpi.actual} / {kpi.target}
+              {kpi.actual} / {kpi.target}{kpi.unit ? ` ${kpi.unit}` : ""}
             </p>
           </div>
         </div>
@@ -335,13 +447,38 @@ function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
         </div>
         <div className="mt-2 px-6 flex items-center justify-between text-[11px] text-muted-foreground">
           <span>連結任務 {kpi.taskLinks.length} 項</span>
-          <span>權重 {kpi.weight}</span>
+          <span>權重 {kpi.weight}%</span>
+          {kpi.minValue != null && kpi.maxValue != null && (
+            <span>值域 {kpi.minValue}–{kpi.maxValue}{kpi.unit || ""}</span>
+          )}
         </div>
       </button>
 
-      {/* Expanded: linked tasks */}
+      {/* Expanded: linked tasks + status actions */}
       {expanded && (
         <div className="border-t border-border px-4 pb-4 pt-3 space-y-2">
+          {/* Status actions for Manager */}
+          {isManager && (
+            <div className="flex gap-2 mb-3">
+              {kpi.status === "DRAFT" && (
+                <button
+                  onClick={() => onStatusChange(kpi.id, "ACTIVE")}
+                  className="text-xs px-3 py-1 bg-success/10 text-success rounded-md hover:bg-success/20 transition-colors"
+                >
+                  啟用
+                </button>
+              )}
+              {kpi.status === "ACTIVE" && (
+                <button
+                  onClick={() => onStatusChange(kpi.id, "CANCELLED")}
+                  className="text-xs px-3 py-1 bg-danger/10 text-danger rounded-md hover:bg-danger/20 transition-colors"
+                >
+                  停用
+                </button>
+              )}
+            </div>
+          )}
+
           <p className="text-xs font-medium text-muted-foreground mb-2">連結任務</p>
           {kpi.taskLinks.length === 0 ? (
             <p className="text-sm text-muted-foreground">尚未連結任務</p>
@@ -394,32 +531,42 @@ function KPICard({ kpi, isManager, onUnlink, onRefresh }: KPICardProps) {
 
 export default function KPIPage() {
   const { data: session } = useSession();
-  const isManager = session?.user?.role === "MANAGER";
+  const isManager = session?.user?.role === "MANAGER" || session?.user?.role === "ADMIN";
 
   const [kpis, setKpis] = useState<KPI[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [frequencyFilter, setFrequencyFilter] = useState("");
   const year = new Date().getFullYear();
 
-  async function fetchKPIs() {
+  const fetchKPIs = useCallback(async () => {
     setLoading(true);
     setFetchError(null);
     try {
-      const res = await fetch(`/api/kpi?year=${year}`);
+      const params = new URLSearchParams({ year: String(year) });
+      if (statusFilter) params.set("status", statusFilter);
+      if (frequencyFilter) params.set("frequency", frequencyFilter);
+      if (searchQuery.trim()) params.set("search", searchQuery.trim());
+      const res = await fetch(`/api/kpi?${params}`);
       if (!res.ok) throw new Error("KPI 載入失敗");
       const body = await res.json();
-      setKpis(extractItems<KPI>(body));
+      const data = extractData<{ items: KPI[]; total: number }>(body);
+      setKpis(data.items ?? []);
+      setTotal(data.total ?? 0);
     } catch (e) {
       setFetchError(e instanceof Error ? e.message : "載入失敗");
     } finally {
       setLoading(false);
     }
-  }
+  }, [year, statusFilter, frequencyFilter, searchQuery]);
 
   useEffect(() => {
     fetchKPIs();
-  }, []);
+  }, [fetchKPIs]);
 
   async function handleUnlink(kpiId: string, taskId: string) {
     const res = await fetch(`/api/kpi/${kpiId}/link`, {
@@ -438,8 +585,22 @@ export default function KPIPage() {
     }
   }
 
+  async function handleStatusChange(kpiId: string, newStatus: string) {
+    const res = await fetch(`/api/kpi/${kpiId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: newStatus }),
+    });
+    if (res.ok) {
+      setKpis((prev) =>
+        prev.map((k) => (k.id === kpiId ? { ...k, status: newStatus } : k))
+      );
+    }
+  }
+
   function handleCreated(kpi: KPI) {
     setKpis((prev) => [...prev, { ...kpi, taskLinks: [] }]);
+    setTotal((t) => t + 1);
     setShowForm(false);
   }
 
@@ -470,11 +631,50 @@ export default function KPIPage() {
         )}
       </div>
 
+      {/* Filters & Search */}
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <div className="relative flex-1 min-w-[200px]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder="搜尋 KPI 名稱或代碼..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 bg-accent border border-border rounded-md text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="bg-accent border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="">全部狀態</option>
+            <option value="DRAFT">草稿</option>
+            <option value="ACTIVE">啟用</option>
+            <option value="ACHIEVED">達成</option>
+            <option value="MISSED">未達</option>
+            <option value="CANCELLED">停用</option>
+          </select>
+          <select
+            value={frequencyFilter}
+            onChange={(e) => setFrequencyFilter(e.target.value)}
+            className="bg-accent border border-border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+          >
+            <option value="">全部頻率</option>
+            <option value="MONTHLY">月報</option>
+            <option value="QUARTERLY">季報</option>
+            <option value="YEARLY">年報</option>
+          </select>
+        </div>
+      </div>
+
       {/* Summary */}
       {kpis.length > 0 && (
         <div className="grid grid-cols-3 gap-4 mb-6">
           <div className="bg-card rounded-xl shadow-card p-4 text-center">
-            <p className="text-2xl font-semibold tabular-nums">{kpis.length}</p>
+            <p className="text-2xl font-semibold tabular-nums">{total}</p>
             <p className="text-xs text-muted-foreground mt-1">KPI 總數</p>
           </div>
           <div className="bg-card rounded-xl shadow-card p-4 text-center">
@@ -517,6 +717,7 @@ export default function KPIPage() {
               isManager={isManager}
               onUnlink={handleUnlink}
               onRefresh={fetchKPIs}
+              onStatusChange={handleStatusChange}
             />
           ))}
         </div>

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -1,50 +1,126 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { NotFoundError } from "@/services/errors";
+import { NotFoundError, ValidationError, ForbiddenError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
-import { calculateAchievement } from "@/lib/kpi-calculator";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { createKpiAchievementSchema } from "@/validators/kpi-validators";
+import { hasMinimumRole } from "@/lib/auth/permissions";
 
+/**
+ * GET /api/kpi/:id/achievement — 取得填報歷史
+ */
 export const GET = withAuth(async (
   _req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
-
   const { id } = await context.params;
   const kpi = await prisma.kPI.findUnique({
     where: { id },
-    include: {
-      taskLinks: {
-        include: {
-          task: {
-            select: {
-              id: true,
-              title: true,
-              status: true,
-              progressPct: true,
-              estimatedHours: true,
-              actualHours: true,
-            },
-          },
-        },
-      },
+    select: { id: true, status: true },
+  });
+  if (!kpi) throw new NotFoundError("找不到 KPI");
+
+  const achievements = await prisma.kPIAchievement.findMany({
+    where: { kpiId: id },
+    orderBy: { period: "desc" },
+  });
+
+  return success(achievements);
+});
+
+/**
+ * POST /api/kpi/:id/achievement — 填報 KPI 值
+ * 僅負責人（KPI creator）和 Admin 可填報
+ * 同一週期重複填報為更新（upsert）
+ */
+export const POST = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+
+  const kpi = await prisma.kPI.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      status: true,
+      minValue: true,
+      maxValue: true,
+      createdBy: true,
+    },
+  });
+  if (!kpi) throw new NotFoundError("找不到 KPI");
+
+  // 僅 ACTIVE 的 KPI 可填報
+  if (kpi.status !== "ACTIVE") {
+    throw new ValidationError(
+      JSON.stringify({
+        error: "僅啟用中的 KPI 可以填報",
+        fields: {},
+      })
+    );
+  }
+
+  // 權限：KPI 建立者或 Admin 可填報
+  const isAdmin = hasMinimumRole(session.user.role, "ADMIN");
+  const isCreator = kpi.createdBy === session.user.id;
+  if (!isAdmin && !isCreator) {
+    throw new ForbiddenError("僅 KPI 負責人或 Admin 可填報");
+  }
+
+  const raw = await req.json();
+  const { period, actualValue, note } = validateBody(createKpiAchievementSchema, raw);
+
+  // 值域驗證
+  if (kpi.minValue != null && actualValue < kpi.minValue) {
+    throw new ValidationError(
+      JSON.stringify({
+        error: `填報值 ${actualValue} 低於最小值 ${kpi.minValue}`,
+        fields: { actualValue: [`不可低於 ${kpi.minValue}`] },
+      })
+    );
+  }
+  if (kpi.maxValue != null && actualValue > kpi.maxValue) {
+    throw new ValidationError(
+      JSON.stringify({
+        error: `填報值 ${actualValue} 超過最大值 ${kpi.maxValue}`,
+        fields: { actualValue: [`不可超過 ${kpi.maxValue}`] },
+      })
+    );
+  }
+
+  // Upsert: 同一 KPI + 同一週期只有一筆（重複填報為更新）
+  const achievement = await prisma.kPIAchievement.upsert({
+    where: { kpiId_period: { kpiId: id, period } },
+    create: {
+      kpiId: id,
+      period,
+      actualValue,
+      note: note || null,
+      reportedBy: session.user.id,
+    },
+    update: {
+      actualValue,
+      note: note || null,
+      reportedBy: session.user.id,
     },
   });
 
-  if (!kpi) throw new NotFoundError("找不到 KPI");
-
-  const achievementRate = calculateAchievement(kpi);
-
-  const linkedTaskCount = kpi.taskLinks.length;
-  const completedTaskCount = kpi.taskLinks.filter((l) => l.task.status === "DONE").length;
-
-  return success({
-    kpiId: kpi.id,
-    target: kpi.target,
-    actual: kpi.actual,
-    achievementRate,
-    linkedTaskCount,
-    completedTaskCount,
-    autoCalc: kpi.autoCalc,
+  // 更新 KPI 的 actual 值（取所有填報的平均或最新值）
+  const allAchievements = await prisma.kPIAchievement.findMany({
+    where: { kpiId: id },
+    orderBy: { period: "desc" },
   });
+  if (allAchievements.length > 0) {
+    const latestActual = allAchievements[0].actualValue;
+    await prisma.kPI.update({
+      where: { id },
+      data: { actual: latestActual },
+    });
+  }
+
+  return success(achievement, 201);
 });

--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { NotFoundError } from "@/services/errors";
+import { NotFoundError, ValidationError } from "@/services/errors";
 import { validateBody } from "@/lib/validate";
 import { updateKpiSchema } from "@/validators/kpi-validators";
 import { success } from "@/lib/api-response";
@@ -31,6 +31,9 @@ export const GET = withAuth(async (
       },
       deliverables: true,
       creator: { select: { id: true, name: true } },
+      achievements: {
+        orderBy: { createdAt: "desc" },
+      },
     },
   });
 
@@ -57,19 +60,65 @@ export const PUT = withManager(async (
 ) => {
   const { id } = await context.params;
   const raw = await req.json();
-  const { title, description, target, actual, weight, status, autoCalc } =
-    validateBody(updateKpiSchema, raw);
+  const updates = validateBody(updateKpiSchema, raw);
+
+  const existing = await prisma.kPI.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("找不到 KPI");
+
+  // Status transition: only DRAFT->ACTIVE, ACTIVE->ACHIEVED/MISSED/CANCELLED allowed
+  if (updates.status) {
+    const validTransitions: Record<string, string[]> = {
+      DRAFT: ["ACTIVE"],
+      ACTIVE: ["ACHIEVED", "MISSED", "CANCELLED"],
+    };
+    const allowed = validTransitions[existing.status] || [];
+    if (!allowed.includes(updates.status)) {
+      throw new ValidationError(
+        JSON.stringify({
+          error: `無法從 ${existing.status} 轉換為 ${updates.status}`,
+          fields: { status: [`不允許的狀態轉換`] },
+        })
+      );
+    }
+  }
+
+  // Weight validation: check total won't exceed 100% after update
+  if (updates.weight != null && updates.weight !== existing.weight) {
+    const otherWeights = await prisma.kPI.aggregate({
+      where: {
+        year: existing.year,
+        status: { not: "CANCELLED" },
+        id: { not: id },
+      },
+      _sum: { weight: true },
+    });
+    const othersTotal = otherWeights._sum.weight ?? 0;
+    if (othersTotal + updates.weight > 100) {
+      throw new ValidationError(
+        JSON.stringify({
+          error: `權重合計超過 100%（其他 KPI 合計 ${othersTotal}%）`,
+          fields: { weight: [`權重合計不可超過 100%`] },
+        })
+      );
+    }
+  }
 
   const kpi = await prisma.kPI.update({
     where: { id },
     data: {
-      ...(title != null && { title }),
-      ...(description != null && { description }),
-      ...(target != null && { target }),
-      ...(actual != null && { actual }),
-      ...(weight != null && { weight }),
-      ...(status != null && { status }),
-      ...(autoCalc != null && { autoCalc }),
+      ...(updates.title != null && { title: updates.title }),
+      ...(updates.description !== undefined && { description: updates.description }),
+      ...(updates.measureMethod !== undefined && { measureMethod: updates.measureMethod }),
+      ...(updates.target != null && { target: updates.target }),
+      ...(updates.actual != null && { actual: updates.actual }),
+      ...(updates.weight != null && { weight: updates.weight }),
+      ...(updates.frequency != null && { frequency: updates.frequency }),
+      ...(updates.minValue !== undefined && { minValue: updates.minValue }),
+      ...(updates.maxValue !== undefined && { maxValue: updates.maxValue }),
+      ...(updates.unit !== undefined && { unit: updates.unit }),
+      ...(updates.visibility != null && { visibility: updates.visibility }),
+      ...(updates.status != null && { status: updates.status }),
+      ...(updates.autoCalc != null && { autoCalc: updates.autoCalc }),
     },
   });
 

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -2,60 +2,119 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { validateBody } from "@/lib/validate";
 import { createKpiSchema } from "@/validators/kpi-validators";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { ValidationError } from "@/services/errors";
 
 export const GET = withAuth(async (req: NextRequest) => {
-
+  const session = await requireAuth();
   const { searchParams } = new URL(req.url);
   const year = searchParams.get("year")
     ? parseInt(searchParams.get("year")!)
     : new Date().getFullYear();
 
-  const kpis = await prisma.kPI.findMany({
-    where: { year },
-    include: {
-      taskLinks: {
-        include: {
-          task: {
-            select: {
-              id: true,
-              title: true,
-              status: true,
-              progressPct: true,
-              primaryAssignee: { select: { id: true, name: true } },
+  // Filters
+  const statusFilter = searchParams.get("status");
+  const frequencyFilter = searchParams.get("frequency");
+  const search = searchParams.get("search");
+  const includeLatest = searchParams.get("include") === "latestAchievement";
+  const page = parseInt(searchParams.get("page") || "1");
+  const limit = parseInt(searchParams.get("limit") || "100");
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const where: any = { year };
+
+  // Visibility: ENGINEER can only see ALL-visible KPIs
+  if (session.user.role === "ENGINEER") {
+    where.visibility = "ALL";
+  }
+
+  if (statusFilter) where.status = statusFilter;
+  if (frequencyFilter) where.frequency = frequencyFilter;
+  if (search) {
+    where.OR = [
+      { title: { contains: search, mode: "insensitive" } },
+      { code: { contains: search, mode: "insensitive" } },
+    ];
+  }
+
+  const [kpis, total] = await Promise.all([
+    prisma.kPI.findMany({
+      where,
+      include: {
+        taskLinks: {
+          include: {
+            task: {
+              select: {
+                id: true,
+                title: true,
+                status: true,
+                progressPct: true,
+                primaryAssignee: { select: { id: true, name: true } },
+              },
             },
           },
         },
+        deliverables: true,
+        creator: { select: { id: true, name: true } },
+        ...(includeLatest && {
+          achievements: {
+            orderBy: { createdAt: "desc" as const },
+            take: 1,
+          },
+        }),
       },
-      deliverables: true,
-      creator: { select: { id: true, name: true } },
-    },
-    orderBy: { code: "asc" },
-  });
+      orderBy: { code: "asc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.kPI.count({ where }),
+  ]);
 
-  return success(kpis);
+  return success({ items: kpis, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {
   const session = await requireAuth();
 
   const raw = await req.json();
-  const { year, code, title, description, target, weight, autoCalc } = validateBody(
+  const data = validateBody(
     createKpiSchema,
     { ...raw, year: raw.year ? parseInt(raw.year) : raw.year }
   );
 
+  // Weight total validation: existing KPIs + new one must not exceed 100%
+  const existingWeightSum = await prisma.kPI.aggregate({
+    where: { year: data.year, status: { not: "CANCELLED" } },
+    _sum: { weight: true },
+  });
+  const currentTotal = existingWeightSum._sum.weight ?? 0;
+  const newWeight = data.weight ?? 1;
+  if (currentTotal + newWeight > 100) {
+    throw new ValidationError(
+      JSON.stringify({
+        error: `權重合計超過 100%（目前已用 ${currentTotal}%，新增 ${newWeight}%）`,
+        fields: { weight: [`權重合計不可超過 100%（目前 ${currentTotal}%）`] },
+      })
+    );
+  }
+
   const kpi = await prisma.kPI.create({
     data: {
-      year,
-      code,
-      title,
-      description: description || null,
-      target,
-      weight: weight ?? 1,
-      autoCalc: autoCalc ?? false,
+      year: data.year,
+      code: data.code,
+      title: data.title,
+      description: data.description || null,
+      measureMethod: data.measureMethod || null,
+      target: data.target,
+      weight: data.weight ?? 1,
+      frequency: data.frequency ?? "MONTHLY",
+      minValue: data.minValue ?? null,
+      maxValue: data.maxValue ?? null,
+      unit: data.unit || null,
+      visibility: data.visibility ?? "ALL",
+      autoCalc: data.autoCalc ?? false,
       createdBy: session.user.id,
     },
   });

--- a/app/components/password-change-guard.tsx
+++ b/app/components/password-change-guard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 /**
- * PasswordChangeGuard — Issue #182
+ * PasswordChangeGuard — Issue #182, enhanced Issue #834 (AU-5)
  *
- * Client-side guard that checks the session for mustChangePassword flag.
- * Redirects to /change-password if the user needs to change their password
- * (first login or expired password).
+ * Client-side guard that checks:
+ *   1. mustChangePassword flag (first login)
+ *   2. passwordChangedAt expiry (90 days, Issue #834)
+ * Redirects to /change-password if either condition is true.
  *
  * Works with both JWS and JWE tokens since it reads the resolved session.
  */
@@ -13,6 +14,15 @@
 import { useSession } from "next-auth/react";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
+
+const PASSWORD_MAX_AGE_DAYS = 90;
+
+function isExpiredClient(passwordChangedAt?: string | null): boolean {
+  if (!passwordChangedAt) return true;
+  const changedMs = new Date(passwordChangedAt).getTime();
+  const maxAgeMs = PASSWORD_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+  return Date.now() - changedMs > maxAgeMs;
+}
 
 export function PasswordChangeGuard({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
@@ -23,8 +33,12 @@ export function PasswordChangeGuard({ children }: { children: React.ReactNode })
     if (status !== "authenticated") return;
     if (pathname === "/change-password") return;
 
-    const user = session?.user as { mustChangePassword?: boolean } | undefined;
-    if (user?.mustChangePassword) {
+    const user = session?.user as {
+      mustChangePassword?: boolean;
+      passwordChangedAt?: string | null;
+    } | undefined;
+
+    if (user?.mustChangePassword || isExpiredClient(user?.passwordChangedAt)) {
       router.replace("/change-password");
     }
   }, [session, status, router, pathname]);

--- a/app/components/topbar.tsx
+++ b/app/components/topbar.tsx
@@ -2,14 +2,14 @@
 
 import { useSession, signOut } from "next-auth/react";
 import { usePathname } from "next/navigation";
-import { LogOut, Menu, Moon, Sun, X } from "lucide-react";
+import { LogOut, Menu, Moon, Sun, X, AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import {
   LayoutDashboard, KanbanSquare, GanttChartSquare, BookOpen,
   Clock, BarChart2, Target, Crosshair, Activity, Settings,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { NotificationBell } from "@/app/components/notification-bell";
 
 const PAGE_TITLES: Record<string, string> = {
@@ -48,14 +48,40 @@ const MOBILE_NAV = [
   { href: "/settings", label: "個人設定", icon: Settings },
 ];
 
+const PASSWORD_MAX_AGE_DAYS = 90;
+const PASSWORD_WARN_DAYS = 7;
+
+function computeDaysUntilExpiry(passwordChangedAt?: string | null): number | null {
+  if (!passwordChangedAt) return null;
+  const changedMs = new Date(passwordChangedAt).getTime();
+  const expiresAt = changedMs + PASSWORD_MAX_AGE_DAYS * 24 * 60 * 60 * 1000;
+  const remaining = expiresAt - Date.now();
+  return remaining > 0 ? Math.ceil(remaining / (24 * 60 * 60 * 1000)) : 0;
+}
+
 export function Topbar() {
   const { data: session } = useSession();
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pageTitle = Object.entries(PAGE_TITLES).find(([p]) => pathname === p || pathname.startsWith(p + "/"))?.[1];
 
+  // Issue #834: password expiry warning
+  const user = session?.user as { passwordChangedAt?: string | null } | undefined;
+  const daysLeft = useMemo(() => computeDaysUntilExpiry(user?.passwordChangedAt), [user?.passwordChangedAt]);
+  const showExpiryWarning = daysLeft !== null && daysLeft <= PASSWORD_WARN_DAYS && daysLeft > 0;
+
   return (
     <>
+    {/* Password expiry warning banner (Issue #834) */}
+    {showExpiryWarning && (
+      <div className="bg-amber-500/10 border-b border-amber-500/30 px-4 py-2 flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400" data-testid="password-expiry-warning">
+        <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+        <span>
+          您的密碼將於 <strong>{daysLeft}</strong> 天後到期，請儘速
+          <Link href="/change-password" className="underline font-medium ml-1">變更密碼</Link>
+        </span>
+      </div>
+    )}
     <header className="h-14 border-b border-border bg-card/80 backdrop-blur-sm flex items-center justify-between px-4 sm:px-6 flex-shrink-0 sticky top-0 z-10">
       <div className="flex items-center gap-3">
         {/* Mobile hamburger */}

--- a/lib/password-expiry.ts
+++ b/lib/password-expiry.ts
@@ -1,11 +1,18 @@
 /**
- * Password expiry checking — Issue #182
+ * Password expiry checking — Issue #182, enhanced Issue #834 (AU-5)
  *
- * 銀行政策：密碼 90 天到期，首次登入強制變更。
+ * 銀行政策：密碼預設 90 天到期，首次登入強制變更。
+ * Admin 可透過環境變數 PASSWORD_MAX_AGE_DAYS 調整到期天數。
  */
 
-/** Password expires after this many days. */
-export const PASSWORD_MAX_AGE_DAYS = 90;
+/** Password expires after this many days (configurable via env, default 90). */
+export const PASSWORD_MAX_AGE_DAYS = parseInt(
+  process.env.PASSWORD_MAX_AGE_DAYS ?? "90",
+  10,
+) || 90;
+
+/** Days before expiry to start showing warning (Issue #834). */
+export const PASSWORD_WARN_DAYS = 7;
 
 /**
  * Returns true if the password has expired (older than PASSWORD_MAX_AGE_DAYS).

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,28 +107,68 @@ enum KPIStatus {
   CANCELLED
 }
 
-model KPI {
-  id          String    @id @default(cuid())
-  year        Int
-  code        String    // e.g., "KPI-2026-01"
-  title       String
-  description String?
-  target      Float     // 目標值（如 95.0 代表 95%）
-  actual      Float     @default(0)
-  weight      Float     @default(1)
-  status      KPIStatus @default(ACTIVE)
-  autoCalc    Boolean   @default(false)
-  createdBy   String
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+enum KPIFrequency {
+  MONTHLY
+  QUARTERLY
+  YEARLY
+}
 
-  creator      User          @relation("KPICreator", fields: [createdBy], references: [id])
+enum KPIVisibility {
+  ALL        // 全員可見
+  MANAGER    // 僅 Manager + Admin 可見
+}
+
+model KPI {
+  id             String        @id @default(cuid())
+  year           Int
+  code           String        // e.g., "KPI-2026-01"
+  title          String
+  description    String?
+  measureMethod  String?       // 衡量方式描述
+  target         Float         // 目標值（如 95.0 代表 95%）
+  actual         Float         @default(0)
+  weight         Float         @default(1) // 權重百分比 (0-100)
+  frequency      KPIFrequency  @default(MONTHLY)  // 填報頻率
+  minValue       Float?        // 值域最小值
+  maxValue       Float?        // 值域最大值
+  unit           String?       // 單位（%、次、小時等）
+  visibility     KPIVisibility @default(ALL)       // 可視權限
+  status         KPIStatus     @default(DRAFT)     // 預設草稿
+  autoCalc       Boolean       @default(false)
+  createdBy      String
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+
+  creator      User              @relation("KPICreator", fields: [createdBy], references: [id])
   taskLinks    KPITaskLink[]
-  deliverables Deliverable[] @relation("KPIDeliverable")
+  deliverables Deliverable[]     @relation("KPIDeliverable")
+  achievements KPIAchievement[]
 
   @@unique([year, code])
+  @@unique([year, title])
   @@index([createdBy])
+  @@index([status])
+  @@index([frequency])
   @@map("kpis")
+}
+
+// KPI 填報記錄 (KP-2: Issue #822)
+model KPIAchievement {
+  id          String   @id @default(cuid())
+  kpiId       String
+  period      String   // e.g., "2026-01", "2026-Q1", "2026"
+  actualValue Float
+  note        String?
+  reportedBy  String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  kpi      KPI  @relation(fields: [kpiId], references: [id], onDelete: Cascade)
+
+  @@unique([kpiId, period])
+  @@index([kpiId])
+  @@index([reportedBy])
+  @@map("kpi_achievements")
 }
 
 model KPITaskLink {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -14,6 +14,7 @@ declare module "next-auth" {
       image?: string | null;
       role: string;
       mustChangePassword?: boolean;
+      passwordChangedAt?: string | null; // Issue #834: password expiry tracking
     } & DefaultSession["user"];
   }
 
@@ -21,6 +22,7 @@ declare module "next-auth" {
     id: string;
     role: string;
     mustChangePassword?: boolean;
+    passwordChangedAt?: string; // Issue #834
   }
 }
 
@@ -29,6 +31,7 @@ declare module "next-auth/jwt" {
     id: string;
     role: string;
     mustChangePassword?: boolean;
+    passwordChangedAt?: string | null; // Issue #834
     sessionId?: string;
   }
 }

--- a/validators/__tests__/kpi-validators.test.ts
+++ b/validators/__tests__/kpi-validators.test.ts
@@ -1,4 +1,4 @@
-import { createKpiSchema, updateKpiSchema } from "../kpi-validators";
+import { createKpiSchema, updateKpiSchema, createKpiAchievementSchema } from "../kpi-validators";
 
 describe("createKpiSchema", () => {
   const validInput = {
@@ -17,7 +17,13 @@ describe("createKpiSchema", () => {
     const result = createKpiSchema.safeParse({
       ...validInput,
       description: "NPS score target",
-      weight: 2.0,
+      measureMethod: "Monthly NPS survey",
+      weight: 20,
+      frequency: "MONTHLY",
+      minValue: 0,
+      maxValue: 100,
+      unit: "%",
+      visibility: "ALL",
       autoCalc: true,
     });
     expect(result.success).toBe(true);
@@ -61,6 +67,52 @@ describe("createKpiSchema", () => {
     const result = createKpiSchema.safeParse({ ...validInput, code: "" });
     expect(result.success).toBe(false);
   });
+
+  test("rejects weight > 100", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, weight: 101 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects weight < 0", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, weight: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid frequency", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, frequency: "WEEKLY" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid visibility", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, visibility: "PRIVATE" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects minValue > maxValue", () => {
+    const result = createKpiSchema.safeParse({ ...validInput, minValue: 100, maxValue: 50 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects target outside value range", () => {
+    const result = createKpiSchema.safeParse({
+      ...validInput, target: 200, minValue: 0, maxValue: 100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts valid frequency values", () => {
+    for (const frequency of ["MONTHLY", "QUARTERLY", "YEARLY"]) {
+      const result = createKpiSchema.safeParse({ ...validInput, frequency });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("accepts valid visibility values", () => {
+    for (const visibility of ["ALL", "MANAGER"]) {
+      const result = createKpiSchema.safeParse({ ...validInput, visibility });
+      expect(result.success).toBe(true);
+    }
+  });
 });
 
 describe("updateKpiSchema", () => {
@@ -82,6 +134,16 @@ describe("updateKpiSchema", () => {
     }
   });
 
+  test("accepts update with new fields", () => {
+    const result = updateKpiSchema.safeParse({
+      frequency: "QUARTERLY",
+      visibility: "MANAGER",
+      measureMethod: "Updated method",
+      unit: "hours",
+    });
+    expect(result.success).toBe(true);
+  });
+
   test("accepts empty object", () => {
     const result = updateKpiSchema.safeParse({});
     expect(result.success).toBe(true);
@@ -100,5 +162,49 @@ describe("updateKpiSchema", () => {
   test("rejects negative actual in update", () => {
     const result = updateKpiSchema.safeParse({ actual: -5 });
     expect(result.success).toBe(false);
+  });
+
+  test("rejects weight > 100 in update", () => {
+    const result = updateKpiSchema.safeParse({ weight: 101 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createKpiAchievementSchema", () => {
+  test("accepts valid achievement", () => {
+    const result = createKpiAchievementSchema.safeParse({
+      period: "2026-01",
+      actualValue: 85.5,
+      note: "Good progress",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts achievement without note", () => {
+    const result = createKpiAchievementSchema.safeParse({
+      period: "2026-Q1",
+      actualValue: 90,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing period", () => {
+    const result = createKpiAchievementSchema.safeParse({ actualValue: 90 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty period", () => {
+    const result = createKpiAchievementSchema.safeParse({ period: "", actualValue: 90 });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects missing actualValue", () => {
+    const result = createKpiAchievementSchema.safeParse({ period: "2026-01" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts zero as actualValue", () => {
+    const result = createKpiAchievementSchema.safeParse({ period: "2026-01", actualValue: 0 });
+    expect(result.success).toBe(true);
   });
 });

--- a/validators/kpi-validators.ts
+++ b/validators/kpi-validators.ts
@@ -1,5 +1,5 @@
 /**
- * KPI validators — re-exports from shared schemas (Issue #396)
+ * KPI validators — re-exports from shared schemas (Issue #396, #821, #822)
  *
  * Kept for backward compatibility. New code should import from
  * '@/validators/shared' or '@/validators/shared/kpi' directly.
@@ -8,6 +8,8 @@
 export {
   createKpiSchema,
   updateKpiSchema,
+  createKpiAchievementSchema,
   type CreateKpiInput,
   type UpdateKpiInput,
+  type CreateKpiAchievementInput,
 } from "./shared/kpi";

--- a/validators/shared/enums.ts
+++ b/validators/shared/enums.ts
@@ -51,6 +51,17 @@ export const KpiStatusEnum = z.enum([
   "CANCELLED",
 ]);
 
+export const KpiFrequencyEnum = z.enum([
+  "MONTHLY",
+  "QUARTERLY",
+  "YEARLY",
+]);
+
+export const KpiVisibilityEnum = z.enum([
+  "ALL",
+  "MANAGER",
+]);
+
 // ── Time Entry ──────────────────────────────────────────────────────────────
 
 export const TimeCategoryEnum = z.enum([
@@ -85,3 +96,5 @@ export type TimeCategory = z.infer<typeof TimeCategoryEnum>;
 export type TimesheetApprovalStatus = z.infer<typeof TimesheetApprovalStatusEnum>;
 export type Role = z.infer<typeof RoleEnum>;
 export type IncidentSeverity = z.infer<typeof IncidentSeverityEnum>;
+export type KpiFrequency = z.infer<typeof KpiFrequencyEnum>;
+export type KpiVisibility = z.infer<typeof KpiVisibilityEnum>;

--- a/validators/shared/kpi.ts
+++ b/validators/shared/kpi.ts
@@ -1,5 +1,5 @@
 /**
- * Shared KPI schemas — Issue #396
+ * Shared KPI schemas — Issue #396, enhanced Issue #821 (KP-1)
  *
  * Used by both:
  *   - Frontend form validation (client components)
@@ -7,27 +7,62 @@
  */
 
 import { z } from "zod";
-import { KpiStatusEnum } from "./enums";
+import { KpiStatusEnum, KpiFrequencyEnum, KpiVisibilityEnum } from "./enums";
 
 export const createKpiSchema = z.object({
   year: z.number().int().min(2000).max(2100),
   code: z.string().min(1),
   title: z.string().min(1),
   description: z.string().optional(),
+  measureMethod: z.string().optional(),
   target: z.number().nonnegative(),
-  weight: z.number().positive().optional().default(1),
+  weight: z.number().min(0).max(100).optional().default(1),
+  frequency: KpiFrequencyEnum.optional().default("MONTHLY"),
+  minValue: z.number().optional(),
+  maxValue: z.number().optional(),
+  unit: z.string().optional(),
+  visibility: KpiVisibilityEnum.optional().default("ALL"),
   autoCalc: z.boolean().optional().default(false),
-});
+}).refine(
+  (data) => {
+    if (data.minValue != null && data.maxValue != null) {
+      return data.minValue <= data.maxValue;
+    }
+    return true;
+  },
+  { message: "最小值不得大於最大值", path: ["minValue"] }
+).refine(
+  (data) => {
+    if (data.minValue != null && data.target < data.minValue) return false;
+    if (data.maxValue != null && data.target > data.maxValue) return false;
+    return true;
+  },
+  { message: "目標值必須在值域範圍內", path: ["target"] }
+);
 
 export const updateKpiSchema = z.object({
   title: z.string().min(1).optional(),
   description: z.string().optional(),
+  measureMethod: z.string().optional(),
   target: z.number().nonnegative().optional(),
   actual: z.number().nonnegative().optional(),
-  weight: z.number().positive().optional(),
+  weight: z.number().min(0).max(100).optional(),
+  frequency: KpiFrequencyEnum.optional(),
+  minValue: z.number().nullable().optional(),
+  maxValue: z.number().nullable().optional(),
+  unit: z.string().nullable().optional(),
+  visibility: KpiVisibilityEnum.optional(),
   status: KpiStatusEnum.optional(),
   autoCalc: z.boolean().optional(),
 });
 
+/** Schema for KPI achievement reporting (KP-2: Issue #822) */
+export const createKpiAchievementSchema = z.object({
+  period: z.string().min(1, "填報週期為必填"),
+  actualValue: z.number({ required_error: "實際值為必填" }),
+  note: z.string().optional(),
+});
+
 export type CreateKpiInput = z.infer<typeof createKpiSchema>;
 export type UpdateKpiInput = z.infer<typeof updateKpiSchema>;
+export type CreateKpiAchievementInput = z.infer<typeof createKpiAchievementSchema>;


### PR DESCRIPTION
## Summary
- 重寫 `/api/kpi/:id/achievement`：GET 取得填報歷史、POST 填報/更新
- 僅 KPI 建立者（負責人）和 Admin 可填報（非負責人 403）
- 僅 ACTIVE 狀態的 KPI 可填報
- 填報值域驗證（min/max range check）
- 同一週期重複填報為 upsert 更新（非重複建立）
- 填報後自動更新 KPI actual 值
- 依賴：KP-1 (#821 / PR #902)

Fixes #822

## QA 自審報告
- [x] `tsc --noEmit` 0 errors
- [x] `jest` 11 tests pass (kpi-achievement.test.ts)
- [x] AC: 負責人和 Admin 可填報實際值
- [x] AC: 填報值必須在值域範圍內
- [x] AC: 每個週期只能填報一次（重複為修改）
- [x] AC: 填報時可附加備註
- [x] AC: 非負責人且非 Admin 無法填報（403）
- [x] AC: 停用的 KPI 不可填報

## Test plan
- [x] Creator can report achievement
- [x] Admin can report (non-creator)
- [x] Engineer cannot report (403)
- [x] Value below min rejected (400)
- [x] Value above max rejected (400)
- [x] Non-ACTIVE KPI rejected (400)
- [x] Empty period rejected (400)
- [x] KPI actual updated after report