### PR TITLE
fix(seed): console.log 顯示正確密碼 Admin@2026!x

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -266,8 +266,8 @@ async function main() {
   console.log(`  KPI：${kpiData.length} 個`);
   console.log(`  工時：${timeEntryData.length} 筆`);
   console.log("\n登入帳號：");
-  console.log("  主管：admin / Titan@2026Dev!");
-  console.log("  工程師：eng01 ~ eng04 / Titan@2026Dev!");
+  console.log("  主管：admin@titan.local / Admin@2026!x");
+  console.log("  工程師：eng-a ~ eng-d @titan.local / Admin@2026!x");
 }
 
 main()


### PR DESCRIPTION
## Summary

- seed.ts 的 console.log 輸出 `Titan@2026Dev!` 但實際 hash 的是 `Admin@2026!x`
- 修正為顯示正確密碼和 email 格式

## Changes

| File | Change |
|------|--------|
| `prisma/seed.ts` | 修正第 269-270 行 console.log 密碼和 email |

## Test plan

- [x] `npx prisma db seed` 輸出顯示 `Admin@2026!x`
- [x] 使用該密碼可成功登入

Closes #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)