### PR TITLE
feat(timesheet): 工時記錄支援選擇子任務

### DIFF
--- a/__tests__/components/timesheet-phase1-track-a.test.tsx
+++ b/__tests__/components/timesheet-phase1-track-a.test.tsx
@@ -229,7 +229,8 @@ describe("Item 7: Multi-entry individual editing", () => {
         "PLANNED_TASK",
         "API work",
         "NONE",
-        "e1"
+        "e1",
+        null              // Issue #933: subTaskId
       );
     });
   });

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -37,6 +37,14 @@ export default function TimesheetPage() {
 
   const ts = useTimesheet(userFilter || undefined);
 
+  // Issue #933: pre-fetch subtasks for all task rows
+  useEffect(() => {
+    for (const row of ts.taskRows) {
+      if (row.taskId) ts.fetchSubTasks(row.taskId);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ts.taskRows]);
+
   // Fetch pivot data when tab switches (Issue #832)
   const fetchPivot = useCallback(async (tab: SummaryTab) => {
     if (tab === "timesheet") return;
@@ -206,6 +214,7 @@ export default function TimesheetPage() {
               weeklyTotal={ts.weeklyTotal}
               dayLabels={ts.dayLabels}
               daysCount={ts.daysCount}
+              subTasksMap={ts.subTasksMap}
               getDateStr={ts.getDateStr}
               formatDateLabel={ts.formatDateLabel}
               getEntriesForCell={ts.getEntriesForCell}

--- a/app/api/time-entries/[id]/route.ts
+++ b/app/api/time-entries/[id]/route.ts
@@ -49,7 +49,22 @@ export const PUT = withAuth(async (
   }
 
   const raw = await req.json();
-  const { taskId, date, hours, category, description } = validateBody(updateTimeEntrySchema, raw);
+  const { taskId, date, hours, category, description, subTaskId } = validateBody(updateTimeEntrySchema, raw);
+
+  // Issue #933: validate subTaskId belongs to the resolved taskId
+  if (subTaskId) {
+    const resolvedTaskId = taskId !== undefined ? taskId : existing.taskId;
+    if (!resolvedTaskId) {
+      throw new ValidationError("選擇子任務時必須先指定主任務");
+    }
+    const subTask = await prisma.subTask.findUnique({
+      where: { id: subTaskId },
+      select: { taskId: true },
+    });
+    if (!subTask || subTask.taskId !== resolvedTaskId) {
+      throw new ValidationError("子任務不屬於所選主任務");
+    }
+  }
 
   // T-1: Enforce daily 24hr limit when hours change
   if (hours !== undefined) {
@@ -71,6 +86,7 @@ export const PUT = withAuth(async (
 
   const updates: Record<string, unknown> = {};
   if (taskId !== undefined) updates.taskId = taskId || null;
+  if (subTaskId !== undefined) updates.subTaskId = subTaskId || null;  // Issue #933
   if (date !== undefined) updates.date = new Date(date);
   if (hours !== undefined) updates.hours = hours;
   if (category !== undefined) updates.category = category as TimeCategory;
@@ -86,6 +102,7 @@ export const PUT = withAuth(async (
     data: updates,
     include: {
       task: { select: { id: true, title: true, category: true } },
+      subTask: { select: { id: true, title: true } },  // Issue #933
     },
   });
 

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -44,6 +44,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     where,
     include: {
       task: { select: { id: true, title: true, category: true } },
+      subTask: { select: { id: true, title: true } },  // Issue #933
     },
     orderBy: [{ date: "asc" }, { createdAt: "asc" }],
   });
@@ -55,7 +56,21 @@ export const POST = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
 
   const raw = await req.json();
-  const { taskId, date, hours, category, description } = validateBody(createTimeEntrySchema, raw);
+  const { taskId, date, hours, category, description, subTaskId } = validateBody(createTimeEntrySchema, raw);
+
+  // Issue #933: validate subTaskId belongs to the specified taskId
+  if (subTaskId) {
+    if (!taskId) {
+      throw new ValidationError("選擇子任務時必須先指定主任務");
+    }
+    const subTask = await prisma.subTask.findUnique({
+      where: { id: subTaskId },
+      select: { taskId: true },
+    });
+    if (!subTask || subTask.taskId !== taskId) {
+      throw new ValidationError("子任務不屬於所選主任務");
+    }
+  }
 
   // T-1: Enforce daily 24hr limit — sum existing entries for this date
   const targetDate = new Date(date);
@@ -78,6 +93,7 @@ export const POST = withAuth(async (req: NextRequest) => {
   const entry = await prisma.timeEntry.create({
     data: {
       taskId: taskId || null,
+      subTaskId: subTaskId || null,       // Issue #933
       userId: session.user.id,
       date: new Date(date),
       hours,
@@ -87,6 +103,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     },
     include: {
       task: { select: { id: true, title: true, category: true } },
+      subTask: { select: { id: true, title: true } },  // Issue #933
     },
   });
 

--- a/app/components/time-entry-cell.tsx
+++ b/app/components/time-entry-cell.tsx
@@ -8,6 +8,7 @@ export type OvertimeType = "NONE" | "WEEKDAY" | "REST_DAY" | "HOLIDAY";
 export type TimeEntry = {
   id: string;
   taskId: string | null;
+  subTaskId?: string | null;              // Issue #933
   date: string;
   hours: number;
   startTime?: string | null;
@@ -17,6 +18,7 @@ export type TimeEntry = {
   overtimeType?: OvertimeType;
   category: string;
   description: string | null;
+  subTask?: { id: string; title: string } | null;  // Issue #933
 };
 
 const OVERTIME_OPTIONS: { value: OvertimeType; label: string }[] = [
@@ -42,6 +44,7 @@ function getCatStyle(cat: string) {
 type TimeEntryCellProps = {
   entry?: TimeEntry;
   taskId: string | null;
+  subTaskId?: string | null;              // Issue #933
   date: string;
   onSave: (taskId: string | null, date: string, hours: number, category: string, description: string, existingId?: string) => Promise<void>;
   onDelete: (id: string) => Promise<void>;

--- a/app/components/timesheet-list-view.tsx
+++ b/app/components/timesheet-list-view.tsx
@@ -70,6 +70,7 @@ export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps)
             <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground hidden sm:table-cell">結束</th>
             <th className="text-right px-3 py-2.5 text-xs font-medium text-muted-foreground">工時</th>
             <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">任務</th>
+            <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground hidden lg:table-cell">子任務</th>
             <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground">分類</th>
             <th className="text-left px-3 py-2.5 text-xs font-medium text-muted-foreground hidden md:table-cell">備註</th>
             {onDelete && (
@@ -102,6 +103,9 @@ export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps)
                 <td className="px-3 py-2 text-xs text-foreground max-w-[200px] truncate" title={task?.title ?? "自由工時"}>
                   {task?.title ?? "自由工時"}
                 </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground max-w-[150px] truncate hidden lg:table-cell">
+                  {(entry as Record<string, unknown>).subTask ? ((entry as Record<string, unknown>).subTask as { title: string })?.title : "—"}
+                </td>
                 <td className="px-3 py-2">
                   <span className={cn("inline-block px-2 py-0.5 text-xs rounded-md border", getCategoryColor(entry.category))}>
                     {getCategoryLabel(entry.category)}
@@ -133,7 +137,7 @@ export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps)
             <td className="px-3 py-2.5 text-right text-xs font-bold text-foreground tabular-nums">
               {safeFixed(totalHours, 1)}h
             </td>
-            <td colSpan={onDelete ? 4 : 3} />
+            <td colSpan={onDelete ? 5 : 4} />
           </tr>
         </tfoot>
       </table>

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -6,5 +6,5 @@ export { TimesheetCell } from "./timesheet-cell";
 export { TimesheetToolbar } from "./timesheet-toolbar";
 export { TimesheetTimer } from "./timesheet-timer";
 export { TemplateSelector } from "./template-selector";
-export type { TimeEntry, TaskRow, TaskOption, OvertimeType, TimerState } from "./use-timesheet";
+export type { TimeEntry, TaskRow, TaskOption, SubTaskOption, OvertimeType, TimerState } from "./use-timesheet";
 export type { ViewMode } from "./timesheet-toolbar";

--- a/app/components/timesheet/timesheet-cell.tsx
+++ b/app/components/timesheet/timesheet-cell.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/lib/utils";
-import { type TimeEntry, type OvertimeType } from "./use-timesheet";
+import { type TimeEntry, type OvertimeType, type SubTaskOption } from "./use-timesheet";
 import { safeFixed } from "@/lib/safe-number";
 import { Lock } from "lucide-react";
 
@@ -35,6 +35,7 @@ type TimesheetCellProps = {
   entries: TimeEntry[];
   taskId: string | null;
   date: string;
+  subTasks?: SubTaskOption[];              // Issue #933
   onQuickSave: (taskId: string | null, date: string, hours: number, existingId?: string) => Promise<void>;
   onFullSave: (
     taskId: string | null,
@@ -43,7 +44,8 @@ type TimesheetCellProps = {
     category: string,
     description: string,
     overtimeType: OvertimeType,
-    existingId?: string
+    existingId?: string,
+    subTaskId?: string | null              // Issue #933
   ) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   onNavigate?: (direction: "next" | "prev" | "up" | "down") => void;
@@ -57,6 +59,7 @@ type EntryEditState = {
   category: string;
   description: string;
   overtimeType: OvertimeType;
+  subTaskId: string;                       // Issue #933: "" means no subtask
   saving: boolean;
 };
 
@@ -66,6 +69,7 @@ function initEditState(entry: TimeEntry): EntryEditState {
     category: entry.category,
     description: entry.description ?? "",
     overtimeType: (entry.overtimeType as OvertimeType) ?? "NONE",
+    subTaskId: entry.subTaskId ?? "",      // Issue #933
     saving: false,
   };
 }
@@ -98,6 +102,7 @@ export function TimesheetCell({
   entries,
   taskId,
   date,
+  subTasks = [],
   onQuickSave,
   onFullSave,
   onDelete,
@@ -131,6 +136,7 @@ export function TimesheetCell({
     category: "PLANNED_TASK",
     description: "",
     overtimeType: "NONE",
+    subTaskId: "",
     saving: false,
   });
 
@@ -261,7 +267,7 @@ export function TimesheetCell({
       return next;
     });
     try {
-      await onFullSave(taskId, date, h, state.category, state.description, state.overtimeType, entryId);
+      await onFullSave(taskId, date, h, state.category, state.description, state.overtimeType, entryId, state.subTaskId || null);
     } finally {
       setEntryStates((prev) => {
         const next = new Map(prev);
@@ -318,13 +324,14 @@ export function TimesheetCell({
     if (isNaN(h) || h <= 0) return;
     setNewEntryState((s) => ({ ...s, saving: true }));
     try {
-      await onFullSave(taskId, date, h, newEntryState.category, newEntryState.description, newEntryState.overtimeType);
+      await onFullSave(taskId, date, h, newEntryState.category, newEntryState.description, newEntryState.overtimeType, undefined, newEntryState.subTaskId || null);
       setShowNewEntry(false);
       setNewEntryState({
         hours: "",
         category: "PLANNED_TASK",
         description: "",
         overtimeType: "NONE",
+        subTaskId: "",
         saving: false,
       });
     } finally {
@@ -467,6 +474,27 @@ export function TimesheetCell({
                     </select>
                   </div>
 
+                  {/* Issue #933: Subtask selector */}
+                  {taskId && subTasks.length > 0 && (
+                    <div>
+                      <label className="block text-xs text-muted-foreground mb-1">子任務</label>
+                      <select
+                        value={state.subTaskId}
+                        onChange={(ev) => !isLocked && updateEntryField(e.id, "subTaskId", ev.target.value)}
+                        disabled={isLocked}
+                        className={cn(
+                          "w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer",
+                          isLocked && "opacity-60 cursor-not-allowed"
+                        )}
+                      >
+                        <option value="">整體（無子任務）</option>
+                        {subTasks.map((st) => (
+                          <option key={st.id} value={st.id}>{st.title}</option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+
                   <div>
                     <label className="block text-xs text-muted-foreground mb-1">備註</label>
                     <input
@@ -581,6 +609,22 @@ export function TimesheetCell({
                   ))}
                 </select>
               </div>
+              {/* Issue #933: Subtask selector for new entry */}
+              {taskId && subTasks.length > 0 && (
+                <div>
+                  <label className="block text-xs text-muted-foreground mb-1">子任務</label>
+                  <select
+                    value={newEntryState.subTaskId}
+                    onChange={(ev) => setNewEntryState((s) => ({ ...s, subTaskId: ev.target.value }))}
+                    className="w-full bg-background border border-border rounded-md px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+                  >
+                    <option value="">整體（無子任務）</option>
+                    {subTasks.map((st) => (
+                      <option key={st.id} value={st.id}>{st.title}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 <label className="block text-xs text-muted-foreground mb-1">備註</label>
                 <input

--- a/app/components/timesheet/timesheet-grid.tsx
+++ b/app/components/timesheet/timesheet-grid.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { safeFixed } from "@/lib/safe-number";
 import { TimesheetCell } from "./timesheet-cell";
-import { type TimeEntry, type TaskRow, type OvertimeType, type TaskOption } from "./use-timesheet";
+import { type TimeEntry, type TaskRow, type OvertimeType, type TaskOption, type SubTaskOption } from "./use-timesheet";
 import { Plus } from "lucide-react";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -18,6 +18,7 @@ type TimesheetGridProps = {
   weeklyTotal: number;
   dayLabels: string[];
   daysCount: number;
+  subTasksMap?: Map<string, SubTaskOption[]>;  // Issue #933
   getDateStr: (offset: number) => string;
   formatDateLabel: (offset: number) => string;
   getEntriesForCell: (taskId: string | null, dateStr: string) => TimeEntry[];
@@ -29,7 +30,8 @@ type TimesheetGridProps = {
     category: string,
     description: string,
     overtimeType: OvertimeType,
-    existingId?: string
+    existingId?: string,
+    subTaskId?: string | null              // Issue #933
   ) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   onAddTaskRow: (taskId: string, label: string) => void;
@@ -45,6 +47,7 @@ export function TimesheetGrid({
   weeklyTotal,
   dayLabels,
   daysCount,
+  subTasksMap = new Map(),
   getDateStr,
   formatDateLabel,
   getEntriesForCell,
@@ -166,18 +169,39 @@ export function TimesheetGrid({
                 className="border-b border-border/40 hover:bg-accent/10 transition-colors group"
               >
                 <td className="px-3 py-1.5 sticky left-0 bg-card group-hover:bg-accent/10 z-10">
-                  <span
-                    className="text-xs text-muted-foreground truncate block max-w-[168px]"
-                    title={row.label}
-                  >
-                    {row.taskId ? "# " : ""}
-                    {row.label}
-                  </span>
+                  {(() => {
+                    // Issue #933: show subtask info in label
+                    const rowEntries = entries.filter((e) => (e.taskId ?? null) === (row.taskId ?? null));
+                    const subTaskTitles = new Set(
+                      rowEntries
+                        .filter((e) => e.subTask?.title)
+                        .map((e) => e.subTask!.title)
+                    );
+                    const subLabel = subTaskTitles.size === 1
+                      ? ` > ${[...subTaskTitles][0]}`
+                      : subTaskTitles.size > 1
+                        ? ` > (${subTaskTitles.size} 子任務)`
+                        : "";
+                    const fullLabel = `${row.label}${subLabel}`;
+                    return (
+                      <span
+                        className="text-xs text-muted-foreground truncate block max-w-[168px]"
+                        title={fullLabel}
+                      >
+                        {row.taskId ? "# " : ""}
+                        {row.label}
+                        {subLabel && (
+                          <span className="text-muted-foreground/60">{subLabel}</span>
+                        )}
+                      </span>
+                    );
+                  })()}
                 </td>
                 {Array.from({ length: daysCount }, (_, dayIdx) => {
                   const dateStr = getDateStr(dayIdx);
                   const cellEntries = getEntriesForCell(row.taskId, dateStr);
                   const isWeekend = dayIdx >= 5;
+                  const cellSubTasks = row.taskId ? (subTasksMap.get(row.taskId) ?? []) : [];
                   return (
                     <td
                       key={dayIdx}
@@ -189,6 +213,7 @@ export function TimesheetGrid({
                         entries={cellEntries}
                         taskId={row.taskId}
                         date={dateStr}
+                        subTasks={cellSubTasks}
                         onQuickSave={onQuickSave}
                         onFullSave={onFullSave}
                         onDelete={onDelete}

--- a/app/components/timesheet/use-timesheet.ts
+++ b/app/components/timesheet/use-timesheet.ts
@@ -19,6 +19,7 @@ export type OvertimeType = "NONE" | "WEEKDAY" | "REST_DAY" | "HOLIDAY";
 export type TimeEntry = {
   id: string;
   taskId: string | null;
+  subTaskId?: string | null;              // Issue #933
   date: string;
   hours: number;
   startTime?: string | null;
@@ -31,6 +32,12 @@ export type TimeEntry = {
   sortOrder?: number;
   locked?: boolean;
   task?: { id: string; title: string; category?: string } | null;
+  subTask?: { id: string; title: string } | null;  // Issue #933
+};
+
+export type SubTaskOption = {
+  id: string;
+  title: string;
 };
 
 export type TaskOption = {
@@ -67,6 +74,9 @@ export function useTimesheet(userFilter?: string) {
   const [tasks, setTasks] = useState<TaskOption[]>([]);
   const [stats, setStats] = useState<StatsData | null>(null);
 
+  // Issue #933: subtask cache keyed by taskId
+  const [subTasksMap, setSubTasksMap] = useState<Map<string, SubTaskOption[]>>(new Map());
+
   // Loading states
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -79,6 +89,23 @@ export function useTimesheet(userFilter?: string) {
       .then((body) => setTasks(extractItems<TaskOption>(body)))
       .catch(() => {});
   }, []);
+
+  // Issue #933: fetch subtasks for a task (cached)
+  const fetchSubTasks = useCallback(async (taskId: string): Promise<SubTaskOption[]> => {
+    const cached = subTasksMap.get(taskId);
+    if (cached) return cached;
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`);
+      if (!res.ok) return [];
+      const body = await res.json();
+      const task = extractData<{ subTasks?: SubTaskOption[] }>(body);
+      const subs = task?.subTasks ?? [];
+      setSubTasksMap((prev) => new Map(prev).set(taskId, subs));
+      return subs;
+    } catch {
+      return [];
+    }
+  }, [subTasksMap]);
 
   // Load entries for the week
   const loadEntries = useCallback(async () => {
@@ -152,10 +179,12 @@ export function useTimesheet(userFilter?: string) {
     category: string,
     description: string,
     overtimeType: OvertimeType,
-    existingId?: string
+    existingId?: string,
+    subTaskId?: string | null            // Issue #933
   ) {
     const payload = {
       taskId,
+      subTaskId: subTaskId ?? null,      // Issue #933
       date,
       hours,
       category,
@@ -294,6 +323,8 @@ export function useTimesheet(userFilter?: string) {
     taskRows,
     tasks,
     stats,
+    subTasksMap,                           // Issue #933
+    fetchSubTasks,                         // Issue #933
 
     // Loading
     loading,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -504,7 +504,8 @@ model SubTask {
   completedAt DateTime? // 完成時間戳
   createdAt   DateTime  @default(now())
 
-  task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  task        Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  timeEntries TimeEntry[]
 
   @@index([taskId])
   @@map("sub_tasks")
@@ -676,10 +677,15 @@ model TimeEntry {
   // TS-06: 排序（同日同任務多筆排序）
   sortOrder Int @default(0)
 
+  // #935: 子任務關聯（onDelete: SetNull）
+  subTaskId String?
+  subTask   SubTask? @relation(fields: [subTaskId], references: [id], onDelete: SetNull)
+
   task Task? @relation(fields: [taskId], references: [id])
   user User  @relation(fields: [userId], references: [id])
 
   @@index([taskId])
+  @@index([subTaskId])
   @@index([userId])
   @@index([date])
   @@index([userId, isRunning])

--- a/validators/shared/time-entry.ts
+++ b/validators/shared/time-entry.ts
@@ -26,6 +26,7 @@ export const createTimeEntrySchema = z.object({
   date: z.string().date(),
   hours: hoursSchema,
   taskId: z.string().nullish(),
+  subTaskId: z.string().nullish(),          // Issue #933: optional subtask
   category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
   description: z.string().nullish(),
 });
@@ -34,6 +35,7 @@ export const updateTimeEntrySchema = z.object({
   date: z.string().date().optional(),
   hours: hoursSchema.optional(),
   taskId: z.string().optional(),
+  subTaskId: z.string().nullish(),          // Issue #933: optional subtask
   category: TimeCategoryEnum.optional(),
   description: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- TimeEntry 新增 optional `subTaskId` 欄位，支援工時記錄對應到主任務下的子任務
- API POST/PUT 接受 `subTaskId` 並驗證子任務歸屬正確主任務
- 前端展開編輯器與新增表單加入子任務下拉選單（「整體（無子任務）」為預設）
- Grid 顯示「主任務 > 子任務」格式，List view 新增子任務欄位

Closes #933

## 變更範圍

| 層級 | 檔案 | 變更 |
|------|------|------|
| Schema | `prisma/schema.prisma` | TimeEntry 加 `subTaskId`, `subTask` relation |
| Validator | `validators/shared/time-entry.ts` | create/update schema 加 `subTaskId` |
| API | `app/api/time-entries/route.ts` | GET include subTask, POST 接受並驗證 subTaskId |
| API | `app/api/time-entries/[id]/route.ts` | PUT 接受並驗證 subTaskId |
| Hook | `use-timesheet.ts` | SubTaskOption type, subTasksMap cache, fetchSubTasks |
| UI | `timesheet-cell.tsx` | 展開編輯器 + 新增表單加子任務下拉 |
| UI | `timesheet-grid.tsx` | 任務欄顯示子任務名稱 |
| UI | `timesheet-list-view.tsx` | 新增子任務欄位 |
| Test | `timesheet-phase1-track-a.test.tsx` | 更新 onFullSave 斷言 |

## QA 自審報告

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — 2522 passed（1 pre-existing failure: jwt-auth-flow）
- [x] AC: subTaskId 為 optional，向後相容
- [x] AC: 選擇子任務時驗證歸屬主任務
- [x] AC: 前端展開編輯器顯示子任務下拉（有子任務的任務才顯示）
- [x] AC: Grid 顯示「主任務 > 子任務」格式
- [x] AC: List view 新增子任務欄位
- [x] 無密鑰或敏感資料 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)