### PR TITLE
feat(reports): R-3 CSV 匯出 — UTF-8 BOM + streaming

### DIFF
--- a/app/components/export-button.tsx
+++ b/app/components/export-button.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ExportButtonProps {
+  /** Report type for the API call (e.g., "weekly", "monthly", "kpi") */
+  reportType: string;
+  /** Additional query params for the export API */
+  queryParams?: Record<string, string>;
+  /** Button label override */
+  label?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * R-3: CSV export button component.
+ * Triggers a CSV download from /api/reports/export?type={reportType}&format=csv.
+ * Shows loading state during download.
+ */
+export function ExportButton({
+  reportType,
+  queryParams = {},
+  label = "匯出 CSV",
+  className,
+  disabled = false,
+}: ExportButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  async function handleExport() {
+    if (loading || disabled) return;
+    setLoading(true);
+
+    try {
+      const params = new URLSearchParams({
+        type: reportType,
+        format: "csv",
+        ...queryParams,
+      });
+
+      const res = await fetch(`/api/reports/export?${params.toString()}`);
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        throw new Error(errBody?.message ?? "匯出失敗");
+      }
+
+      // Extract filename from Content-Disposition header or build default
+      const disposition = res.headers.get("Content-Disposition");
+      const filenameMatch = disposition?.match(/filename="?([^"]+)"?/);
+      const filename = filenameMatch?.[1] ?? `${reportType}-report.csv`;
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "匯出失敗，請稍後再試");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={loading || disabled}
+      className={cn(
+        "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md transition-colors",
+        "bg-accent hover:bg-accent/80 text-foreground border border-border",
+        (loading || disabled) && "opacity-50 cursor-not-allowed",
+        className,
+      )}
+    >
+      {loading ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Download className="h-3.5 w-3.5" />
+      )}
+      {label}
+    </button>
+  );
+}

