### PR TITLE
feat(reports): R-1 任務完成率報表 — 折線圖 + 週/月切換

### DIFF
--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Download, RefreshCw, BarChart3, Printer, FileSpreadsheet } from "lucide-react";
+import { Download, RefreshCw, BarChart3, Printer, FileSpreadsheet, TrendingUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractData } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
@@ -23,7 +23,7 @@ function PrintButton() {
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
-type TabId = "weekly" | "monthly" | "kpi" | "workload" | "trends" | "audit";
+type TabId = "weekly" | "monthly" | "completion" | "kpi" | "workload" | "trends" | "audit";
 
 interface Tab {
   id: TabId;
@@ -33,6 +33,7 @@ interface Tab {
 const TABS: Tab[] = [
   { id: "weekly", label: "週報" },
   { id: "monthly", label: "月報" },
+  { id: "completion", label: "完成率" },
   { id: "kpi", label: "KPI 報表" },
   { id: "workload", label: "計畫外負荷" },
   { id: "trends", label: "趨勢分析" },
@@ -312,6 +313,153 @@ function MonthlyReport() {
               </div>
             </div>
           )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Completion Rate Report (R-1 #836) ─────────────────────────────────────
+
+interface CompletionDataPoint {
+  label: string;
+  completionRate: number;
+  completedCount: number;
+  totalCount: number;
+}
+
+function CompletionRateReport() {
+  const [granularity, setGranularity] = useState<"week" | "month">("month");
+  const [data, setData] = useState<CompletionDataPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [CompletionChart, setCompletionChart] = useState<React.ComponentType<{
+    data: CompletionDataPoint[];
+    granularity: "week" | "month";
+  }> | null>(null);
+
+  // Lazy-load ECharts component
+  useEffect(() => {
+    import("@/app/components/completion-rate-chart").then((mod) => {
+      setCompletionChart(() => mod.CompletionRateChart);
+    });
+  }, []);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    fetch(`/api/reports/completion-rate?granularity=${granularity}`)
+      .then((r) => { if (!r.ok) throw new Error("完成率報表載入失敗"); return r.json(); })
+      .then((body) => {
+        const d = extractData<{ data: CompletionDataPoint[] }>(body);
+        setData(d?.data ?? []);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "載入失敗"))
+      .finally(() => setLoading(false));
+  }, [granularity]);
+
+  useEffect(() => { load(); }, [load]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>統計粒度</span>
+          <select
+            value={granularity}
+            onChange={(e) => setGranularity(e.target.value as "week" | "month")}
+            className="h-9 bg-card border border-border text-sm rounded-lg px-3 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 cursor-pointer"
+          >
+            <option value="week">週統計</option>
+            <option value="month">月統計</option>
+          </select>
+        </div>
+        <button
+          onClick={load}
+          className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </button>
+      </div>
+
+      {loading ? (
+        <PageLoading message="載入完成率報表..." />
+      ) : error ? (
+        <PageError message={error} onRetry={load} />
+      ) : data.length === 0 ? (
+        <PageEmpty
+          icon={<TrendingUp className="h-8 w-8" />}
+          title="無完成率資料"
+          description="所選期間尚無任務數據"
+        />
+      ) : (
+        <>
+          {/* Summary stats */}
+          <div className="grid grid-cols-3 gap-4">
+            <div className="bg-card rounded-xl shadow-card p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums">
+                {data.reduce((s, d) => s + d.totalCount, 0)}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">總任務數</p>
+            </div>
+            <div className="bg-card rounded-xl shadow-card p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums text-success">
+                {data.reduce((s, d) => s + d.completedCount, 0)}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">已完成</p>
+            </div>
+            <div className="bg-card rounded-xl shadow-card p-4 text-center">
+              <p className="text-2xl font-semibold tabular-nums">
+                {(() => {
+                  const total = data.reduce((s, d) => s + d.totalCount, 0);
+                  const done = data.reduce((s, d) => s + d.completedCount, 0);
+                  return total > 0 ? Math.round((done / total) * 100) : 0;
+                })()}%
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">整體完成率</p>
+            </div>
+          </div>
+
+          {/* Chart */}
+          <div className="bg-card rounded-xl shadow-card p-4">
+            <SectionTitle>
+              {granularity === "week" ? "每週" : "每月"}任務完成率趨勢
+            </SectionTitle>
+            {CompletionChart ? (
+              <CompletionChart data={data} granularity={granularity} />
+            ) : (
+              <div className="h-80 flex items-center justify-center text-muted-foreground text-sm">
+                載入圖表元件...
+              </div>
+            )}
+          </div>
+
+          {/* Data table */}
+          <div className="bg-card rounded-xl shadow-card p-4">
+            <SectionTitle>明細</SectionTitle>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-xs font-medium text-muted-foreground px-3 py-2">期間</th>
+                    <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">總任務</th>
+                    <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">已完成</th>
+                    <th className="text-right text-xs font-medium text-muted-foreground px-3 py-2">完成率</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.map((d) => (
+                    <tr key={d.label} className="border-b border-border/50 last:border-0">
+                      <td className="px-3 py-2 text-foreground">{d.label}</td>
+                      <td className="px-3 py-2 text-right tabular-nums">{d.totalCount}</td>
+                      <td className="px-3 py-2 text-right tabular-nums text-success">{d.completedCount}</td>
+                      <td className="px-3 py-2 text-right tabular-nums font-medium">{d.completionRate}%</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         </>
       )}
     </div>
@@ -910,6 +1058,7 @@ function AuditReport() {
 const TAB_COMPONENTS: Record<TabId, React.ComponentType> = {
   weekly: WeeklyReport,
   monthly: MonthlyReport,
+  completion: CompletionRateReport,
   kpi: KPIReport,
   workload: WorkloadReport,
   trends: TrendsReport,

--- a/app/api/reports/completion-rate/route.ts
+++ b/app/api/reports/completion-rate/route.ts
@@ -1,0 +1,58 @@
+/**
+ * GET /api/reports/completion-rate?granularity=week|month&dateFrom=&dateTo=&userId=
+ *
+ * R-1: Task completion rate report — returns completion rate data points
+ * for rendering a line chart (weekly or monthly aggregation).
+ *
+ * - Manager can see all team members, optionally filter by userId
+ * - Member sees only their own tasks
+ * - Empty periods return 0% (not omitted)
+ *
+ * Fixes #836
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import {
+  getWeekBounds,
+  getCompletionRateData,
+  type CompletionRatePoint,
+} from "@/lib/completion-rate";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const { searchParams } = new URL(req.url);
+
+  const granularity = (searchParams.get("granularity") ?? "month") as "week" | "month";
+  const dateFrom = searchParams.get("dateFrom");
+  const dateTo = searchParams.get("dateTo");
+  const filterUserId = searchParams.get("userId");
+
+  const isManager = session.user.role === "MANAGER";
+
+  // Default range: last 6 months
+  const now = new Date();
+  const defaultFrom = new Date(now.getFullYear(), now.getMonth() - 5, 1);
+  const startDate = dateFrom ? new Date(dateFrom) : defaultFrom;
+  const endDate = dateTo ? new Date(dateTo + "T23:59:59.999Z") : now;
+
+  // Determine user filter
+  const userFilter: { primaryAssigneeId?: string } = {};
+  if (!isManager) {
+    userFilter.primaryAssigneeId = session.user.id;
+  } else if (filterUserId) {
+    userFilter.primaryAssigneeId = filterUserId;
+  }
+
+  const data = await getCompletionRateData(
+    prisma,
+    startDate,
+    endDate,
+    granularity,
+    userFilter,
+  );
+
+  return success({ granularity, dateFrom: startDate.toISOString(), dateTo: endDate.toISOString(), data });
+});

--- a/app/components/completion-rate-chart.tsx
+++ b/app/components/completion-rate-chart.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { CanvasRenderer } from "echarts/renderers";
+import {
+  TooltipComponent,
+  GridComponent,
+  LegendComponent,
+} from "echarts/components";
+
+echarts.use([LineChart, CanvasRenderer, TooltipComponent, GridComponent, LegendComponent]);
+
+export interface CompletionDataPoint {
+  label: string;
+  completionRate: number;
+  completedCount: number;
+  totalCount: number;
+}
+
+interface CompletionRateChartProps {
+  data: CompletionDataPoint[];
+  granularity: "week" | "month";
+  /** Optional: member filter display label */
+  memberLabel?: string;
+}
+
+/**
+ * R-1: Task completion rate line chart (ECharts).
+ * Shows completion rate trend over weeks or months.
+ * Empty periods show 0% (no broken lines).
+ */
+export function CompletionRateChart({ data, granularity, memberLabel }: CompletionRateChartProps) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstance = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    if (!chartInstance.current) {
+      chartInstance.current = echarts.init(chartRef.current);
+    }
+
+    const labels = data.map((d) => d.label);
+    const rates = data.map((d) => d.completionRate);
+
+    chartInstance.current.setOption({
+      tooltip: {
+        trigger: "axis",
+        formatter: (params: { dataIndex: number; name: string; value: number }[]) => {
+          const p = params[0];
+          if (!p) return "";
+          const d = data[p.dataIndex];
+          return `<strong>${p.name}</strong><br/>` +
+            `完成率：${d.completionRate}%<br/>` +
+            `完成：${d.completedCount} / ${d.totalCount} 件`;
+        },
+      },
+      grid: {
+        left: "3%",
+        right: "4%",
+        bottom: "3%",
+        containLabel: true,
+      },
+      xAxis: {
+        type: "category",
+        data: labels,
+        axisLabel: {
+          fontSize: 11,
+          color: "#888",
+          rotate: granularity === "week" && labels.length > 12 ? 45 : 0,
+        },
+        boundaryGap: false,
+      },
+      yAxis: {
+        type: "value",
+        min: 0,
+        max: 100,
+        axisLabel: {
+          formatter: "{value}%",
+          fontSize: 11,
+          color: "#888",
+        },
+      },
+      series: [
+        {
+          name: memberLabel ?? "任務完成率",
+          type: "line",
+          data: rates,
+          smooth: true,
+          symbol: "circle",
+          symbolSize: 6,
+          lineStyle: { width: 2.5 },
+          areaStyle: {
+            opacity: 0.15,
+          },
+          connectNulls: false,
+          itemStyle: {
+            color: "#6366f1",
+          },
+        },
+      ],
+    });
+
+    const handleResize = () => chartInstance.current?.resize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [data, granularity, memberLabel]);
+
+  useEffect(() => {
+    return () => {
+      chartInstance.current?.dispose();
+    };
+  }, []);
+
+  return <div ref={chartRef} className="w-full h-80" />;
+}

--- a/lib/__tests__/completion-rate.test.ts
+++ b/lib/__tests__/completion-rate.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for completion rate calculation — R-1 (#836)
+ */
+import { getWeekBounds, getCompletionRateData } from "../completion-rate";
+import { createMockPrisma } from "../test-utils";
+
+/** Helper: format local date as YYYY-MM-DD */
+function localDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+describe("getWeekBounds", () => {
+  it("returns Monday-Sunday for a Wednesday", () => {
+    // Use local date constructor to avoid UTC offset issues
+    const { start, end } = getWeekBounds(new Date(2026, 2, 25)); // Wed Mar 25 2026
+    expect(start.getDay()).toBe(1); // Monday
+    expect(end.getDay()).toBe(0);   // Sunday
+    expect(localDateStr(start)).toBe("2026-03-23");
+    expect(localDateStr(end)).toBe("2026-03-29");
+  });
+
+  it("returns Monday-Sunday for a Sunday", () => {
+    const { start, end } = getWeekBounds(new Date(2026, 2, 29)); // Sun Mar 29 2026
+    expect(localDateStr(start)).toBe("2026-03-23");
+    expect(localDateStr(end)).toBe("2026-03-29");
+  });
+
+  it("returns Monday-Sunday for a Monday", () => {
+    const { start, end } = getWeekBounds(new Date(2026, 2, 23)); // Mon Mar 23 2026
+    expect(localDateStr(start)).toBe("2026-03-23");
+    expect(localDateStr(end)).toBe("2026-03-29");
+  });
+});
+
+describe("getCompletionRateData", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+  });
+
+  it("returns 0% for periods with no tasks", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await getCompletionRateData(
+      prisma as never,
+      new Date("2026-01-01"),
+      new Date("2026-03-31"),
+      "month",
+      {},
+    );
+
+    expect(result.length).toBe(3);
+    expect(result[0].completionRate).toBe(0);
+    expect(result[0].totalCount).toBe(0);
+    expect(result[0].completedCount).toBe(0);
+    expect(result[0].label).toBe("2026/01");
+  });
+
+  it("calculates correct completion rate for monthly granularity", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([
+      { id: "1", status: "DONE", createdAt: new Date("2026-01-05"), updatedAt: new Date("2026-01-20"), dueDate: new Date("2026-01-15") },
+      { id: "2", status: "DONE", createdAt: new Date("2026-01-10"), updatedAt: new Date("2026-01-25"), dueDate: new Date("2026-01-31") },
+      { id: "3", status: "IN_PROGRESS", createdAt: new Date("2026-01-03"), updatedAt: new Date("2026-01-15"), dueDate: new Date("2026-01-20") },
+    ]);
+
+    const result = await getCompletionRateData(
+      prisma as never,
+      new Date("2026-01-01"),
+      new Date("2026-01-31"),
+      "month",
+      {},
+    );
+
+    expect(result.length).toBe(1);
+    expect(result[0].totalCount).toBe(3);
+    expect(result[0].completedCount).toBe(2);
+    // 2/3 * 100 = 66.7%
+    expect(result[0].completionRate).toBe(66.7);
+  });
+
+  it("handles divide-by-zero when no tasks in period", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await getCompletionRateData(
+      prisma as never,
+      new Date("2026-02-01"),
+      new Date("2026-02-28"),
+      "month",
+      {},
+    );
+
+    expect(result[0].completionRate).toBe(0);
+    expect(result[0].totalCount).toBe(0);
+  });
+
+  it("generates weekly buckets correctly", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await getCompletionRateData(
+      prisma as never,
+      new Date("2026-03-02"), // Monday
+      new Date("2026-03-22"), // Sunday
+      "week",
+      {},
+    );
+
+    expect(result.length).toBe(3);
+    expect(result[0].label).toBe("3/2");
+    expect(result[1].label).toBe("3/9");
+    expect(result[2].label).toBe("3/16");
+  });
+
+  it("respects user filter parameter", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    await getCompletionRateData(
+      prisma as never,
+      new Date("2026-01-01"),
+      new Date("2026-01-31"),
+      "month",
+      { primaryAssigneeId: "user-123" },
+    );
+
+    expect(prisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          primaryAssigneeId: "user-123",
+        }),
+      }),
+    );
+  });
+
+  it("empty periods show 0% not gaps", async () => {
+    // Task only in January, querying Jan-Mar
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([
+      { id: "1", status: "DONE", createdAt: new Date("2026-01-05"), updatedAt: new Date("2026-01-20"), dueDate: new Date("2026-01-15") },
+    ]);
+
+    const result = await getCompletionRateData(
+      prisma as never,
+      new Date("2026-01-01"),
+      new Date("2026-03-31"),
+      "month",
+      {},
+    );
+
+    expect(result.length).toBe(3);
+    expect(result[0].completionRate).toBe(100); // Jan: 1/1
+    expect(result[1].completionRate).toBe(0);   // Feb: 0/0 → 0%
+    expect(result[2].completionRate).toBe(0);   // Mar: 0/0 → 0%
+  });
+});

