### PR TITLE
feat(config): Feature Flag 機制 (TITAN_V2_ENABLED)

### DIFF
--- a/__tests__/api/feature-flags.test.ts
+++ b/__tests__/api/feature-flags.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Feature Flags — Issue #988
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Mock auth ────────────────────────────────────────────────────────────
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+// Mock prisma (needed by apiHandler audit logging)
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    auditLog: { create: jest.fn() },
+  },
+}));
+
+const ADMIN_SESSION = {
+  user: { id: "a1", name: "Admin", email: "a@e.com", role: "ADMIN" },
+  expires: "2099-01-01",
+};
+const MANAGER_SESSION = {
+  user: { id: "m1", name: "Manager", email: "m@e.com", role: "MANAGER" },
+  expires: "2099-01-01",
+};
+const ENGINEER_SESSION = {
+  user: { id: "e1", name: "Engineer", email: "e@e.com", role: "ENGINEER" },
+  expires: "2099-01-01",
+};
+
+// ── lib/feature-flags.ts unit tests ──────────────────────────────────────
+describe("lib/feature-flags", () => {
+  beforeEach(() => {
+    // Clear all TITAN_FF_ env vars
+    delete process.env.TITAN_FF_V2_DASHBOARD;
+    delete process.env.TITAN_FF_V2_REPORTS;
+    delete process.env.TITAN_FF_ALERT_BANNER;
+  });
+
+  it("returns default values when env vars not set", async () => {
+    const { getAllFeatureFlags } = await import("@/lib/feature-flags");
+    const flags = getAllFeatureFlags();
+    expect(flags.V2_DASHBOARD).toBe(false);
+    expect(flags.V2_REPORTS).toBe(false);
+    expect(flags.ALERT_BANNER).toBe(true);
+  });
+
+  it("reads true from env var", async () => {
+    process.env.TITAN_FF_V2_DASHBOARD = "true";
+    const { getFeatureFlag } = await import("@/lib/feature-flags");
+    expect(getFeatureFlag("V2_DASHBOARD")).toBe(true);
+  });
+
+  it("reads 1 as true", async () => {
+    process.env.TITAN_FF_V2_REPORTS = "1";
+    const { getFeatureFlag } = await import("@/lib/feature-flags");
+    expect(getFeatureFlag("V2_REPORTS")).toBe(true);
+  });
+
+  it("reads false from env var", async () => {
+    process.env.TITAN_FF_ALERT_BANNER = "false";
+    const { getFeatureFlag } = await import("@/lib/feature-flags");
+    expect(getFeatureFlag("ALERT_BANNER")).toBe(false);
+  });
+
+  it("validates flag names", async () => {
+    const { isValidFlagName } = await import("@/lib/feature-flags");
+    expect(isValidFlagName("V2_DASHBOARD")).toBe(true);
+    expect(isValidFlagName("INVALID_FLAG")).toBe(false);
+  });
+});
+
+// ── API route tests ──────────────────────────────────────────────────────
+describe("GET /api/admin/feature-flags", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.TITAN_FF_V2_DASHBOARD;
+    delete process.env.TITAN_FF_V2_REPORTS;
+    delete process.env.TITAN_FF_ALERT_BANNER;
+  });
+
+  it("returns flags for any authenticated user", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+    const { GET } = await import("@/app/api/admin/feature-flags/route");
+    const res = await GET(createMockRequest("/api/admin/feature-flags"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.flags).toHaveProperty("V2_DASHBOARD");
+    expect(body.data.flags).toHaveProperty("ALERT_BANNER");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/admin/feature-flags/route");
+    const res = await GET(createMockRequest("/api/admin/feature-flags"));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("PUT /api/admin/feature-flags", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.TITAN_FF_V2_DASHBOARD;
+  });
+
+  it("updates flag for ADMIN", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    const { PUT } = await import("@/app/api/admin/feature-flags/route");
+    const res = await PUT(
+      createMockRequest("/api/admin/feature-flags", {
+        method: "PUT",
+        body: { name: "V2_DASHBOARD", enabled: true },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.flags.V2_DASHBOARD).toBe(true);
+  });
+
+  it("returns 403 for MANAGER", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    const { PUT } = await import("@/app/api/admin/feature-flags/route");
+    const res = await PUT(
+      createMockRequest("/api/admin/feature-flags", {
+        method: "PUT",
+        body: { name: "V2_DASHBOARD", enabled: true },
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for invalid flag name", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    const { PUT } = await import("@/app/api/admin/feature-flags/route");
+    const res = await PUT(
+      createMockRequest("/api/admin/feature-flags", {
+        method: "PUT",
+        body: { name: "INVALID", enabled: true },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing fields", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
+    const { PUT } = await import("@/app/api/admin/feature-flags/route");
+    const res = await PUT(
+      createMockRequest("/api/admin/feature-flags", {
+        method: "PUT",
+        body: { name: "V2_DASHBOARD" },
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -1,0 +1,36 @@
+/**
+ * Feature Flags API — Issue #988
+ *
+ * GET  /api/admin/feature-flags — read all flags (any authenticated user)
+ * PUT  /api/admin/feature-flags — update a flag (ADMIN only)
+ */
+import { NextRequest } from "next/server";
+import { success } from "@/lib/api-response";
+import { withAuth, withAdmin } from "@/lib/auth-middleware";
+import { getAllFeatureFlags, isValidFlagName } from "@/lib/feature-flags";
+import { ValidationError } from "@/services/errors";
+
+export const GET = withAuth(async (_req: NextRequest) => {
+  const flags = getAllFeatureFlags();
+  return success({ flags });
+});
+
+export const PUT = withAdmin(async (req: NextRequest) => {
+  const body = await req.json();
+  const { name, enabled } = body;
+
+  if (!name || typeof enabled !== "boolean") {
+    throw new ValidationError("需提供 name (string) 和 enabled (boolean)");
+  }
+
+  if (!isValidFlagName(name)) {
+    throw new ValidationError(`未知的 feature flag: ${name}`);
+  }
+
+  // Set the env var at runtime (in-memory only, persists until restart)
+  const envKey = `TITAN_FF_${name}`;
+  process.env[envKey] = enabled ? "true" : "false";
+
+  const flags = getAllFeatureFlags();
+  return success({ flags });
+});

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,57 @@
+/**
+ * Feature Flags — Issue #988
+ *
+ * Simple env-var based feature flag system.
+ * Flags are read from process.env with prefix TITAN_FF_.
+ *
+ * Supported flags:
+ * - V2_DASHBOARD: Toggle new dashboard vs old
+ * - V2_REPORTS: Toggle v2 reports
+ * - ALERT_BANNER: Toggle global alert banner
+ */
+
+export type FeatureFlagName = "V2_DASHBOARD" | "V2_REPORTS" | "ALERT_BANNER";
+
+/** Default values when env var is not set */
+const FLAG_DEFAULTS: Record<FeatureFlagName, boolean> = {
+  V2_DASHBOARD: false,
+  V2_REPORTS: false,
+  ALERT_BANNER: true,
+};
+
+/** All known flag names */
+export const ALL_FLAGS: FeatureFlagName[] = ["V2_DASHBOARD", "V2_REPORTS", "ALERT_BANNER"];
+
+/**
+ * Get a feature flag value (server-side).
+ * Reads from `process.env.TITAN_FF_<NAME>`.
+ * Values: "true"/"1" = enabled, anything else = disabled.
+ */
+export function getFeatureFlag(name: FeatureFlagName): boolean {
+  const envKey = `TITAN_FF_${name}`;
+  const envVal = process.env[envKey];
+
+  if (envVal === undefined || envVal === "") {
+    return FLAG_DEFAULTS[name] ?? false;
+  }
+
+  return envVal === "true" || envVal === "1";
+}
+
+/**
+ * Get all feature flags (server-side).
+ */
+export function getAllFeatureFlags(): Record<FeatureFlagName, boolean> {
+  const flags: Record<string, boolean> = {};
+  for (const name of ALL_FLAGS) {
+    flags[name] = getFeatureFlag(name);
+  }
+  return flags as Record<FeatureFlagName, boolean>;
+}
+
+/**
+ * Check if a flag name is valid.
+ */
+export function isValidFlagName(name: string): name is FeatureFlagName {
+  return ALL_FLAGS.includes(name as FeatureFlagName);
+}

--- a/lib/hooks/use-feature-flag.ts
+++ b/lib/hooks/use-feature-flag.ts
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * useFeatureFlag — Issue #988
+ *
+ * Client-side hook to read feature flags from /api/admin/feature-flags.
+ * Caches the result to avoid repeated fetches within same page lifecycle.
+ */
+
+import { useState, useEffect } from "react";
+
+type FlagName = string;
+
+let cachedFlags: Record<FlagName, boolean> | null = null;
+let fetchPromise: Promise<Record<FlagName, boolean>> | null = null;
+
+async function fetchFlags(): Promise<Record<FlagName, boolean>> {
+  if (cachedFlags) return cachedFlags;
+  if (fetchPromise) return fetchPromise;
+
+  fetchPromise = fetch("/api/admin/feature-flags")
+    .then(async (res) => {
+      if (!res.ok) return {};
+      const body = await res.json();
+      const flags = body.data?.flags ?? {};
+      cachedFlags = flags;
+      return flags;
+    })
+    .catch(() => ({}))
+    .finally(() => {
+      fetchPromise = null;
+    });
+
+  return fetchPromise;
+}
+
+/** Reset cache — useful for testing or after admin updates a flag */
+export function resetFeatureFlagCache() {
+  cachedFlags = null;
+  fetchPromise = null;
+}
+
+export function useFeatureFlag(name: FlagName): { enabled: boolean; loading: boolean } {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    fetchFlags().then((flags) => {
+      if (!cancelled) {
+        setEnabled(flags[name] ?? false);
+        setLoading(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [name]);
+
+  return { enabled, loading };
+}


### PR DESCRIPTION
## Summary

- 新增 `lib/feature-flags.ts`：env-var 基礎的 feature flag 系統（TITAN_FF_* 前綴）
- 新增 `useFeatureFlag` hook：client-side 讀取 + 快取
- 新增 `GET /api/admin/feature-flags`：任何登入用戶可讀取所有 flags
- 新增 `PUT /api/admin/feature-flags`：僅 ADMIN 可更新（runtime in-memory）
- 支援 3 個 flags：V2_DASHBOARD、V2_REPORTS、ALERT_BANNER

Closes #988

## QA 自審報告

| 項目 | 結果 |
|------|------|
| tsc --noEmit | 0 errors |
| jest feature-flags.test.ts | 11 passed, 0 failed |
| env var 讀取 | true/1/false 全部正確 |
| 預設值 | V2_DASHBOARD=false, ALERT_BANNER=true |
| GET API (任何用戶) | 測試通過 |
| PUT API (ADMIN only) | 測試通過 |
| 403 for MANAGER PUT | 測試通過 |
| 400 invalid flag | 測試通過 |
| 400 missing fields | 測試通過 |
| isValidFlagName | 測試通過 |

## Test plan

- [x] tsc 0 errors
- [x] 11 jest tests pass (5 unit + 6 API)
- [x] Flag defaults, env reading, validation
- [x] Auth enforcement: 401 + 403