### PR TITLE
feat(gantt): G-2 甘特圖里程碑標記

### DIFF
--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -15,6 +15,8 @@ type User = { id: string; name: string };
 type Milestone = {
   id: string;
   title: string;
+  description?: string | null;
+  type: string;
   plannedEnd: string;
   status: string;
 };
@@ -222,6 +224,26 @@ function GanttBar({ task, year, totalDays, onClick, canDrag, onDateChange }: Gan
   );
 }
 
+// ─── Milestone Type Config ────────────────────────────────────────────────────
+
+const MILESTONE_TYPE_COLOR: Record<string, string> = {
+  LAUNCH: "text-emerald-500",
+  AUDIT: "text-rose-500",
+  CUSTOM: "text-amber-500",
+};
+
+const MILESTONE_TYPE_LINE: Record<string, string> = {
+  LAUNCH: "bg-emerald-500/30",
+  AUDIT: "bg-rose-500/30",
+  CUSTOM: "bg-amber-500/30",
+};
+
+const MILESTONE_TYPE_LABEL: Record<string, string> = {
+  LAUNCH: "上線日",
+  AUDIT: "稽核日",
+  CUSTOM: "自訂",
+};
+
 // ─── Milestone Marker ─────────────────────────────────────────────────────────
 
 type MilestoneMarkerProps = {
@@ -231,23 +253,44 @@ type MilestoneMarkerProps = {
 };
 
 function MilestoneMarker({ milestone, year, totalDays }: MilestoneMarkerProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
   const day = dayOfYear(milestone.plannedEnd, year);
   if (day < 0 || day > totalDays) return null;
   const leftPct = (day / totalDays) * 100;
+  const typeColor = MILESTONE_TYPE_COLOR[milestone.type] ?? MILESTONE_TYPE_COLOR.CUSTOM;
+  const lineColor = MILESTONE_TYPE_LINE[milestone.type] ?? MILESTONE_TYPE_LINE.CUSTOM;
+  const typeLabel = MILESTONE_TYPE_LABEL[milestone.type] ?? "自訂";
+  const dateLabel = new Date(milestone.plannedEnd).toLocaleDateString("zh-TW");
 
   return (
     <div
-      className="absolute top-0 bottom-0 flex flex-col items-center pointer-events-none"
+      className="absolute top-0 bottom-0 flex flex-col items-center"
       style={{ left: `${leftPct}%` }}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
     >
-      <div className="w-px h-full bg-amber-500/30" />
+      <div className={cn("w-px h-full", lineColor)} />
       <div
-        className={cn("absolute top-0 -translate-x-1/2 flex flex-col items-center gap-0.5", MILESTONE_STATUS_COLOR[milestone.status] ?? "text-muted-foreground")}
+        className={cn("absolute top-0 -translate-x-1/2 flex flex-col items-center gap-0.5", typeColor)}
         style={{ whiteSpace: "nowrap" }}
       >
         <Diamond className="h-3 w-3 fill-current" />
         <span className="text-[9px] font-medium bg-background/80 px-1 rounded">{milestone.title}</span>
       </div>
+      {/* Hover tooltip */}
+      {showTooltip && (
+        <div className="absolute top-8 -translate-x-1/2 z-30 bg-popover border border-border rounded-lg shadow-xl px-3 py-2 min-w-[160px] pointer-events-none">
+          <div className="text-xs font-semibold text-foreground">{milestone.title}</div>
+          <div className="text-[10px] text-muted-foreground mt-1 space-y-0.5">
+            <div>類型：{typeLabel}</div>
+            <div>日期：{dateLabel}</div>
+            <div>狀態：{MILESTONE_STATUS_COLOR[milestone.status] ? milestone.status : "PENDING"}</div>
+            {milestone.description && (
+              <div className="mt-1 text-foreground/70">{milestone.description}</div>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/api/milestones/[id]/route.ts
+++ b/app/api/milestones/[id]/route.ts
@@ -29,6 +29,7 @@ export const PUT = withAuth(async (
   const milestone = await getService().updateMilestone(id, {
     title: data.title,
     description: data.description,
+    type: data.type,
     plannedStart: data.plannedStart,
     plannedEnd: data.plannedEnd,
     actualStart: data.actualStart,

--- a/app/api/milestones/route.ts
+++ b/app/api/milestones/route.ts
@@ -26,6 +26,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     annualPlanId: data.annualPlanId,
     title: data.title,
     description: data.description,
+    type: data.type,
     plannedStart: data.plannedStart,
     plannedEnd: data.plannedEnd,
     order: data.order,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -258,11 +258,18 @@ enum MilestoneStatus {
   CANCELLED
 }
 
+enum MilestoneType {
+  LAUNCH     // 上線日
+  AUDIT      // 稽核日
+  CUSTOM     // 自訂
+}
+
 model Milestone {
   id           String          @id @default(cuid())
   annualPlanId String
   title        String
   description  String?
+  type         MilestoneType   @default(CUSTOM)
   plannedStart DateTime?
   plannedEnd   DateTime
   actualStart  DateTime?

--- a/services/__tests__/tdd8-milestone-type.test.ts
+++ b/services/__tests__/tdd8-milestone-type.test.ts
@@ -1,0 +1,82 @@
+import { MilestoneService } from "../milestone-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+describe("MilestoneService — type field (G-2, Issue #843)", () => {
+  let service: MilestoneService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new MilestoneService(prisma as never);
+  });
+
+  test("createMilestone defaults type to CUSTOM", async () => {
+    const input = {
+      annualPlanId: "plan-1",
+      title: "Release",
+      plannedEnd: new Date("2026-06-01"),
+    };
+    (prisma.milestone.create as jest.Mock).mockResolvedValue({ id: "ms-1", ...input, type: "CUSTOM" });
+
+    const result = await service.createMilestone(input);
+
+    expect(prisma.milestone.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "CUSTOM" }),
+      })
+    );
+    expect(result.type).toBe("CUSTOM");
+  });
+
+  test("createMilestone accepts LAUNCH type", async () => {
+    const input = {
+      annualPlanId: "plan-1",
+      title: "Go Live",
+      type: "LAUNCH" as const,
+      plannedEnd: new Date("2026-09-01"),
+    };
+    (prisma.milestone.create as jest.Mock).mockResolvedValue({ id: "ms-2", ...input });
+
+    const result = await service.createMilestone(input);
+
+    expect(prisma.milestone.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "LAUNCH" }),
+      })
+    );
+    expect(result.type).toBe("LAUNCH");
+  });
+
+  test("createMilestone accepts AUDIT type", async () => {
+    const input = {
+      annualPlanId: "plan-1",
+      title: "ISO Audit",
+      type: "AUDIT" as const,
+      plannedEnd: new Date("2026-11-15"),
+    };
+    (prisma.milestone.create as jest.Mock).mockResolvedValue({ id: "ms-3", ...input });
+
+    const result = await service.createMilestone(input);
+
+    expect(prisma.milestone.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "AUDIT" }),
+      })
+    );
+    expect(result.type).toBe("AUDIT");
+  });
+
+  test("updateMilestone can change type", async () => {
+    (prisma.milestone.findUnique as jest.Mock).mockResolvedValue({ id: "ms-1", type: "CUSTOM" });
+    (prisma.milestone.update as jest.Mock).mockResolvedValue({ id: "ms-1", type: "LAUNCH" });
+
+    const result = await service.updateMilestone("ms-1", { type: "LAUNCH" });
+
+    expect(prisma.milestone.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ type: "LAUNCH" }),
+      })
+    );
+    expect(result.type).toBe("LAUNCH");
+  });
+});

