### PR TITLE
feat(dashboard): Dashboard Tab 整合 — 團隊全局/我的工作 可切換

### DIFF
--- a/__tests__/api/dashboard-tabs.test.ts
+++ b/__tests__/api/dashboard-tabs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Dashboard Tab Integration — Issue #990
+ * Verifies the view param on /api/my-day works correctly.
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// ── Mock prisma ──────────────────────────────────────────────────────────
+const mockTask = { findMany: jest.fn() };
+const mockTimeEntry = { aggregate: jest.fn(), findMany: jest.fn() };
+const mockUser = { findMany: jest.fn() };
+const mockAnnualPlan = { findMany: jest.fn() };
+const mockMonthlyGoal = { findMany: jest.fn() };
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    task: mockTask,
+    timeEntry: mockTimeEntry,
+    user: mockUser,
+    annualPlan: mockAnnualPlan,
+    monthlyGoal: mockMonthlyGoal,
+  },
+}));
+
+const mockGetServerSession = jest.fn();
+jest.mock("next-auth", () => ({
+  getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
+}));
+
+const MANAGER_SESSION = {
+  user: { id: "m1", name: "Manager", email: "m@e.com", role: "MANAGER" },
+  expires: "2099-01-01",
+};
+
+const ENGINEER_SESSION = {
+  user: { id: "e1", name: "Engineer", email: "e@e.com", role: "ENGINEER" },
+  expires: "2099-01-01",
+};
+
+function resetMocks() {
+  jest.clearAllMocks();
+  mockTask.findMany.mockResolvedValue([]);
+  mockTimeEntry.aggregate.mockResolvedValue({ _sum: { hours: 0 }, _count: 0 });
+  mockTimeEntry.findMany.mockResolvedValue([]);
+  mockUser.findMany.mockResolvedValue([]);
+  mockAnnualPlan.findMany.mockResolvedValue([]);
+  mockMonthlyGoal.findMany.mockResolvedValue([]);
+}
+
+describe("GET /api/my-day — view param (Issue #990)", () => {
+  beforeEach(resetMocks);
+
+  it("returns MANAGER data by default for managers", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(createMockRequest("/api/my-day"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role).toBe("MANAGER");
+  });
+
+  it("returns MANAGER data with view=team", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(
+      createMockRequest("/api/my-day", { searchParams: { view: "team" } })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role).toBe("MANAGER");
+    expect(body.data).toHaveProperty("memberWorkload");
+  });
+
+  it("returns ENGINEER data when manager requests view=my-day", async () => {
+    mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(
+      createMockRequest("/api/my-day", { searchParams: { view: "my-day" } })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role).toBe("ENGINEER");
+    expect(body.data).toHaveProperty("dueTodayTasks");
+    expect(body.data).toHaveProperty("dailyTarget");
+  });
+
+  it("returns ENGINEER data for engineers regardless of view param", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(
+      createMockRequest("/api/my-day", { searchParams: { view: "team" } })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role).toBe("ENGINEER");
+  });
+
+  it("backward compatible — no view param for engineer", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(createMockRequest("/api/my-day"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.role).toBe("ENGINEER");
+    expect(body.data).toHaveProperty("inProgressTasks");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/my-day/route");
+    const res = await GET(createMockRequest("/api/my-day"));
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/pages/dashboard.test.tsx
+++ b/__tests__/pages/dashboard.test.tsx
@@ -148,7 +148,7 @@ describe("Dashboard Page", () => {
     setSession("MANAGER");
     mockFetch.mockResolvedValue({ ok: true, json: async () => MANAGER_DATA } as Response);
     await act(async () => { render(<DashboardPage />); });
-    await waitFor(() => expect(screen.getByText(/團隊全局/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getAllByText(/團隊全局/).length).toBeGreaterThan(0));
   });
 
   it("shows 團隊健康快照 section for Manager", async () => {

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -438,6 +438,60 @@ function ManagerMyDay({ data }: { data: ManagerData }) {
   );
 }
 
+// ── Tab types ─────────────────────────────────────────────────────────────
+type DashboardTab = "my-day" | "team";
+
+const TAB_STORAGE_KEY = "titan-dashboard-tab";
+
+function getStoredTab(): DashboardTab | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const val = localStorage.getItem(TAB_STORAGE_KEY);
+    if (val === "my-day" || val === "team") return val;
+  } catch { /* ignore */ }
+  return null;
+}
+
+function storeTab(tab: DashboardTab) {
+  try {
+    localStorage.setItem(TAB_STORAGE_KEY, tab);
+  } catch { /* ignore */ }
+}
+
+// ── Dashboard Tabs ────────────────────────────────────────────────────────
+
+function DashboardTabs({
+  activeTab,
+  onTabChange,
+}: {
+  activeTab: DashboardTab;
+  onTabChange: (tab: DashboardTab) => void;
+}) {
+  const tabs: { key: DashboardTab; label: string }[] = [
+    { key: "my-day", label: "我的一天" },
+    { key: "team", label: "團隊全局" },
+  ];
+
+  return (
+    <div className="flex gap-1 border-b border-border mb-6" data-testid="dashboard-tabs">
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          onClick={() => onTabChange(tab.key)}
+          className={cn(
+            "px-4 py-2 text-sm transition-colors relative -mb-px",
+            activeTab === tab.key
+              ? "font-semibold text-foreground border-b-2 border-primary"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────
 
 export default function DashboardPage() {
@@ -446,11 +500,32 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchMyDay = useCallback(async () => {
+  const isManager = session?.user?.role === "MANAGER" || session?.user?.role === "ADMIN";
+
+  // Issue #990: Tab state — Manager defaults to "team", Engineer always "my-day"
+  const [activeTab, setActiveTab] = useState<DashboardTab>(() => {
+    const stored = getStoredTab();
+    if (stored) return stored;
+    return "team"; // will be forced to "my-day" for engineers in the effect
+  });
+
+  // Force engineers to my-day
+  useEffect(() => {
+    if (status === "authenticated" && !isManager) {
+      setActiveTab("my-day");
+    } else if (status === "authenticated" && isManager) {
+      const stored = getStoredTab();
+      if (stored) setActiveTab(stored);
+    }
+  }, [status, isManager]);
+
+  const fetchMyDay = useCallback(async (view?: DashboardTab) => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch("/api/my-day");
+      const viewParam = view ?? activeTab;
+      const url = isManager ? `/api/my-day?view=${viewParam}` : "/api/my-day";
+      const res = await fetch(url);
       if (!res.ok) throw new Error(`載入失敗 (${res.status})`);
       const body = await res.json();
       setData(extractData<MyDayData>(body));
@@ -459,7 +534,7 @@ export default function DashboardPage() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [activeTab, isManager]);
 
   useEffect(() => {
     if (status === "authenticated") {
@@ -467,21 +542,33 @@ export default function DashboardPage() {
     }
   }, [status, fetchMyDay]);
 
-  const isManager = session?.user?.role === "MANAGER" || session?.user?.role === "ADMIN";
+  const handleTabChange = (tab: DashboardTab) => {
+    setActiveTab(tab);
+    storeTab(tab);
+    fetchMyDay(tab);
+  };
+
   const greeting = getGreeting();
   const userName = session?.user?.name ?? "";
+
+  const subtitle = activeTab === "team"
+    ? "團隊全局 — 今日需關注事項"
+    : "我的一天 — 今日工作安排";
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
       {/* Header */}
-      <div className="mb-6">
+      <div className="mb-4">
         <h1 className="text-xl font-semibold tracking-tight">
           {greeting}，{userName}
         </h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {isManager ? "團隊全局 — 今日需關注事項" : "我的一天 — 今日工作安排"}
-        </p>
+        <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
       </div>
+
+      {/* Tabs — only shown for Manager/Admin */}
+      {isManager && (
+        <DashboardTabs activeTab={activeTab} onTabChange={handleTabChange} />
+      )}
 
       {/* Progressive loading with skeletons */}
       {status === "loading" || loading ? (
@@ -496,7 +583,7 @@ export default function DashboardPage() {
           </div>
         </div>
       ) : error ? (
-        <PageError message={error} onRetry={fetchMyDay} />
+        <PageError message={error} onRetry={() => fetchMyDay()} />
       ) : !data ? (
         <PageEmpty title="尚無資料" description="無法載入 My Day 資料" />
       ) : data.role === "MANAGER" ? (

--- a/app/api/my-day/route.ts
+++ b/app/api/my-day/route.ts
@@ -20,12 +20,19 @@ export const GET = withAuth(async (req: NextRequest) => {
   const role = session.user.role;
   const isManager = role === "MANAGER" || role === "ADMIN";
 
+  // Issue #990: support view param for tab switching
+  const { searchParams } = new URL(req.url);
+  const viewParam = searchParams.get("view"); // "my-day" | "team" | null
+
   const now = new Date();
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const todayEnd = new Date(todayStart);
   todayEnd.setDate(todayEnd.getDate() + 1);
 
-  if (isManager) {
+  // If manager explicitly requests "my-day" view, show engineer view with their data
+  const showTeamView = isManager && viewParam !== "my-day";
+
+  if (showTeamView) {
     // ── Manager View ──────────────────────────────────────────────────
     const [flaggedTasks, overdueTasks, teamMembers, todayTimeEntries, plans] =
       await Promise.all([


### PR DESCRIPTION
## Summary

- Dashboard 頂部新增可切換 Tab：「我的一天」/「團隊全局」
- Manager/ADMIN 可見雙 Tab 切換；ENGINEER 只見「我的一天」
- `/api/my-day` 新增 `?view=my-day|team` 參數支援
- Tab 狀態持久化到 localStorage (`titan-dashboard-tab`)
- 完全向下相容：不帶 view 參數時行為不變

Closes #990

## QA 自審報告

| 項目 | 結果 |
|------|------|
| tsc --noEmit | 0 errors |
| jest dashboard-tabs.test.ts | 6 passed, 0 failed |
| jest 全部 | 2742 passed, 1 pre-existing fail (jwt-auth) |
| Manager 預設 team view | 測試通過 |
| Manager view=my-day | 回傳 ENGINEER data，測試通過 |
| Manager view=team | 回傳 MANAGER data，測試通過 |
| Engineer 忽略 view param | 測試通過 |
| 向下相容 | 測試通過 |
| 401 auth | 測試通過 |
| Tab UI | DashboardTabs 元件，active 底線 + 粗體 |
| localStorage 持久化 | storeTab/getStoredTab 實作 |

## Test plan

- [x] tsc 0 errors
- [x] 6 jest tests pass
- [x] Manager tab switching: team / my-day
- [x] Engineer: no tabs, always my-day
- [x] Backward compatibility verified
- [x] Auth enforcement