### PR TITLE
fix(schema): add onDelete SetNull for TimeEntry.subTaskId

### DIFF
--- a/prisma/migrations/20260326040000_add_subtask_ondelete_setnull/migration.sql
+++ b/prisma/migrations/20260326040000_add_subtask_ondelete_setnull/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable: add subTaskId to TimeEntry with onDelete SetNull (#935)
+ALTER TABLE "time_entries" ADD COLUMN "subTaskId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "time_entries_subTaskId_idx" ON "time_entries"("subTaskId");
+
+-- AddForeignKey
+ALTER TABLE "time_entries"
+  ADD CONSTRAINT "time_entries_subTaskId_fkey"
+  FOREIGN KEY ("subTaskId") REFERENCES "sub_tasks"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -504,7 +504,8 @@ model SubTask {
   completedAt DateTime? // 完成時間戳
   createdAt   DateTime  @default(now())
 
-  task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task        Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  timeEntries TimeEntry[]
 
   @@index([taskId])
   @@map("sub_tasks")
@@ -676,10 +677,15 @@ model TimeEntry {
   // TS-06: 排序（同日同任務多筆排序）
   sortOrder Int @default(0)
 
+  // #935: 子任務關聯（onDelete: SetNull）
+  subTaskId String?
+  subTask   SubTask? @relation(fields: [subTaskId], references: [id], onDelete: SetNull)
+
   task Task? @relation(fields: [taskId], references: [id])
   user User  @relation(fields: [userId], references: [id])
 
   @@index([taskId])
+  @@index([subTaskId])
   @@index([userId])
   @@index([date])
   @@index([userId, isRunning])


### PR DESCRIPTION
## Summary
- TimeEntry 新增 `subTaskId` 欄位及 `subTask` relation，設定 `onDelete: SetNull`
- SubTask model 新增 `timeEntries` 反向關聯
- 新增 `@@index([subTaskId])` 加速查詢
- 包含 migration SQL

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx prisma generate` — 成功
- [x] Migration SQL 語法正確
- [x] onDelete: SetNull 確保刪除子任務不會 cascade 刪除工時記錄

Refs #935

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>