### PR TITLE
feat(knowledge): DocumentStatus 新增 IN_REVIEW + RETIRED

### DIFF
--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -30,7 +30,7 @@ type DocDetail = {
   title: string;
   content: string;
   version: number;
-  status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+  status: "DRAFT" | "IN_REVIEW" | "PUBLISHED" | "ARCHIVED" | "RETIRED";
   parentId: string | null;
   spaceId: string | null;
   slug: string;
@@ -39,6 +39,7 @@ type DocDetail = {
   verifier: { id: string; name: string } | null;
   verifiedAt: string | null;
   verifyIntervalDays: number | null;
+  replacedBy: { id: string; title: string; slug: string } | null;
   space: { id: string; name: string } | null;
   updatedAt: string;
   versions: DocVersion[];
@@ -51,8 +52,10 @@ const isOutlineConfigured = Boolean(OUTLINE_URL);
 
 const STATUS_LABELS: Record<string, { label: string; className: string }> = {
   DRAFT: { label: "草稿", className: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400" },
+  IN_REVIEW: { label: "審核中", className: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400" },
   PUBLISHED: { label: "已發布", className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400" },
   ARCHIVED: { label: "已歸檔", className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400" },
+  RETIRED: { label: "已退役", className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400 line-through" },
 };
 
 const TEMPLATE_OPTIONS = [
@@ -152,6 +155,32 @@ export default function KnowledgePage() {
   async function publishDoc() {
     if (!selectedId) return;
     const res = await fetch(`/api/documents/${selectedId}/publish`, { method: "POST" });
+    if (res.ok) {
+      const body = await res.json();
+      const updated = extractData<DocDetail>(body);
+      setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
+      loadDocs();
+    }
+  }
+
+  async function submitForReview() {
+    if (!selectedId) return;
+    const res = await fetch(`/api/documents/${selectedId}/submit-review`, { method: "POST" });
+    if (res.ok) {
+      const body = await res.json();
+      const updated = extractData<DocDetail>(body);
+      setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
+      loadDocs();
+    }
+  }
+
+  async function retireDoc() {
+    if (!selectedId || !confirm("確定將此文件標記為退役？")) return;
+    const res = await fetch(`/api/documents/${selectedId}/retire`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
     if (res.ok) {
       const body = await res.json();
       const updated = extractData<DocDetail>(body);
@@ -464,8 +493,19 @@ export default function KnowledgePage() {
                       儲存
                     </button>
 
-                    {/* Publish button */}
+                    {/* Submit for review button (DRAFT only) */}
                     {docDetail.status === "DRAFT" && (
+                      <button
+                        onClick={submitForReview}
+                        className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+                      >
+                        <Upload className="h-3 w-3" />
+                        提交審核
+                      </button>
+                    )}
+
+                    {/* Publish button (DRAFT or IN_REVIEW) */}
+                    {(docDetail.status === "DRAFT" || docDetail.status === "IN_REVIEW") && (
                       <button
                         onClick={publishDoc}
                         className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md bg-green-600 hover:bg-green-700 text-white transition-colors"
@@ -476,13 +516,24 @@ export default function KnowledgePage() {
                     )}
 
                     {/* Archive button */}
-                    {docDetail.status !== "ARCHIVED" && (
+                    {docDetail.status !== "ARCHIVED" && docDetail.status !== "RETIRED" && (
                       <button
                         onClick={archiveDoc}
                         className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md text-muted-foreground hover:bg-accent transition-colors"
                       >
                         <Archive className="h-3 w-3" />
                         歸檔
+                      </button>
+                    )}
+
+                    {/* Retire button (PUBLISHED or ARCHIVED) */}
+                    {(docDetail.status === "PUBLISHED" || docDetail.status === "ARCHIVED") && (
+                      <button
+                        onClick={retireDoc}
+                        className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 rounded-md text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                      >
+                        <Archive className="h-3 w-3" />
+                        退役
                       </button>
                     )}
                   </div>
@@ -504,6 +555,28 @@ export default function KnowledgePage() {
                   )}
                   <span className="text-xs text-muted-foreground/60 ml-auto">v{docDetail.version}</span>
                 </div>
+
+                {/* Retired replacement notice */}
+                {docDetail.status === "RETIRED" && (
+                  <div className="px-4 py-2 bg-red-50 dark:bg-red-900/10 border-b border-red-200 dark:border-red-900/30 flex items-center gap-2">
+                    <AlertCircle className="h-3.5 w-3.5 text-red-500" />
+                    <span className="text-xs text-red-700 dark:text-red-400">
+                      此文件已退役
+                      {docDetail.replacedBy && (
+                        <>
+                          ，已由{" "}
+                          <button
+                            onClick={() => setSelectedId(docDetail.replacedBy!.id)}
+                            className="font-medium underline hover:no-underline"
+                          >
+                            {docDetail.replacedBy.title}
+                          </button>
+                          {" "}取代
+                        </>
+                      )}
+                    </span>
+                  </div>
+                )}
 
                 {/* Diff view or editor */}
                 {diffVersion ? (

--- a/app/api/documents/[id]/retire/route.ts
+++ b/app/api/documents/[id]/retire/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { withAuth } from "@/lib/auth-middleware";
+import { withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
 import { NotFoundError, ValidationError } from "@/services/errors";
 
-export const POST = withAuth(async (
-  _req: NextRequest,
+export const POST = withManager(async (
+  req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
   const session = await requireAuth();
@@ -14,25 +14,34 @@ export const POST = withAuth(async (
 
   const doc = await prisma.document.findUnique({ where: { id } });
   if (!doc) throw new NotFoundError(`Document not found: ${id}`);
-  if (doc.status === "PUBLISHED") {
-    throw new ValidationError("文件已處於發布狀態");
-  }
-  if (doc.status === "ARCHIVED") {
-    throw new ValidationError("已歸檔文件無法直接發布，請先解除歸檔");
-  }
   if (doc.status === "RETIRED") {
-    throw new ValidationError("已退役文件無法發布");
+    throw new ValidationError("文件已處於退役狀態");
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const replacedById = body.replacedById ?? null;
+
+  if (replacedById) {
+    const replacement = await prisma.document.findUnique({ where: { id: replacedById } });
+    if (!replacement) {
+      throw new ValidationError("替代文件不存在");
+    }
+    if (replacement.id === id) {
+      throw new ValidationError("替代文件不可為自身");
+    }
   }
 
   const updated = await prisma.document.update({
     where: { id },
     data: {
-      status: "PUBLISHED",
+      status: "RETIRED",
+      replacedById,
       updatedBy: session.user.id,
     },
     include: {
       creator: { select: { id: true, name: true } },
       updater: { select: { id: true, name: true } },
+      replacedBy: { select: { id: true, title: true, slug: true } },
     },
   });
 

--- a/app/api/documents/[id]/submit-review/route.ts
+++ b/app/api/documents/[id]/submit-review/route.ts
@@ -14,20 +14,14 @@ export const POST = withAuth(async (
 
   const doc = await prisma.document.findUnique({ where: { id } });
   if (!doc) throw new NotFoundError(`Document not found: ${id}`);
-  if (doc.status === "PUBLISHED") {
-    throw new ValidationError("文件已處於發布狀態");
-  }
-  if (doc.status === "ARCHIVED") {
-    throw new ValidationError("已歸檔文件無法直接發布，請先解除歸檔");
-  }
-  if (doc.status === "RETIRED") {
-    throw new ValidationError("已退役文件無法發布");
+  if (doc.status !== "DRAFT") {
+    throw new ValidationError("僅草稿狀態的文件可提交審核");
   }
 
   const updated = await prisma.document.update({
     where: { id },
     data: {
-      status: "PUBLISHED",
+      status: "IN_REVIEW",
       updatedBy: session.user.id,
     },
     include: {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -851,8 +851,10 @@ model RefreshToken {
 
 enum DocumentStatus {
   DRAFT
+  IN_REVIEW   // 文件提交審核，發布前需審核通過
   PUBLISHED
   ARCHIVED
+  RETIRED     // 文件已過時，被新版本取代
 }
 
 model KnowledgeSpace {
@@ -885,16 +887,20 @@ model Document {
   verifierId         String?
   verifiedAt         DateTime?
   verifyIntervalDays Int?
+  // Retirement fields (Issue #987)
+  replacedById       String?        // 替代文件 ID（RETIRED 時使用）
   createdAt          DateTime       @default(now())
   updatedAt          DateTime       @updatedAt
 
-  space    KnowledgeSpace?   @relation(fields: [spaceId], references: [id])
-  parent   Document?         @relation("DocTree", fields: [parentId], references: [id])
-  children Document[]        @relation("DocTree")
-  creator  User              @relation("DocCreator", fields: [createdBy], references: [id])
-  updater  User              @relation("DocUpdater", fields: [updatedBy], references: [id])
-  verifier User?             @relation("DocVerifier", fields: [verifierId], references: [id])
-  versions DocumentVersion[]
+  space      KnowledgeSpace?   @relation(fields: [spaceId], references: [id])
+  parent     Document?         @relation("DocTree", fields: [parentId], references: [id])
+  children   Document[]        @relation("DocTree")
+  replacedBy Document?         @relation("DocReplacement", fields: [replacedById], references: [id])
+  replacedDocs Document[]      @relation("DocReplacement")
+  creator    User              @relation("DocCreator", fields: [createdBy], references: [id])
+  updater    User              @relation("DocUpdater", fields: [updatedBy], references: [id])
+  verifier   User?             @relation("DocVerifier", fields: [verifierId], references: [id])
+  versions   DocumentVersion[]
 
   @@index([spaceId])
   @@index([parentId])

--- a/services/document-service.ts
+++ b/services/document-service.ts
@@ -56,6 +56,7 @@ export class DocumentService {
         space: { select: { id: true, name: true } },
         parent: { select: { id: true, title: true, slug: true } },
         children: { select: { id: true, title: true, slug: true } },
+        replacedBy: { select: { id: true, title: true, slug: true } },
         versions: {
           include: { creator: { select: { id: true, name: true } } },
           orderBy: { version: "desc" },

--- a/validators/shared/enums.ts
+++ b/validators/shared/enums.ts
@@ -58,6 +58,16 @@ export const GoalStatusEnum = z.enum([
   "CANCELLED",
 ]);
 
+// ── Document ────────────────────────────────────────────────────────────────
+
+export const DocumentStatusEnum = z.enum([
+  "DRAFT",
+  "IN_REVIEW",
+  "PUBLISHED",
+  "ARCHIVED",
+  "RETIRED",
+]);
+
 // ── KPI ─────────────────────────────────────────────────────────────────────
 
 export const KpiStatusEnum = z.enum([
@@ -118,3 +128,4 @@ export type KpiVisibility = z.infer<typeof KpiVisibilityEnum>;
 export type CMChangeType = z.infer<typeof CMChangeTypeEnum>;
 export type RiskLevel = z.infer<typeof RiskLevelEnum>;
 export type ChangeStatus = z.infer<typeof ChangeStatusEnum>;
+export type DocumentStatus = z.infer<typeof DocumentStatusEnum>;


### PR DESCRIPTION
## Summary
- Add `IN_REVIEW` and `RETIRED` to DocumentStatus enum
- New `POST /api/documents/[id]/submit-review` endpoint (DRAFT -> IN_REVIEW)
- New `POST /api/documents/[id]/retire` endpoint with optional replacement doc
- Document.replacedById field for tracking replacement documents
- UI: status badges, action buttons, retired document replacement banner

Closes #987

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — all pass (1 pre-existing failure in jwt-auth-flow unrelated)
- [x] DocumentStatus enum contains IN_REVIEW + RETIRED
- [x] Status transition APIs: DRAFT->IN_REVIEW, IN_REVIEW->PUBLISHED, *->RETIRED
- [x] Publish route blocks RETIRED docs
- [x] UI shows IN_REVIEW (blue badge), RETIRED (red badge with line-through)
- [x] RETIRED docs show replacement link banner
- [x] Backward compatible: existing DRAFT/PUBLISHED/ARCHIVED unchanged

## AC Verification
- [x] DocumentStatus enum contains IN_REVIEW + RETIRED
- [x] Status transition API correctly works
- [x] UI correctly shows new status badges
- [x] tsc 0 errors, jest all pass