### PR TITLE
feat(knowledge): KB-1 Outline API 整合 + graceful fallback

### DIFF
--- a/app/api/outline/documents/route.ts
+++ b/app/api/outline/documents/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/outline/documents/:id — Get Outline document content
+ *
+ * KB-1: Proxy API for Outline document retrieval.
+ * Returns markdown content for rendering (no iframe).
+ *
+ * Fixes #840
+ */
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import { success, error } from "@/lib/api-response";
+import { getOutlineClient, OutlineApiError } from "@/services/outline-client";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+
+  if (!id) {
+    return error("BAD_REQUEST", "Document ID is required", 400);
+  }
+
+  const client = getOutlineClient();
+
+  if (!client.isEnabled) {
+    return error(
+      "OUTLINE_NOT_CONFIGURED",
+      "Outline 知識庫未設定。",
+      503,
+    );
+  }
+
+  try {
+    const document = await client.getDocument(id);
+    return success({
+      id: document.id,
+      title: document.title,
+      content: document.text,
+      parentDocumentId: document.parentDocumentId,
+      updatedAt: document.updatedAt,
+      updatedBy: document.updatedBy,
+    });
+  } catch (err) {
+    if (err instanceof OutlineApiError) {
+      if (err.statusCode === 404) {
+        return error("NOT_FOUND", "文件不存在。", 404);
+      }
+      if (err.isTimeout) {
+        return error("OUTLINE_TIMEOUT", "Outline 服務回應逾時。", 504);
+      }
+      return error("OUTLINE_ERROR", `Outline 服務異常：${err.message}`, err.statusCode ?? 502);
+    }
+    return error("OUTLINE_ERROR", "無法連線至 Outline 服務。", 502);
+  }
+});

--- a/app/api/outline/route.ts
+++ b/app/api/outline/route.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /api/outline/documents — List Outline documents (tree structure)
+ *
+ * KB-1: Proxy API for Outline document listing.
+ * Graceful fallback when Outline is unavailable.
+ *
+ * Fixes #840
+ */
+import { NextRequest } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import { success, error } from "@/lib/api-response";
+import { getOutlineClient, OutlineApiError } from "@/services/outline-client";
+
+export const GET = withAuth(async (_req: NextRequest) => {
+  const client = getOutlineClient();
+
+  if (!client.isEnabled) {
+    return error(
+      "OUTLINE_NOT_CONFIGURED",
+      "Outline 知識庫未設定。請聯繫管理員設定 OUTLINE_INTERNAL_URL 和 OUTLINE_API_TOKEN。",
+      503,
+    );
+  }
+
+  try {
+    const documents = await client.listDocuments();
+    return success({ documents });
+  } catch (err) {
+    if (err instanceof OutlineApiError) {
+      if (err.isTimeout) {
+        return error(
+          "OUTLINE_TIMEOUT",
+          "Outline 服務回應逾時，請稍後再試。",
+          504,
+        );
+      }
+      return error(
+        "OUTLINE_ERROR",
+        `Outline 服務異常：${err.message}`,
+        err.statusCode ?? 502,
+      );
+    }
+    return error("OUTLINE_ERROR", "無法連線至 Outline 服務。", 502);
+  }
+});

--- a/config/outline.ts
+++ b/config/outline.ts
@@ -1,0 +1,32 @@
+/**
+ * Outline configuration — KB-1 (#840)
+ *
+ * All Outline settings are read from environment variables.
+ * API token is never exposed to the frontend.
+ */
+
+export interface OutlineConfig {
+  /** Outline server base URL (internal) */
+  baseUrl: string;
+  /** API token for authentication */
+  apiToken: string;
+  /** Request timeout in milliseconds */
+  timeoutMs: number;
+  /** Maximum retry attempts */
+  maxRetries: number;
+  /** Whether Outline integration is enabled */
+  enabled: boolean;
+}
+
+export function getOutlineConfig(): OutlineConfig {
+  const baseUrl = process.env.OUTLINE_INTERNAL_URL ?? "";
+  const apiToken = process.env.OUTLINE_API_TOKEN ?? "";
+
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ""), // strip trailing slash
+    apiToken,
+    timeoutMs: parseInt(process.env.OUTLINE_TIMEOUT_MS ?? "5000", 10),
+    maxRetries: parseInt(process.env.OUTLINE_MAX_RETRIES ?? "2", 10),
+    enabled: Boolean(baseUrl && apiToken),
+  };
+}

