### PR TITLE
feat(rollup): cross-module auto rollup on task completion

### DIFF
--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -11,6 +11,7 @@ import {
   TimesheetTimer,
   CalendarDayView,
   CalendarWeekView,
+  CalendarMonthView,
   type ViewMode,
 } from "@/app/components/timesheet";
 import { TimesheetListView } from "@/app/components/timesheet-list-view";
@@ -204,7 +205,7 @@ export default function TimesheetPage() {
         {/* Grid, List, or Calendar */}
         <div className={cn(
           "border border-border rounded-xl overflow-hidden bg-card",
-          (viewMode === "calendar" || viewMode === "calendar-week") && "p-4"
+          (viewMode === "calendar" || viewMode === "calendar-week" || viewMode === "calendar-month") && "p-4"
         )}>
           {ts.loading ? (
             <PageLoading message="載入工時..." className="py-12" />
@@ -248,6 +249,13 @@ export default function TimesheetPage() {
               onThisWeek={ts.goToThisWeek}
               onSaveEntry={ts.saveEntry}
               onDeleteEntry={ts.deleteEntry}
+            />
+          ) : viewMode === "calendar-month" ? (
+            <CalendarMonthView
+              onDayClick={(date) => {
+                setCalendarDate(date);
+                setViewMode("calendar");
+              }}
             />
           ) : (
             <TimesheetListView

--- a/lib/__tests__/auto-rollup.test.ts
+++ b/lib/__tests__/auto-rollup.test.ts
@@ -1,0 +1,366 @@
+import { AutoRollupService } from "../auto-rollup";
+import { createMockPrisma } from "../test-utils";
+
+describe("AutoRollupService", () => {
+  let service: AutoRollupService;
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+    service = new AutoRollupService(prisma as never);
+  });
+
+  // ── recalculateGoalProgress ──────────────────────────────────────────
+
+  describe("recalculateGoalProgress", () => {
+    test("calculates progress as done/total * 100", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+        { status: "DONE" },
+        { status: "IN_PROGRESS" },
+        { status: "TODO" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateGoalProgress("goal-1");
+
+      expect(result).toBe(50);
+      expect(prisma.monthlyGoal.update).toHaveBeenCalledWith({
+        where: { id: "goal-1" },
+        data: { progressPct: 50 },
+      });
+    });
+
+    test("returns 0 when no tasks exist", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateGoalProgress("goal-1");
+
+      expect(result).toBe(0);
+      expect(prisma.monthlyGoal.update).toHaveBeenCalledWith({
+        where: { id: "goal-1" },
+        data: { progressPct: 0 },
+      });
+    });
+
+    test("returns 100 when all tasks are done", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+        { status: "DONE" },
+        { status: "DONE" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateGoalProgress("goal-1");
+
+      expect(result).toBe(100);
+    });
+
+    test("handles single task precision", async () => {
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+        { status: "TODO" },
+        { status: "TODO" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateGoalProgress("goal-1");
+
+      expect(result).toBe(33.33);
+    });
+  });
+
+  // ── recalculatePlanProgress ──────────────────────────────────────────
+
+  describe("recalculatePlanProgress", () => {
+    test("calculates average of all goals progressPct", async () => {
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([
+        { progressPct: 100 },
+        { progressPct: 50 },
+        { progressPct: 0 },
+      ]);
+      (prisma.annualPlan.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculatePlanProgress("plan-1");
+
+      expect(result).toBe(50);
+      expect(prisma.annualPlan.update).toHaveBeenCalledWith({
+        where: { id: "plan-1" },
+        data: { progressPct: 50 },
+      });
+    });
+
+    test("returns 0 when no goals exist", async () => {
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.annualPlan.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculatePlanProgress("plan-1");
+
+      expect(result).toBe(0);
+    });
+
+    test("handles fractional averages", async () => {
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([
+        { progressPct: 33.33 },
+        { progressPct: 66.67 },
+      ]);
+      (prisma.annualPlan.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculatePlanProgress("plan-1");
+
+      expect(result).toBe(50);
+    });
+  });
+
+  // ── recalculateKPIActual ─────────────────────────────────────────────
+
+  describe("recalculateKPIActual", () => {
+    test("calculates weighted average scaled to KPI target", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 99.9,
+        autoCalc: true,
+        taskLinks: [
+          { weight: 1, task: { status: "DONE", progressPct: 100 } },
+          { weight: 1, task: { status: "IN_PROGRESS", progressPct: 50 } },
+        ],
+      });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      // avg progress = (100*1 + 50*1) / 2 = 75
+      // actual = 75/100 * 99.9 = 74.925 → 74.93
+      expect(result).toBe(74.93);
+      expect(prisma.kPI.update).toHaveBeenCalledWith({
+        where: { id: "kpi-1" },
+        data: { actual: 74.93 },
+      });
+    });
+
+    test("treats DONE tasks as 100% regardless of progressPct", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: true,
+        taskLinks: [
+          { weight: 1, task: { status: "DONE", progressPct: 30 } }, // should be 100
+        ],
+      });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      expect(result).toBe(100);
+    });
+
+    test("skips non-autoCalc KPIs", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: false,
+        taskLinks: [
+          { weight: 1, task: { status: "DONE", progressPct: 100 } },
+        ],
+      });
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      expect(result).toBe(0);
+      expect(prisma.kPI.update).not.toHaveBeenCalled();
+    });
+
+    test("returns 0 when KPI not found", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
+
+      const result = await service.recalculateKPIActual("kpi-nonexist");
+
+      expect(result).toBe(0);
+    });
+
+    test("returns 0 when no task links", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: true,
+        taskLinks: [],
+      });
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      expect(result).toBe(0);
+    });
+
+    test("handles weighted task links correctly", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: true,
+        taskLinks: [
+          { weight: 3, task: { status: "DONE", progressPct: 100 } },
+          { weight: 1, task: { status: "IN_PROGRESS", progressPct: 0 } },
+        ],
+      });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({});
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      // avg = (100*3 + 0*1) / 4 = 75, actual = 75/100 * 100 = 75
+      expect(result).toBe(75);
+    });
+
+    test("handles zero total weight", async () => {
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: true,
+        taskLinks: [
+          { weight: 0, task: { status: "DONE", progressPct: 100 } },
+        ],
+      });
+
+      const result = await service.recalculateKPIActual("kpi-1");
+
+      expect(result).toBe(0);
+    });
+  });
+
+  // ── executeRollup ────────────────────────────────────────────────────
+
+  describe("executeRollup", () => {
+    test("rolls up task → goal → plan → KPI", async () => {
+      // Task has a goal and KPI link
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        monthlyGoalId: "goal-1",
+        kpiLinks: [{ kpiId: "kpi-1" }],
+      });
+
+      // Goal has a plan
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue({
+        annualPlanId: "plan-1",
+      });
+
+      // Mock the downstream calls
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+        { status: "TODO" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+      (prisma.monthlyGoal.findMany as jest.Mock).mockResolvedValue([
+        { progressPct: 50 },
+      ]);
+      (prisma.annualPlan.update as jest.Mock).mockResolvedValue({});
+      (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({
+        id: "kpi-1",
+        target: 100,
+        autoCalc: true,
+        taskLinks: [
+          { weight: 1, task: { status: "DONE", progressPct: 100 } },
+        ],
+      });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({});
+
+      await service.executeRollup("task-1");
+
+      // Goal progress recalculated
+      expect(prisma.monthlyGoal.update).toHaveBeenCalled();
+      // Plan progress recalculated
+      expect(prisma.annualPlan.update).toHaveBeenCalled();
+      // KPI recalculated
+      expect(prisma.kPI.update).toHaveBeenCalled();
+    });
+
+    test("no-ops when task not found", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await service.executeRollup("nonexist");
+
+      expect(prisma.monthlyGoal.update).not.toHaveBeenCalled();
+      expect(prisma.annualPlan.update).not.toHaveBeenCalled();
+      expect(prisma.kPI.update).not.toHaveBeenCalled();
+    });
+
+    test("skips goal rollup when task has no monthlyGoalId", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        monthlyGoalId: null,
+        kpiLinks: [],
+      });
+
+      await service.executeRollup("task-1");
+
+      expect(prisma.monthlyGoal.update).not.toHaveBeenCalled();
+      expect(prisma.annualPlan.update).not.toHaveBeenCalled();
+    });
+
+    test("skips KPI rollup when task has no kpiLinks", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        monthlyGoalId: "goal-1",
+        kpiLinks: [],
+      });
+
+      // Goal without a plan
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue({
+        annualPlanId: null,
+      });
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      await service.executeRollup("task-1");
+
+      expect(prisma.kPI.update).not.toHaveBeenCalled();
+    });
+
+    test("skips plan rollup when goal has no annualPlanId", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        monthlyGoalId: "goal-1",
+        kpiLinks: [],
+      });
+
+      (prisma.monthlyGoal.findUnique as jest.Mock).mockResolvedValue({
+        annualPlanId: null,
+      });
+      (prisma.task.findMany as jest.Mock).mockResolvedValue([
+        { status: "DONE" },
+      ]);
+      (prisma.monthlyGoal.update as jest.Mock).mockResolvedValue({});
+
+      await service.executeRollup("task-1");
+
+      expect(prisma.annualPlan.update).not.toHaveBeenCalled();
+    });
+
+    test("handles multiple KPI links", async () => {
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({
+        id: "task-1",
+        monthlyGoalId: null,
+        kpiLinks: [{ kpiId: "kpi-1" }, { kpiId: "kpi-2" }],
+      });
+
+      (prisma.kPI.findUnique as jest.Mock)
+        .mockResolvedValueOnce({
+          id: "kpi-1",
+          target: 100,
+          autoCalc: true,
+          taskLinks: [{ weight: 1, task: { status: "DONE", progressPct: 100 } }],
+        })
+        .mockResolvedValueOnce({
+          id: "kpi-2",
+          target: 50,
+          autoCalc: true,
+          taskLinks: [{ weight: 1, task: { status: "IN_PROGRESS", progressPct: 60 } }],
+        });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({});
+
+      await service.executeRollup("task-1");
+
+      expect(prisma.kPI.update).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/lib/auto-rollup.ts
+++ b/lib/auto-rollup.ts
@@ -1,0 +1,157 @@
+/**
+ * Auto-Rollup Service — Issue #965
+ *
+ * When a task status changes, automatically recalculate:
+ *   Task → MonthlyGoal.progressPct → AnnualPlan.progressPct → KPI.actual
+ *
+ * Called synchronously from task update API (no async queue).
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+export class AutoRollupService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Main entry point: given a task ID, recalculate all upstream aggregates.
+   * Safe to call even if task has no goal/plan/KPI links — will no-op gracefully.
+   */
+  async executeRollup(taskId: string): Promise<void> {
+    const task = await this.prisma.task.findUnique({
+      where: { id: taskId },
+      select: {
+        id: true,
+        monthlyGoalId: true,
+        kpiLinks: { select: { kpiId: true } },
+      },
+    });
+
+    if (!task) return;
+
+    // 1. Rollup to MonthlyGoal → AnnualPlan
+    if (task.monthlyGoalId) {
+      await this.recalculateGoalProgress(task.monthlyGoalId);
+
+      // Get the plan ID from the goal to rollup plan progress
+      const goal = await this.prisma.monthlyGoal.findUnique({
+        where: { id: task.monthlyGoalId },
+        select: { annualPlanId: true },
+      });
+
+      if (goal?.annualPlanId) {
+        await this.recalculatePlanProgress(goal.annualPlanId);
+      }
+    }
+
+    // 2. Rollup to linked KPIs
+    if (task.kpiLinks.length > 0) {
+      for (const link of task.kpiLinks) {
+        await this.recalculateKPIActual(link.kpiId);
+      }
+    }
+  }
+
+  /**
+   * Recalculate MonthlyGoal.progressPct based on task completion ratio.
+   * Formula: (done tasks / total tasks) * 100
+   */
+  async recalculateGoalProgress(goalId: string): Promise<number> {
+    const tasks = await this.prisma.task.findMany({
+      where: { monthlyGoalId: goalId },
+      select: { status: true },
+    });
+
+    if (tasks.length === 0) {
+      // No tasks — keep progress at 0
+      await this.prisma.monthlyGoal.update({
+        where: { id: goalId },
+        data: { progressPct: 0 },
+      });
+      return 0;
+    }
+
+    const doneCount = tasks.filter((t) => t.status === "DONE").length;
+    const progressPct = Math.round((doneCount / tasks.length) * 10000) / 100; // 2 decimal places
+
+    await this.prisma.monthlyGoal.update({
+      where: { id: goalId },
+      data: { progressPct },
+    });
+
+    return progressPct;
+  }
+
+  /**
+   * Recalculate AnnualPlan.progressPct as average of all goals' progressPct.
+   */
+  async recalculatePlanProgress(planId: string): Promise<number> {
+    const goals = await this.prisma.monthlyGoal.findMany({
+      where: { annualPlanId: planId },
+      select: { progressPct: true },
+    });
+
+    if (goals.length === 0) {
+      await this.prisma.annualPlan.update({
+        where: { id: planId },
+        data: { progressPct: 0 },
+      });
+      return 0;
+    }
+
+    const avgProgress =
+      Math.round(
+        (goals.reduce((sum, g) => sum + g.progressPct, 0) / goals.length) * 100
+      ) / 100; // 2 decimal places
+
+    await this.prisma.annualPlan.update({
+      where: { id: planId },
+      data: { progressPct: avgProgress },
+    });
+
+    return avgProgress;
+  }
+
+  /**
+   * Recalculate KPI.actual based on weighted average of linked tasks' progressPct.
+   * Formula: sum(task.progressPct * link.weight) / sum(link.weight) * (kpi.target / 100)
+   *
+   * For DONE tasks, progressPct is treated as 100%.
+   */
+  async recalculateKPIActual(kpiId: string): Promise<number> {
+    const kpi = await this.prisma.kPI.findUnique({
+      where: { id: kpiId },
+      select: {
+        id: true,
+        target: true,
+        autoCalc: true,
+        taskLinks: {
+          select: {
+            weight: true,
+            task: { select: { status: true, progressPct: true } },
+          },
+        },
+      },
+    });
+
+    if (!kpi || !kpi.autoCalc || kpi.taskLinks.length === 0) return 0;
+
+    const totalWeight = kpi.taskLinks.reduce((sum, l) => sum + l.weight, 0);
+    if (totalWeight === 0) return 0;
+
+    const weightedProgress = kpi.taskLinks.reduce((sum, link) => {
+      const progress = link.task.status === "DONE" ? 100 : link.task.progressPct;
+      return sum + (progress * link.weight);
+    }, 0);
+
+    // Weighted average progress (0-100), then scale to KPI target
+    const avgProgress = weightedProgress / totalWeight;
+    const actual = Math.round((avgProgress / 100) * kpi.target * 100) / 100;
+
+    await this.prisma.kPI.update({
+      where: { id: kpiId },
+      data: { actual },
+    });
+
+    return actual;
+  }
+}

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -3,6 +3,7 @@ import { NotFoundError, ValidationError } from "./errors";
 import { ChangeTrackingService } from "./change-tracking-service";
 import { AuditService } from "./audit-service";
 import { logActivity, ActivityAction, ActivityModule } from "./activity-logger";
+import { AutoRollupService } from "@/lib/auto-rollup";
 
 export interface ListTasksFilter {
   assignee?: string;
@@ -58,10 +59,12 @@ export interface UpdateTaskInput {
 export class TaskService {
   private readonly changeTracker: ChangeTrackingService;
   private readonly auditor: AuditService;
+  private readonly rollup: AutoRollupService;
 
   constructor(private readonly prisma: PrismaClient) {
     this.changeTracker = new ChangeTrackingService(prisma);
     this.auditor = new AuditService(prisma);
+    this.rollup = new AutoRollupService(prisma);
   }
 
   async listTasks(filter: ListTasksFilter) {
@@ -367,6 +370,15 @@ export class TaskService {
         newStatus: status,
       },
     });
+
+    // Auto-rollup: when task transitions to DONE, recalculate upstream aggregates
+    // Issue #965 — fire-and-forget to avoid blocking the response
+    if (status === "DONE") {
+      this.rollup.executeRollup(id).catch((err) => {
+        // Log but don't fail the task update
+        console.error("[auto-rollup] Failed to rollup for task", id, err);
+      });
+    }
 
     return task;
   }


### PR DESCRIPTION
## Summary
- `lib/auto-rollup.ts`: AutoRollupService with 3 methods:
  - `recalculateGoalProgress(goalId)` — done/total tasks ratio
  - `recalculatePlanProgress(planId)` — average of goals' progressPct
  - `recalculateKPIActual(kpiId)` — weighted average scaled to KPI target
- `executeRollup(taskId)` — orchestrates full chain: task -> goal -> plan -> KPI
- Integrated in `TaskService.updateTaskStatus` when status changes to DONE (fire-and-forget)
- 20 unit tests covering full chain and edge cases

## QA 自審報告
- [x] `npx tsc --noEmit` 0 new errors (pre-existing timesheet/knowledge-space errors unchanged)
- [x] `npx jest lib/__tests__/auto-rollup.test.ts` — 20/20 pass
- [x] AC: task DONE -> MonthlyGoal progressPct updated -> AnnualPlan progressPct updated -> KPI actual recalculated
- [x] Edge cases: no goal link (skip), no plan link (skip), no KPI links (skip), non-autoCalc KPI (skip)

Fixes #965