--- a/lib/completion-rate.ts
+++ b/lib/completion-rate.ts
@@ -1,0 +1,157 @@
+/**
+ * Completion rate calculation utilities — R-1 (#836)
+ *
+ * Computes task completion rate (completed/total * 100%) aggregated
+ * by week or month. Empty periods return 0% (no gaps in the line chart).
+ *
+ * Week bounds follow Asia/Taipei Monday–Sunday convention.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+export interface CompletionRatePoint {
+  label: string;
+  periodStart: string;
+  periodEnd: string;
+  completedCount: number;
+  totalCount: number;
+  completionRate: number;
+}
+
+/** Get Monday 00:00 of the week containing `date`. */
+export function getWeekBounds(date: Date): { start: Date; end: Date } {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diffToMon = day === 0 ? -6 : 1 - day;
+  const start = new Date(d);
+  start.setDate(d.getDate() + diffToMon);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return { start, end };
+}
+
+function formatDateStr(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function formatWeekLabel(start: Date): string {
+  const m = start.getMonth() + 1;
+  const d = start.getDate();
+  return `${m}/${d}`;
+}
+
+function formatMonthLabel(year: number, month: number): string {
+  return `${year}/${String(month).padStart(2, "0")}`;
+}
+
+/**
+ * Generate weekly period buckets between startDate and endDate.
+ */
+function generateWeekBuckets(startDate: Date, endDate: Date): Array<{ start: Date; end: Date; label: string }> {
+  const buckets: Array<{ start: Date; end: Date; label: string }> = [];
+  let { start } = getWeekBounds(startDate);
+
+  while (start <= endDate) {
+    const end = new Date(start);
+    end.setDate(start.getDate() + 6);
+    end.setHours(23, 59, 59, 999);
+    buckets.push({ start: new Date(start), end, label: formatWeekLabel(start) });
+    start = new Date(start);
+    start.setDate(start.getDate() + 7);
+  }
+  return buckets;
+}
+
+/**
+ * Generate monthly period buckets between startDate and endDate.
+ */
+function generateMonthBuckets(startDate: Date, endDate: Date): Array<{ start: Date; end: Date; label: string }> {
+  const buckets: Array<{ start: Date; end: Date; label: string }> = [];
+  let year = startDate.getFullYear();
+  let month = startDate.getMonth(); // 0-based
+
+  while (true) {
+    const start = new Date(year, month, 1, 0, 0, 0, 0);
+    const end = new Date(year, month + 1, 0, 23, 59, 59, 999);
+    if (start > endDate) break;
+    buckets.push({ start, end, label: formatMonthLabel(year, month + 1) });
+    month++;
+    if (month > 11) { month = 0; year++; }
+  }
+  return buckets;
+}
+
+/**
+ * Query and compute completion rate data points.
+ *
+ * For each period bucket:
+ * - totalCount = tasks that existed in the period (created before period end, with due date in period OR active in period)
+ * - completedCount = tasks marked DONE within the period
+ * - completionRate = completedCount / totalCount * 100 (0% when totalCount is 0)
+ */
+export async function getCompletionRateData(
+  prisma: PrismaClient,
+  startDate: Date,
+  endDate: Date,
+  granularity: "week" | "month",
+  userFilter: { primaryAssigneeId?: string },
+): Promise<CompletionRatePoint[]> {
+  const buckets = granularity === "week"
+    ? generateWeekBuckets(startDate, endDate)
+    : generateMonthBuckets(startDate, endDate);
+
+  // Fetch all tasks in the full date range in one query for performance
+  const allTasks = await prisma.task.findMany({
+    where: {
+      ...userFilter,
+      createdAt: { lte: endDate },
+      OR: [
+        { dueDate: { gte: startDate, lte: endDate } },
+        { status: "DONE", updatedAt: { gte: startDate, lte: endDate } },
+      ],
+    },
+    select: {
+      id: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+      dueDate: true,
+    },
+  });
+
+  return buckets.map((bucket) => {
+    // Tasks relevant to this period: created before period end AND
+    // (has dueDate in period OR was completed in period)
+    const periodTasks = allTasks.filter((t) => {
+      const created = new Date(t.createdAt);
+      if (created > bucket.end) return false;
+      const due = t.dueDate ? new Date(t.dueDate) : null;
+      const updated = new Date(t.updatedAt);
+      const dueInPeriod = due && due >= bucket.start && due <= bucket.end;
+      const doneInPeriod = t.status === "DONE" && updated >= bucket.start && updated <= bucket.end;
+      return dueInPeriod || doneInPeriod;
+    });
+
+    const completedCount = periodTasks.filter((t) => {
+      if (t.status !== "DONE") return false;
+      const updated = new Date(t.updatedAt);
+      return updated >= bucket.start && updated <= bucket.end;
+    }).length;
+
+    const totalCount = periodTasks.length;
+    const completionRate = totalCount > 0
+      ? Math.round((completedCount / totalCount) * 1000) / 10
+      : 0;
+
+    return {
+      label: bucket.label,
+      periodStart: formatDateStr(bucket.start),
+      periodEnd: formatDateStr(bucket.end),
+      completedCount,
+      totalCount,
+      completionRate,
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- 新增 `CompletionRateChart` ECharts 折線圖元件，支援週/月統計切換
- 新增 `/api/reports/completion-rate` API，支援 granularity、dateFrom/dateTo、userId 篩選
- 新增 `lib/completion-rate.ts` 共用計算邏輯（週/月 bucket 生成、完成率聚合）
- 報表頁面新增「完成率」tab，含摘要統計卡片 + 折線圖 + 明細表格
- 空時段顯示 0%（無斷線），除以零防護

## QA 自審報告
- [x] `tsc --noEmit` 0 errors
- [x] `jest lib/__tests__/completion-rate.test.ts` — 9/9 passed
- [x] AC: 折線圖顯示每週/每月完成率 ✓
- [x] AC: 支援週/月切換 ✓
- [x] AC: ECharts 渲染 + hover tooltip ✓
- [x] AC: Manager 全團隊 / Member 自己 ✓
- [x] AC: 空資料時段顯示 0% ✓
- [x] AC: 除以零防護 ✓

## Test plan
- [x] 單元測試：getWeekBounds 正確計算 Monday-Sunday
- [x] 單元測試：月度/週度 bucket 生成正確
- [x] 單元測試：完成率計算含邊界案例
- [x] 單元測試：user filter 參數傳遞
- [x] 單元測試：空期間 0% 不斷線

Fixes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)