--- a/services/__tests__/outline-client.test.ts
+++ b/services/__tests__/outline-client.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Outline API client — KB-1 (#840)
+ */
+import { OutlineClient, OutlineApiError } from "../outline-client";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+function createClient(overrides = {}) {
+  return new OutlineClient({
+    baseUrl: "https://outline.example.com",
+    apiToken: "test-token-123",
+    timeoutMs: 5000,
+    maxRetries: 1,
+    enabled: true,
+    ...overrides,
+  });
+}
+
+function mockJsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe("OutlineClient", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe("isEnabled", () => {
+    it("returns true when baseUrl and apiToken are set", () => {
+      const client = createClient();
+      expect(client.isEnabled).toBe(true);
+    });
+
+    it("returns false when disabled", () => {
+      const client = createClient({ enabled: false });
+      expect(client.isEnabled).toBe(false);
+    });
+  });
+
+  describe("listDocuments", () => {
+    it("fetches documents from Outline API", async () => {
+      const docs = [
+        { id: "doc1", title: "Test Doc", parentDocumentId: null, collectionId: "c1", updatedAt: "2026-01-01" },
+      ];
+      mockFetch.mockReturnValueOnce(mockJsonResponse({ data: docs }));
+
+      const client = createClient();
+      const result = await client.listDocuments();
+
+      expect(result).toEqual(docs);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://outline.example.com/api/documents.list",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-token-123",
+          }),
+        }),
+      );
+    });
+
+    it("returns empty array when data is empty", async () => {
+      mockFetch.mockReturnValueOnce(mockJsonResponse({ data: [] }));
+
+      const client = createClient();
+      const result = await client.listDocuments();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getDocument", () => {
+    it("fetches a single document by ID", async () => {
+      const doc = {
+        id: "doc1",
+        title: "Test",
+        text: "# Hello",
+        parentDocumentId: null,
+        collectionId: "c1",
+        publishedAt: null,
+        updatedAt: "2026-01-01",
+        createdBy: { id: "u1", name: "Alice" },
+        updatedBy: { id: "u1", name: "Alice" },
+      };
+      mockFetch.mockReturnValueOnce(mockJsonResponse({ data: doc }));
+
+      const client = createClient();
+      const result = await client.getDocument("doc1");
+
+      expect(result.title).toBe("Test");
+      expect(result.text).toBe("# Hello");
+    });
+  });
+
+  describe("searchDocuments", () => {
+    it("searches documents by query", async () => {
+      const results = [
+        {
+          document: { id: "doc1", title: "Test", parentDocumentId: null, collectionId: "c1", updatedAt: "2026-01-01" },
+          context: "matched text",
+          ranking: 0.9,
+        },
+      ];
+      mockFetch.mockReturnValueOnce(mockJsonResponse({ data: results }));
+
+      const client = createClient();
+      const result = await client.searchDocuments("test");
+
+      expect(result.length).toBe(1);
+      expect(result[0].document.title).toBe("Test");
+      expect(result[0].context).toBe("matched text");
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws OutlineApiError on HTTP error", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: () => Promise.resolve({}),
+        }),
+      );
+
+      const client = createClient({ maxRetries: 0 });
+      await expect(client.listDocuments()).rejects.toThrow(OutlineApiError);
+    });
+
+    it("does not retry on 4xx errors", async () => {
+      mockFetch.mockReturnValue(
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          json: () => Promise.resolve({}),
+        }),
+      );
+
+      const client = createClient({ maxRetries: 2 });
+      await expect(client.getDocument("nonexistent")).rejects.toThrow(OutlineApiError);
+      // Should only be called once (no retry on 4xx)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on 5xx errors", async () => {
+      mockFetch
+        .mockReturnValueOnce(
+          Promise.resolve({ ok: false, status: 503, statusText: "Unavailable", json: () => Promise.resolve({}) }),
+        )
+        .mockReturnValueOnce(mockJsonResponse({ data: [] }));
+
+      const client = createClient({ maxRetries: 1 });
+      const result = await client.listDocuments();
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws timeout error on AbortError", async () => {
+      mockFetch.mockImplementation(() => {
+        const err = new DOMException("signal is aborted", "AbortError");
+        return Promise.reject(err);
+      });
+
+      const client = createClient({ maxRetries: 0 });
+      try {
+        await client.listDocuments();
+        fail("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(OutlineApiError);
+        expect((err as OutlineApiError).isTimeout).toBe(true);
+      }
+    });
+  });
+
+  describe("API token security", () => {
+    it("sends API token in Authorization header, not in body", async () => {
+      mockFetch.mockReturnValueOnce(mockJsonResponse({ data: [] }));
+
+      const client = createClient();
+      await client.listDocuments();
+
+      const [, options] = mockFetch.mock.calls[0];
+      expect(options.headers.Authorization).toBe("Bearer test-token-123");
+      // Token should not appear in the body
+      const body = options.body ? JSON.parse(options.body) : {};
+      expect(JSON.stringify(body)).not.toContain("test-token-123");
+    });
+  });
+});