--- a/lib/utils/__tests__/csv-builder.test.ts
+++ b/lib/utils/__tests__/csv-builder.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for CSV builder — R-3 (#838)
+ */
+import {
+  escapeCsvField,
+  generateCsvString,
+  buildCsvWithBom,
+  buildExportFilename,
+  streamCsvRows,
+  UTF8_BOM,
+} from "../csv-builder";
+
+describe("escapeCsvField", () => {
+  it("returns plain string as-is", () => {
+    expect(escapeCsvField("hello")).toBe("hello");
+  });
+
+  it("quotes fields containing commas", () => {
+    expect(escapeCsvField("a,b")).toBe('"a,b"');
+  });
+
+  it("quotes fields containing double quotes and escapes them", () => {
+    expect(escapeCsvField('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("quotes fields containing newlines", () => {
+    expect(escapeCsvField("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("handles null and undefined as empty string", () => {
+    expect(escapeCsvField(null)).toBe("");
+    expect(escapeCsvField(undefined)).toBe("");
+  });
+
+  it("converts numbers to string", () => {
+    expect(escapeCsvField(42)).toBe("42");
+    expect(escapeCsvField(3.14)).toBe("3.14");
+  });
+});
+
+describe("generateCsvString", () => {
+  const columns = [
+    { header: "Name", key: "name" },
+    { header: "Value", key: "value" },
+  ];
+
+  it("generates header row", () => {
+    const csv = generateCsvString([], columns);
+    expect(csv).toBe("Name,Value");
+  });
+
+  it("generates header + data rows", () => {
+    const rows = [
+      { name: "Alice", value: 10 },
+      { name: "Bob", value: 20 },
+    ];
+    const csv = generateCsvString(rows, columns);
+    expect(csv).toBe("Name,Value\r\nAlice,10\r\nBob,20");
+  });
+
+  it("handles missing keys as empty", () => {
+    const rows = [{ name: "Alice" }];
+    const csv = generateCsvString(rows, columns);
+    expect(csv).toBe("Name,Value\r\nAlice,");
+  });
+
+  it("escapes special chars in data", () => {
+    const rows = [{ name: "O'Brien, Jr.", value: 'say "hi"' }];
+    const csv = generateCsvString(rows, columns);
+    expect(csv).toContain('"O\'Brien, Jr."');
+    expect(csv).toContain('"say ""hi"""');
+  });
+});
+
+describe("buildCsvWithBom", () => {
+  it("prepends UTF-8 BOM", () => {
+    const csv = buildCsvWithBom([], [{ header: "A", key: "a" }]);
+    expect(csv.charCodeAt(0)).toBe(0xFEFF);
+    expect(csv.startsWith(UTF8_BOM)).toBe(true);
+  });
+
+  it("contains correct CSV content after BOM", () => {
+    const csv = buildCsvWithBom(
+      [{ a: "1" }],
+      [{ header: "A", key: "a" }],
+    );
+    expect(csv.slice(1)).toBe("A\r\n1");
+  });
+});
+
+describe("buildExportFilename", () => {
+  it("generates filename with report type and export date", () => {
+    const filename = buildExportFilename("weekly");
+    const today = new Date().toISOString().slice(0, 10);
+    expect(filename).toBe(`weekly_${today}.csv`);
+  });
+
+  it("includes date range when provided", () => {
+    const filename = buildExportFilename("kpi", "2026-01-01", "2026-03-31");
+    const today = new Date().toISOString().slice(0, 10);
+    expect(filename).toBe(`kpi_2026-01-01_2026-03-31_${today}.csv`);
+  });
+});
+
+describe("streamCsvRows", () => {
+  const columns = [
+    { header: "ID", key: "id" },
+    { header: "Name", key: "name" },
+  ];
+
+  it("yields BOM + header as first chunk", () => {
+    const rows = [{ id: 1, name: "Alice" }];
+    const gen = streamCsvRows(rows, columns);
+    const first = gen.next().value;
+    expect(first).toContain(UTF8_BOM);
+    expect(first).toContain("ID,Name");
+  });
+
+  it("yields data in batches", () => {
+    const rows = Array.from({ length: 5 }, (_, i) => ({ id: i, name: `User${i}` }));
+    const gen = streamCsvRows(rows, columns, 2);
+
+    const chunks: string[] = [];
+    for (const chunk of gen) {
+      chunks.push(chunk);
+    }
+    // 1 header + 3 data chunks (2+2+1)
+    expect(chunks.length).toBe(4);
+  });
+
+  it("handles empty rows", () => {
+    const gen = streamCsvRows([], columns);
+    const chunks: string[] = [];
+    for (const chunk of gen) chunks.push(chunk);
+    // Just the header chunk
+    expect(chunks.length).toBe(1);
+  });
+});

--- a/lib/utils/csv-builder.ts
+++ b/lib/utils/csv-builder.ts
@@ -1,0 +1,90 @@
+/**
+ * CSV Builder — R-3 (#838)
+ *
+ * RFC 4180 compliant CSV generation with:
+ * - UTF-8 BOM for Excel CJK compatibility
+ * - Proper quoting for commas, quotes, newlines
+ * - Streaming support for large datasets
+ * - Configurable filename format: {type}_{dateRange}_{exportDate}.csv
+ */
+
+export interface CsvColumn {
+  header: string;
+  key: string;
+}
+
+/**
+ * Escape a CSV field value according to RFC 4180.
+ * Quotes fields containing commas, double-quotes, or newlines.
+ */
+export function escapeCsvField(value: unknown): string {
+  const str = value == null ? "" : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Generate a RFC 4180 CSV string from rows and column definitions.
+ */
+export function generateCsvString(
+  rows: Record<string, unknown>[],
+  columns: CsvColumn[],
+): string {
+  const headerLine = columns.map((c) => escapeCsvField(c.header)).join(",");
+  const dataLines = rows.map((row) =>
+    columns.map((c) => escapeCsvField(row[c.key])).join(","),
+  );
+  return [headerLine, ...dataLines].join("\r\n");
+}
+
+/** UTF-8 BOM prefix for Excel compatibility with CJK text */
+export const UTF8_BOM = "\uFEFF";
+
+/**
+ * Generate a complete CSV string with UTF-8 BOM.
+ */
+export function buildCsvWithBom(
+  rows: Record<string, unknown>[],
+  columns: CsvColumn[],
+): string {
+  return UTF8_BOM + generateCsvString(rows, columns);
+}
+
+/**
+ * Generate a standardized export filename.
+ * Format: {reportType}_{dateFrom}-{dateTo}_{exportDate}.csv
+ */
+export function buildExportFilename(
+  reportType: string,
+  dateFrom?: string,
+  dateTo?: string,
+): string {
+  const exportDate = new Date().toISOString().slice(0, 10);
+  const rangePart = dateFrom && dateTo ? `_${dateFrom}_${dateTo}` : "";
+  return `${reportType}${rangePart}_${exportDate}.csv`;
+}
+
+/**
+ * Create a streaming CSV generator for large datasets.
+ * Yields chunks: BOM + header, then batches of data rows.
+ */
+export function* streamCsvRows(
+  rows: Record<string, unknown>[],
+  columns: CsvColumn[],
+  batchSize = 500,
+): Generator<string> {
+  // First chunk: BOM + header
+  const header = UTF8_BOM + columns.map((c) => escapeCsvField(c.header)).join(",") + "\r\n";
+  yield header;
+
+  // Data chunks
+  for (let i = 0; i < rows.length; i += batchSize) {
+    const batch = rows.slice(i, i + batchSize);
+    const chunk = batch
+      .map((row) => columns.map((c) => escapeCsvField(row[c.key])).join(","))
+      .join("\r\n");
+    yield chunk + "\r\n";
+  }
+}


### PR DESCRIPTION
## Summary
- 新增 `lib/utils/csv-builder.ts`：RFC 4180 CSV 產生器，含 UTF-8 BOM、欄位 escape、streaming generator、標準化檔名
- 新增 `ExportButton` 元件：loading 狀態、Content-Disposition 檔名解析、錯誤處理
- CSV 編碼使用 UTF-8 BOM（\uFEFF），確保 Excel 正確開啟中文
- 檔名格式：`{報表類型}_{日期範圍}_{匯出日期}.csv`
- 大量資料支援 streaming 匯出（batchSize=500）

## QA 自審報告
- [x] `tsc --noEmit` 0 errors
- [x] `jest lib/utils/__tests__/csv-builder.test.ts` — 17/17 passed
- [x] AC: UTF-8 BOM header (EF BB BF) ✓
- [x] AC: 逗號、引號正確 escape ✓
- [x] AC: 檔名格式正確 ✓
- [x] AC: streaming 匯出 ✓
- [x] AC: 空報表匯出只有 header 行 ✓

## Test plan
- [x] escapeCsvField: plain, comma, quotes, newlines, null/undefined, numbers
- [x] generateCsvString: header only, header+data, missing keys, special chars
- [x] buildCsvWithBom: BOM prefix, content after BOM
- [x] buildExportFilename: with/without date range
- [x] streamCsvRows: header chunk, batch splitting, empty rows

Fixes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)