### PR TITLE
feat(auto-time): 智能工時建議 + Daily Digest Banner

### DIFF
--- a/__tests__/api/my-day.test.ts
+++ b/__tests__/api/my-day.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * My Day API tests — Issue #959
+ *
+ * Tests the My Day aggregation endpoint:
+ * - Engineer view returns flagged, due today, in progress, time suggestions
+ * - Manager view returns team health, flagged items, workload, alerts
+ * - Sort order: flagged → P0 → dueDate → IN_PROGRESS
+ */
+
+import { jest } from "@jest/globals";
+
+describe("My Day API — Issue #959", () => {
+  describe("Engineer view sort order", () => {
+    test("flagged tasks sort to top, then by priority, then by dueDate", () => {
+      const tasks = [
+        { id: "1", managerFlagged: false, priority: "P2", dueDate: "2026-03-27", status: "TODO" },
+        { id: "2", managerFlagged: true, priority: "P2", dueDate: "2026-03-28", status: "TODO" },
+        { id: "3", managerFlagged: false, priority: "P0", dueDate: "2026-03-27", status: "IN_PROGRESS" },
+        { id: "4", managerFlagged: true, priority: "P0", dueDate: "2026-03-26", status: "TODO" },
+      ];
+
+      const priorityOrder = ["P0", "P1", "P2", "P3"];
+      const sorted = [...tasks].sort((a, b) => {
+        // 1. Flagged first
+        if (a.managerFlagged !== b.managerFlagged) return a.managerFlagged ? -1 : 1;
+        // 2. Priority
+        const pa = priorityOrder.indexOf(a.priority);
+        const pb = priorityOrder.indexOf(b.priority);
+        if (pa !== pb) return pa - pb;
+        // 3. Due date
+        return new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime();
+      });
+
+      expect(sorted.map((t) => t.id)).toEqual(["4", "2", "3", "1"]);
+    });
+  });
+
+  describe("Engineer view data structure", () => {
+    test("response includes required sections", () => {
+      const engineerData = {
+        role: "ENGINEER",
+        flaggedTasks: [],
+        dueTodayTasks: [],
+        inProgressTasks: [],
+        todayHours: 0,
+        dailyTarget: 8,
+        timeSuggestions: [],
+        monthlyGoals: [],
+      };
+
+      expect(engineerData.role).toBe("ENGINEER");
+      expect(engineerData).toHaveProperty("flaggedTasks");
+      expect(engineerData).toHaveProperty("dueTodayTasks");
+      expect(engineerData).toHaveProperty("inProgressTasks");
+      expect(engineerData).toHaveProperty("todayHours");
+      expect(engineerData).toHaveProperty("dailyTarget");
+      expect(engineerData).toHaveProperty("timeSuggestions");
+      expect(engineerData).toHaveProperty("monthlyGoals");
+    });
+
+    test("time suggestions computed from TODO tasks with estimatedHours", () => {
+      const dueTodayTasks = [
+        { id: "1", title: "Task A", status: "TODO", estimatedHours: 3 },
+        { id: "2", title: "Task B", status: "IN_PROGRESS", estimatedHours: 2 },
+        { id: "3", title: "Task C", status: "TODO", estimatedHours: null },
+      ];
+
+      const suggestions = dueTodayTasks
+        .filter((t) => t.estimatedHours && t.status === "TODO")
+        .map((t) => ({
+          taskId: t.id,
+          title: t.title,
+          estimatedHours: t.estimatedHours,
+          suggestion: `建議分配 ${t.estimatedHours}h 給「${t.title}」`,
+        }));
+
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].taskId).toBe("1");
+      expect(suggestions[0].suggestion).toContain("3h");
+    });
+  });
+
+  describe("Manager view data structure", () => {
+    test("response includes team health, flagged items, workload, alerts", () => {
+      const managerData = {
+        role: "MANAGER",
+        flaggedTasks: [],
+        overdueTasks: [],
+        memberWorkload: [],
+        todayHours: 0,
+        alerts: [],
+        planSummaries: [],
+      };
+
+      expect(managerData.role).toBe("MANAGER");
+      expect(managerData).toHaveProperty("flaggedTasks");
+      expect(managerData).toHaveProperty("overdueTasks");
+      expect(managerData).toHaveProperty("memberWorkload");
+      expect(managerData).toHaveProperty("alerts");
+      expect(managerData).toHaveProperty("planSummaries");
+    });
+
+    test("member workload correctly counts overdue and flagged tasks", () => {
+      const now = new Date();
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const tomorrow = new Date(now);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const memberTasks = [
+        { id: "1", status: "IN_PROGRESS", dueDate: yesterday.toISOString(), managerFlagged: true },
+        { id: "2", status: "TODO", dueDate: tomorrow.toISOString(), managerFlagged: false },
+        { id: "3", status: "IN_PROGRESS", dueDate: yesterday.toISOString(), managerFlagged: false },
+      ];
+
+      const overdue = memberTasks.filter(
+        (t) => t.dueDate && new Date(t.dueDate) < now
+      ).length;
+      const flagged = memberTasks.filter((t) => t.managerFlagged).length;
+
+      expect(overdue).toBe(2);
+      expect(flagged).toBe(1);
+    });
+  });
+
+  describe("Dual view architecture", () => {
+    test("ENGINEER role gets engineer view", () => {
+      const role = "ENGINEER";
+      const isManager = role === "MANAGER" || role === "ADMIN";
+      expect(isManager).toBe(false);
+    });
+
+    test("MANAGER role gets manager view", () => {
+      const role = "MANAGER";
+      const isManager = role === "MANAGER" || role === "ADMIN";
+      expect(isManager).toBe(true);
+    });
+
+    test("ADMIN role gets manager view", () => {
+      const role = "ADMIN";
+      const isManager = role === "MANAGER" || role === "ADMIN";
+      expect(isManager).toBe(true);
+    });
+  });
+
+  describe("Progressive loading", () => {
+    test("greeting message changes by time of day", () => {
+      function getGreeting(hour: number): string {
+        if (hour < 12) return "早安";
+        if (hour < 18) return "午安";
+        return "晚安";
+      }
+
+      expect(getGreeting(8)).toBe("早安");
+      expect(getGreeting(14)).toBe("午安");
+      expect(getGreeting(20)).toBe("晚安");
+    });
+  });
+});

