### PR TITLE
feat(reports-v2): 15 個 v2 報表 API endpoint

### DIFF
--- a/__mocks__/prisma.ts
+++ b/__mocks__/prisma.ts
@@ -44,6 +44,8 @@ export const mockPrisma = {
   kPIHistory: createMockModel(),
   recurringRule: createMockModel(),
   knowledgeSpace: createMockModel(),
+  changeRecord: createMockModel(),
+  incidentRecord: createMockModel(),
   $transaction: jest.fn(),
   $connect: jest.fn(),
   $disconnect: jest.fn(),

--- a/__tests__/api/reports-v2.test.ts
+++ b/__tests__/api/reports-v2.test.ts
@@ -1,0 +1,471 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Reports V2 API endpoints — Issue #984
+ * 15 endpoints, 1+ test per endpoint.
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Mock prisma ──────────────────────────────────────────────────────────
+const mockUser = { findMany: jest.fn() };
+const mockTimeEntry = { findMany: jest.fn() };
+const mockTask = { findMany: jest.fn() };
+const mockAnnualPlan = { findUnique: jest.fn() };
+const mockMilestone = { findMany: jest.fn() };
+const mockKPI = { findMany: jest.fn() };
+const mockKPIHistory = { findMany: jest.fn() };
+const mockChangeRecord = { findMany: jest.fn() };
+const mockIncidentRecord = { findMany: jest.fn() };
+const mockAuditLog = { findMany: jest.fn() };
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: mockUser,
+    timeEntry: mockTimeEntry,
+    task: mockTask,
+    annualPlan: mockAnnualPlan,
+    milestone: mockMilestone,
+    kPI: mockKPI,
+    kPIHistory: mockKPIHistory,
+    changeRecord: mockChangeRecord,
+    incidentRecord: mockIncidentRecord,
+    auditLog: mockAuditLog,
+  },
+}));
+
+// ── Mock auth (MANAGER session) ──────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const MANAGER_SESSION = {
+  user: { id: "m1", name: "Manager", email: "m@e.com", role: "MANAGER" },
+  expires: "2099-01-01",
+};
+
+const ENGINEER_SESSION = {
+  user: { id: "e1", name: "Engineer", email: "e@e.com", role: "ENGINEER" },
+  expires: "2099-01-01",
+};
+
+function resetMocks() {
+  jest.clearAllMocks();
+  mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+  mockUser.findMany.mockResolvedValue([]);
+  mockTimeEntry.findMany.mockResolvedValue([]);
+  mockTask.findMany.mockResolvedValue([]);
+  mockAnnualPlan.findUnique.mockResolvedValue(null);
+  mockMilestone.findMany.mockResolvedValue([]);
+  mockKPI.findMany.mockResolvedValue([]);
+  mockKPIHistory.findMany.mockResolvedValue([]);
+  mockChangeRecord.findMany.mockResolvedValue([]);
+  mockIncidentRecord.findMany.mockResolvedValue([]);
+  mockAuditLog.findMany.mockResolvedValue([]);
+}
+
+// ── 1. Utilization ───────────────────────────────────────────────────────
+describe("GET /api/reports/v2/utilization", () => {
+  beforeEach(resetMocks);
+
+  it("returns utilization data for manager", async () => {
+    mockUser.findMany.mockResolvedValue([
+      { id: "u1", name: "Alice" },
+      { id: "u2", name: "Bob" },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      { userId: "u1", hours: 32 },
+      { userId: "u2", hours: 40 },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/utilization/route");
+    const res = await GET(
+      createMockRequest("/api/reports/v2/utilization", {
+        searchParams: { startDate: "2026-03-01", endDate: "2026-03-07" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.users).toHaveLength(2);
+    expect(body.data).toHaveProperty("avgUtilization");
+  });
+
+  it("returns 403 for engineer", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+    const { GET } = await import("@/app/api/reports/v2/utilization/route");
+    const res = await GET(createMockRequest("/api/reports/v2/utilization"));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── 2. Unplanned Trend ──────────────────────────────────────────────────
+describe("GET /api/reports/v2/unplanned-trend", () => {
+  beforeEach(resetMocks);
+
+  it("returns unplanned trend data", async () => {
+    mockTimeEntry.findMany.mockResolvedValue([
+      { date: new Date("2026-01-15"), hours: 8, category: "PLANNED_TASK" },
+      { date: new Date("2026-01-16"), hours: 4, category: "INCIDENT" },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/unplanned-trend/route");
+    const res = await GET(createMockRequest("/api/reports/v2/unplanned-trend"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("months");
+    expect(body.data).toHaveProperty("avgUnplannedRate");
+  });
+});
+
+// ── 3. Workload Distribution ────────────────────────────────────────────
+describe("GET /api/reports/v2/workload-distribution", () => {
+  beforeEach(resetMocks);
+
+  it("returns workload distribution", async () => {
+    mockTimeEntry.findMany.mockResolvedValue([
+      { userId: "u1", hours: 6, category: "PLANNED_TASK", user: { id: "u1", name: "Alice" } },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/workload-distribution/route");
+    const res = await GET(createMockRequest("/api/reports/v2/workload-distribution"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.users).toHaveLength(1);
+    expect(body.data.users[0]).toHaveProperty("byCategory");
+  });
+});
+
+// ── 4. Velocity ─────────────────────────────────────────────────────────
+describe("GET /api/reports/v2/velocity", () => {
+  beforeEach(resetMocks);
+
+  it("returns velocity data", async () => {
+    const now = new Date();
+    mockTask.findMany.mockResolvedValue([
+      { id: "t1", status: "DONE", createdAt: now, updatedAt: now },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/velocity/route");
+    const res = await GET(createMockRequest("/api/reports/v2/velocity"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("weeks");
+    expect(body.data).toHaveProperty("avgVelocity");
+  });
+});
+
+// ── 5. Time Efficiency ──────────────────────────────────────────────────
+describe("GET /api/reports/v2/time-efficiency", () => {
+  beforeEach(resetMocks);
+
+  it("returns time efficiency data", async () => {
+    mockTimeEntry.findMany.mockResolvedValue([
+      { userId: "u1", hours: 16, user: { id: "u1", name: "Alice" } },
+    ]);
+    mockTask.findMany.mockResolvedValue([
+      { id: "t1", primaryAssigneeId: "u1" },
+      { id: "t2", primaryAssigneeId: "u1" },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/time-efficiency/route");
+    const res = await GET(createMockRequest("/api/reports/v2/time-efficiency"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("avgHoursPerTask");
+    expect(body.data.users[0].hoursPerTask).toBe(8);
+  });
+});
+
+// ── 6. Earned Value ─────────────────────────────────────────────────────
+describe("GET /api/reports/v2/earned-value", () => {
+  beforeEach(resetMocks);
+
+  it("returns earned value for a plan", async () => {
+    mockAnnualPlan.findUnique.mockResolvedValue({
+      id: "p1",
+      title: "2026 Plan",
+      linkedTasks: [
+        { id: "t1", status: "DONE", estimatedHours: 100, actualHours: 90, progressPct: 100, dueDate: new Date("2026-01-01"), createdAt: new Date() },
+        { id: "t2", status: "IN_PROGRESS", estimatedHours: 50, actualHours: 30, progressPct: 50, dueDate: new Date("2026-06-01"), createdAt: new Date() },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/reports/v2/earned-value/route");
+    const res = await GET(
+      createMockRequest("/api/reports/v2/earned-value", {
+        searchParams: { planId: "p1" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("spi");
+    expect(body.data).toHaveProperty("cpi");
+    expect(body.data.planId).toBe("p1");
+  });
+
+  it("returns 404 for nonexistent plan", async () => {
+    mockAnnualPlan.findUnique.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/reports/v2/earned-value/route");
+    const res = await GET(
+      createMockRequest("/api/reports/v2/earned-value", {
+        searchParams: { planId: "nonexistent" },
+      })
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 without planId", async () => {
+    const { GET } = await import("@/app/api/reports/v2/earned-value/route");
+    const res = await GET(createMockRequest("/api/reports/v2/earned-value"));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── 7. Overdue Analysis ─────────────────────────────────────────────────
+describe("GET /api/reports/v2/overdue-analysis", () => {
+  beforeEach(resetMocks);
+
+  it("returns overdue analysis", async () => {
+    mockTask.findMany.mockResolvedValue([
+      {
+        id: "t1",
+        title: "Late task",
+        dueDate: new Date("2026-03-01"),
+        status: "IN_PROGRESS",
+        category: "PLANNED",
+        primaryAssignee: { id: "u1", name: "Alice" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/overdue-analysis/route");
+    const res = await GET(createMockRequest("/api/reports/v2/overdue-analysis"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.totalOverdue).toBe(1);
+    expect(body.data).toHaveProperty("byPerson");
+  });
+});
+
+// ── 8. Milestone Achievement ────────────────────────────────────────────
+describe("GET /api/reports/v2/milestone-achievement", () => {
+  beforeEach(resetMocks);
+
+  it("returns milestone achievement rate", async () => {
+    mockMilestone.findMany.mockResolvedValue([
+      {
+        id: "ms1",
+        title: "Launch",
+        status: "COMPLETED",
+        plannedEnd: new Date("2026-03-01"),
+        actualEnd: new Date("2026-03-02"),
+        annualPlan: { title: "2026 Plan" },
+      },
+      {
+        id: "ms2",
+        title: "Audit",
+        status: "DELAYED",
+        plannedEnd: new Date("2026-06-01"),
+        actualEnd: null,
+        annualPlan: { title: "2026 Plan" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/milestone-achievement/route");
+    const res = await GET(createMockRequest("/api/reports/v2/milestone-achievement"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.achievementRate).toBe(50);
+    expect(body.data.milestones).toHaveLength(2);
+  });
+});
+
+// ── 9. KPI Trend ────────────────────────────────────────────────────────
+describe("GET /api/reports/v2/kpi-trend", () => {
+  beforeEach(resetMocks);
+
+  it("returns KPI trend with history", async () => {
+    mockKPI.findMany.mockResolvedValue([
+      { id: "kpi1", title: "Availability", target: 99.9 },
+    ]);
+    mockKPIHistory.findMany.mockResolvedValue([
+      { kpiId: "kpi1", period: "2026-01", actual: 99.8 },
+      { kpiId: "kpi1", period: "2026-02", actual: 99.95 },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/kpi-trend/route");
+    const res = await GET(createMockRequest("/api/reports/v2/kpi-trend"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.kpis[0].months).toHaveLength(2);
+    expect(body.data.kpis[0]).toHaveProperty("forecast");
+  });
+});
+
+// ── 10. KPI Correlation ─────────────────────────────────────────────────
+describe("GET /api/reports/v2/kpi-correlation", () => {
+  beforeEach(resetMocks);
+
+  it("returns KPI correlation data", async () => {
+    mockKPI.findMany.mockResolvedValue([
+      { id: "kpi1", title: "SLA", target: 95, actual: 92, taskLinks: [{ taskId: "t1" }] },
+    ]);
+    mockTimeEntry.findMany.mockResolvedValue([
+      { taskId: "t1", hours: 20 },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/kpi-correlation/route");
+    const res = await GET(createMockRequest("/api/reports/v2/kpi-correlation"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.kpis[0]).toHaveProperty("linkedTaskHours");
+    expect(body.data.kpis[0]).toHaveProperty("correlation");
+  });
+});
+
+// ── 11. KPI Composite ───────────────────────────────────────────────────
+describe("GET /api/reports/v2/kpi-composite", () => {
+  beforeEach(resetMocks);
+
+  it("returns composite KPI score", async () => {
+    mockKPI.findMany.mockResolvedValue([
+      { id: "kpi1", title: "SLA", target: 95, actual: 95, weight: 60 },
+      { id: "kpi2", title: "MTTR", target: 30, actual: 25, weight: 40 },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/kpi-composite/route");
+    const res = await GET(createMockRequest("/api/reports/v2/kpi-composite"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("compositeScore");
+    expect(body.data.kpis).toHaveLength(2);
+  });
+});
+
+// ── 12. Overtime Analysis ───────────────────────────────────────────────
+describe("GET /api/reports/v2/overtime-analysis", () => {
+  beforeEach(resetMocks);
+
+  it("returns overtime analysis", async () => {
+    mockTimeEntry.findMany.mockResolvedValue([
+      { userId: "u1", hours: 3, overtimeType: "WEEKDAY", date: new Date("2026-03-15"), user: { id: "u1", name: "Alice" } },
+      { userId: "u1", hours: 8, overtimeType: "REST_DAY", date: new Date("2026-03-16"), user: { id: "u1", name: "Alice" } },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/overtime-analysis/route");
+    const res = await GET(createMockRequest("/api/reports/v2/overtime-analysis"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.users).toHaveLength(1);
+    expect(body.data.users[0].totalOvertimeHours).toBe(11);
+    expect(body.data).toHaveProperty("byMonth");
+  });
+});
+
+// ── 13. Change Summary ──────────────────────────────────────────────────
+describe("GET /api/reports/v2/change-summary", () => {
+  beforeEach(resetMocks);
+
+  it("returns change management summary", async () => {
+    mockChangeRecord.findMany.mockResolvedValue([
+      {
+        id: "cr1",
+        changeNumber: "CHG-2026-0301-01",
+        type: "NORMAL",
+        status: "COMPLETED",
+        riskLevel: "MEDIUM",
+        scheduledStart: new Date(),
+        scheduledEnd: new Date(),
+        createdAt: new Date(),
+        task: { id: "t1", title: "Deploy v2" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/change-summary/route");
+    const res = await GET(createMockRequest("/api/reports/v2/change-summary"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.total).toBe(1);
+    expect(body.data).toHaveProperty("byType");
+    expect(body.data).toHaveProperty("byStatus");
+  });
+});
+
+// ── 14. Incident SLA ────────────────────────────────────────────────────
+describe("GET /api/reports/v2/incident-sla", () => {
+  beforeEach(resetMocks);
+
+  it("returns incident SLA metrics", async () => {
+    mockIncidentRecord.findMany.mockResolvedValue([
+      {
+        id: "inc1",
+        severity: "SEV1",
+        incidentStart: new Date("2026-03-01T10:00:00"),
+        incidentEnd: new Date("2026-03-01T11:00:00"),
+        mttrMinutes: 60,
+        task: { id: "t1", title: "DB Outage", slaDeadline: new Date("2026-03-01T14:00:00"), status: "DONE" },
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/incident-sla/route");
+    const res = await GET(createMockRequest("/api/reports/v2/incident-sla"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.slaMetRate).toBe(100);
+    expect(body.data.avgMttr).toBe(60);
+    expect(body.data).toHaveProperty("bySeverity");
+  });
+});
+
+// ── 15. Permission Audit ────────────────────────────────────────────────
+describe("GET /api/reports/v2/permission-audit", () => {
+  beforeEach(resetMocks);
+
+  it("returns permission audit logs", async () => {
+    mockAuditLog.findMany.mockResolvedValue([
+      {
+        id: "al1",
+        userId: "m1",
+        action: "CREATE_PERMISSIONS",
+        resourceId: "p1",
+        detail: "Granted VIEW_TEAM to u1",
+        createdAt: new Date(),
+        metadata: {},
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/reports/v2/permission-audit/route");
+    const res = await GET(createMockRequest("/api/reports/v2/permission-audit"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.totalChanges).toBe(1);
+    expect(body.data).toHaveProperty("byAction");
+  });
+});
+
+// ── Cross-cutting: Auth denied ──────────────────────────────────────────
+describe("Reports V2 — auth enforcement", () => {
+  beforeEach(resetMocks);
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/reports/v2/utilization/route");
+    const res = await GET(createMockRequest("/api/reports/v2/utilization"));
+    expect(res.status).toBe(401);
+  });
+});

--- a/app/api/reports/v2/change-summary/route.ts
+++ b/app/api/reports/v2/change-summary/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getChangeSummary(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/earned-value/route.ts
+++ b/app/api/reports/v2/earned-value/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { earnedValueSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError, NotFoundError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = earnedValueSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getEarnedValue(parsed.data.planId, parsed.data.asOfDate);
+  if (!data) throw new NotFoundError("計畫不存在");
+  return success(data);
+});

--- a/app/api/reports/v2/incident-sla/route.ts
+++ b/app/api/reports/v2/incident-sla/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getIncidentSLA(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/kpi-composite/route.ts
+++ b/app/api/reports/v2/kpi-composite/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { yearSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = yearSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getKPIComposite(parsed.data.year);
+  return success(data);
+});

--- a/app/api/reports/v2/kpi-correlation/route.ts
+++ b/app/api/reports/v2/kpi-correlation/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { yearSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = yearSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getKPICorrelation(parsed.data.year);
+  return success(data);
+});

--- a/app/api/reports/v2/kpi-trend/route.ts
+++ b/app/api/reports/v2/kpi-trend/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { kpiTrendSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = kpiTrendSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getKPITrend(parsed.data.year, parsed.data.kpiId);
+  return success(data);
+});

--- a/app/api/reports/v2/milestone-achievement/route.ts
+++ b/app/api/reports/v2/milestone-achievement/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { yearSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = yearSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getMilestoneAchievement(parsed.data.year);
+  return success(data);
+});

--- a/app/api/reports/v2/overdue-analysis/route.ts
+++ b/app/api/reports/v2/overdue-analysis/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getOverdueAnalysis(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/overtime-analysis/route.ts
+++ b/app/api/reports/v2/overtime-analysis/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getOvertimeAnalysis(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/permission-audit/route.ts
+++ b/app/api/reports/v2/permission-audit/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getPermissionAudit(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/time-efficiency/route.ts
+++ b/app/api/reports/v2/time-efficiency/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getTimeEfficiency(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/unplanned-trend/route.ts
+++ b/app/api/reports/v2/unplanned-trend/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getUnplannedTrend(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/utilization/route.ts
+++ b/app/api/reports/v2/utilization/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getUtilization(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/velocity/route.ts
+++ b/app/api/reports/v2/velocity/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getVelocity(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/app/api/reports/v2/workload-distribution/route.ts
+++ b/app/api/reports/v2/workload-distribution/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
+import { ReportV2Service } from "@/services/report-v2-service";
+import { dateRangeSchema, searchParamsToObject } from "@/validators/report-v2-validators";
+import { ValidationError } from "@/services/errors";
+
+const svc = new ReportV2Service(prisma);
+
+export const GET = withManager(async (req: NextRequest) => {
+  const parsed = dateRangeSchema.safeParse(searchParamsToObject(new URL(req.url).searchParams));
+  if (!parsed.success) throw new ValidationError(parsed.error.issues[0].message);
+  const data = await svc.getWorkloadDistribution(parsed.data.startDate, parsed.data.endDate);
+  return success(data);
+});

--- a/services/report-v2-service.ts
+++ b/services/report-v2-service.ts
@@ -1,0 +1,687 @@
+/**
+ * Report V2 Service — Issue #984
+ *
+ * 15 advanced report endpoints for management analytics.
+ * Separated from existing ReportService to avoid bloating.
+ */
+import { PrismaClient } from "@prisma/client";
+
+// ── Shared helpers ──────────────────────────────────────────────────────
+
+function defaultDateRange(startDate?: string, endDate?: string) {
+  const now = new Date();
+  const start = startDate
+    ? new Date(startDate + "T00:00:00")
+    : new Date(now.getFullYear(), now.getMonth(), 1);
+  const end = endDate
+    ? new Date(endDate + "T23:59:59.999")
+    : new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+  return { start, end };
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// ── Service ─────────────────────────────────────────────────────────────
+
+export class ReportV2Service {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  // 1. Utilization ──────────────────────────────────────────────────────
+  async getUtilization(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+    const AVAILABLE_HOURS_PER_WEEK = 40;
+
+    const users = await this.prisma.user.findMany({
+      where: { isActive: true },
+      select: { id: true, name: true },
+    });
+
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: { date: { gte: start, lte: end } },
+      select: { userId: true, hours: true },
+    });
+
+    const weeks = Math.max(1, Math.ceil((end.getTime() - start.getTime()) / (7 * 24 * 60 * 60 * 1000)));
+    const hoursByUser: Record<string, number> = {};
+    for (const e of timeEntries) {
+      hoursByUser[e.userId] = (hoursByUser[e.userId] ?? 0) + e.hours;
+    }
+
+    const userResults = users.map((u) => {
+      const totalHours = hoursByUser[u.id] ?? 0;
+      const availableHours = AVAILABLE_HOURS_PER_WEEK * weeks;
+      return {
+        userId: u.id,
+        name: u.name,
+        totalHours: round2(totalHours),
+        availableHours,
+        utilizationRate: round2(availableHours > 0 ? (totalHours / availableHours) * 100 : 0),
+      };
+    });
+
+    const avgUtilization = userResults.length > 0
+      ? round2(userResults.reduce((s, u) => s + u.utilizationRate, 0) / userResults.length)
+      : 0;
+
+    return { users: userResults, avgUtilization, period: { start, end } };
+  }
+
+  // 2. Unplanned Trend ─────────────────────────────────────────────────
+  async getUnplannedTrend(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: { date: { gte: start, lte: end } },
+      select: { date: true, hours: true, category: true },
+    });
+
+    const monthMap: Record<string, { total: number; unplanned: number }> = {};
+    const UNPLANNED_CATEGORIES = ["ADDED_TASK", "INCIDENT", "SUPPORT"];
+
+    for (const e of timeEntries) {
+      const d = new Date(e.date);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      if (!monthMap[key]) monthMap[key] = { total: 0, unplanned: 0 };
+      monthMap[key].total += e.hours;
+      if (UNPLANNED_CATEGORIES.includes(e.category)) {
+        monthMap[key].unplanned += e.hours;
+      }
+    }
+
+    const months = Object.entries(monthMap)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, data]) => ({
+        month,
+        totalHours: round2(data.total),
+        unplannedHours: round2(data.unplanned),
+        unplannedRate: round2(data.total > 0 ? (data.unplanned / data.total) * 100 : 0),
+      }));
+
+    const avgUnplannedRate = months.length > 0
+      ? round2(months.reduce((s, m) => s + m.unplannedRate, 0) / months.length)
+      : 0;
+
+    return { months, avgUnplannedRate, period: { start, end } };
+  }
+
+  // 3. Workload Distribution ───────────────────────────────────────────
+  async getWorkloadDistribution(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: { date: { gte: start, lte: end } },
+      select: {
+        userId: true,
+        hours: true,
+        category: true,
+        user: { select: { id: true, name: true } },
+      },
+    });
+
+    const userMap: Record<string, { userId: string; name: string; byCategory: Record<string, number>; total: number }> = {};
+    for (const e of timeEntries) {
+      if (!userMap[e.userId]) {
+        userMap[e.userId] = { userId: e.userId, name: e.user.name, byCategory: {}, total: 0 };
+      }
+      userMap[e.userId].byCategory[e.category] = (userMap[e.userId].byCategory[e.category] ?? 0) + e.hours;
+      userMap[e.userId].total += e.hours;
+    }
+
+    return {
+      users: Object.values(userMap).map((u) => ({
+        ...u,
+        total: round2(u.total),
+      })),
+      period: { start, end },
+    };
+  }
+
+  // 4. Velocity ────────────────────────────────────────────────────────
+  async getVelocity(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        OR: [
+          { status: "DONE", updatedAt: { gte: start, lte: end } },
+          { createdAt: { gte: start, lte: end } },
+        ],
+      },
+      select: { id: true, status: true, createdAt: true, updatedAt: true },
+    });
+
+    const weekMap: Record<string, { completed: number; created: number }> = {};
+
+    for (const t of tasks) {
+      if (t.createdAt >= start && t.createdAt <= end) {
+        const ws = getWeekStart(t.createdAt).toISOString().slice(0, 10);
+        if (!weekMap[ws]) weekMap[ws] = { completed: 0, created: 0 };
+        weekMap[ws].created++;
+      }
+      if (t.status === "DONE" && t.updatedAt >= start && t.updatedAt <= end) {
+        const ws = getWeekStart(t.updatedAt).toISOString().slice(0, 10);
+        if (!weekMap[ws]) weekMap[ws] = { completed: 0, created: 0 };
+        weekMap[ws].completed++;
+      }
+    }
+
+    const weeks = Object.entries(weekMap)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([weekStart, data]) => ({
+        weekStart,
+        completed: data.completed,
+        created: data.created,
+        netChange: data.completed - data.created,
+      }));
+
+    const avgVelocity = weeks.length > 0
+      ? round2(weeks.reduce((s, w) => s + w.completed, 0) / weeks.length)
+      : 0;
+
+    return { weeks, avgVelocity, period: { start, end } };
+  }
+
+  // 5. Time Efficiency ─────────────────────────────────────────────────
+  async getTimeEfficiency(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: { date: { gte: start, lte: end } },
+      select: { userId: true, hours: true, user: { select: { id: true, name: true } } },
+    });
+
+    const completedTasks = await this.prisma.task.findMany({
+      where: { status: "DONE", updatedAt: { gte: start, lte: end } },
+      select: { id: true, primaryAssigneeId: true },
+    });
+
+    const hoursByUser: Record<string, { name: string; hours: number }> = {};
+    for (const e of timeEntries) {
+      if (!hoursByUser[e.userId]) hoursByUser[e.userId] = { name: e.user.name, hours: 0 };
+      hoursByUser[e.userId].hours += e.hours;
+    }
+
+    const tasksByUser: Record<string, number> = {};
+    for (const t of completedTasks) {
+      if (t.primaryAssigneeId) {
+        tasksByUser[t.primaryAssigneeId] = (tasksByUser[t.primaryAssigneeId] ?? 0) + 1;
+      }
+    }
+
+    const allUserIds = new Set([...Object.keys(hoursByUser), ...Object.keys(tasksByUser)]);
+    const users = Array.from(allUserIds).map((userId) => {
+      const totalHours = hoursByUser[userId]?.hours ?? 0;
+      const completed = tasksByUser[userId] ?? 0;
+      return {
+        userId,
+        name: hoursByUser[userId]?.name ?? "Unknown",
+        totalHours: round2(totalHours),
+        completedTasks: completed,
+        hoursPerTask: completed > 0 ? round2(totalHours / completed) : 0,
+      };
+    });
+
+    const totalCompleted = users.reduce((s, u) => s + u.completedTasks, 0);
+    const totalHours = users.reduce((s, u) => s + u.totalHours, 0);
+    const avgHoursPerTask = totalCompleted > 0 ? round2(totalHours / totalCompleted) : 0;
+
+    return { users, avgHoursPerTask, period: { start, end } };
+  }
+
+  // 6. Earned Value ────────────────────────────────────────────────────
+  async getEarnedValue(planId: string, asOfDate?: string) {
+    const plan = await this.prisma.annualPlan.findUnique({
+      where: { id: planId },
+      include: {
+        linkedTasks: {
+          select: {
+            id: true,
+            status: true,
+            estimatedHours: true,
+            actualHours: true,
+            progressPct: true,
+            dueDate: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!plan) return null;
+
+    const asOf = asOfDate ? new Date(asOfDate + "T23:59:59.999") : new Date();
+    const totalEstimated = plan.linkedTasks.reduce((s, t) => s + (t.estimatedHours ?? 0), 0);
+
+    // PV: planned value — estimated hours for tasks due before asOf
+    const pv = plan.linkedTasks
+      .filter((t) => t.dueDate && t.dueDate <= asOf)
+      .reduce((s, t) => s + (t.estimatedHours ?? 0), 0);
+
+    // EV: earned value — weighted by progress
+    const ev = plan.linkedTasks.reduce((s, t) => s + (t.estimatedHours ?? 0) * (t.progressPct / 100), 0);
+
+    // AC: actual cost (hours)
+    const ac = plan.linkedTasks.reduce((s, t) => s + t.actualHours, 0);
+
+    const sv = ev - pv;
+    const cv = ev - ac;
+    const spi = pv > 0 ? round2(ev / pv) : 0;
+    const cpi = ac > 0 ? round2(ev / ac) : 0;
+    const eac = cpi > 0 ? round2(totalEstimated / cpi) : 0;
+
+    return {
+      planId: plan.id,
+      title: plan.title,
+      pv: round2(pv),
+      ev: round2(ev),
+      ac: round2(ac),
+      sv: round2(sv),
+      cv: round2(cv),
+      spi,
+      cpi,
+      eac,
+    };
+  }
+
+  // 7. Overdue Analysis ────────────────────────────────────────────────
+  async getOverdueAnalysis(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+    const now = new Date();
+
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        status: { not: "DONE" },
+        dueDate: { lt: now, gte: start },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        status: true,
+        category: true,
+        primaryAssignee: { select: { id: true, name: true } },
+      },
+      orderBy: { dueDate: "asc" },
+    });
+
+    const overdueItems = tasks.map((t) => {
+      const daysOverdue = Math.ceil((now.getTime() - (t.dueDate?.getTime() ?? now.getTime())) / (1000 * 60 * 60 * 24));
+      return {
+        id: t.id,
+        title: t.title,
+        assignee: t.primaryAssignee ? { id: t.primaryAssignee.id, name: t.primaryAssignee.name } : null,
+        dueDate: t.dueDate,
+        daysOverdue,
+        cause: t.category,
+      };
+    });
+
+    const byPerson: Record<string, { name: string; count: number; totalDaysOverdue: number }> = {};
+    for (const item of overdueItems) {
+      const key = item.assignee?.id ?? "unassigned";
+      if (!byPerson[key]) byPerson[key] = { name: item.assignee?.name ?? "未指派", count: 0, totalDaysOverdue: 0 };
+      byPerson[key].count++;
+      byPerson[key].totalDaysOverdue += item.daysOverdue;
+    }
+
+    return {
+      tasks: overdueItems,
+      byPerson: Object.entries(byPerson).map(([userId, data]) => ({ userId, ...data })),
+      totalOverdue: overdueItems.length,
+      period: { start, end },
+    };
+  }
+
+  // 8. Milestone Achievement ───────────────────────────────────────────
+  async getMilestoneAchievement(year?: number) {
+    const targetYear = year ?? new Date().getFullYear();
+
+    const milestones = await this.prisma.milestone.findMany({
+      where: { annualPlan: { year: targetYear } },
+      include: { annualPlan: { select: { title: true } } },
+      orderBy: { plannedEnd: "asc" },
+    });
+
+    const results = milestones.map((m) => {
+      const daysVariance = m.actualEnd && m.plannedEnd
+        ? Math.ceil((m.actualEnd.getTime() - m.plannedEnd.getTime()) / (1000 * 60 * 60 * 24))
+        : null;
+      return {
+        id: m.id,
+        title: m.title,
+        planTitle: m.annualPlan.title,
+        status: m.status,
+        plannedEnd: m.plannedEnd,
+        actualEnd: m.actualEnd,
+        daysVariance,
+      };
+    });
+
+    const completed = results.filter((m) => m.status === "COMPLETED");
+    const achievementRate = results.length > 0 ? round2((completed.length / results.length) * 100) : 0;
+
+    return { milestones: results, achievementRate, year: targetYear };
+  }
+
+  // 9. KPI Trend ───────────────────────────────────────────────────────
+  async getKPITrend(year?: number, kpiId?: string) {
+    const targetYear = year ?? new Date().getFullYear();
+
+    const where: Record<string, unknown> = { year: targetYear };
+    if (kpiId) where.id = kpiId;
+
+    const kpis = await this.prisma.kPI.findMany({
+      where,
+      select: { id: true, title: true, target: true },
+    });
+
+    const histories = await this.prisma.kPIHistory.findMany({
+      where: {
+        kpiId: { in: kpis.map((k) => k.id) },
+        period: { startsWith: String(targetYear) },
+      },
+      orderBy: { period: "asc" },
+    });
+
+    const historyByKpi: Record<string, Array<{ period: string; actual: number }>> = {};
+    for (const h of histories) {
+      if (!historyByKpi[h.kpiId]) historyByKpi[h.kpiId] = [];
+      historyByKpi[h.kpiId].push({ period: h.period, actual: h.actual });
+    }
+
+    const results = kpis.map((kpi) => {
+      const monthData = historyByKpi[kpi.id] ?? [];
+      const months = monthData.map((m) => ({
+        period: m.period,
+        actual: m.actual,
+        achievementRate: kpi.target > 0 ? round2((m.actual / kpi.target) * 100) : 0,
+      }));
+
+      // Simple forecast: average of last 3 months
+      const lastThree = months.slice(-3);
+      const forecast = lastThree.length > 0
+        ? round2(lastThree.reduce((s, m) => s + m.actual, 0) / lastThree.length)
+        : 0;
+
+      return { kpiId: kpi.id, title: kpi.title, target: kpi.target, months, forecast };
+    });
+
+    return { kpis: results, year: targetYear };
+  }
+
+  // 10. KPI Correlation ────────────────────────────────────────────────
+  async getKPICorrelation(year?: number) {
+    const targetYear = year ?? new Date().getFullYear();
+
+    const kpis = await this.prisma.kPI.findMany({
+      where: { year: targetYear },
+      select: {
+        id: true,
+        title: true,
+        target: true,
+        actual: true,
+        taskLinks: { select: { taskId: true } },
+      },
+    });
+
+    const taskIds = kpis.flatMap((k) => k.taskLinks.map((tl) => tl.taskId));
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: { taskId: { in: taskIds } },
+      select: { taskId: true, hours: true },
+    });
+
+    const hoursByTask: Record<string, number> = {};
+    for (const e of timeEntries) {
+      if (e.taskId) hoursByTask[e.taskId] = (hoursByTask[e.taskId] ?? 0) + e.hours;
+    }
+
+    const results = kpis.map((kpi) => {
+      const linkedTaskHours = kpi.taskLinks.reduce((s, tl) => s + (hoursByTask[tl.taskId] ?? 0), 0);
+      const achievementRate = kpi.target > 0 ? round2((kpi.actual / kpi.target) * 100) : 0;
+      // Simple correlation: hours invested vs achievement
+      const correlation = linkedTaskHours > 0 && achievementRate > 0
+        ? round2(achievementRate / linkedTaskHours)
+        : 0;
+      return {
+        kpiId: kpi.id,
+        title: kpi.title,
+        linkedTaskHours: round2(linkedTaskHours),
+        achievementRate,
+        correlation,
+      };
+    });
+
+    return { kpis: results, year: targetYear };
+  }
+
+  // 11. KPI Composite ──────────────────────────────────────────────────
+  async getKPIComposite(year?: number) {
+    const targetYear = year ?? new Date().getFullYear();
+
+    const kpis = await this.prisma.kPI.findMany({
+      where: { year: targetYear },
+      select: { id: true, title: true, target: true, actual: true, weight: true },
+    });
+
+    const totalWeight = kpis.reduce((s, k) => s + k.weight, 0);
+    const results = kpis.map((kpi) => {
+      const achievement = kpi.target > 0 ? round2((kpi.actual / kpi.target) * 100) : 0;
+      const normalizedWeight = totalWeight > 0 ? round2(kpi.weight / totalWeight) : 0;
+      const weightedScore = round2(achievement * normalizedWeight);
+      return {
+        kpiId: kpi.id,
+        title: kpi.title,
+        weight: kpi.weight,
+        achievement,
+        weightedScore,
+      };
+    });
+
+    const compositeScore = round2(results.reduce((s, r) => s + r.weightedScore, 0));
+
+    return { year: targetYear, kpis: results, compositeScore };
+  }
+
+  // 12. Overtime Analysis ──────────────────────────────────────────────
+  async getOvertimeAnalysis(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const timeEntries = await this.prisma.timeEntry.findMany({
+      where: {
+        date: { gte: start, lte: end },
+        overtimeType: { not: "NONE" },
+      },
+      select: {
+        userId: true,
+        hours: true,
+        overtimeType: true,
+        date: true,
+        user: { select: { id: true, name: true } },
+      },
+    });
+
+    const userMap: Record<string, { name: string; byType: Record<string, number>; totalOvertimeHours: number }> = {};
+    const monthMap: Record<string, { totalOvertimeHours: number; byType: Record<string, number> }> = {};
+
+    for (const e of timeEntries) {
+      // By user
+      if (!userMap[e.userId]) {
+        userMap[e.userId] = { name: e.user.name, byType: {}, totalOvertimeHours: 0 };
+      }
+      userMap[e.userId].byType[e.overtimeType] = (userMap[e.userId].byType[e.overtimeType] ?? 0) + e.hours;
+      userMap[e.userId].totalOvertimeHours += e.hours;
+
+      // By month
+      const d = new Date(e.date);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      if (!monthMap[key]) monthMap[key] = { totalOvertimeHours: 0, byType: {} };
+      monthMap[key].totalOvertimeHours += e.hours;
+      monthMap[key].byType[e.overtimeType] = (monthMap[key].byType[e.overtimeType] ?? 0) + e.hours;
+    }
+
+    return {
+      users: Object.entries(userMap).map(([userId, data]) => ({
+        userId,
+        ...data,
+        totalOvertimeHours: round2(data.totalOvertimeHours),
+      })),
+      byMonth: Object.entries(monthMap)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([month, data]) => ({
+          month,
+          totalOvertimeHours: round2(data.totalOvertimeHours),
+          byType: data.byType,
+        })),
+      period: { start, end },
+    };
+  }
+
+  // 13. Change Summary ─────────────────────────────────────────────────
+  async getChangeSummary(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const changes = await this.prisma.changeRecord.findMany({
+      where: { createdAt: { gte: start, lte: end } },
+      include: {
+        task: { select: { id: true, title: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const byType: Record<string, number> = {};
+    const byStatus: Record<string, number> = {};
+    for (const c of changes) {
+      byType[c.type] = (byType[c.type] ?? 0) + 1;
+      byStatus[c.status] = (byStatus[c.status] ?? 0) + 1;
+    }
+
+    return {
+      changes: changes.map((c) => ({
+        id: c.id,
+        changeNumber: c.changeNumber,
+        type: c.type,
+        status: c.status,
+        riskLevel: c.riskLevel,
+        taskTitle: c.task.title,
+        scheduledStart: c.scheduledStart,
+        scheduledEnd: c.scheduledEnd,
+        createdAt: c.createdAt,
+      })),
+      byType,
+      byStatus,
+      total: changes.length,
+      period: { start, end },
+    };
+  }
+
+  // 14. Incident SLA ───────────────────────────────────────────────────
+  async getIncidentSLA(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const incidents = await this.prisma.incidentRecord.findMany({
+      where: { incidentStart: { gte: start, lte: end } },
+      include: {
+        task: { select: { id: true, title: true, slaDeadline: true, status: true } },
+      },
+      orderBy: { incidentStart: "desc" },
+    });
+
+    let slaMetCount = 0;
+    let totalMttr = 0;
+    let mttrCount = 0;
+
+    const bySeverity: Record<string, { count: number; slaMet: number; avgMttr: number; totalMttr: number }> = {};
+
+    const results = incidents.map((inc) => {
+      const slaMet = inc.task.slaDeadline
+        ? (inc.incidentEnd ?? new Date()) <= inc.task.slaDeadline
+        : true;
+      if (slaMet) slaMetCount++;
+
+      if (inc.mttrMinutes != null) {
+        totalMttr += inc.mttrMinutes;
+        mttrCount++;
+      }
+
+      if (!bySeverity[inc.severity]) {
+        bySeverity[inc.severity] = { count: 0, slaMet: 0, avgMttr: 0, totalMttr: 0 };
+      }
+      bySeverity[inc.severity].count++;
+      if (slaMet) bySeverity[inc.severity].slaMet++;
+      if (inc.mttrMinutes != null) bySeverity[inc.severity].totalMttr += inc.mttrMinutes;
+
+      return {
+        id: inc.id,
+        taskTitle: inc.task.title,
+        severity: inc.severity,
+        incidentStart: inc.incidentStart,
+        incidentEnd: inc.incidentEnd,
+        mttrMinutes: inc.mttrMinutes,
+        slaMet,
+      };
+    });
+
+    // Calculate avg MTTR per severity
+    for (const sev of Object.values(bySeverity)) {
+      sev.avgMttr = sev.count > 0 ? round2(sev.totalMttr / sev.count) : 0;
+    }
+
+    return {
+      incidents: results,
+      slaMetRate: incidents.length > 0 ? round2((slaMetCount / incidents.length) * 100) : 100,
+      avgMttr: mttrCount > 0 ? round2(totalMttr / mttrCount) : 0,
+      bySeverity: Object.entries(bySeverity).map(([severity, data]) => ({
+        severity,
+        count: data.count,
+        slaMetRate: data.count > 0 ? round2((data.slaMet / data.count) * 100) : 100,
+        avgMttr: data.avgMttr,
+      })),
+      period: { start, end },
+    };
+  }
+
+  // 15. Permission Audit ───────────────────────────────────────────────
+  async getPermissionAudit(startDate?: string, endDate?: string) {
+    const { start, end } = defaultDateRange(startDate, endDate);
+
+    const logs = await this.prisma.auditLog.findMany({
+      where: {
+        createdAt: { gte: start, lte: end },
+        resourceType: { in: ["Permission", "permission", "permissions"] },
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        userId: true,
+        action: true,
+        resourceId: true,
+        detail: true,
+        createdAt: true,
+        metadata: true,
+      },
+    });
+
+    const byAction: Record<string, number> = {};
+    for (const log of logs) {
+      byAction[log.action] = (byAction[log.action] ?? 0) + 1;
+    }
+
+    return {
+      logs,
+      totalChanges: logs.length,
+      byAction,
+      period: { start, end },
+    };
+  }
+}

--- a/validators/report-v2-validators.ts
+++ b/validators/report-v2-validators.ts
@@ -1,0 +1,41 @@
+/**
+ * Zod validators for Reports v2 API — Issue #984
+ */
+import { z } from "zod";
+
+/** Reusable date-range query params */
+export const dateRangeSchema = z.object({
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "格式: YYYY-MM-DD").optional(),
+  endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "格式: YYYY-MM-DD").optional(),
+});
+
+/** Year-only query param */
+export const yearSchema = z.object({
+  year: z.coerce.number().int().min(2020).max(2100).optional(),
+});
+
+/** Earned value needs planId */
+export const earnedValueSchema = z.object({
+  planId: z.string().min(1, "planId 為必填"),
+  asOfDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "格式: YYYY-MM-DD").optional(),
+});
+
+/** KPI trend can optionally filter by kpiId */
+export const kpiTrendSchema = z.object({
+  year: z.coerce.number().int().min(2020).max(2100).optional(),
+  kpiId: z.string().optional(),
+});
+
+export type DateRangeQuery = z.infer<typeof dateRangeSchema>;
+export type YearQuery = z.infer<typeof yearSchema>;
+export type EarnedValueQuery = z.infer<typeof earnedValueSchema>;
+export type KpiTrendQuery = z.infer<typeof kpiTrendSchema>;
+
+/** Parse search params into an object for Zod validation */
+export function searchParamsToObject(searchParams: URLSearchParams): Record<string, string> {
+  const obj: Record<string, string> = {};
+  searchParams.forEach((value, key) => {
+    obj[key] = value;
+  });
+  return obj;
+}


### PR DESCRIPTION
## Summary

- 新增 15 個 v2 報表 API endpoint，涵蓋產能利用率、計畫外趨勢、工作量分佈、速率、工時效率、EVM、逾期分析、里程碑達成率、KPI 趨勢/相關性/綜合評分、加班分析、變更摘要、事件 SLA、權限稽核
- 所有 endpoint 使用 `withManager` 權限控制、Zod schema 驗證
- 獨立 `ReportV2Service` 與 `report-v2-validators.ts`

Closes #984

## QA 自審報告

| 項目 | 結果 |
|------|------|
| tsc --noEmit | 0 errors |
| jest reports-v2.test.ts | 19 passed, 0 failed |
| 15 endpoints 實作 | 全部完成 |
| Zod validation | 每個 endpoint 有 schema |
| MANAGER only | withManager 套用 |
| 401 unauthorized | 測試通過 |
| 403 engineer denied | 測試通過 |
| 400 validation error | earned-value 缺 planId 測試通過 |
| 404 not found | earned-value 不存在 plan 測試通過 |

## Test plan

- [x] tsc 0 errors
- [x] 19 jest tests pass (15 happy path + 3 earned-value edge cases + 1 auth)
- [x] 每個 endpoint 至少 1 個測試
- [x] Auth enforcement: 401 + 403 驗證