### PR TITLE
feat(kb): KB-3 任務卡片連結知識庫文件

### DIFF
--- a/__mocks__/prisma.ts
+++ b/__mocks__/prisma.ts
@@ -32,6 +32,7 @@ export const mockPrisma = {
   subTask: createMockModel(),
   taskAttachment: createMockModel(),
   taskComment: createMockModel(),
+  taskDocument: createMockModel(),
   permission: createMockModel(),
   notification: createMockModel(),
   deliverable: createMockModel(),

--- a/app/api/tasks/[id]/documents/[docId]/route.ts
+++ b/app/api/tasks/[id]/documents/[docId]/route.ts
@@ -1,0 +1,21 @@
+/**
+ * DELETE /api/tasks/:id/documents/:docId — Issue #842 (KB-3)
+ *
+ * Remove a document link from a task.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { success } from "@/lib/api-response";
+import { TaskDocumentService } from "@/services/task-document-service";
+
+const getService = () => new TaskDocumentService(prisma);
+
+export const DELETE = withAuth(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id, docId } = await context.params;
+  await getService().removeDocument(id, docId);
+  return success({ id: docId });
+});

--- a/app/api/tasks/[id]/documents/route.ts
+++ b/app/api/tasks/[id]/documents/route.ts
@@ -1,0 +1,51 @@
+/**
+ * GET/POST /api/tasks/:id/documents — Issue #842 (KB-3)
+ *
+ * GET: List all documents linked to a task.
+ * POST: Link a new document to a task.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success, error } from "@/lib/api-response";
+import { TaskDocumentService } from "@/services/task-document-service";
+
+const getService = () => new TaskDocumentService(prisma);
+
+export const GET = withAuth(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+  const docs = await getService().listByTask(id);
+  return success(docs);
+});
+
+export const POST = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+
+  let body: { outlineDocumentId?: string; title?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return error("ValidationError", "無效的請求格式", 400);
+  }
+
+  if (!body.outlineDocumentId || !body.title) {
+    return error("ValidationError", "outlineDocumentId 和 title 為必填", 400);
+  }
+
+  const doc = await getService().addDocument({
+    taskId: id,
+    outlineDocumentId: body.outlineDocumentId,
+    title: body.title,
+    addedBy: session.user.id,
+  });
+
+  return success(doc, 201);
+});

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect, useCallback } from "react";
 import { X, Save, Loader2, History, MessageSquare, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractData, extractItems } from "@/lib/api-client";
-import { TaskFormFields, TaskSubtaskSection, TaskAttachmentSection, TaskDeliverableSection, TaskIncidentSection, initialForm } from "./task-detail/index";
+import { TaskFormFields, TaskSubtaskSection, TaskAttachmentSection, TaskDeliverableSection, TaskIncidentSection, TaskDocumentSection, initialForm } from "./task-detail/index";
 import type { TaskForm, FormErrors } from "./task-detail/index";
 import { TaskChangeHistory } from "./task-change-history";
 import { MarkdownEditor } from "./markdown-editor";
@@ -291,6 +291,10 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
                 <TaskAttachmentSection
                   taskId={taskId}
                   attachments={(task as unknown as { attachments?: { id: string; fileName: string; fileSize: number; mimeType: string; storagePath: string; uploaderId: string; createdAt: string; uploader?: { id: string; name: string } | null }[] }).attachments ?? []}
+                />
+
+                <TaskDocumentSection
+                  taskId={taskId}
                 />
 
                 <TaskDeliverableSection

--- a/app/components/task-detail/index.ts
+++ b/app/components/task-detail/index.ts
@@ -4,3 +4,4 @@ export { TaskSubtaskSection } from "./task-subtask-section";
 export { TaskAttachmentSection } from "./task-attachment-section";
 export { TaskDeliverableSection } from "./task-deliverable-section";
 export { TaskIncidentSection } from "./task-incident-section";
+export { TaskDocumentSection } from "./task-document-section";

--- a/app/components/task-detail/task-document-section.tsx
+++ b/app/components/task-detail/task-document-section.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * TaskDocumentSection — Issue #842 (KB-3)
+ *
+ * Displays linked documents and allows searching/adding/removing document links.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { FileText, Plus, Trash2, Loader2, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { extractItems } from "@/lib/api-client";
+import { DocumentSearch } from "../document-search";
+
+type LinkedDoc = {
+  id: string;
+  outlineDocumentId: string;
+  title: string;
+  addedBy: string;
+  createdAt: string;
+};
+
+interface TaskDocumentSectionProps {
+  taskId: string;
+}
+
+export function TaskDocumentSection({ taskId }: TaskDocumentSectionProps) {
+  const [docs, setDocs] = useState<LinkedDoc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showSearch, setShowSearch] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  const loadDocs = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/documents`);
+      if (res.ok) {
+        const body = await res.json();
+        setDocs(extractItems<LinkedDoc>(body));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    loadDocs();
+  }, [loadDocs]);
+
+  async function handleAddDocument(documentId: string) {
+    // Search the document title from search results or use a placeholder
+    // We need to get the title — fetch document details
+    const searchRes = await fetch(`/api/documents/search?q=&id=${encodeURIComponent(documentId)}`);
+    let title = "未知文件";
+    if (searchRes.ok) {
+      const body = await searchRes.json();
+      const items = extractItems<{ id: string; title: string }>(body);
+      const found = items.find((i) => i.id === documentId);
+      if (found) title = found.title;
+    }
+
+    const res = await fetch(`/api/tasks/${taskId}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ outlineDocumentId: documentId, title }),
+    });
+
+    if (res.ok) {
+      await loadDocs();
+      setShowSearch(false);
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      alert(errBody?.message ?? "新增連結失敗");
+    }
+  }
+
+  async function handleRemove(docId: string) {
+    setRemoving(docId);
+    try {
+      const res = await fetch(`/api/tasks/${taskId}/documents/${docId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        setDocs((prev) => prev.filter((d) => d.id !== docId));
+      }
+    } finally {
+      setRemoving(null);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          關聯文件
+        </h3>
+        <button
+          onClick={() => setShowSearch(!showSearch)}
+          className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
+        >
+          <Plus className="h-3 w-3" />
+          連結文件
+        </button>
+      </div>
+
+      {showSearch && (
+        <DocumentSearch onSelect={handleAddDocument} />
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      ) : docs.length === 0 ? (
+        <p className="text-xs text-muted-foreground py-2">尚未連結任何文件</p>
+      ) : (
+        <div className="space-y-1">
+          {docs.map((doc) => (
+            <div
+              key={doc.id}
+              className={cn(
+                "flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-border",
+                "hover:bg-accent/30 transition-colors group"
+              )}
+            >
+              <a
+                href={`/knowledge/${doc.outlineDocumentId}`}
+                className="flex items-center gap-2 min-w-0 flex-1"
+              >
+                <FileText className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+                <span className="text-sm text-foreground truncate">
+                  {doc.title}
+                </span>
+                <span className="text-[10px] text-muted-foreground flex-shrink-0">
+                  Outline
+                </span>
+              </a>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleRemove(doc.id);
+                }}
+                disabled={removing === doc.id}
+                className="opacity-0 group-hover:opacity-100 p-1 text-muted-foreground hover:text-destructive transition-all"
+                title="移除連結"
+              >
+                {removing === doc.id ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3 w-3" />
+                )}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -36,6 +36,7 @@ export function createMockPrisma(): MockPrismaClient {
     milestone: createMockModel(),
     subTask: createMockModel(),
     taskComment: createMockModel(),
+    taskDocument: createMockModel(),
     permission: createMockModel(),
     notification: createMockModel(),
     deliverable: createMockModel(),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -337,6 +337,7 @@ model Task {
   backupAssignee  User?         @relation("TaskBackupAssignee", fields: [backupAssigneeId], references: [id])
   creator         User          @relation("TaskCreator", fields: [creatorId], references: [id])
   subTasks        SubTask[]
+  taskDocuments   TaskDocument[]
   attachments     TaskAttachment[]
   comments        TaskComment[]
   activities      TaskActivity[]
@@ -382,6 +383,25 @@ model IncidentRecord {
   task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
 
   @@map("incident_records")
+}
+
+// ═══════════════════════════════════════
+// 任務關聯文件 (Issue #842 — KB-3)
+// ═══════════════════════════════════════
+
+model TaskDocument {
+  id                 String   @id @default(cuid())
+  taskId             String
+  outlineDocumentId  String   // Outline 文件 ID 或內部文件 ID
+  title              String   // 文件標題（快照）
+  addedBy            String   // 新增關聯的使用者 ID
+  createdAt          DateTime @default(now())
+
+  task  Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+
+  @@unique([taskId, outlineDocumentId])
+  @@index([taskId])
+  @@map("task_documents")
 }
 
 // ═══════════════════════════════════════

--- a/services/__tests__/task-document-service.test.ts
+++ b/services/__tests__/task-document-service.test.ts
@@ -1,0 +1,138 @@
+import { TaskDocumentService } from "../task-document-service";
+import { createMockPrisma } from "../../lib/test-utils";
+import { NotFoundError, ValidationError, ConflictError } from "../errors";
+
+describe("TaskDocumentService", () => {
+  let service: TaskDocumentService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new TaskDocumentService(prisma as never);
+  });
+
+  describe("listByTask", () => {
+    test("returns documents linked to a task", async () => {
+      const mockDocs = [
+        { id: "td-1", taskId: "task-1", outlineDocumentId: "doc-1", title: "SOP" },
+      ];
+      (prisma.taskDocument.findMany as jest.Mock).mockResolvedValue(mockDocs);
+
+      const result = await service.listByTask("task-1");
+
+      expect(prisma.taskDocument.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { taskId: "task-1" } })
+      );
+      expect(result).toEqual(mockDocs);
+    });
+  });
+
+  describe("addDocument", () => {
+    test("creates a task-document link", async () => {
+      const input = {
+        taskId: "task-1",
+        outlineDocumentId: "doc-1",
+        title: "SOP v2",
+        addedBy: "user-1",
+      };
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.taskDocument.findUnique as jest.Mock).mockResolvedValue(null);
+      (prisma.taskDocument.create as jest.Mock).mockResolvedValue({ id: "td-1", ...input });
+
+      const result = await service.addDocument(input);
+
+      expect(prisma.taskDocument.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            taskId: "task-1",
+            outlineDocumentId: "doc-1",
+            title: "SOP v2",
+            addedBy: "user-1",
+          }),
+        })
+      );
+      expect(result.id).toBe("td-1");
+    });
+
+    test("throws ConflictError for duplicate link", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.taskDocument.findUnique as jest.Mock).mockResolvedValue({ id: "td-existing" });
+
+      await expect(
+        service.addDocument({
+          taskId: "task-1",
+          outlineDocumentId: "doc-1",
+          title: "SOP",
+          addedBy: "user-1",
+        })
+      ).rejects.toThrow(ConflictError);
+    });
+
+    test("throws NotFoundError for non-existent task", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.addDocument({
+          taskId: "nonexistent",
+          outlineDocumentId: "doc-1",
+          title: "SOP",
+          addedBy: "user-1",
+        })
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    test("throws ValidationError for empty taskId", async () => {
+      await expect(
+        service.addDocument({
+          taskId: "",
+          outlineDocumentId: "doc-1",
+          title: "SOP",
+          addedBy: "user-1",
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("throws ValidationError for empty outlineDocumentId", async () => {
+      await expect(
+        service.addDocument({
+          taskId: "task-1",
+          outlineDocumentId: "",
+          title: "SOP",
+          addedBy: "user-1",
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+
+    test("throws ValidationError for empty title", async () => {
+      await expect(
+        service.addDocument({
+          taskId: "task-1",
+          outlineDocumentId: "doc-1",
+          title: "",
+          addedBy: "user-1",
+        })
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("removeDocument", () => {
+    test("removes a document link", async () => {
+      (prisma.taskDocument.findFirst as jest.Mock).mockResolvedValue({ id: "td-1" });
+      (prisma.taskDocument.delete as jest.Mock).mockResolvedValue({ id: "td-1" });
+
+      await service.removeDocument("task-1", "td-1");
+
+      expect(prisma.taskDocument.delete).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "td-1" } })
+      );
+    });
+
+    test("throws NotFoundError for non-existent link", async () => {
+      (prisma.taskDocument.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(service.removeDocument("task-1", "nonexistent")).rejects.toThrow(
+        NotFoundError
+      );
+    });
+  });
+});

--- a/services/task-document-service.ts
+++ b/services/task-document-service.ts
@@ -1,0 +1,79 @@
+/**
+ * TaskDocumentService — Issue #842 (KB-3)
+ *
+ * Manages task-to-document links. A task can link to multiple
+ * Outline documents. Duplicate links are rejected.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { NotFoundError, ValidationError, ConflictError } from "./errors";
+
+export interface CreateTaskDocumentInput {
+  taskId: string;
+  outlineDocumentId: string;
+  title: string;
+  addedBy: string;
+}
+
+export class TaskDocumentService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listByTask(taskId: string) {
+    return this.prisma.taskDocument.findMany({
+      where: { taskId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async addDocument(input: CreateTaskDocumentInput) {
+    if (!input.taskId?.trim()) {
+      throw new ValidationError("taskId 為必填");
+    }
+    if (!input.outlineDocumentId?.trim()) {
+      throw new ValidationError("outlineDocumentId 為必填");
+    }
+    if (!input.title?.trim()) {
+      throw new ValidationError("title 為必填");
+    }
+
+    // Verify task exists
+    const task = await this.prisma.task.findUnique({
+      where: { id: input.taskId },
+      select: { id: true },
+    });
+    if (!task) throw new NotFoundError(`Task not found: ${input.taskId}`);
+
+    // Check for duplicate
+    const existing = await this.prisma.taskDocument.findUnique({
+      where: {
+        taskId_outlineDocumentId: {
+          taskId: input.taskId,
+          outlineDocumentId: input.outlineDocumentId,
+        },
+      },
+    });
+    if (existing) {
+      throw new ConflictError("此文件已連結至該任務");
+    }
+
+    return this.prisma.taskDocument.create({
+      data: {
+        taskId: input.taskId,
+        outlineDocumentId: input.outlineDocumentId,
+        title: input.title,
+        addedBy: input.addedBy,
+      },
+    });
+  }
+
+  async removeDocument(taskId: string, docId: string) {
+    const link = await this.prisma.taskDocument.findFirst({
+      where: { taskId, id: docId },
+    });
+    if (!link) throw new NotFoundError("關聯文件不存在");
+
+    return this.prisma.taskDocument.delete({
+      where: { id: docId },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `TaskDocument` model（taskId + outlineDocumentId 聯合唯一）
- 實作 TaskDocumentService（CRUD、重複偵測、驗證）
- 新增 API：`GET/POST /api/tasks/:id/documents`、`DELETE /api/tasks/:id/documents/:docId`
- 新增 `TaskDocumentSection` 元件整合至任務詳情 modal

## QA 自審報告
- [x] `tsc --noEmit` 0 new errors（pre-existing reports/page.tsx error 不影響）
- [x] Jest 9/9 tests pass（task-document-service）
- [x] AC 驗證：重複連結拒絕、驗證空值、移除連結、多文件連結
- [x] 無密鑰洩漏

## Test plan
- [ ] 搜尋並連結 Outline 文件
- [ ] 重複連結同一文件被拒
- [ ] 移除連結不影響文件本身
- [ ] 10+ 文件連結 UI 正常

Fixes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)