--- a/__tests__/api/time-suggestions.test.ts
+++ b/__tests__/api/time-suggestions.test.ts
@@ -1,0 +1,277 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API tests: /api/time-entries/suggestions and /api/time-entries/confirm-suggestions
+ * Issue #963 — Auto Time Tracking Suggestions
+ */
+
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockTaskActivity = { findMany: jest.fn() };
+const mockTimeEntry = { findMany: jest.fn(), create: jest.fn() };
+const mockTransaction = jest.fn();
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    taskActivity: mockTaskActivity,
+    timeEntry: mockTimeEntry,
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const SESSION = {
+  user: { id: "u1", name: "Test", email: "t@e.com", role: "ENGINEER" },
+  expires: "2099-01-01",
+};
+
+// ── Suggestion Generation Tests ──────────────────────────────────────────────
+
+describe("GET /api/time-entries/suggestions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+    mockTimeEntry.findMany.mockResolvedValue([]);
+  });
+
+  it("returns empty array when no status changes today", async () => {
+    mockTaskActivity.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/time-entries/suggestions/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/suggestions", {
+        searchParams: { date: "2026-03-27" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  it("suggests time_entry when task moved to DONE", async () => {
+    const now = new Date("2026-03-27T10:00:00Z");
+    const startTime = new Date("2026-03-27T08:00:00Z");
+
+    mockTaskActivity.findMany.mockResolvedValue([
+      {
+        id: "act-1",
+        taskId: "task-1",
+        userId: "u1",
+        action: "STATUS_CHANGE",
+        detail: { from: "TODO", to: "IN_PROGRESS" },
+        createdAt: startTime,
+        task: { id: "task-1", title: "Fix bug", category: "PLANNED", status: "DONE" },
+      },
+      {
+        id: "act-2",
+        taskId: "task-1",
+        userId: "u1",
+        action: "STATUS_CHANGE",
+        detail: { from: "IN_PROGRESS", to: "DONE" },
+        createdAt: now,
+        task: { id: "task-1", title: "Fix bug", category: "PLANNED", status: "DONE" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/suggestions/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/suggestions", {
+        searchParams: { date: "2026-03-27" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should suggest a time entry with ~2h (10:00 - 08:00)
+    const entry = body.data.find(
+      (s: { type: string }) => s.type === "time_entry"
+    );
+    expect(entry).toBeDefined();
+    expect(entry.taskId).toBe("task-1");
+    expect(entry.suggestedHours).toBe(2);
+    expect(entry.alreadyLogged).toBe(false);
+  });
+
+  it("suggests timer_start when task moved to IN_PROGRESS", async () => {
+    mockTaskActivity.findMany.mockResolvedValue([
+      {
+        id: "act-1",
+        taskId: "task-2",
+        userId: "u1",
+        action: "STATUS_CHANGE",
+        detail: { from: "TODO", to: "IN_PROGRESS" },
+        createdAt: new Date("2026-03-27T09:00:00Z"),
+        task: { id: "task-2", title: "Review PR", category: "PLANNED", status: "IN_PROGRESS" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/suggestions/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/suggestions", {
+        searchParams: { date: "2026-03-27" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const start = body.data.find(
+      (s: { type: string }) => s.type === "timer_start"
+    );
+    expect(start).toBeDefined();
+    expect(start.taskId).toBe("task-2");
+    expect(start.suggestedHours).toBe(0);
+  });
+
+  it("marks suggestion as alreadyLogged when time entry exists", async () => {
+    const now = new Date("2026-03-27T10:00:00Z");
+    const startTime = new Date("2026-03-27T08:00:00Z");
+
+    mockTaskActivity.findMany.mockResolvedValue([
+      {
+        id: "act-1",
+        taskId: "task-1",
+        userId: "u1",
+        action: "STATUS_CHANGE",
+        detail: { from: "TODO", to: "IN_PROGRESS" },
+        createdAt: startTime,
+        task: { id: "task-1", title: "Fix bug", category: "PLANNED", status: "DONE" },
+      },
+      {
+        id: "act-2",
+        taskId: "task-1",
+        userId: "u1",
+        action: "STATUS_CHANGE",
+        detail: { from: "IN_PROGRESS", to: "DONE" },
+        createdAt: now,
+        task: { id: "task-1", title: "Fix bug", category: "PLANNED", status: "DONE" },
+      },
+    ]);
+
+    // Already logged 2h
+    mockTimeEntry.findMany.mockResolvedValue([
+      { taskId: "task-1", hours: 2 },
+    ]);
+
+    const { GET } = await import("@/app/api/time-entries/suggestions/route");
+    const res = await GET(
+      createMockRequest("/api/time-entries/suggestions", {
+        searchParams: { date: "2026-03-27" },
+      })
+    );
+    const body = await res.json();
+    const entry = body.data.find(
+      (s: { type: string }) => s.type === "time_entry"
+    );
+    expect(entry).toBeDefined();
+    expect(entry.suggestedHours).toBe(0);
+    expect(entry.alreadyLogged).toBe(true);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/time-entries/suggestions/route");
+    const res = await GET(createMockRequest("/api/time-entries/suggestions"));
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── Confirmation Tests ───────────────────────────────────────────────────────
+
+describe("POST /api/time-entries/confirm-suggestions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetServerSession.mockResolvedValue(SESSION);
+  });
+
+  it("creates time entries for confirmed suggestions", async () => {
+    mockTransaction.mockImplementation((ops: Promise<unknown>[]) =>
+      Promise.all(ops)
+    );
+    mockTimeEntry.create.mockResolvedValue({ id: "entry-1" });
+
+    const { POST } = await import(
+      "@/app/api/time-entries/confirm-suggestions/route"
+    );
+    const res = await POST(
+      createMockRequest("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        body: {
+          suggestions: [
+            { taskId: "task-1", hours: 2, date: "2026-03-27", category: "PLANNED_TASK" },
+          ],
+        },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.confirmed).toBe(1);
+  });
+
+  it("rejects empty suggestions array", async () => {
+    const { POST } = await import(
+      "@/app/api/time-entries/confirm-suggestions/route"
+    );
+    const res = await POST(
+      createMockRequest("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        body: { suggestions: [] },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid hours", async () => {
+    const { POST } = await import(
+      "@/app/api/time-entries/confirm-suggestions/route"
+    );
+    const res = await POST(
+      createMockRequest("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        body: {
+          suggestions: [
+            { taskId: "task-1", hours: -1, date: "2026-03-27" },
+          ],
+        },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects invalid date format", async () => {
+    const { POST } = await import(
+      "@/app/api/time-entries/confirm-suggestions/route"
+    );
+    const res = await POST(
+      createMockRequest("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        body: {
+          suggestions: [
+            { taskId: "task-1", hours: 1, date: "invalid" },
+          ],
+        },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { POST } = await import(
+      "@/app/api/time-entries/confirm-suggestions/route"
+    );
+    const res = await POST(
+      createMockRequest("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        body: { suggestions: [{ taskId: "t1", hours: 1, date: "2026-03-27" }] },
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,779 +1,516 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
-import { Target, ClipboardList, Clock, BarChart3, Users, CalendarClock, AlertTriangle, ToggleLeft, ToggleRight } from "lucide-react";
-import { TeamOverview } from "@/app/components/team-overview";
-import { OverdueAlert } from "@/app/components/overdue-alert";
-import { TaskStatusSummary } from "@/app/components/task-status-summary";
-import { MyTodoList } from "@/app/components/my-todo-list";
-import { safeFixed, safePct } from "@/lib/safe-number";
+import {
+  Flame,
+  Calendar,
+  Clock,
+  AlertTriangle,
+  Users,
+  Target,
+  BarChart3,
+  ArrowRight,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
+import { extractData } from "@/lib/api-client";
 import { formatDate } from "@/lib/format";
-import { extractItems, extractData } from "@/lib/api-client";
+import { safeFixed } from "@/lib/safe-number";
 
-// ── Types ──────────────────────────────────────────────────────────────────
+// ── Skeleton loader ─────────────────────────────────────────────────────
 
-interface KPIAchievement {
-  id: string;
-  code: string;
-  title: string;
-  target: number;
-  actual: number;
-  status: string;
-  achievementRate: number;
+function Skeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("animate-pulse bg-muted rounded", className)} />
+  );
 }
 
-interface WorkloadPerson {
-  userId: string;
-  name: string;
-  total: number;
-  planned: number;
-  unplanned: number;
+function SectionSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="bg-card rounded-xl shadow-card p-5 space-y-3">
+      <Skeleton className="h-4 w-32" />
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
 }
 
-interface WorkloadData {
-  byPerson: WorkloadPerson[];
-  plannedRate: number;
-  unplannedRate: number;
-  totalHours: number;
-}
+// ── Shared types ────────────────────────────────────────────────────────
 
-interface WeeklyData {
-  completedCount: number;
-  overdueCount: number;
-  delayCount: number;
-  scopeChangeCount: number;
-  totalHours: number;
-}
-
-interface Task {
+interface TaskItem {
   id: string;
   title: string;
   status: string;
   priority: string;
   dueDate: string | null;
+  flagReason?: string | null;
+  managerFlagged?: boolean;
+  estimatedHours?: number | null;
+  actualHours?: number | null;
+  primaryAssignee?: { id: string; name: string; avatar?: string | null } | null;
 }
 
-// ── Today's Tasks Card ──────────────────────────────────────────────────────
-
-function dueCountdownText(dueDate: string): { text: string; urgent: boolean } {
-  const now = new Date();
-  const due = new Date(dueDate);
-  const diffMs = due.getTime() - now.getTime();
-  const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays < 0) return { text: `逾期 ${Math.abs(diffDays)} 天`, urgent: true };
-  if (diffDays === 0) return { text: "今天截止", urgent: true };
-  if (diffDays === 1) return { text: "明天截止", urgent: true };
-  if (diffDays <= 3) return { text: `${diffDays} 天後截止`, urgent: true };
-  if (diffDays <= 7) return { text: `${diffDays} 天後截止`, urgent: false };
-  return { text: `${diffDays} 天後截止`, urgent: false };
+interface Alert {
+  type: string;
+  message: string;
 }
 
-function TodayTasksCard() {
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  async function fetchTodayTasks() {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS");
-      if (!res.ok) throw new Error("無法載入待辦任務");
-      const body = await res.json();
-      const all: Task[] = extractItems<Task>(body);
-      // Sort by dueDate (closest first), tasks without dueDate go last
-      const withDue = all
-        .filter((t) => t.dueDate)
-        .sort((a, b) => new Date(a.dueDate!).getTime() - new Date(b.dueDate!).getTime());
-      const withoutDue = all.filter((t) => !t.dueDate);
-      setTasks([...withDue, ...withoutDue].slice(0, 5));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { fetchTodayTasks(); }, []);
-
-  if (loading) return <PageLoading message="載入待辦..." className="py-8" />;
-  if (error) return <PageError message={error} onRetry={fetchTodayTasks} className="py-8" />;
-  if (tasks.length === 0) return (
-    <PageEmpty
-      icon={<CalendarClock className="h-8 w-8" />}
-      title="沒有待辦任務"
-      description="目前沒有進行中或待辦的任務"
-      className="py-8"
-    />
-  );
-
-  const PRIORITY_DOT: Record<string, string> = {
-    URGENT: "bg-danger",
-    HIGH: "bg-warning",
-    MEDIUM: "bg-yellow-400",
-    LOW: "bg-muted-foreground",
-  };
-  const STATUS_LABEL: Record<string, string> = {
-    TODO: "待辦",
-    IN_PROGRESS: "進行中",
-  };
-
-  return (
-    <div className="bg-card rounded-xl shadow-card p-5">
-      <h2 className="text-sm font-medium mb-4 flex items-center gap-2">
-        <CalendarClock className="h-4 w-4 text-primary" />
-        今日待辦
-        <span className="text-xs text-muted-foreground font-normal">（最近 5 項）</span>
-      </h2>
-      <div className="space-y-2">
-        {tasks.map((t) => {
-          const countdown = t.dueDate ? dueCountdownText(t.dueDate) : null;
-          return (
-            <div
-              key={t.id}
-              className="flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors"
-            >
-              <span
-                className={cn(
-                  "w-2 h-2 rounded-full flex-shrink-0",
-                  PRIORITY_DOT[t.priority] ?? "bg-muted-foreground"
-                )}
-              />
-              <span className="flex-1 text-xs sm:text-sm text-foreground truncate min-w-0">{t.title}</span>
-              <span className="text-[11px] text-muted-foreground flex-shrink-0">
-                {STATUS_LABEL[t.status] ?? t.status}
-              </span>
-              {countdown ? (
-                <span
-                  className={cn(
-                    "text-[11px] tabular-nums flex-shrink-0 flex items-center gap-1",
-                    countdown.urgent ? "text-danger font-medium" : "text-muted-foreground"
-                  )}
-                >
-                  {countdown.urgent && <AlertTriangle className="h-3 w-3" />}
-                  {countdown.text}
-                </span>
-              ) : (
-                <span className="text-[11px] text-muted-foreground flex-shrink-0">無截止日</span>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+interface MemberWorkload {
+  id: string;
+  name: string;
+  avatar: string | null;
+  activeTasks: number;
+  overdueTasks: number;
+  flaggedTasks: number;
 }
 
-// ── KPI Achievement Section ─────────────────────────────────────────────────
+interface PlanSummary {
+  id: string;
+  title: string;
+  progressPct: number;
+  flaggedCount: number;
+}
 
-const KPI_STATUS_COLOR: Record<string, string> = {
-  ON_TRACK: "text-success bg-success/10",
-  AT_RISK:  "text-yellow-400 bg-warning/10",
-  BEHIND:   "text-danger bg-danger/10",
-  ACHIEVED: "text-blue-400 bg-blue-500/10",
-};
-const KPI_STATUS_LABEL: Record<string, string> = {
-  ON_TRACK: "進行中",
-  AT_RISK:  "風險",
-  BEHIND:   "落後",
-  ACHIEVED: "達成",
+interface MonthlyGoalItem {
+  id: string;
+  title: string;
+  progressPct: number;
+  status: string;
+}
+
+interface TimeSuggestion {
+  taskId: string;
+  title: string;
+  estimatedHours: number | null;
+  suggestion: string;
+}
+
+interface EngineerData {
+  role: "ENGINEER";
+  flaggedTasks: TaskItem[];
+  dueTodayTasks: TaskItem[];
+  inProgressTasks: TaskItem[];
+  todayHours: number;
+  dailyTarget: number;
+  timeSuggestions: TimeSuggestion[];
+  monthlyGoals: MonthlyGoalItem[];
+}
+
+interface ManagerData {
+  role: "MANAGER";
+  flaggedTasks: TaskItem[];
+  overdueTasks: TaskItem[];
+  memberWorkload: MemberWorkload[];
+  todayHours: number;
+  alerts: Alert[];
+  planSummaries: PlanSummary[];
+}
+
+type MyDayData = EngineerData | ManagerData;
+
+// ── Task Row ────────────────────────────────────────────────────────────
+
+const PRIORITY_DOT: Record<string, string> = {
+  P0: "bg-red-500",
+  P1: "bg-orange-500",
+  P2: "bg-yellow-400",
+  P3: "bg-gray-400",
 };
 
-function KPIAchievementSection() {
-  const [kpis, setKpis] = useState<KPIAchievement[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  async function fetchKPIs() {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(`/api/kpi?year=${new Date().getFullYear()}`);
-      if (!res.ok) throw new Error("無法載入 KPI");
-      const body = await res.json();
-      const data = extractItems<{
-        id: string; code: string; title: string; target: number; actual: number; status: string;
-        taskLinks: Array<{ weight: number; task: { status: string; progressPct: number } }>;
-        autoCalc: boolean;
-      }>(body);
-      const mapped: KPIAchievement[] = data.map((k) => {
-        let rate = 0;
-        if (k.autoCalc && k.taskLinks.length > 0) {
-          const totalW = k.taskLinks.reduce((s, l) => s + l.weight, 0);
-          const weighted = k.taskLinks.reduce((s, l) => {
-            const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
-            return s + (prog * l.weight) / 100;
-          }, 0);
-          rate = totalW > 0 ? Math.min((weighted / totalW) * k.target, 100) : 0;
-        } else {
-          rate = k.target > 0 ? Math.min((k.actual / k.target) * 100, 100) : 0;
-        }
-        return { id: k.id, code: k.code, title: k.title, target: k.target, actual: k.actual, status: k.status, achievementRate: rate };
-      });
-      setKpis(mapped);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { fetchKPIs(); }, []);
-
-  if (loading) return <PageLoading message="載入 KPI..." className="py-8" />;
-  if (error) return <PageError message={error} onRetry={fetchKPIs} className="py-8" />;
-  if (kpis.length === 0) return (
-    <PageEmpty
-      icon={<Target className="h-8 w-8" />}
-      title="尚無 KPI"
-      description="本年度尚未建立 KPI 指標"
-      className="py-8"
-    />
-  );
+function TaskRow({ task }: { task: TaskItem }) {
+  const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && task.status !== "DONE";
 
   return (
-    <div className="bg-card rounded-xl shadow-card p-5">
-      <h2 className="text-sm font-medium mb-4 flex items-center gap-2">
-        <Target className="h-4 w-4 text-primary" />
-        KPI 達成狀況（{new Date().getFullYear()} 年度）
-      </h2>
-      <div className="space-y-3">
-        {kpis.map((kpi) => {
-          const barColor =
-            kpi.achievementRate >= 100 ? "bg-success" :
-            kpi.achievementRate >= 60  ? "bg-primary" :
-            kpi.achievementRate >= 30  ? "bg-warning" : "bg-danger";
-          return (
-            <div key={kpi.id} className="space-y-1.5">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-[10px] font-mono text-muted-foreground flex-shrink-0">{kpi.code}</span>
-                  <span className="text-sm text-foreground truncate">{kpi.title}</span>
-                  {kpi.status && (
-                    <span className={cn("text-[10px] px-1.5 py-0.5 rounded-full font-medium flex-shrink-0",
-                      KPI_STATUS_COLOR[kpi.status] ?? "text-muted-foreground bg-accent")}>
-                      {KPI_STATUS_LABEL[kpi.status] ?? kpi.status}
-                    </span>
-                  )}
-                </div>
-                <div className="text-right flex-shrink-0">
-                  <span className="text-sm font-semibold tabular-nums">{safePct(kpi.achievementRate, 0, "0")}%</span>
-                  <span className="text-[10px] text-muted-foreground tabular-nums ml-1.5">
-                    {kpi.actual} / {kpi.target}
-                  </span>
-                </div>
-              </div>
-              <div className="h-1.5 w-full bg-accent rounded-full overflow-hidden">
-                <div
-                  className={cn("h-full rounded-full transition-all", barColor)}
-                  style={{ width: `${Math.min(kpi.achievementRate, 100)}%` }}
-                />
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-// ── Helper ─────────────────────────────────────────────────────────────────
-
-function ProgressBar({ pct, color = "bg-primary" }: { pct: number; color?: string }) {
-  return (
-    <div className="h-2 w-full bg-accent rounded-full overflow-hidden">
-      <div
-        className={cn("h-full rounded-full transition-all", color)}
-        style={{ width: `${Math.min(pct, 100)}%` }}
-      />
-    </div>
-  );
-}
-
-function StatCard({
-  label,
-  value,
-  sub,
-  accent,
-}: {
-  label: string;
-  value: string | number;
-  sub?: string;
-  accent?: boolean;
-}) {
-  return (
-    <div className="bg-card rounded-xl shadow-card p-4 flex flex-col gap-1">
-      <p className="text-xs text-muted-foreground">{label}</p>
-      <p className={cn("text-2xl font-semibold tabular-nums", accent && "text-danger")}>
-        {value}
-      </p>
-      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
-    </div>
-  );
-}
-
-// ── Manager Dashboard ──────────────────────────────────────────────────────
-
-function ManagerDashboard() {
-  const [workload, setWorkload] = useState<WorkloadData | null>(null);
-  const [weekly, setWeekly] = useState<WeeklyData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  async function load() {
-    setLoading(true);
-    setError(null);
-    try {
-      const [wlRaw, wrRaw] = await Promise.all([
-        fetch("/api/reports/workload").then((r) => { if (!r.ok) throw new Error("工作負載載入失敗"); return r.json(); }),
-        fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
-      ]);
-      const wl = extractData<WorkloadData>(wlRaw);
-      setWorkload(wl && typeof wl === "object" ? wl : null);
-      const weeklyData = extractData<WeeklyData>(wrRaw);
-      setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { load(); }, []);
-
-  if (loading) return <PageLoading />;
-  if (error) return <PageError message={error} onRetry={load} />;
-
-  // Check if there is truly no data at all
-  const hasNoData =
-    (weekly?.completedCount ?? 0) === 0 &&
-    (weekly?.totalHours ?? 0) === 0 &&
-    (weekly?.overdueCount ?? 0) === 0 &&
-    (workload?.totalHours ?? 0) === 0 &&
-    (!workload?.byPerson || workload.byPerson.length === 0);
-
-  if (hasNoData) {
-    return (
-      <div className="space-y-6">
-        <PageEmpty
-          icon={<BarChart3 className="h-8 w-8" />}
-          title="尚無團隊數據"
-          description="目前沒有任務完成紀錄與工時資料。當團隊成員開始記錄工時與完成任務後，此處將自動顯示團隊整體狀況。"
-          className="py-16"
-        />
-        <div className="bg-card rounded-xl shadow-card p-6">
-          <h3 className="text-sm font-medium mb-3">快速開始指南</h3>
-          <div className="space-y-3">
-            <div className="flex items-start gap-3">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <span className="text-xs font-semibold text-primary">1</span>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground">建立年度計畫</p>
-                <p className="text-xs text-muted-foreground">前往「計畫」頁面建立年度計畫與月度目標</p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <span className="text-xs font-semibold text-primary">2</span>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground">指派任務給團隊成員</p>
-                <p className="text-xs text-muted-foreground">在看板或任務列表中建立任務並指派負責人</p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <span className="text-xs font-semibold text-primary">3</span>
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground">記錄工時</p>
-                <p className="text-xs text-muted-foreground">請團隊成員在「工時」頁面每日登錄工時，即可在此追蹤進度</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  const maxPersonHours =
-    workload?.byPerson?.length
-      ? Math.max(...workload.byPerson.map((p) => p.total), 1)
-      : 1;
-
-  return (
-    <div className="space-y-6">
-      {/* ── Stats cards ── */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard label="本週完成任務" value={weekly?.completedCount ?? "—"} />
-        <StatCard label="本週總工時 (h)" value={safeFixed(weekly?.totalHours, 1, "—")} />
-        <StatCard
-          label="逾期任務"
-          value={weekly?.overdueCount ?? "—"}
-          accent={(weekly?.overdueCount ?? 0) > 0}
-        />
-        <StatCard label="本月計畫外比例" value={workload ? `${workload.unplannedRate}%` : "—"} />
-      </div>
-
-      {/* ── Team workload ── */}
-      <div className="bg-card rounded-xl shadow-card p-5">
-        <h2 className="text-sm font-medium mb-4">團隊工時分佈（本月）</h2>
-        {workload?.byPerson?.length ? (
-          <div className="space-y-3">
-            {workload.byPerson.slice(0, 5).map((p) => {
-              const pct = (p.total / maxPersonHours) * 100;
-              const unplannedPct = p.total > 0 ? (p.unplanned / p.total) * 100 : 0;
-              return (
-                <div key={p.userId} className="space-y-1">
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="text-foreground font-medium">{p.name}</span>
-                    <span className="tabular-nums text-muted-foreground">
-                      {safeFixed(p.total, 1)} h
-                    </span>
-                  </div>
-                  <ProgressBar pct={pct} />
-                  {unplannedPct > 0 && (
-                    <p className="text-[11px] text-muted-foreground tabular-nums">
-                      計畫外 {safePct(unplannedPct, 0)}%
-                    </p>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <PageEmpty
-            icon={<Users className="h-6 w-6" />}
-            title="本月尚無工時紀錄"
-            description="團隊成員開始記錄工時後，此處將顯示每人的工時分佈與計畫外比例"
-            className="py-8"
-          />
-        )}
-      </div>
-
-      {/* ── 投入率 ── */}
-      <div className="bg-card rounded-xl shadow-card p-5">
-        <h2 className="text-sm font-medium mb-4">投入率分析（計畫任務 vs 加入任務）</h2>
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-1">
-            <div className="flex justify-between text-xs">
-              <span className="text-muted-foreground">計畫內投入</span>
-              <span className="tabular-nums font-medium text-success">
-                {workload?.plannedRate ?? 0}%
-              </span>
-            </div>
-            <ProgressBar pct={workload?.plannedRate ?? 0} color="bg-success" />
-          </div>
-          <div className="space-y-1">
-            <div className="flex justify-between text-xs">
-              <span className="text-muted-foreground">計畫外投入</span>
-              <span className="tabular-nums font-medium text-warning">
-                {workload?.unplannedRate ?? 0}%
-              </span>
-            </div>
-            <ProgressBar pct={workload?.unplannedRate ?? 0} color="bg-warning" />
-          </div>
-        </div>
-      </div>
-
-      {/* ── This month ── */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <StatCard label="本週延遲次數" value={weekly?.delayCount ?? "—"} accent={(weekly?.delayCount ?? 0) > 0} />
-        <StatCard label="本週範疇變更" value={weekly?.scopeChangeCount ?? "—"} />
-        <StatCard
-          label="計畫外負荷率"
-          value={workload ? `${workload.unplannedRate}%` : "—"}
-          sub="(ADDED+INCIDENT+SUPPORT)"
-        />
-        <StatCard
-          label="計畫投入率"
-          value={workload ? `${workload.plannedRate}%` : "—"}
-          sub="(PLANNED_TASK)"
-        />
-      </div>
-    </div>
-  );
-}
-
-// ── Engineer Dashboard ─────────────────────────────────────────────────────
-
-function EngineerDashboard() {
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [weekly, setWeekly] = useState<WeeklyData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  async function load() {
-    setLoading(true);
-    setError(null);
-    try {
-      const [taskBody, wrBody] = await Promise.all([
-        fetch("/api/tasks?assignee=me&status=TODO,IN_PROGRESS").then((r) => { if (!r.ok) throw new Error("任務載入失敗"); return r.json(); }),
-        fetch("/api/reports/weekly").then((r) => { if (!r.ok) throw new Error("週報載入失敗"); return r.json(); }),
-      ]);
-      setTasks(extractItems<Task>(taskBody));
-      const weeklyData = extractData<WeeklyData>(wrBody);
-      setWeekly(weeklyData && typeof weeklyData === "object" ? weeklyData : null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => { load(); }, []);
-
-  if (loading) return <PageLoading />;
-  if (error) return <PageError message={error} onRetry={load} />;
-
-  // Check if engineer has no data at all
-  const hasNoData = tasks.length === 0 && (weekly?.totalHours ?? 0) === 0;
-
-  if (hasNoData) {
-    return (
-      <div className="space-y-6">
-        <PageEmpty
-          icon={<ClipboardList className="h-8 w-8" />}
-          title="尚無待處理任務"
-          description="目前沒有進行中的任務與工時紀錄。當主管指派任務給您後，此處將顯示您的工作狀況。"
-          className="py-16"
-        />
-        <div className="bg-card rounded-xl shadow-card p-6">
-          <h3 className="text-sm font-medium mb-3">開始使用</h3>
-          <div className="space-y-3">
-            <div className="flex items-start gap-3">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <Clock className="h-3 w-3 text-primary" />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground">記錄每日工時</p>
-                <p className="text-xs text-muted-foreground">前往「工時」頁面登錄您的每日工作時數，協助團隊追蹤進度</p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <div className="w-6 h-6 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
-                <ClipboardList className="h-3 w-3 text-primary" />
-              </div>
-              <div>
-                <p className="text-sm font-medium text-foreground">查看看板</p>
-                <p className="text-xs text-muted-foreground">在「看板」頁面查看與管理您被指派的任務</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  const weeklyPct = Math.min(((weekly?.totalHours ?? 0) / 40) * 100, 100);
-  const today = new Date().toDateString();
-  const overdue = tasks.filter(
-    (t) => t.dueDate && new Date(t.dueDate) < new Date() && t.status !== "DONE"
-  );
-
-  const PRIORITY_LABEL: Record<string, string> = {
-    URGENT: "緊急",
-    HIGH: "高",
-    MEDIUM: "中",
-    LOW: "低",
-  };
-  const PRIORITY_COLOR: Record<string, string> = {
-    URGENT: "text-danger",
-    HIGH: "text-warning",
-    MEDIUM: "text-yellow-400",
-    LOW: "text-muted-foreground",
-  };
-  const STATUS_LABEL: Record<string, string> = {
-    TODO: "待辦",
-    IN_PROGRESS: "進行中",
-    DONE: "完成",
-    BLOCKED: "封鎖",
-  };
-
-  return (
-    <div className="space-y-6">
-      {/* ── Summary cards ── */}
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-        <StatCard label="進行中任務" value={tasks.length} />
-        <StatCard label="逾期任務" value={overdue.length} accent={overdue.length > 0} />
-        <StatCard
-          label="本週工時 (h)"
-          value={`${safeFixed(weekly?.totalHours, 1)} / 40`}
-          sub={`進度 ${safePct(weeklyPct, 0)}%`}
-        />
-      </div>
-
-      {/* ── Weekly hours bar ── */}
-      <div className="bg-card rounded-xl shadow-card p-5">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-sm font-medium">本週工時進度</h2>
-          <span className="text-xs tabular-nums text-muted-foreground">
-            {safeFixed(weekly?.totalHours, 1)} / 40 h
-          </span>
-        </div>
-        <ProgressBar
-          pct={weeklyPct}
-          color={weeklyPct >= 90 ? "bg-success" : weeklyPct >= 60 ? "bg-primary" : "bg-warning"}
-        />
-      </div>
-
-      {/* ── My tasks today ── */}
-      <div className="bg-card rounded-xl shadow-card p-5">
-        <h2 className="text-sm font-medium mb-4">我的任務（待辦 + 進行中）</h2>
-        {tasks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">目前沒有待處理的任務</p>
-        ) : (
-          <div className="space-y-2">
-            {tasks.map((t) => (
-              <div
-                key={t.id}
-                className="flex items-center gap-2 sm:gap-3 p-2.5 sm:p-3 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors"
-              >
-                <span
-                  className={cn(
-                    "text-[11px] font-medium w-8 flex-shrink-0",
-                    PRIORITY_COLOR[t.priority] ?? "text-muted-foreground"
-                  )}
-                >
-                  {PRIORITY_LABEL[t.priority] ?? t.priority}
-                </span>
-                <span className="flex-1 text-xs sm:text-sm text-foreground truncate min-w-0">{t.title}</span>
-                <span className="text-[11px] text-muted-foreground flex-shrink-0">
-                  {STATUS_LABEL[t.status] ?? t.status}
-                </span>
-                {t.dueDate && (
-                  <span
-                    className={cn(
-                      "text-[11px] tabular-nums flex-shrink-0",
-                      new Date(t.dueDate) < new Date()
-                        ? "text-danger"
-                        : "text-muted-foreground"
-                    )}
-                  >
-                    {formatDate(t.dueDate)}
-                  </span>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* ── Overdue ── */}
-      {overdue.length > 0 && (
-        <div className="bg-card border-l-[3px] border-l-danger shadow-card rounded-lg p-5">
-          <h2 className="text-sm font-medium text-danger mb-3">逾期任務</h2>
-          <div className="space-y-2">
-            {overdue.map((t) => (
-              <div key={t.id} className="flex items-center justify-between text-sm">
-                <span className="text-foreground truncate">{t.title}</span>
-                <span className="text-danger tabular-nums text-xs flex-shrink-0 ml-2">
-                  {t.dueDate ? formatDate(t.dueDate) : ""}
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
+    <div className="flex items-center gap-2 p-2.5 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors">
+      {task.managerFlagged && (
+        <Flame className="h-3.5 w-3.5 text-red-500 fill-red-500 flex-shrink-0" />
+      )}
+      <span className={cn("w-2 h-2 rounded-full flex-shrink-0", PRIORITY_DOT[task.priority] ?? "bg-gray-400")} />
+      <span className="flex-1 text-sm text-foreground truncate min-w-0">{task.title}</span>
+      {task.primaryAssignee && (
+        <span className="text-[11px] text-muted-foreground flex-shrink-0">{task.primaryAssignee.name}</span>
+      )}
+      {task.dueDate && (
+        <span className={cn("text-[11px] tabular-nums flex-shrink-0", isOverdue ? "text-red-500 font-medium" : "text-muted-foreground")}>
+          {isOverdue && <AlertTriangle className="h-3 w-3 inline mr-0.5" />}
+          {formatDate(task.dueDate)}
+        </span>
       )}
     </div>
   );
 }
 
-// ── Page ───────────────────────────────────────────────────────────────────
+// ── Engineer My Day ─────────────────────────────────────────────────────
 
-const DASHBOARD_VIEW_KEY = "titan-dashboard-view";
-type DashboardView = "personal" | "team";
+function EngineerMyDay({ data }: { data: EngineerData }) {
+  const hoursPct = Math.min((data.todayHours / data.dailyTarget) * 100, 100);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[65%_35%] gap-6">
+      {/* Left column — Task sections */}
+      <div className="space-y-4">
+        {/* Flagged tasks (red top) */}
+        {data.flaggedTasks.length > 0 && (
+          <div className="bg-card rounded-xl shadow-card p-5 border-l-[3px] border-l-red-500">
+            <h2 className="text-sm font-medium mb-3 flex items-center gap-2 text-red-600 dark:text-red-400">
+              <Flame className="h-4 w-4 fill-current" />
+              主管標記任務
+            </h2>
+            <div className="space-y-2">
+              {data.flaggedTasks.map((t) => (
+                <TaskRow key={t.id} task={t} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Due today (yellow) */}
+        <div className="bg-card rounded-xl shadow-card p-5">
+          <h2 className="text-sm font-medium mb-3 flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-yellow-500" />
+            今日到期
+            <span className="text-xs text-muted-foreground font-normal">({data.dueTodayTasks.length})</span>
+          </h2>
+          {data.dueTodayTasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-2">今天沒有到期任務</p>
+          ) : (
+            <div className="space-y-2">
+              {data.dueTodayTasks.map((t) => (
+                <TaskRow key={t.id} task={t} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* In progress */}
+        <div className="bg-card rounded-xl shadow-card p-5">
+          <h2 className="text-sm font-medium mb-3 flex items-center gap-2">
+            <Clock className="h-4 w-4 text-blue-500" />
+            進行中
+            <span className="text-xs text-muted-foreground font-normal">({data.inProgressTasks.length})</span>
+          </h2>
+          {data.inProgressTasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-2">目前沒有進行中的任務</p>
+          ) : (
+            <div className="space-y-2">
+              {data.inProgressTasks.map((t) => (
+                <TaskRow key={t.id} task={t} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Time suggestions */}
+        {data.timeSuggestions.length > 0 && (
+          <div className="bg-card rounded-xl shadow-card p-5">
+            <h2 className="text-sm font-medium mb-3 flex items-center gap-2">
+              <Clock className="h-4 w-4 text-purple-500" />
+              時間建議
+            </h2>
+            <div className="space-y-2">
+              {data.timeSuggestions.map((s) => (
+                <div key={s.taskId} className="flex items-center gap-2 p-2 bg-purple-50 dark:bg-purple-950/30 rounded text-sm text-purple-700 dark:text-purple-300">
+                  <ArrowRight className="h-3 w-3 flex-shrink-0" />
+                  <span>{s.suggestion}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Right column — Info panels */}
+      <div className="space-y-4">
+        {/* Today hours summary */}
+        <div className="bg-card rounded-xl shadow-card p-5">
+          <h2 className="text-sm font-medium mb-3">今日工時</h2>
+          <div className="text-2xl font-semibold tabular-nums">
+            {safeFixed(data.todayHours, 1)}h <span className="text-sm text-muted-foreground font-normal">/ {data.dailyTarget}h</span>
+          </div>
+          <div className="mt-2 h-2 bg-accent rounded-full overflow-hidden">
+            <div
+              className={cn(
+                "h-full rounded-full transition-all",
+                hoursPct >= 90 ? "bg-green-500" : hoursPct >= 50 ? "bg-blue-500" : "bg-yellow-500"
+              )}
+              style={{ width: `${hoursPct}%` }}
+            />
+          </div>
+          {data.todayHours === 0 && (
+            <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-2 flex items-center gap-1">
+              <AlertTriangle className="h-3 w-3" />
+              尚未記錄任何工時
+            </p>
+          )}
+        </div>
+
+        {/* Monthly goals */}
+        {data.monthlyGoals.length > 0 && (
+          <div className="bg-card rounded-xl shadow-card p-5">
+            <h2 className="text-sm font-medium mb-3 flex items-center gap-2">
+              <Target className="h-4 w-4 text-primary" />
+              本月目標
+            </h2>
+            <div className="space-y-3">
+              {data.monthlyGoals.map((g) => (
+                <div key={g.id} className="space-y-1">
+                  <div className="flex justify-between text-xs">
+                    <span className="text-foreground truncate">{g.title}</span>
+                    <span className="tabular-nums text-muted-foreground ml-2">{Math.round(g.progressPct)}%</span>
+                  </div>
+                  <div className="h-1.5 bg-accent rounded-full overflow-hidden">
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all",
+                        g.progressPct >= 80 ? "bg-green-500" : g.progressPct >= 40 ? "bg-blue-500" : "bg-yellow-500"
+                      )}
+                      style={{ width: `${Math.min(g.progressPct, 100)}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Manager My Day ──────────────────────────────────────────────────────
+
+function ManagerMyDay({ data }: { data: ManagerData }) {
+  return (
+    <div className="space-y-6">
+      {/* Alerts bar */}
+      {data.alerts.length > 0 && (
+        <div className="space-y-2">
+          {data.alerts.map((alert, i) => (
+            <div
+              key={i}
+              className={cn(
+                "flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium",
+                alert.type === "CRITICAL"
+                  ? "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200"
+                  : "bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200"
+              )}
+            >
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+              {alert.message}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-[65%_35%] gap-6">
+        {/* Left — Team health + flagged items */}
+        <div className="space-y-4">
+          {/* Team health snapshot */}
+          <div className="bg-card rounded-xl shadow-card p-5">
+            <h2 className="text-sm font-medium mb-4 flex items-center gap-2">
+              <Users className="h-4 w-4 text-primary" />
+              團隊健康快照
+            </h2>
+            {data.memberWorkload.length === 0 ? (
+              <p className="text-sm text-muted-foreground">尚無團隊成員資料</p>
+            ) : (
+              <div className="space-y-3">
+                {data.memberWorkload.map((m) => (
+                  <div key={m.id} className="flex items-center gap-3 p-2.5 bg-accent/40 rounded-md">
+                    <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium flex-shrink-0">
+                      {m.avatar ? (
+                        <img src={m.avatar} alt={m.name} className="h-full w-full rounded-full object-cover" />
+                      ) : (
+                        m.name.charAt(0)
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-medium truncate">{m.name}</div>
+                      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+                        <span>進行中 {m.activeTasks}</span>
+                        {m.overdueTasks > 0 && <span className="text-red-500">逾期 {m.overdueTasks}</span>}
+                        {m.flaggedTasks > 0 && <span className="text-red-500">標記 {m.flaggedTasks}</span>}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Flagged items */}
+          {data.flaggedTasks.length > 0 && (
+            <div className="bg-card rounded-xl shadow-card p-5 border-l-[3px] border-l-red-500">
+              <h2 className="text-sm font-medium mb-3 flex items-center gap-2 text-red-600 dark:text-red-400">
+                <Flame className="h-4 w-4 fill-current" />
+                已標記任務
+                <span className="text-xs font-normal">({data.flaggedTasks.length})</span>
+              </h2>
+              <div className="space-y-2">
+                {data.flaggedTasks.map((t) => (
+                  <TaskRow key={t.id} task={t} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Overdue tasks */}
+          {data.overdueTasks.length > 0 && (
+            <div className="bg-card rounded-xl shadow-card p-5 border-l-[3px] border-l-orange-500">
+              <h2 className="text-sm font-medium mb-3 flex items-center gap-2 text-orange-600 dark:text-orange-400">
+                <AlertTriangle className="h-4 w-4" />
+                逾期任務
+                <span className="text-xs font-normal">({data.overdueTasks.length})</span>
+              </h2>
+              <div className="space-y-2">
+                {data.overdueTasks.slice(0, 10).map((t) => (
+                  <TaskRow key={t.id} task={t} />
+                ))}
+                {data.overdueTasks.length > 10 && (
+                  <p className="text-xs text-muted-foreground pt-1">還有 {data.overdueTasks.length - 10} 個逾期任務...</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Right — Workload + plan summaries */}
+        <div className="space-y-4">
+          {/* Plan summaries */}
+          {data.planSummaries.length > 0 && (
+            <div className="bg-card rounded-xl shadow-card p-5">
+              <h2 className="text-sm font-medium mb-3 flex items-center gap-2">
+                <BarChart3 className="h-4 w-4 text-primary" />
+                年度計畫
+              </h2>
+              <div className="space-y-3">
+                {data.planSummaries.map((p) => (
+                  <div key={p.id} className="space-y-1.5">
+                    <div className="flex justify-between text-xs">
+                      <span className="text-foreground truncate">{p.title}</span>
+                      <span className="tabular-nums text-muted-foreground ml-2">{Math.round(p.progressPct)}%</span>
+                    </div>
+                    <div className="h-1.5 bg-accent rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-primary rounded-full transition-all"
+                        style={{ width: `${Math.min(p.progressPct, 100)}%` }}
+                      />
+                    </div>
+                    {p.flaggedCount > 0 && (
+                      <p className="text-[11px] text-red-500 flex items-center gap-1">
+                        <Flame className="h-3 w-3 fill-current" />
+                        {p.flaggedCount} 個標記任務
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Quick links */}
+          <div className="bg-card rounded-xl shadow-card p-5">
+            <h2 className="text-sm font-medium mb-3">快速前往</h2>
+            <div className="grid grid-cols-2 gap-2">
+              <a href="/cockpit" className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/60 hover:bg-accent transition-colors text-sm">
+                <BarChart3 className="h-4 w-4 text-primary" />
+                駕駛艙
+              </a>
+              <a href="/kanban" className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/60 hover:bg-accent transition-colors text-sm">
+                <Target className="h-4 w-4 text-primary" />
+                看板
+              </a>
+              <a href="/reports" className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/60 hover:bg-accent transition-colors text-sm">
+                <BarChart3 className="h-4 w-4 text-primary" />
+                報表
+              </a>
+              <a href="/timesheet" className="flex items-center gap-2 px-3 py-2 rounded-lg bg-accent/60 hover:bg-accent transition-colors text-sm">
+                <Clock className="h-4 w-4 text-primary" />
+                工時
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────
 
 export default function DashboardPage() {
   const { data: session, status } = useSession();
+  const [data, setData] = useState<MyDayData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMyDay = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/my-day");
+      if (!res.ok) throw new Error(`載入失敗 (${res.status})`);
+      const body = await res.json();
+      setData(extractData<MyDayData>(body));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      fetchMyDay();
+    }
+  }, [status, fetchMyDay]);
+
   const isManager = session?.user?.role === "MANAGER" || session?.user?.role === "ADMIN";
-
-  // View toggle (persisted in localStorage)
-  const [view, setView] = useState<DashboardView>(() => {
-    if (typeof window === "undefined") return "team";
-    return (localStorage.getItem(DASHBOARD_VIEW_KEY) as DashboardView) || "team";
-  });
-
-  function toggleView() {
-    const next: DashboardView = view === "personal" ? "team" : "personal";
-    setView(next);
-    localStorage.setItem(DASHBOARD_VIEW_KEY, next);
-  }
-
-  const showTeam = isManager && view === "team";
+  const greeting = getGreeting();
+  const userName = session?.user?.name ?? "";
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="flex items-center justify-between gap-3 mb-6">
-        <div>
-          <h1 className="text-lg sm:text-xl font-semibold tracking-tight">儀表板</h1>
-          <p className="text-xs sm:text-sm text-muted-foreground mt-1 truncate">
-            {showTeam ? "團隊視角 — 團隊整體狀況" : "個人視角 — 我的工作狀況"}
-          </p>
-        </div>
-        {/* View toggle — only for Manager/Admin */}
-        {isManager && status !== "loading" && (
-          <button
-            onClick={toggleView}
-            className="flex items-center gap-2 px-3 py-1.5 bg-card border border-border rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors"
-          >
-            {view === "team" ? (
-              <ToggleRight className="h-4 w-4 text-primary" />
-            ) : (
-              <ToggleLeft className="h-4 w-4 text-muted-foreground" />
-            )}
-            {view === "team" ? "團隊" : "個人"}
-          </button>
-        )}
+    <div className="max-w-6xl mx-auto px-4 py-6">
+      {/* Header */}
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold tracking-tight">
+          {greeting}，{userName}
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {isManager ? "團隊全局 — 今日需關注事項" : "我的一天 — 今日工作安排"}
+        </p>
       </div>
 
-      {/* ── Overdue Alert (Issue #809, top of dashboard) ── */}
-      {status !== "loading" && (
-        <div className="mb-6">
-          <OverdueAlert />
-        </div>
-      )}
-
-      {/* ── Task Status Summary Cards (Issue #808) ── */}
-      {status !== "loading" && (
-        <div className="mb-8">
-          <TaskStatusSummary />
-        </div>
-      )}
-
-      {status === "loading" ? (
-        <PageLoading />
-      ) : showTeam ? (
-        <>
-          <TeamOverview />
-          <div className="mt-8">
-            <ManagerDashboard />
+      {/* Progressive loading with skeletons */}
+      {status === "loading" || loading ? (
+        <div className="grid grid-cols-1 lg:grid-cols-[65%_35%] gap-6">
+          <div className="space-y-4">
+            <SectionSkeleton rows={2} />
+            <SectionSkeleton rows={3} />
           </div>
-        </>
-      ) : isManager ? (
-        <EngineerDashboard />
+          <div className="space-y-4">
+            <SectionSkeleton rows={1} />
+            <SectionSkeleton rows={2} />
+          </div>
+        </div>
+      ) : error ? (
+        <PageError message={error} onRetry={fetchMyDay} />
+      ) : !data ? (
+        <PageEmpty title="尚無資料" description="無法載入 My Day 資料" />
+      ) : data.role === "MANAGER" ? (
+        <ManagerMyDay data={data} />
       ) : (
-        <EngineerDashboard />
-      )}
-
-      {/* ── My Todo List (both views, Issue #807) ── */}
-      {status !== "loading" && (
-        <div className="mt-8">
-          <MyTodoList />
-        </div>
-      )}
-
-      {/* ── KPI Achievement Cards ── */}
-      {status !== "loading" && (
-        <div className="mt-8">
-          <KPIAchievementSection />
-        </div>
+        <EngineerMyDay data={data} />
       )}
     </div>
   );
+}
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "早安";
+  if (hour < 18) return "午安";
+  return "晚安";
 }

--- a/app/api/my-day/route.ts
+++ b/app/api/my-day/route.ts
@@ -1,0 +1,273 @@
+/**
+ * My Day Aggregation API — Issue #959
+ *
+ * GET /api/my-day?role=ENGINEER|MANAGER
+ *
+ * Engineer view: flagged tasks, due today, in progress, time suggestions
+ * Manager view: team health snapshot, flagged items, member workload, alerts
+ *
+ * Returns a unified payload for the My Day homepage.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+  const role = session.user.role;
+  const isManager = role === "MANAGER" || role === "ADMIN";
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const todayEnd = new Date(todayStart);
+  todayEnd.setDate(todayEnd.getDate() + 1);
+
+  if (isManager) {
+    // ── Manager View ──────────────────────────────────────────────────
+    const [flaggedTasks, overdueTasks, teamMembers, todayTimeEntries, plans] =
+      await Promise.all([
+        // Flagged tasks across team
+        prisma.task.findMany({
+          where: { managerFlagged: true, status: { not: "DONE" } },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            priority: true,
+            dueDate: true,
+            flagReason: true,
+            flaggedAt: true,
+            managerFlagged: true,
+            primaryAssignee: { select: { id: true, name: true, avatar: true } },
+          },
+          orderBy: { flaggedAt: "desc" },
+          take: 10,
+        }),
+        // Overdue tasks
+        prisma.task.findMany({
+          where: {
+            status: { not: "DONE" },
+            dueDate: { lt: now },
+          },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            priority: true,
+            dueDate: true,
+            managerFlagged: true,
+            primaryAssignee: { select: { id: true, name: true } },
+          },
+          orderBy: { dueDate: "asc" },
+          take: 20,
+        }),
+        // Team members with active task counts
+        prisma.user.findMany({
+          where: { isActive: true, role: "ENGINEER" },
+          select: {
+            id: true,
+            name: true,
+            avatar: true,
+            primaryTasks: {
+              where: { status: { in: ["TODO", "IN_PROGRESS"] } },
+              select: { id: true, status: true, dueDate: true, managerFlagged: true },
+            },
+          },
+        }),
+        // Today's time entries summary
+        prisma.timeEntry.aggregate({
+          where: {
+            date: { gte: todayStart, lt: todayEnd },
+          },
+          _sum: { hours: true },
+          _count: true,
+        }),
+        // Active plans for health snapshot
+        prisma.annualPlan.findMany({
+          where: { year: now.getFullYear(), archivedAt: null },
+          select: {
+            id: true,
+            title: true,
+            progressPct: true,
+            monthlyGoals: {
+              select: {
+                id: true,
+                title: true,
+                month: true,
+                progressPct: true,
+                tasks: {
+                  where: { status: { not: "DONE" } },
+                  select: { id: true, managerFlagged: true },
+                },
+              },
+            },
+          },
+        }),
+      ]);
+
+    // Build member workload
+    const memberWorkload = teamMembers.map((m) => {
+      const overdue = m.primaryTasks.filter(
+        (t) => t.dueDate && new Date(t.dueDate) < now
+      ).length;
+      const flagged = m.primaryTasks.filter((t) => t.managerFlagged).length;
+      return {
+        id: m.id,
+        name: m.name,
+        avatar: m.avatar,
+        activeTasks: m.primaryTasks.length,
+        overdueTasks: overdue,
+        flaggedTasks: flagged,
+      };
+    });
+
+    // Alerts
+    const alerts: { type: string; message: string }[] = [];
+    if (overdueTasks.length > 0) {
+      alerts.push({
+        type: "WARNING",
+        message: `${overdueTasks.length} 個任務已逾期`,
+      });
+    }
+    for (const plan of plans) {
+      const currentMonth = now.getMonth() + 1;
+      for (const goal of plan.monthlyGoals) {
+        if (goal.month === currentMonth && goal.progressPct < 50) {
+          alerts.push({
+            type: "CRITICAL",
+            message: `「${goal.title}」本月目標進度僅 ${Math.round(goal.progressPct)}%`,
+          });
+        }
+      }
+    }
+
+    // Plan flagged counts
+    const planSummaries = plans.map((p) => {
+      const flaggedCount = p.monthlyGoals.reduce(
+        (sum, g) => sum + g.tasks.filter((t) => t.managerFlagged).length,
+        0
+      );
+      return {
+        id: p.id,
+        title: p.title,
+        progressPct: p.progressPct,
+        flaggedCount,
+      };
+    });
+
+    return success({
+      role: "MANAGER",
+      flaggedTasks,
+      overdueTasks,
+      memberWorkload,
+      todayHours: todayTimeEntries._sum.hours ?? 0,
+      alerts,
+      planSummaries,
+    });
+  }
+
+  // ── Engineer View ──────────────────────────────────────────────────
+  const [flaggedTasks, dueTodayTasks, inProgressTasks, todayHours, monthlyGoals] =
+    await Promise.all([
+      // Flagged tasks for this engineer
+      prisma.task.findMany({
+        where: {
+          managerFlagged: true,
+          status: { not: "DONE" },
+          OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
+        },
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          priority: true,
+          dueDate: true,
+          flagReason: true,
+          flaggedAt: true,
+          managerFlagged: true,
+        },
+        orderBy: { flaggedAt: "desc" },
+      }),
+      // Due today
+      prisma.task.findMany({
+        where: {
+          status: { not: "DONE" },
+          dueDate: { gte: todayStart, lt: todayEnd },
+          OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
+        },
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          priority: true,
+          dueDate: true,
+          estimatedHours: true,
+          managerFlagged: true,
+        },
+        orderBy: [{ priority: "asc" }, { dueDate: "asc" }],
+      }),
+      // In progress
+      prisma.task.findMany({
+        where: {
+          status: "IN_PROGRESS",
+          OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
+        },
+        select: {
+          id: true,
+          title: true,
+          status: true,
+          priority: true,
+          dueDate: true,
+          estimatedHours: true,
+          actualHours: true,
+          managerFlagged: true,
+        },
+        orderBy: [{ priority: "asc" }, { dueDate: "asc" }],
+      }),
+      // Today's logged hours
+      prisma.timeEntry.aggregate({
+        where: {
+          userId,
+          date: { gte: todayStart, lt: todayEnd },
+        },
+        _sum: { hours: true },
+      }),
+      // Current month goals
+      prisma.monthlyGoal.findMany({
+        where: {
+          annualPlan: { year: now.getFullYear(), archivedAt: null },
+          month: now.getMonth() + 1,
+        },
+        select: {
+          id: true,
+          title: true,
+          progressPct: true,
+          status: true,
+        },
+      }),
+    ]);
+
+  // Time suggestions: tasks with estimated hours that haven't been started
+  const timeSuggestions = dueTodayTasks
+    .filter((t) => t.estimatedHours && t.status === "TODO")
+    .map((t) => ({
+      taskId: t.id,
+      title: t.title,
+      estimatedHours: t.estimatedHours,
+      suggestion: `建議分配 ${t.estimatedHours}h 給「${t.title}」`,
+    }));
+
+  return success({
+    role: "ENGINEER",
+    flaggedTasks,
+    dueTodayTasks,
+    inProgressTasks,
+    todayHours: todayHours._sum.hours ?? 0,
+    dailyTarget: 8,
+    timeSuggestions,
+    monthlyGoals,
+  });
+});

--- a/app/api/time-entries/confirm-suggestions/route.ts
+++ b/app/api/time-entries/confirm-suggestions/route.ts
@@ -1,0 +1,67 @@
+/**
+ * POST /api/time-entries/confirm-suggestions — Issue #963
+ *
+ * Batch confirm time entry suggestions. Creates time entries for all
+ * confirmed suggestions in a single transaction.
+ *
+ * Body: { suggestions: Array<{ taskId, hours, date, category }> }
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { TimeCategory } from "@prisma/client";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { ValidationError } from "@/services/errors";
+
+interface ConfirmItem {
+  taskId: string;
+  hours: number;
+  date: string;
+  category?: string;
+  description?: string;
+}
+
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const body = await req.json();
+  const items: ConfirmItem[] = body?.suggestions;
+
+  if (!Array.isArray(items) || items.length === 0) {
+    throw new ValidationError("至少需要一筆工時建議");
+  }
+
+  // Validate all items
+  for (const item of items) {
+    if (!item.taskId || typeof item.taskId !== "string") {
+      throw new ValidationError("每筆建議必須包含 taskId");
+    }
+    if (typeof item.hours !== "number" || item.hours <= 0 || item.hours > 24) {
+      throw new ValidationError(`工時必須在 0.01 ~ 24 之間（taskId: ${item.taskId}）`);
+    }
+    if (!item.date || !/^\d{4}-\d{2}-\d{2}$/.test(item.date)) {
+      throw new ValidationError(`日期格式錯誤（taskId: ${item.taskId}）`);
+    }
+  }
+
+  // Create all entries in a transaction
+  const created = await prisma.$transaction(
+    items.map((item) =>
+      prisma.timeEntry.create({
+        data: {
+          userId,
+          taskId: item.taskId,
+          date: new Date(item.date),
+          hours: Math.round(item.hours * 100) / 100, // 2 decimal precision
+          category: (item.category as TimeCategory) ?? "PLANNED_TASK",
+          description: item.description ?? "自動建議確認",
+        },
+      })
+    )
+  );
+
+  return success({ confirmed: created.length, entries: created });
+});

--- a/app/api/time-entries/suggestions/route.ts
+++ b/app/api/time-entries/suggestions/route.ts
@@ -1,0 +1,170 @@
+/**
+ * GET /api/time-entries/suggestions — Issue #963
+ *
+ * Analyze today's task status changes and suggest time entries.
+ * - When task moved to IN_PROGRESS → suggest timer start
+ * - When task moved to DONE → suggest time entry (duration = time in IN_PROGRESS)
+ *
+ * Query params:
+ *   date — ISO date string (defaults to today)
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+export interface TimeSuggestion {
+  id: string;
+  taskId: string;
+  taskTitle: string;
+  type: "timer_start" | "time_entry";
+  suggestedHours: number;
+  date: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  category: string;
+  alreadyLogged: boolean;
+}
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const { searchParams } = new URL(req.url);
+  const dateParam = searchParams.get("date");
+  const targetDate = dateParam ? new Date(dateParam) : new Date();
+
+  // Normalize to start/end of day
+  const dayStart = new Date(targetDate);
+  dayStart.setHours(0, 0, 0, 0);
+  const dayEnd = new Date(targetDate);
+  dayEnd.setHours(23, 59, 59, 999);
+
+  // 1. Find task activities for today (status changes)
+  const activities = await prisma.taskActivity.findMany({
+    where: {
+      userId,
+      createdAt: { gte: dayStart, lte: dayEnd },
+      action: "STATUS_CHANGE",
+    },
+    include: {
+      task: {
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          status: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // 2. Find existing time entries for today to avoid duplicate suggestions
+  const existingEntries = await prisma.timeEntry.findMany({
+    where: {
+      userId,
+      date: { gte: dayStart, lte: dayEnd },
+    },
+    select: { taskId: true, hours: true },
+  });
+
+  const loggedTaskIds = new Set(existingEntries.map((e) => e.taskId).filter(Boolean));
+  const loggedHoursByTask = new Map<string, number>();
+  for (const entry of existingEntries) {
+    if (entry.taskId) {
+      loggedHoursByTask.set(
+        entry.taskId,
+        (loggedHoursByTask.get(entry.taskId) ?? 0) + entry.hours
+      );
+    }
+  }
+
+  // 3. Build suggestions from status changes
+  // Process DONE first (higher priority — includes time entry suggestion),
+  // then IN_PROGRESS for tasks not yet completed today.
+  const suggestions: TimeSuggestion[] = [];
+  const processedTasks = new Set<string>();
+
+  // Pass 1: DONE activities → time entry suggestions
+  for (const activity of activities) {
+    if (!activity.task) continue;
+    const detail = activity.detail as { from?: string; to?: string } | null;
+    if (!detail || detail.to !== "DONE") continue;
+
+    const taskId = activity.task.id;
+    if (processedTasks.has(taskId)) continue;
+    processedTasks.add(taskId);
+
+    // Find when it was moved to IN_PROGRESS (look for earlier activity)
+    const startActivity = activities.find(
+      (a) =>
+        a.task?.id === taskId &&
+        (a.detail as { to?: string } | null)?.to === "IN_PROGRESS"
+    );
+
+    let suggestedHours = 1; // Default 1h if no start time found
+    if (startActivity) {
+      const diffMs =
+        activity.createdAt.getTime() - startActivity.createdAt.getTime();
+      suggestedHours = Math.max(0.25, Math.round((diffMs / 3600000) * 4) / 4); // Round to 0.25h
+    }
+
+    // Subtract already logged hours
+    const logged = loggedHoursByTask.get(taskId) ?? 0;
+    const remaining = Math.max(0, suggestedHours - logged);
+
+    suggestions.push({
+      id: `suggest-entry-${taskId}`,
+      taskId,
+      taskTitle: activity.task.title,
+      type: "time_entry",
+      suggestedHours: remaining,
+      date: dayStart.toISOString().split("T")[0],
+      startedAt: startActivity?.createdAt.toISOString() ?? null,
+      completedAt: activity.createdAt.toISOString(),
+      category: mapCategory(activity.task.category),
+      alreadyLogged: loggedTaskIds.has(taskId) && remaining <= 0,
+    });
+  }
+
+  // Pass 2: IN_PROGRESS activities → timer start suggestions (only if not already DONE)
+  for (const activity of activities) {
+    if (!activity.task) continue;
+    const detail = activity.detail as { from?: string; to?: string } | null;
+    if (!detail || detail.to !== "IN_PROGRESS") continue;
+
+    const taskId = activity.task.id;
+    if (processedTasks.has(taskId)) continue;
+    processedTasks.add(taskId);
+
+    suggestions.push({
+      id: `suggest-start-${taskId}`,
+      taskId,
+      taskTitle: activity.task.title,
+      type: "timer_start",
+      suggestedHours: 0,
+      date: dayStart.toISOString().split("T")[0],
+      startedAt: activity.createdAt.toISOString(),
+      completedAt: null,
+      category: mapCategory(activity.task.category),
+      alreadyLogged: loggedTaskIds.has(taskId),
+    });
+  }
+
+  return success(suggestions);
+});
+
+function mapCategory(taskCategory: string): string {
+  const map: Record<string, string> = {
+    PLANNED: "PLANNED_TASK",
+    ADDED: "ADDED_TASK",
+    INCIDENT: "INCIDENT",
+    SUPPORT: "SUPPORT",
+    ADMIN: "ADMIN",
+    LEARNING: "LEARNING",
+  };
+  return map[taskCategory] ?? "PLANNED_TASK";
+}

--- a/app/components/timesheet/daily-digest-banner.tsx
+++ b/app/components/timesheet/daily-digest-banner.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+/**
+ * DailyDigestBanner — Issue #963
+ *
+ * Displays at top of timesheet page: "今天有 N 筆工時建議待確認"
+ * Fetches suggestions from GET /api/time-entries/suggestions
+ * and allows batch confirmation via POST /api/time-entries/confirm-suggestions.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { Clock, Check, ChevronDown, ChevronUp, X, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface Suggestion {
+  id: string;
+  taskId: string;
+  taskTitle: string;
+  type: "timer_start" | "time_entry";
+  suggestedHours: number;
+  date: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  category: string;
+  alreadyLogged: boolean;
+}
+
+export function DailyDigestBanner() {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const fetchSuggestions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/time-entries/suggestions");
+      if (res.ok) {
+        const body = await res.json();
+        const items: Suggestion[] = body?.data ?? [];
+        // Only show non-already-logged suggestions
+        const pending = items.filter((s) => !s.alreadyLogged && s.suggestedHours > 0);
+        setSuggestions(pending);
+        // Default: select all
+        setSelected(new Set(pending.map((s) => s.id)));
+      }
+    } catch {
+      // Silently fail — banner is non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSuggestions();
+  }, [fetchSuggestions]);
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const confirmSelected = async () => {
+    const toConfirm = suggestions.filter((s) => selected.has(s.id) && s.type === "time_entry");
+    if (toConfirm.length === 0) return;
+
+    setConfirming(true);
+    try {
+      const res = await fetch("/api/time-entries/confirm-suggestions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          suggestions: toConfirm.map((s) => ({
+            taskId: s.taskId,
+            hours: s.suggestedHours,
+            date: s.date,
+            category: s.category,
+          })),
+        }),
+      });
+      if (res.ok) {
+        // Remove confirmed from list
+        setSuggestions((prev) => prev.filter((s) => !selected.has(s.id)));
+        setSelected(new Set());
+      }
+    } catch {
+      // Silent fail
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  // Don't render if dismissed, loading, or no suggestions
+  if (dismissed || loading || suggestions.length === 0) return null;
+
+  const confirmableCount = suggestions.filter(
+    (s) => selected.has(s.id) && s.type === "time_entry"
+  ).length;
+
+  return (
+    <div className="border border-amber-500/30 bg-amber-500/5 rounded-xl overflow-hidden">
+      {/* Summary bar */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+          <Clock className="h-4 w-4" />
+          <span className="text-sm font-medium">
+            今天有 {suggestions.length} 筆工時建議待確認
+          </span>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {confirmableCount > 0 && (
+            <button
+              onClick={confirmSelected}
+              disabled={confirming}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-amber-500 text-white rounded-md hover:bg-amber-600 transition-colors disabled:opacity-50"
+            >
+              {confirming ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Check className="h-3 w-3" />
+              )}
+              確認 {confirmableCount} 筆
+            </button>
+          )}
+
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="p-1.5 rounded-md hover:bg-amber-500/10 transition-colors text-amber-600 dark:text-amber-400"
+            aria-label={expanded ? "收合" : "展開"}
+          >
+            {expanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </button>
+
+          <button
+            onClick={() => setDismissed(true)}
+            className="p-1.5 rounded-md hover:bg-amber-500/10 transition-colors text-muted-foreground"
+            aria-label="關閉"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div className="border-t border-amber-500/20 px-4 py-2 space-y-1">
+          {suggestions.map((s) => (
+            <label
+              key={s.id}
+              className={cn(
+                "flex items-center gap-3 py-2 px-2 rounded-md hover:bg-amber-500/5 cursor-pointer transition-colors",
+                selected.has(s.id) && "bg-amber-500/5"
+              )}
+            >
+              <input
+                type="checkbox"
+                checked={selected.has(s.id)}
+                onChange={() => toggleSelect(s.id)}
+                className="rounded border-amber-400 text-amber-500 focus:ring-amber-500"
+              />
+              <div className="flex-1 min-w-0">
+                <span className="text-sm text-foreground truncate block">
+                  {s.taskTitle}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {s.type === "time_entry"
+                    ? `建議工時：${s.suggestedHours}h`
+                    : "建議開始計時"}
+                  {s.startedAt && (
+                    <> · 開始：{new Date(s.startedAt).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit" })}</>
+                  )}
+                  {s.completedAt && (
+                    <> · 完成：{new Date(s.completedAt).toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit" })}</>
+                  )}
+                </span>
+              </div>
+              <span className="text-xs font-medium text-amber-600 dark:text-amber-400 tabular-nums flex-shrink-0">
+                {s.suggestedHours > 0 ? `${s.suggestedHours}h` : "—"}
+              </span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -10,3 +10,4 @@ export { CalendarDayView } from "./calendar-day-view";
 export { CalendarWeekView } from "./calendar-week/index";
 export type { TimeEntry, TaskRow, TaskOption, SubTaskOption, OvertimeType, TimerState } from "./use-timesheet";
 export type { ViewMode } from "./timesheet-toolbar";
+export { DailyDigestBanner } from "./daily-digest-banner";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,8 @@ model User {
   assignedGoals            MonthlyGoal[]        @relation("GoalAssignee")
   kpiHistoryUpdates        KPIHistory[]         @relation("KPIHistoryUpdater")
   createdRecurringRules    RecurringRule[]       @relation("RecurringRuleCreator")
+  createdSpaces            KnowledgeSpace[]     @relation("SpaceCreator")
+  verifiedDocuments        Document[]           @relation("DocVerifier")
 
   @@map("users")
 }
@@ -339,6 +341,10 @@ model Task {
   addedReason       String?
   addedSource       String?
   slaDeadline       DateTime?    // Issue #860: SLA 截止時間
+  managerFlagged    Boolean      @default(false) // Issue #960: 主管標記
+  flagReason        String?      // Issue #960: 標記原因
+  flaggedAt         DateTime?    // Issue #960: 標記時間
+  flaggedBy         String?      // Issue #960: 標記者 userId
   createdAt         DateTime     @default(now())
   updatedAt         DateTime     @updatedAt
 
@@ -763,6 +769,7 @@ enum NotificationType {
   TIMESHEET_REMINDER
   TIMESHEET_REJECTED    // Phase 2: 工時被駁回通知
   SLA_EXPIRING          // Issue #860: SLA 即將到期
+  MANAGER_FLAG          // Issue #960: 主管標記任務
 }
 
 model Notification {
@@ -837,33 +844,69 @@ model RefreshToken {
 // 知識庫文件
 // ═══════════════════════════════════════
 
+// ═══════════════════════════════════════
+// 知識空間 (Issue #967: Knowledge Base v2)
+// ═══════════════════════════════════════
+
+enum DocumentStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+model KnowledgeSpace {
+  id          String   @id @default(cuid())
+  name        String
+  description String?
+  createdBy   String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  creator   User       @relation("SpaceCreator", fields: [createdBy], references: [id])
+  documents Document[]
+
+  @@map("knowledge_spaces")
+}
+
 model Document {
-  id        String   @id @default(cuid())
+  id        String         @id @default(cuid())
+  spaceId   String?        // FK to KnowledgeSpace (nullable for migration)
   parentId  String?
   title     String
-  content   String   // Markdown
-  slug      String   @unique
-  tags      String[] // Issue #859: 標籤（如 "Oracle", "batch", "EOD", "DR"）
+  content   String         // Markdown
+  slug      String         @unique
+  tags      String[]       // Issue #859: 標籤（如 "Oracle", "batch", "EOD", "DR"）
+  status    DocumentStatus @default(DRAFT)
   createdBy String
   updatedBy String
-  version   Int      @default(1)
+  version   Int            @default(1)
+  // Verification fields (Issue #968)
+  verifierId        String?
+  verifiedAt        DateTime?
+  verifyIntervalDays Int?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  space    KnowledgeSpace?   @relation(fields: [spaceId], references: [id])
   parent   Document?         @relation("DocTree", fields: [parentId], references: [id])
   children Document[]        @relation("DocTree")
   creator  User              @relation("DocCreator", fields: [createdBy], references: [id])
   updater  User              @relation("DocUpdater", fields: [updatedBy], references: [id])
+  verifier User?             @relation("DocVerifier", fields: [verifierId], references: [id])
   versions DocumentVersion[]
 
+  @@index([spaceId])
   @@index([parentId])
   @@index([createdBy])
+  @@index([status])
+  @@index([verifierId])
   @@map("documents")
 }
 
 model DocumentVersion {
   id         String   @id @default(cuid())
   documentId String
+  title      String?  // track title changes (Issue #967)
   content    String
   version    Int
   createdBy  String


### PR DESCRIPTION
## Summary
- `GET /api/time-entries/suggestions` — 分析今日任務狀態變更，產生工時建議
  - 任務移至 IN_PROGRESS → 建議開始計時
  - 任務移至 DONE → 建議工時記錄（duration = IN_PROGRESS 停留時間）
  - 自動扣除已記錄工時，避免重複
- `POST /api/time-entries/confirm-suggestions` — 批次確認建議為實際工時記錄
- `DailyDigestBanner` 元件 — 「今天有 N 筆工時建議待確認」banner
  - 可展開查看每筆建議詳情
  - 支援勾選 + 批次確認
  - 確認後自動更新列表

## QA 自審報告
- [x] tsc 0 新增錯誤
- [x] jest: 10/10 tests pass（建議生成、確認、驗證、auth）
- [x] DONE 活動優先於 IN_PROGRESS（同任務不產生重複建議）
- [x] 已記錄工時自動扣除，remaining <= 0 標記為 alreadyLogged
- [x] 輸入驗證：hours 0.01~24, date ISO format, taskId required

Fixes #963