--- a/services/milestone-service.ts
+++ b/services/milestone-service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, MilestoneStatus } from "@prisma/client";
+import { PrismaClient, MilestoneStatus, MilestoneType } from "@prisma/client";
 import { NotFoundError, ValidationError } from "./errors";
 
 export interface ListMilestonesFilter {
@@ -9,6 +9,7 @@ export interface CreateMilestoneInput {
   annualPlanId: string;
   title: string;
   description?: string | null;
+  type?: MilestoneType | string;
   plannedStart?: Date | null;
   plannedEnd: Date;
   order?: number;
@@ -17,6 +18,7 @@ export interface CreateMilestoneInput {
 export interface UpdateMilestoneInput {
   title?: string;
   description?: string | null;
+  type?: MilestoneType | string;
   plannedStart?: Date | null;
   plannedEnd?: Date;
   actualStart?: Date | null;
@@ -70,6 +72,7 @@ export class MilestoneService {
         annualPlanId: input.annualPlanId,
         title: input.title,
         description: input.description ?? null,
+        type: (input.type ?? "CUSTOM") as MilestoneType,
         plannedStart: input.plannedStart ?? null,
         plannedEnd: input.plannedEnd,
         order: input.order ?? 0,
@@ -87,6 +90,7 @@ export class MilestoneService {
     const updates: Record<string, unknown> = {};
     if (input.title !== undefined) updates.title = input.title;
     if (input.description !== undefined) updates.description = input.description;
+    if (input.type !== undefined) updates.type = input.type;
     if (input.plannedStart !== undefined) updates.plannedStart = input.plannedStart;
     if (input.plannedEnd !== undefined) updates.plannedEnd = input.plannedEnd;
     if (input.actualStart !== undefined) updates.actualStart = input.actualStart;

--- a/validators/milestone-validators.ts
+++ b/validators/milestone-validators.ts
@@ -8,11 +8,18 @@ const MilestoneStatusEnum = z.enum([
   "CANCELLED",
 ]);
 
+const MilestoneTypeEnum = z.enum([
+  "LAUNCH",
+  "AUDIT",
+  "CUSTOM",
+]);
+
 export const createMilestoneSchema = z
   .object({
     annualPlanId: z.string().min(1),
     title: z.string().min(1),
     description: z.string().optional(),
+    type: MilestoneTypeEnum.optional().default("CUSTOM"),
     plannedStart: z.coerce.date().optional(),
     plannedEnd: z.coerce.date(),
     order: z.number().int().min(0).optional(),
@@ -30,6 +37,7 @@ export const createMilestoneSchema = z
 export const updateMilestoneSchema = z.object({
   title: z.string().min(1).optional(),
   description: z.string().optional(),
+  type: MilestoneTypeEnum.optional(),
   plannedStart: z.coerce.date().optional(),
   plannedEnd: z.coerce.date().optional(),
   actualStart: z.coerce.date().optional(),


### PR DESCRIPTION
## Summary
- 新增 `MilestoneType` enum（LAUNCH/AUDIT/CUSTOM）至 Prisma schema
- 更新 MilestoneService、validators、API routes 支援 type 欄位
- 甘特圖里程碑菱形圖示依類型顯示不同顏色（綠=上線、紅=稽核、琥珀=自訂）
- Hover tooltip 顯示名稱、日期、類型、描述

## QA 自審報告
- [x] `tsc --noEmit` 0 new errors
- [x] Jest 13/13 tests pass（milestone-service + tdd8-milestone-type）
- [x] AC 驗證：建立里程碑含類型、菱形顏色區分、tooltip、CRUD
- [x] 無密鑰洩漏

## Test plan
- [ ] 建立 LAUNCH/AUDIT/CUSTOM 里程碑驗證顏色
- [ ] Hover 菱形圖示確認 tooltip 內容
- [ ] 同一天多個里程碑正常顯示
- [ ] Member 只讀不可管理

Fixes #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)