### PR TITLE
feat(workspace): 統一工作空間 Context + View Switcher

### DIFF
--- a/__tests__/components/workspace-context.test.tsx
+++ b/__tests__/components/workspace-context.test.tsx
@@ -1,0 +1,411 @@
+/**
+ * WorkspaceContext + Unified Workspace Tests — Issue #961
+ */
+
+import { jest } from "@jest/globals";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace, back: jest.fn(), forward: jest.fn(), refresh: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => "/work",
+  useSearchParams: () => mockSearchParams,
+  useServerInsertedHTML: jest.fn(),
+  ServerInsertedHTMLContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}));
+
+jest.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { id: "u1", role: "MANAGER" } } }),
+  SessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Mock fetch
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+import {
+  WorkspaceProvider,
+  useWorkspace,
+  type WorkspaceViewMode,
+} from "@/lib/workspace-context";
+import {
+  ViewSwitcher,
+  ConnectedViewSwitcher,
+  WorkspaceShell,
+  VIEW_TABS,
+} from "@/app/components/workspace/workspace-context";
+
+// ── Test Helper Component ────────────────────────────────────────────────────
+
+function TestConsumer() {
+  const ws = useWorkspace();
+  return (
+    <div>
+      <span data-testid="view-mode">{ws.viewMode}</span>
+      <span data-testid="task-count">{ws.tasks.length}</span>
+      <span data-testid="loading">{ws.loading ? "true" : "false"}</span>
+      <span data-testid="has-filters">{ws.hasActiveFilters ? "true" : "false"}</span>
+      <button data-testid="set-kanban" onClick={() => ws.setViewMode("kanban")}>
+        kanban
+      </button>
+      <button data-testid="set-list" onClick={() => ws.setViewMode("list")}>
+        list
+      </button>
+      <button data-testid="set-gantt" onClick={() => ws.setViewMode("gantt")}>
+        gantt
+      </button>
+      <button
+        data-testid="set-filter"
+        onClick={() =>
+          ws.setFilters({
+            ...ws.filters,
+            assignee: "u1",
+          })
+        }
+      >
+        filter
+      </button>
+      <button data-testid="refresh" onClick={() => ws.refresh()}>
+        refresh
+      </button>
+    </div>
+  );
+}
+
+function renderWithProvider(params?: URLSearchParams) {
+  if (params) mockSearchParams = params;
+  else mockSearchParams = new URLSearchParams();
+  return render(
+    <WorkspaceProvider>
+      <TestConsumer />
+    </WorkspaceProvider>
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("WorkspaceContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockFetch.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.includes("/api/tasks")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: [
+              {
+                id: "t1",
+                title: "Task 1",
+                status: "IN_PROGRESS",
+                priority: "P1",
+                progressPct: 50,
+                position: 1,
+              },
+              {
+                id: "t2",
+                title: "Task 2",
+                status: "TODO",
+                priority: "P2",
+                progressPct: 0,
+                dueDate: "2026-04-01",
+                position: 2,
+              },
+            ],
+          }),
+          { status: 200 }
+        );
+      }
+      if (url.includes("/api/users")) {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            data: [{ id: "u1", name: "Alice" }],
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("{}", { status: 200 });
+    });
+  });
+
+  it("defaults to kanban view when no URL param", async () => {
+    renderWithProvider();
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("kanban");
+  });
+
+  it("reads view mode from URL param", async () => {
+    renderWithProvider(new URLSearchParams("view=list"));
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("list");
+  });
+
+  it("reads gantt view from URL param", async () => {
+    renderWithProvider(new URLSearchParams("view=gantt"));
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("gantt");
+  });
+
+  it("falls back to kanban for invalid view param", async () => {
+    renderWithProvider(new URLSearchParams("view=invalid"));
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("kanban");
+  });
+
+  it("fetches tasks on mount", async () => {
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+    expect(screen.getByTestId("task-count")).toHaveTextContent("2");
+  });
+
+  it("switches view mode and updates URL", async () => {
+    renderWithProvider();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("set-list"));
+    });
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("list");
+    expect(mockReplace).toHaveBeenCalled();
+    const calledUrl = mockReplace.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("view=list");
+  });
+
+  it("sets filter and updates URL", async () => {
+    renderWithProvider();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("set-filter"));
+    });
+    expect(screen.getByTestId("has-filters")).toHaveTextContent("true");
+    expect(mockReplace).toHaveBeenCalled();
+    const calledUrl = mockReplace.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("assignee=u1");
+  });
+
+  it("reads initial filters from URL params", async () => {
+    renderWithProvider(new URLSearchParams("view=kanban&priority=P0"));
+    // The fetch should include the priority param
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    const taskCall = mockFetch.mock.calls.find((c) =>
+      (typeof c[0] === "string" ? c[0] : "").includes("/api/tasks")
+    );
+    expect(taskCall).toBeDefined();
+    expect(String(taskCall![0])).toContain("priority=P0");
+  });
+
+  it("refresh re-fetches tasks", async () => {
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("false");
+    });
+
+    const callCount = mockFetch.mock.calls.filter((c) =>
+      (typeof c[0] === "string" ? c[0] : "").includes("/api/tasks")
+    ).length;
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("refresh"));
+    });
+
+    await waitFor(() => {
+      const newCount = mockFetch.mock.calls.filter((c) =>
+        (typeof c[0] === "string" ? c[0] : "").includes("/api/tasks")
+      ).length;
+      expect(newCount).toBeGreaterThan(callCount);
+    });
+  });
+
+  it("useWorkspace throws when used outside provider", () => {
+    // Suppress React error boundary noise
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<TestConsumer />)).toThrow(
+      "useWorkspace must be used within <WorkspaceProvider>"
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("WorkspaceTableView", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders table with task rows", async () => {
+    const { WorkspaceTableView } = await import(
+      "@/app/components/workspace-table-view"
+    );
+    const tasks = [
+      {
+        id: "t1",
+        title: "First Task",
+        status: "IN_PROGRESS",
+        priority: "P1",
+        progressPct: 50,
+        primaryAssignee: { name: "Alice" },
+      },
+      {
+        id: "t2",
+        title: "Second Task",
+        status: "TODO",
+        priority: "P2",
+        progressPct: 0,
+        dueDate: "2026-04-01",
+      },
+    ] as any;
+
+    const onTaskClick = jest.fn();
+    render(<WorkspaceTableView tasks={tasks} onTaskClick={onTaskClick} />);
+
+    expect(screen.getByText("First Task")).toBeInTheDocument();
+    expect(screen.getByText("Second Task")).toBeInTheDocument();
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+
+    // Click a row
+    fireEvent.click(screen.getByText("First Task"));
+    expect(onTaskClick).toHaveBeenCalledWith("t1");
+  });
+
+  it("shows empty message when no tasks", async () => {
+    const { WorkspaceTableView } = await import(
+      "@/app/components/workspace-table-view"
+    );
+    render(<WorkspaceTableView tasks={[]} onTaskClick={() => {}} />);
+    expect(screen.getByText("無符合條件的任務")).toBeInTheDocument();
+  });
+
+  it("sorts by clicking column header", async () => {
+    const { WorkspaceTableView } = await import(
+      "@/app/components/workspace-table-view"
+    );
+    const tasks = [
+      { id: "t1", title: "BBB", status: "TODO", priority: "P2", progressPct: 0 },
+      { id: "t2", title: "AAA", status: "IN_PROGRESS", priority: "P1", progressPct: 50 },
+    ] as any;
+
+    render(<WorkspaceTableView tasks={tasks} onTaskClick={() => {}} />);
+
+    // Click title header to sort by title asc
+    fireEvent.click(screen.getByText("任務名稱"));
+    const rows = screen.getAllByRole("row");
+    // First data row should be AAA (alphabetical asc)
+    expect(rows[1]).toHaveTextContent("AAA");
+  });
+});
+
+// ── Issue #961: ViewSwitcher component tests ─────────────────────────────────
+
+describe("ViewSwitcher", () => {
+  it("renders three view tabs: 看板, 甘特, 列表", () => {
+    const onChange = jest.fn();
+    render(<ViewSwitcher viewMode="kanban" onViewModeChange={onChange} />);
+    expect(screen.getByRole("tab", { name: /看板/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /甘特/ })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /列表/ })).toBeInTheDocument();
+  });
+
+  it("marks active tab as aria-selected", () => {
+    const onChange = jest.fn();
+    render(<ViewSwitcher viewMode="gantt" onViewModeChange={onChange} />);
+    expect(screen.getByRole("tab", { name: /甘特/ })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: /看板/ })).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("fires onViewModeChange on tab click", () => {
+    const onChange = jest.fn();
+    render(<ViewSwitcher viewMode="kanban" onViewModeChange={onChange} />);
+    fireEvent.click(screen.getByRole("tab", { name: /列表/ }));
+    expect(onChange).toHaveBeenCalledWith("list");
+  });
+
+  it("has tablist role for accessibility", () => {
+    render(<ViewSwitcher viewMode="kanban" onViewModeChange={jest.fn()} />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+});
+
+describe("VIEW_TABS config", () => {
+  it("contains 3 modes: kanban, gantt, list", () => {
+    expect(VIEW_TABS).toHaveLength(3);
+    expect(VIEW_TABS.map((t) => t.mode)).toEqual(["kanban", "gantt", "list"]);
+  });
+});
+
+describe("ConnectedViewSwitcher", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockFetch.mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, data: [] }), { status: 200 })
+    );
+  });
+
+  it("renders inside WorkspaceProvider and reads view mode", async () => {
+    render(
+      <WorkspaceProvider>
+        <ConnectedViewSwitcher />
+        <TestConsumer />
+      </WorkspaceProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("view-mode")).toHaveTextContent("kanban");
+    });
+    // Click gantt tab
+    await act(async () => {
+      fireEvent.click(screen.getByRole("tab", { name: /甘特/ }));
+    });
+    expect(screen.getByTestId("view-mode")).toHaveTextContent("gantt");
+  });
+});
+
+describe("WorkspaceShell", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockFetch.mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, data: [] }), { status: 200 })
+    );
+  });
+
+  it("wraps children with provider and suspense", async () => {
+    render(
+      <WorkspaceShell>
+        <div data-testid="child">Hello</div>
+      </WorkspaceShell>
+    );
+    expect(await screen.findByTestId("child")).toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceFilterBar", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+    mockFetch.mockImplementation(async () =>
+      new Response(JSON.stringify({ ok: true, data: [] }), { status: 200 })
+    );
+  });
+
+  it("renders filter controls", async () => {
+    const { WorkspaceFilterBar } = await import(
+      "@/app/components/workspace-filters"
+    );
+    render(
+      <WorkspaceProvider>
+        <WorkspaceFilterBar />
+      </WorkspaceProvider>
+    );
+
+    expect(screen.getByLabelText("篩選負責人")).toBeInTheDocument();
+    expect(screen.getByLabelText("篩選狀態")).toBeInTheDocument();
+    expect(screen.getByLabelText("篩選優先度")).toBeInTheDocument();
+    expect(screen.getByLabelText("篩選分類")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/work/page.tsx
+++ b/app/(app)/work/page.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+/**
+ * Unified Workspace Page — Issue #961
+ *
+ * Single page with view switcher: 看板 | 甘特 | 列表
+ * All views share the same WorkspaceContext (task data + filters).
+ */
+
+import { useState } from "react";
+import { KanbanSquare, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  WorkspaceShell,
+  ConnectedViewSwitcher,
+  useWorkspace,
+} from "@/app/components/workspace/workspace-context";
+import { WorkspaceFilterBar } from "@/app/components/workspace-filters";
+import { WorkspaceTableView } from "@/app/components/workspace-table-view";
+import { TaskDetailModal } from "@/app/components/task-detail-modal";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { KanbanColumn } from "@/app/components/kanban-column";
+import { type TaskCardData } from "@/app/components/task-card";
+
+// ─── Kanban Constants (from original kanban page) ────────────────────────────
+
+type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
+const COLUMN_ORDER: TaskStatus[] = ["BACKLOG", "TODO", "IN_PROGRESS", "REVIEW", "DONE"];
+
+const DEFAULT_COLUMNS: { status: TaskStatus; label: string; color: string }[] = [
+  { status: "BACKLOG", label: "待辦清單", color: "text-muted-foreground" },
+  { status: "TODO", label: "待處理", color: "text-blue-400" },
+  { status: "IN_PROGRESS", label: "進行中", color: "text-yellow-400" },
+  { status: "REVIEW", label: "審核中", color: "text-purple-400" },
+  { status: "DONE", label: "已完成", color: "text-emerald-400" },
+];
+
+const columnBorder: Record<TaskStatus, string> = {
+  BACKLOG: "border-border",
+  TODO: "border-blue-500/20",
+  IN_PROGRESS: "border-yellow-500/20",
+  REVIEW: "border-purple-500/20",
+  DONE: "border-emerald-500/20",
+};
+
+const columnHeaderBg: Record<TaskStatus, string> = {
+  BACKLOG: "bg-muted/60",
+  TODO: "bg-blue-500/10",
+  IN_PROGRESS: "bg-yellow-500/10",
+  REVIEW: "bg-purple-500/10",
+  DONE: "bg-emerald-500/10",
+};
+
+// ─── Inner Content (uses workspace context) ──────────────────────────────────
+
+function WorkspaceContent() {
+  const ws = useWorkspace();
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  // Kanban-specific state
+  const [dragOver, setDragOver] = useState<TaskStatus | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [movingTask, setMovingTask] = useState<string | null>(null);
+
+  // ── Kanban helpers ─────────────────────────────────────────────────────────
+
+  const tasksByStatus = (status: TaskStatus) =>
+    (ws.tasks as (TaskCardData & { position?: number })[])
+      .filter((t) => t.status === status)
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+  async function moveTask(taskId: string, newStatus: TaskStatus, targetIndex?: number) {
+    const task = ws.tasks.find((t) => t.id === taskId);
+    if (!task || task.status === newStatus) return;
+
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (res.ok) ws.refresh();
+    } catch {
+      // Silent fail — refresh to restore
+      ws.refresh();
+    }
+  }
+
+  function handleDragStart(e: React.DragEvent, taskId: string) {
+    e.dataTransfer.setData("taskId", taskId);
+    e.dataTransfer.effectAllowed = "move";
+    setDraggingId(taskId);
+  }
+
+  function handleDragEnd() {
+    setDraggingId(null);
+    setDragOver(null);
+  }
+
+  function handleDragOver(e: React.DragEvent, status: TaskStatus) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOver(status);
+  }
+
+  function handleDragLeave() {
+    setDragOver(null);
+  }
+
+  function handleDrop(e: React.DragEvent, status: TaskStatus) {
+    e.preventDefault();
+    const taskId = e.dataTransfer.getData("taskId");
+    if (taskId) moveTask(taskId, status);
+    setDragOver(null);
+    setDraggingId(null);
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex flex-col h-full gap-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 flex-shrink-0">
+        <div>
+          <h1 className="text-lg sm:text-xl font-semibold tracking-tight">工作空間</h1>
+          <p className="text-muted-foreground text-xs sm:text-sm mt-0.5">
+            共 {ws.tasks.length} 項任務
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* View switcher — Issue #961 */}
+          <ConnectedViewSwitcher />
+
+          {/* Add task */}
+          <button
+            onClick={async () => {
+              const title = prompt("任務標題：");
+              if (!title?.trim()) return;
+              const res = await fetch("/api/tasks", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  title: title.trim(),
+                  status: "BACKLOG",
+                  priority: "P2",
+                  category: "PLANNED",
+                }),
+              });
+              if (res.ok) ws.refresh();
+              else {
+                const errBody = await res.json().catch(() => ({}));
+                alert(errBody?.message ?? errBody?.error ?? "建立失敗");
+              }
+            }}
+            className="flex items-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-primary text-primary-foreground rounded-lg shadow-sm transition-all hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            新增任務
+          </button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex-shrink-0">
+        <WorkspaceFilterBar />
+      </div>
+
+      {/* Content */}
+      {ws.loading ? (
+        <div className="flex-1">
+          <PageLoading message="載入工作空間..." />
+        </div>
+      ) : ws.fetchError ? (
+        <div className="flex-1">
+          <PageError message={ws.fetchError} onRetry={ws.refresh} />
+        </div>
+      ) : ws.tasks.length === 0 && !ws.hasActiveFilters ? (
+        <div className="flex-1">
+          <PageEmpty
+            icon={<KanbanSquare className="h-10 w-10" />}
+            title="尚無任務"
+            description="目前沒有任何任務，請點擊「新增任務」開始"
+          />
+        </div>
+      ) : (
+        <>
+          {/* ── Kanban View ── */}
+          {ws.viewMode === "kanban" && (
+            <div
+              className="flex-1 flex flex-col md:flex-row gap-3 overflow-y-auto md:overflow-x-auto md:overflow-y-hidden pb-4 min-h-0"
+              role="region"
+              aria-label="看板欄位"
+            >
+              {DEFAULT_COLUMNS.map(({ status, label, color }) => (
+                <div key={status} className="group/col">
+                  <KanbanColumn
+                    status={status}
+                    label={label}
+                    color={color}
+                    borderClass={columnBorder[status]}
+                    headerBgClass={columnHeaderBg[status]}
+                    tasks={tasksByStatus(status)}
+                    draggingId={draggingId}
+                    isDragOver={dragOver === status}
+                    movingTaskId={movingTask}
+                    selectedIds={new Set()}
+                    hasSelection={false}
+                    onDragStart={handleDragStart}
+                    onDragEnd={handleDragEnd}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                    onTaskClick={setSelectedTaskId}
+                    onToggleSelect={() => {}}
+                    onKeyboardMove={() => {}}
+                    onKeyboardReorder={() => {}}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* ── Gantt View ── */}
+          {ws.viewMode === "gantt" && (
+            <div className="flex-1 overflow-auto border border-border rounded-xl bg-card p-4">
+              <GanttMiniView tasks={ws.tasks} onTaskClick={setSelectedTaskId} />
+            </div>
+          )}
+
+          {/* ── List View ── */}
+          {ws.viewMode === "list" && (
+            <div className="flex-1 min-h-0">
+              <WorkspaceTableView tasks={ws.tasks} onTaskClick={setSelectedTaskId} />
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Task detail modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+          onUpdated={() => {
+            setSelectedTaskId(null);
+            ws.refresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Simple Gantt Mini View ──────────────────────────────────────────────────
+
+const STATUS_BAR: Record<string, string> = {
+  BACKLOG: "bg-muted",
+  TODO: "bg-blue-500/70",
+  IN_PROGRESS: "bg-warning/80",
+  REVIEW: "bg-purple-500/80",
+  DONE: "bg-emerald-500/80",
+};
+
+function GanttMiniView({
+  tasks,
+  onTaskClick,
+}: {
+  tasks: TaskCardData[];
+  onTaskClick: (id: string) => void;
+}) {
+  const now = new Date();
+  const year = now.getFullYear();
+  const daysInYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0) ? 366 : 365;
+
+  function dayOfYear(dateStr: string): number {
+    const d = new Date(dateStr);
+    const start = new Date(year, 0, 1);
+    return Math.floor((d.getTime() - start.getTime()) / 86400000);
+  }
+
+  const MONTHS = ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
+
+  return (
+    <div className="min-w-[700px]">
+      {/* Month header */}
+      <div className="flex border-b border-border mb-2">
+        {MONTHS.map((m, i) => {
+          const widthPct = (new Date(year, i + 1, 0).getDate() / daysInYear) * 100;
+          return (
+            <div
+              key={i}
+              className="text-center text-xs text-muted-foreground py-1.5 border-r border-border/50 last:border-0"
+              style={{ width: `${widthPct}%` }}
+            >
+              {m}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Task rows */}
+      {tasks.map((task) => {
+        const t = task as TaskCardData & { startDate?: string | null; dueDate?: string | null };
+        if (!t.startDate && !t.dueDate) return null;
+
+        const startDay = t.startDate
+          ? Math.max(0, dayOfYear(t.startDate))
+          : t.dueDate
+          ? Math.max(0, dayOfYear(t.dueDate) - 7)
+          : 0;
+        const endDay = t.dueDate
+          ? Math.min(daysInYear, dayOfYear(t.dueDate))
+          : Math.min(daysInYear, startDay + 7);
+
+        const leftPct = (startDay / daysInYear) * 100;
+        const widthPct = Math.max(0.3, ((endDay - startDay) / daysInYear) * 100);
+
+        return (
+          <div
+            key={task.id}
+            className="flex items-center border-b border-border/20 hover:bg-accent/20 transition-colors cursor-pointer h-7"
+            onClick={() => onTaskClick(task.id)}
+          >
+            <div className="w-40 flex-shrink-0 px-2 truncate text-xs text-muted-foreground">
+              {task.title}
+            </div>
+            <div className="flex-1 relative h-4">
+              <div
+                className={cn("absolute h-4 rounded-sm", STATUS_BAR[task.status] ?? "bg-muted")}
+                style={{ left: `${leftPct}%`, width: `${widthPct}%`, minWidth: "4px" }}
+                title={task.title}
+              >
+                {widthPct > 5 && (
+                  <span className="text-[9px] text-white/80 font-medium truncate leading-none px-1">
+                    {task.title}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {tasks.filter((t) => {
+        const tt = t as TaskCardData & { startDate?: string | null; dueDate?: string | null };
+        return tt.startDate || tt.dueDate;
+      }).length === 0 && (
+        <div className="text-center text-sm text-muted-foreground py-8">
+          所有任務都沒有設定日期，無法顯示甘特圖
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Page (wrapped with WorkspaceShell — Issue #961) ─────────────────────────
+
+export default function WorkPage() {
+  return (
+    <WorkspaceShell>
+      <WorkspaceContent />
+    </WorkspaceShell>
+  );
+}

--- a/app/components/workspace/workspace-context.tsx
+++ b/app/components/workspace/workspace-context.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+/**
+ * Unified Workspace Context — Issue #961
+ *
+ * Component-level wrapper that provides:
+ * 1. WorkspaceProvider (shared task data, filters, view mode)
+ * 2. ViewSwitcher component (看板 | 甘特 | 列表 tabs)
+ * 3. Shared filter state persisted to URL params
+ *
+ * All views (Kanban, Gantt, Table) consume from the same context,
+ * ensuring data consistency and avoiding redundant API calls.
+ */
+
+import { Suspense } from "react";
+import { KanbanSquare, GanttChartSquare, List } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  WorkspaceProvider,
+  useWorkspace,
+  type WorkspaceViewMode,
+  type WorkspaceFilters,
+  type WorkspaceContextValue,
+  emptyWorkspaceFilters,
+} from "@/lib/workspace-context";
+import { PageLoading } from "@/app/components/page-states";
+
+// ─── Re-exports ──────────────────────────────────────────────────────────────
+
+export {
+  WorkspaceProvider,
+  useWorkspace,
+  emptyWorkspaceFilters,
+};
+export type {
+  WorkspaceViewMode,
+  WorkspaceFilters,
+  WorkspaceContextValue,
+};
+
+// ─── View Tab Config ─────────────────────────────────────────────────────────
+
+export const VIEW_TABS: {
+  mode: WorkspaceViewMode;
+  label: string;
+  icon: typeof KanbanSquare;
+}[] = [
+  { mode: "kanban", label: "看板", icon: KanbanSquare },
+  { mode: "gantt", label: "甘特", icon: GanttChartSquare },
+  { mode: "list", label: "列表", icon: List },
+];
+
+// ─── ViewSwitcher Component ──────────────────────────────────────────────────
+
+export interface ViewSwitcherProps {
+  /** Currently active view mode */
+  viewMode: WorkspaceViewMode;
+  /** Callback when user selects a different view */
+  onViewModeChange: (mode: WorkspaceViewMode) => void;
+  /** Optional extra CSS class */
+  className?: string;
+}
+
+/**
+ * Tab-style view switcher: 看板 | 甘特 | 列表
+ *
+ * Designed for the workspace toolbar — renders inline tab buttons
+ * that switch the active view while preserving all filter state.
+ */
+export function ViewSwitcher({
+  viewMode,
+  onViewModeChange,
+  className,
+}: ViewSwitcherProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center bg-muted/50 rounded-lg p-0.5 gap-0.5",
+        className
+      )}
+      role="tablist"
+      aria-label="檢視模式"
+    >
+      {VIEW_TABS.map(({ mode, label, icon: Icon }) => (
+        <button
+          key={mode}
+          role="tab"
+          aria-selected={viewMode === mode}
+          aria-label={`切換到${label}檢視`}
+          onClick={() => onViewModeChange(mode)}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md transition-colors",
+            viewMode === mode
+              ? "bg-background text-foreground font-medium shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Connected ViewSwitcher — reads/writes from WorkspaceContext automatically.
+ * Use this when rendering inside a WorkspaceProvider.
+ */
+export function ConnectedViewSwitcher({ className }: { className?: string }) {
+  const { viewMode, setViewMode } = useWorkspace();
+  return (
+    <ViewSwitcher
+      viewMode={viewMode}
+      onViewModeChange={setViewMode}
+      className={className}
+    />
+  );
+}
+
+// ─── WorkspaceShell — convenience wrapper ────────────────────────────────────
+
+export interface WorkspaceShellProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Top-level shell that wraps content with WorkspaceProvider + Suspense.
+ * Use this in page.tsx to bootstrap the unified workspace:
+ *
+ * ```tsx
+ * export default function WorkPage() {
+ *   return (
+ *     <WorkspaceShell>
+ *       <WorkspaceContent />
+ *     </WorkspaceShell>
+ *   );
+ * }
+ * ```
+ */
+export function WorkspaceShell({ children }: WorkspaceShellProps) {
+  return (
+    <Suspense fallback={<PageLoading message="載入工作空間..." />}>
+      <WorkspaceProvider>{children}</WorkspaceProvider>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- 建立 `app/components/workspace/workspace-context.tsx` — 統一工作空間的 React Context 模組
- 提供 `ViewSwitcher`（看板 | 甘特 | 列表）tab 切換元件，支援 ARIA accessibility
- `ConnectedViewSwitcher` 自動從 WorkspaceContext 讀取/寫入 view mode
- `WorkspaceShell` 包裝 Provider + Suspense，簡化頁面使用
- Shared filter state（assignee, status, priority, category, date range, tags）持久化至 URL params
- 重構 `/work` 頁面改用新元件，減少重複程式碼

## QA 自審報告
- [x] tsc 0 新增錯誤（25 baseline = 25 after，全部為 pre-existing）
- [x] jest: ViewSwitcher 4 tests pass, VIEW_TABS 1 test pass, useWorkspace throw test pass
- [x] 看板/甘特/列表 tab 切換共用同一份資料，URL 參數同步
- [x] 既有 kanban page 不受影響（獨立頁面保留）

Fixes #961