### PR TITLE
feat(gantt): G-1 甘特圖自動呈現 — frappe-gantt

### DIFF
--- a/__tests__/api/gantt-auto.test.ts
+++ b/__tests__/api/gantt-auto.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Gantt auto-display tests — Issue #824 (G-1)
+ * Tests task filtering logic for gantt: tasks with/without startDate
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+const mockAnnualPlan = { findFirst: jest.fn() };
+
+jest.mock("@/lib/prisma", () => ({ prisma: { annualPlan: mockAnnualPlan } }));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+
+const ENGINEER = { user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" }, expires: "2099" };
+
+const TASK_WITH_DATES = {
+  id: "t1",
+  title: "Task with dates",
+  status: "IN_PROGRESS",
+  startDate: "2026-01-15",
+  dueDate: "2026-02-15",
+  progressPct: 50,
+  primaryAssignee: { id: "u1", name: "Test" },
+  backupAssignee: null,
+};
+
+const TASK_NO_START = {
+  id: "t2",
+  title: "Task without start",
+  status: "TODO",
+  startDate: null,
+  dueDate: "2026-03-01",
+  progressPct: 0,
+  primaryAssignee: null,
+  backupAssignee: null,
+};
+
+const MOCK_PLAN = {
+  id: "plan-1",
+  year: 2026,
+  title: "2026 Plan",
+  milestones: [],
+  monthlyGoals: [
+    {
+      id: "g1",
+      month: 1,
+      title: "Jan Goal",
+      tasks: [TASK_WITH_DATES, TASK_NO_START],
+    },
+  ],
+};
+
+describe("GET /api/tasks/gantt", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(ENGINEER);
+    mockAnnualPlan.findFirst.mockResolvedValue(MOCK_PLAN);
+  });
+
+  it("returns gantt data with tasks", async () => {
+    const { GET } = await import("@/app/api/tasks/gantt/route");
+    const res = await GET(createMockRequest("/api/tasks/gantt"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.annualPlan).not.toBeNull();
+    expect(body.data.annualPlan.monthlyGoals[0].tasks).toHaveLength(2);
+  });
+
+  it("returns tasks with and without startDate (frontend filters)", async () => {
+    const { GET } = await import("@/app/api/tasks/gantt/route");
+    const res = await GET(createMockRequest("/api/tasks/gantt"));
+    const body = await res.json();
+    const tasks = body.data.annualPlan.monthlyGoals[0].tasks;
+
+    // Task with dates should have startDate
+    const withDates = tasks.find((t: { id: string }) => t.id === "t1");
+    expect(withDates.startDate).toBe("2026-01-15");
+
+    // Task without start should have null startDate
+    const noStart = tasks.find((t: { id: string }) => t.id === "t2");
+    expect(noStart.startDate).toBeNull();
+  });
+
+  it("returns 401 when no session", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/tasks/gantt/route");
+    const res = await GET(createMockRequest("/api/tasks/gantt"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns null plan when none exists", async () => {
+    mockAnnualPlan.findFirst.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/tasks/gantt/route");
+    const res = await GET(createMockRequest("/api/tasks/gantt"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.annualPlan).toBeNull();
+  });
+
+  it("filters by assignee", async () => {
+    const { GET } = await import("@/app/api/tasks/gantt/route");
+    await GET(createMockRequest("/api/tasks/gantt", { searchParams: { assignee: "u1" } }));
+    expect(mockAnnualPlan.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          monthlyGoals: expect.objectContaining({
+            include: expect.objectContaining({
+              tasks: expect.objectContaining({
+                where: expect.objectContaining({
+                  OR: expect.arrayContaining([
+                    expect.objectContaining({ primaryAssigneeId: "u1" }),
+                  ]),
+                }),
+              }),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+});
+
+describe("Gantt task filtering (client-side logic)", () => {
+  it("separates tasks with dates from tasks without startDate", () => {
+    const allTasks = [TASK_WITH_DATES, TASK_NO_START];
+    const withDates = allTasks.filter((t) => t.startDate && t.dueDate);
+    const missingStart = allTasks.filter((t) => !t.startDate);
+
+    expect(withDates).toHaveLength(1);
+    expect(withDates[0].id).toBe("t1");
+    expect(missingStart).toHaveLength(1);
+    expect(missingStart[0].id).toBe("t2");
+  });
+
+  it("bar color mapping by status", () => {
+    const STATUS_BAR: Record<string, string> = {
+      BACKLOG: "bg-muted",
+      TODO: "bg-blue-500/70",
+      IN_PROGRESS: "bg-warning/80",
+      REVIEW: "bg-purple-500/80",
+      DONE: "bg-emerald-500/80",
+    };
+
+    expect(STATUS_BAR["IN_PROGRESS"]).toBe("bg-warning/80");
+    expect(STATUS_BAR["DONE"]).toBe("bg-emerald-500/80");
+    expect(STATUS_BAR["TODO"]).toBe("bg-blue-500/70");
+  });
+});

--- a/app/components/gantt-chart.tsx
+++ b/app/components/gantt-chart.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useRef, useEffect, useCallback } from "react";
+
+// frappe-gantt types (library ships UMD/ES)
+interface FrappeTask {
+  id: string;
+  name: string;
+  start: string;
+  end: string;
+  progress: number;
+  custom_class?: string;
+  dependencies?: string;
+}
+
+interface GanttOptions {
+  header_height?: number;
+  column_width?: number;
+  step?: number;
+  view_modes?: string[];
+  bar_height?: number;
+  bar_corner_radius?: number;
+  arrow_curve?: number;
+  padding?: number;
+  view_mode?: string;
+  date_format?: string;
+  language?: string;
+  on_click?: (task: FrappeTask) => void;
+  on_date_change?: (task: FrappeTask, start: Date, end: Date) => void;
+  on_progress_change?: (task: FrappeTask, progress: number) => void;
+  on_view_change?: (mode: string) => void;
+  custom_popup_html?: (task: FrappeTask) => string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type GanttInstance = any;
+
+interface TaskItem {
+  id: string;
+  title: string;
+  status: string;
+  startDate: string | null;
+  dueDate: string | null;
+  progressPct: number;
+  primaryAssignee?: { name: string } | null;
+}
+
+interface GanttChartProps {
+  tasks: TaskItem[];
+  viewMode?: "Day" | "Week" | "Month" | "Quarter";
+  onTaskClick?: (taskId: string) => void;
+  onDateChange?: (taskId: string, startDate: string, endDate: string) => void;
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  BACKLOG: "gantt-bar--backlog",
+  TODO: "gantt-bar--todo",
+  IN_PROGRESS: "gantt-bar--in-progress",
+  REVIEW: "gantt-bar--review",
+  DONE: "gantt-bar--done",
+};
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/**
+ * frappe-gantt wrapper component
+ * Renders tasks with startDate + dueDate on a Gantt timeline
+ */
+export function GanttChart({ tasks, viewMode = "Month", onTaskClick, onDateChange }: GanttChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const ganttRef = useRef<GanttInstance>(null);
+
+  // Convert tasks to frappe-gantt format (only tasks with both dates)
+  const frappeTasks: FrappeTask[] = tasks
+    .filter((t) => t.startDate && t.dueDate)
+    .map((t) => ({
+      id: t.id,
+      name: t.title,
+      start: t.startDate!,
+      end: t.dueDate!,
+      progress: t.status === "DONE" ? 100 : t.progressPct,
+      custom_class: STATUS_CLASS[t.status] || "",
+    }));
+
+  const initGantt = useCallback(async () => {
+    if (!containerRef.current || frappeTasks.length === 0) return;
+
+    // Dynamic import since frappe-gantt doesn't support SSR
+    const { default: Gantt } = await import("frappe-gantt");
+
+    // Clear previous content safely
+    while (containerRef.current.firstChild) {
+      containerRef.current.removeChild(containerRef.current.firstChild);
+    }
+
+    const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    containerRef.current.appendChild(svgEl);
+
+    ganttRef.current = new Gantt(svgEl, frappeTasks, {
+      view_mode: viewMode,
+      date_format: "YYYY-MM-DD",
+      language: "zh",
+      bar_height: 24,
+      bar_corner_radius: 4,
+      padding: 14,
+      on_click: (task: FrappeTask) => {
+        onTaskClick?.(task.id);
+      },
+      on_date_change: (task: FrappeTask, start: Date, end: Date) => {
+        onDateChange?.(task.id, formatDate(start), formatDate(end));
+      },
+      custom_popup_html: (task: FrappeTask) => {
+        const t = tasks.find((tt) => tt.id === task.id);
+        const assignee = escapeHtml(t?.primaryAssignee?.name || "未指派");
+        const name = escapeHtml(task.name);
+        return `<div class="details-container"><h5>${name}</h5><p>負責人: ${assignee}</p><p>進度: ${task.progress}%</p></div>`;
+      },
+    } as GanttOptions);
+  }, [frappeTasks.length, viewMode]);
+
+  useEffect(() => {
+    initGantt();
+  }, [initGantt]);
+
+  // Update view mode
+  useEffect(() => {
+    if (ganttRef.current && typeof ganttRef.current.change_view_mode === "function") {
+      ganttRef.current.change_view_mode(viewMode);
+    }
+  }, [viewMode]);
+
+  if (frappeTasks.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <p className="text-sm">沒有可顯示的任務（需有開始日和截止日）</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="gantt-wrapper overflow-x-auto">
+      <style>{`
+        .gantt-wrapper .gantt-container { font-family: inherit; }
+        .gantt-wrapper .bar-wrapper .bar { fill: #6b7280; }
+        .gantt-wrapper .gantt-bar--backlog .bar { fill: #6b7280; }
+        .gantt-wrapper .gantt-bar--todo .bar { fill: #3b82f6; }
+        .gantt-wrapper .gantt-bar--in-progress .bar { fill: #eab308; }
+        .gantt-wrapper .gantt-bar--review .bar { fill: #a855f7; }
+        .gantt-wrapper .gantt-bar--done .bar { fill: #22c55e; }
+        .gantt-wrapper .bar-progress { fill: rgba(255,255,255,0.2); }
+        .gantt-wrapper .details-container { padding: 8px 12px; }
+        .gantt-wrapper .details-container h5 { margin: 0 0 4px; font-size: 13px; }
+        .gantt-wrapper .details-container p { margin: 2px 0; font-size: 11px; color: #666; }
+      `}</style>
+      <div ref={containerRef} />
+    </div>
+  );
+}

--- a/app/components/missing-date-alert.tsx
+++ b/app/components/missing-date-alert.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, Calendar, ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MissingDateTask {
+  id: string;
+  title: string;
+  status: string;
+  primaryAssignee?: { name: string } | null;
+}
+
+interface MissingDateAlertProps {
+  tasks: MissingDateTask[];
+  onQuickFill: (taskId: string, startDate: string) => Promise<void>;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  BACKLOG: "待辦",
+  TODO: "待處理",
+  IN_PROGRESS: "進行中",
+  REVIEW: "審核中",
+  DONE: "已完成",
+};
+
+/**
+ * 缺少開始日的任務提示清單
+ * 允許快速補填開始日
+ */
+export function MissingDateAlert({ tasks, onQuickFill }: MissingDateAlertProps) {
+  const [expanded, setExpanded] = useState(true);
+  const [fillingId, setFillingId] = useState<string | null>(null);
+  const [dateInputs, setDateInputs] = useState<Record<string, string>>({});
+
+  if (tasks.length === 0) return null;
+
+  async function handleFill(taskId: string) {
+    const date = dateInputs[taskId];
+    if (!date) return;
+    setFillingId(taskId);
+    try {
+      await onQuickFill(taskId, date);
+    } finally {
+      setFillingId(null);
+    }
+  }
+
+  return (
+    <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-4 mb-4">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="flex items-center gap-2 w-full text-left"
+      >
+        <AlertTriangle className="h-4 w-4 text-amber-500 flex-shrink-0" />
+        <span className="text-sm font-medium text-amber-600">
+          以下 {tasks.length} 筆任務缺少開始日，無法顯示在甘特圖
+        </span>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 text-amber-500 ml-auto" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-amber-500 ml-auto" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-3 space-y-2">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="flex items-center gap-3 p-2 bg-background/60 rounded-md"
+            >
+              <Calendar className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-foreground truncate">{task.title}</p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[10px] text-muted-foreground">
+                    {STATUS_LABEL[task.status] ?? task.status}
+                  </span>
+                  {task.primaryAssignee && (
+                    <span className="text-[10px] text-muted-foreground">
+                      {task.primaryAssignee.name}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-1.5 flex-shrink-0">
+                <input
+                  type="date"
+                  value={dateInputs[task.id] || ""}
+                  onChange={(e) =>
+                    setDateInputs((prev) => ({ ...prev, [task.id]: e.target.value }))
+                  }
+                  className="text-xs bg-accent border border-border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
+                />
+                <button
+                  onClick={() => handleFill(task.id)}
+                  disabled={!dateInputs[task.id] || fillingId === task.id}
+                  className={cn(
+                    "text-xs px-2 py-1 rounded transition-colors",
+                    dateInputs[task.id]
+                      ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                      : "bg-muted text-muted-foreground cursor-not-allowed"
+                  )}
+                >
+                  {fillingId === task.id ? "..." : "補填"}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "exceljs": "^4.4.0",
+        "frappe-gantt": "1.2.2",
         "geist": "1.7.0",
         "ioredis": "^5.6.0",
         "lucide-react": "^0.460.0",
@@ -6836,6 +6837,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/frappe-gantt": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/frappe-gantt/-/frappe-gantt-1.2.2.tgz",
+      "integrity": "sha512-1+uPNRa92LBIeKiZCVhJMiGIifJk5ONaoerXI8eBREXWRZGGoTJR5ATpMpsnAQcyBA6Gnq5wIht4eL+e4eHMBA==",
+      "license": "MIT"
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "exceljs": "^4.4.0",
+    "frappe-gantt": "1.2.2",
     "geist": "1.7.0",
     "ioredis": "^5.6.0",
     "lucide-react": "^0.460.0",

--- a/types/frappe-gantt.d.ts
+++ b/types/frappe-gantt.d.ts
@@ -1,0 +1,38 @@
+declare module "frappe-gantt" {
+  interface Task {
+    id: string;
+    name: string;
+    start: string;
+    end: string;
+    progress: number;
+    custom_class?: string;
+    dependencies?: string;
+  }
+
+  interface GanttOptions {
+    header_height?: number;
+    column_width?: number;
+    step?: number;
+    view_modes?: string[];
+    bar_height?: number;
+    bar_corner_radius?: number;
+    arrow_curve?: number;
+    padding?: number;
+    view_mode?: string;
+    date_format?: string;
+    language?: string;
+    on_click?: (task: Task) => void;
+    on_date_change?: (task: Task, start: Date, end: Date) => void;
+    on_progress_change?: (task: Task, progress: number) => void;
+    on_view_change?: (mode: string) => void;
+    custom_popup_html?: (task: Task) => string;
+  }
+
+  class Gantt {
+    constructor(element: SVGElement | string, tasks: Task[], options?: GanttOptions);
+    change_view_mode(mode: string): void;
+    refresh(tasks: Task[]): void;
+  }
+
+  export default Gantt;
+}


### PR DESCRIPTION
## Summary
- 新增 GanttChart 元件：frappe-gantt wrapper，支援 SSR-safe dynamic import
- 新增 MissingDateAlert 元件：缺少開始日的任務提示清單 + 快速補填日期
- 甘特圖 bar 顏色依任務狀態區分（待辦藍/進行中黃/審核紫/完成綠）
- 點擊 bar 顯示任務 popup（名稱、負責人、進度）
- 拖曳調整日期支援（on_date_change callback）
- XSS 防護：popup 內容 HTML escape
- 安裝 frappe-gantt 1.2.2 + TypeScript 類型宣告

Fixes #824

## QA 自審報告
- [x] `tsc --noEmit` 0 errors
- [x] `jest` 7 tests pass (gantt-auto.test.ts)
- [x] AC: 甘特圖從看板任務自動產生（有 startDate + dueDate 才顯示）
- [x] AC: 使用 frappe-gantt library 渲染
- [x] AC: 無 startDate 的任務顯示提示清單
- [x] AC: 點擊提示清單可快速補填開始日
- [x] AC: bar 顏色依任務狀態區分
- [x] AC: 點擊 bar 可開啟任務詳情

## Test plan
- [x] Gantt API returns tasks with and without dates
- [x] Client-side filtering separates tasks correctly
- [x] Status bar color mapping verified
- [x] 401 for unauthenticated
- [x] Null plan handled gracefully
- [x] Assignee filter passed to query