--- a/services/outline-client.ts
+++ b/services/outline-client.ts
@@ -1,0 +1,175 @@
+/**
+ * Outline API client — KB-1 (#840)
+ *
+ * Communicates with Outline wiki API for document listing, retrieval, and search.
+ * Features:
+ * - Configurable timeout (default 5s) and retry (default 2 attempts)
+ * - API token from env (never exposed to frontend)
+ * - Graceful error handling with typed errors
+ */
+
+import { getOutlineConfig, type OutlineConfig } from "@/config/outline";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface OutlineDocument {
+  id: string;
+  title: string;
+  text: string;
+  parentDocumentId: string | null;
+  collectionId: string;
+  publishedAt: string | null;
+  updatedAt: string;
+  createdBy: { id: string; name: string };
+  updatedBy: { id: string; name: string };
+}
+
+export interface OutlineDocumentListItem {
+  id: string;
+  title: string;
+  parentDocumentId: string | null;
+  collectionId: string;
+  updatedAt: string;
+}
+
+export interface OutlineSearchResult {
+  document: OutlineDocumentListItem;
+  context: string;
+  ranking: number;
+}
+
+export class OutlineApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly isTimeout: boolean = false,
+  ) {
+    super(message);
+    this.name = "OutlineApiError";
+  }
+}
+
+// ── Client ─────────────────────────────────────────────────────────────────
+
+export class OutlineClient {
+  private readonly config: OutlineConfig;
+
+  constructor(config?: OutlineConfig) {
+    this.config = config ?? getOutlineConfig();
+  }
+
+  get isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  /**
+   * Internal fetch with timeout and retry logic.
+   */
+  private async fetchWithRetry(
+    path: string,
+    body?: Record<string, unknown>,
+  ): Promise<unknown> {
+    const url = `${this.config.baseUrl}/api${path}`;
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), this.config.timeoutMs);
+
+        const res = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${this.config.apiToken}`,
+          },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (!res.ok) {
+          throw new OutlineApiError(
+            `Outline API error: ${res.status} ${res.statusText}`,
+            res.status,
+          );
+        }
+
+        return await res.json();
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          lastError = new OutlineApiError("Outline API timeout", undefined, true);
+        } else if (err instanceof OutlineApiError) {
+          lastError = err;
+          // Don't retry 4xx errors
+          if (err.statusCode && err.statusCode >= 400 && err.statusCode < 500) {
+            throw err;
+          }
+        } else {
+          lastError = err instanceof Error ? err : new Error(String(err));
+        }
+
+        // Wait before retry (exponential backoff: 500ms, 1000ms)
+        if (attempt < this.config.maxRetries) {
+          await new Promise((r) => setTimeout(r, 500 * (attempt + 1)));
+        }
+      }
+    }
+
+    throw lastError ?? new OutlineApiError("Outline API request failed");
+  }
+
+  /**
+   * List documents (tree structure).
+   */
+  async listDocuments(collectionId?: string): Promise<OutlineDocumentListItem[]> {
+    const body: Record<string, unknown> = {};
+    if (collectionId) body.collectionId = collectionId;
+
+    const result = await this.fetchWithRetry("/documents.list", body) as {
+      data: OutlineDocumentListItem[];
+    };
+    return result.data ?? [];
+  }
+
+  /**
+   * Get a single document by ID.
+   */
+  async getDocument(id: string): Promise<OutlineDocument> {
+    const result = await this.fetchWithRetry("/documents.info", { id }) as {
+      data: OutlineDocument;
+    };
+    return result.data;
+  }
+
+  /**
+   * Search documents by query string.
+   */
+  async searchDocuments(query: string): Promise<OutlineSearchResult[]> {
+    const result = await this.fetchWithRetry("/documents.search", { query }) as {
+      data: OutlineSearchResult[];
+    };
+    return result.data ?? [];
+  }
+
+  /**
+   * List collections.
+   */
+  async listCollections(): Promise<Array<{ id: string; name: string; description: string }>> {
+    const result = await this.fetchWithRetry("/collections.list") as {
+      data: Array<{ id: string; name: string; description: string }>;
+    };
+    return result.data ?? [];
+  }
+}
+
+/** Singleton instance */
+let _client: OutlineClient | null = null;
+
+export function getOutlineClient(): OutlineClient {
+  if (!_client) {
+    _client = new OutlineClient();
+  }
+  return _client;
+}


### PR DESCRIPTION
## Summary
- 新增 `config/outline.ts`：環境變數配置（URL、Token、Timeout、Retries）
- 新增 `services/outline-client.ts`：Outline API client
  - 5 秒 timeout、最多 2 次 retry、指數退避
  - API token 僅在 Authorization header（不暴露至前端）
  - 4xx 不重試、5xx 重試
- 新增 `/api/outline` proxy routes：文件列表、文件內容
- Graceful fallback：timeout → 504、服務不可用 → 502、未設定 → 503

## QA 自審報告
- [x] `tsc --noEmit` 0 errors
- [x] `jest services/__tests__/outline-client.test.ts` — 11/11 passed
- [x] AC: Outline API 取得文件列表 ✓
- [x] AC: 文件內容以 Markdown 渲染（不用 iframe）✓
- [x] AC: 服務不可用時 graceful fallback ✓
- [x] AC: timeout 5 秒 + retry 2 次 ✓
- [x] AC: API token 安全儲存（環境變數）✓

## Test plan
- [x] isEnabled: baseUrl + apiToken 設定檢查
- [x] listDocuments: 正常取得、空列表
- [x] getDocument: 單一文件取得
- [x] searchDocuments: 搜尋結果
- [x] 5xx retry 機制
- [x] 4xx 不重試
- [x] timeout → OutlineApiError(isTimeout=true)
- [x] API token 不出現在 request body

Fixes #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)