### PR TITLE
fix(timesheet): number safety guards for calendar-utils + week-view

### DIFF
--- a/app/components/timesheet/calendar-utils.ts
+++ b/app/components/timesheet/calendar-utils.ts
@@ -19,6 +19,7 @@ export const SNAP_MINUTES = 15;
 /** Convert "HH:MM" string to a fractional hour number (e.g., "09:30" → 9.5). */
 export function timeToHours(time: string): number {
   const [h, m] = time.split(":").map(Number);
+  if (isNaN(h)) return MIN_HOUR;
   return h + (m || 0) / 60;
 }
 

--- a/app/components/timesheet/calendar-week-view.tsx
+++ b/app/components/timesheet/calendar-week-view.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { safeFixed } from "@/lib/safe-number";
+import { safeFixed, safeNum } from "@/lib/safe-number";
 import { type TimeEntry, type OvertimeType, type TaskOption } from "./use-timesheet";
 import { CATEGORIES } from "./timesheet-cell";
 import { ChevronLeft, ChevronRight, Copy } from "lucide-react";
@@ -540,7 +540,7 @@ export function CalendarWeekView({
                 {/* Time blocks */}
                 {dayEntries.map((entry) => {
                   const style = getBlockStyle(entry.startTime!, entry.endTime!, HOUR_HEIGHT);
-                  const height = Number(style.height) || 24;
+                  const height = safeNum(style.height, 24);
                   const isEditing = editingEntryId === entry.id;
 
                   return (


### PR DESCRIPTION
## Summary

- `timeToHours()`: 無效輸入回傳 `MIN_HOUR` 而非 `NaN`
- `CalendarWeekView`: `Number(style.height)` → `safeNum(style.height, 24)`

## Changes

| File | Line | Before | After |
|------|------|--------|-------|
| `calendar-utils.ts` | 22 | — | `if (isNaN(h)) return MIN_HOUR;` |
| `calendar-week-view.tsx` | 5 | `safeFixed` | `safeFixed, safeNum` |
| `calendar-week-view.tsx` | 543 | `Number(style.height) \|\| 24` | `safeNum(style.height, 24)` |

## Test plan

- [x] TypeScript 編譯 0 errors
- [x] 現有測試不受影響

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)