### PR TITLE
feat(knowledge): ReadingList 新人必讀清單 (3+1 models)

### DIFF
--- a/app/api/reading-lists/[id]/assign/route.ts
+++ b/app/api/reading-lists/[id]/assign/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { assignReadingListSchema } from "@/validators/reading-list-validators";
+import { success } from "@/lib/api-response";
+import { NotFoundError, ValidationError } from "@/services/errors";
+
+export const POST = withManager(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+  const raw = await req.json();
+  const body = validateBody(assignReadingListSchema, raw);
+
+  const list = await prisma.readingList.findUnique({ where: { id } });
+  if (!list) throw new NotFoundError("閱讀清單不存在");
+
+  const user = await prisma.user.findUnique({ where: { id: body.userId } });
+  if (!user || !user.isActive) {
+    throw new ValidationError("使用者不存在或已停用");
+  }
+
+  const existing = await prisma.readingListAssignment.findUnique({
+    where: { readingListId_userId: { readingListId: id, userId: body.userId } },
+  });
+  if (existing) {
+    throw new ValidationError("該使用者已被指派此清單");
+  }
+
+  const assignment = await prisma.readingListAssignment.create({
+    data: {
+      readingListId: id,
+      userId: body.userId,
+      assignedBy: session.user.id,
+    },
+    include: {
+      user: { select: { id: true, name: true, avatar: true } },
+      assigner: { select: { id: true, name: true } },
+    },
+  });
+
+  return success(assignment, 201);
+});

--- a/app/api/reading-lists/[id]/items/route.ts
+++ b/app/api/reading-lists/[id]/items/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withManager } from "@/lib/auth-middleware";
+import { validateBody } from "@/lib/validate";
+import { addReadingListItemSchema } from "@/validators/reading-list-validators";
+import { success } from "@/lib/api-response";
+import { NotFoundError, ValidationError } from "@/services/errors";
+
+export const POST = withManager(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+  const raw = await req.json();
+  const body = validateBody(addReadingListItemSchema, raw);
+
+  const list = await prisma.readingList.findUnique({ where: { id } });
+  if (!list) throw new NotFoundError("閱讀清單不存在");
+
+  const doc = await prisma.document.findUnique({ where: { id: body.documentId } });
+  if (!doc) throw new NotFoundError("文件不存在");
+
+  const existing = await prisma.readingListItem.findUnique({
+    where: { readingListId_documentId: { readingListId: id, documentId: body.documentId } },
+  });
+  if (existing) {
+    throw new ValidationError("此文件已在清單中");
+  }
+
+  const item = await prisma.readingListItem.create({
+    data: {
+      readingListId: id,
+      documentId: body.documentId,
+      sortOrder: body.sortOrder ?? 0,
+      required: body.required ?? true,
+    },
+    include: {
+      document: { select: { id: true, title: true, slug: true, status: true } },
+    },
+  });
+
+  return success(item, 201);
+});
+
+export const DELETE = withManager(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+  const { searchParams } = new URL(req.url);
+  const itemId = searchParams.get("itemId");
+
+  if (!itemId) {
+    return success({ error: "itemId is required" }, 400);
+  }
+
+  const item = await prisma.readingListItem.findFirst({
+    where: { id: itemId, readingListId: id },
+  });
+  if (!item) throw new NotFoundError("清單項目不存在");
+
+  await prisma.readingListItem.delete({ where: { id: itemId } });
+  return success({ deleted: true });
+});

--- a/app/api/reading-lists/[id]/mark-read/route.ts
+++ b/app/api/reading-lists/[id]/mark-read/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { NotFoundError, ValidationError } from "@/services/errors";
+
+export const POST = withAuth(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const session = await requireAuth();
+  const { id } = await context.params;
+  const raw = await req.json();
+  const documentId = raw.documentId;
+
+  if (!documentId) {
+    throw new ValidationError("documentId 為必填");
+  }
+
+  // Verify assignment exists
+  const assignment = await prisma.readingListAssignment.findUnique({
+    where: { readingListId_userId: { readingListId: id, userId: session.user.id } },
+  });
+  if (!assignment) throw new NotFoundError("您未被指派此閱讀清單");
+
+  // Verify item exists in list
+  const item = await prisma.readingListItem.findUnique({
+    where: { readingListId_documentId: { readingListId: id, documentId } },
+  });
+  if (!item) throw new NotFoundError("此文件不在閱讀清單中");
+
+  // Upsert read record
+  await prisma.readingListItemRead.upsert({
+    where: {
+      readingListId_documentId_userId: {
+        readingListId: id,
+        documentId,
+        userId: session.user.id,
+      },
+    },
+    create: {
+      readingListId: id,
+      documentId,
+      userId: session.user.id,
+    },
+    update: {
+      readAt: new Date(),
+    },
+  });
+
+  // Check if all required items are read
+  const allItems = await prisma.readingListItem.findMany({
+    where: { readingListId: id, required: true },
+  });
+
+  const readRecords = await prisma.readingListItemRead.findMany({
+    where: {
+      readingListId: id,
+      userId: session.user.id,
+      documentId: { in: allItems.map((i) => i.documentId) },
+    },
+  });
+
+  const readDocIds = new Set(readRecords.map((r) => r.documentId));
+  const allRequiredRead = allItems.every((i) => readDocIds.has(i.documentId));
+
+  // Mark assignment as completed if all required items read
+  if (allRequiredRead && !assignment.completedAt) {
+    await prisma.readingListAssignment.update({
+      where: { id: assignment.id },
+      data: { completedAt: new Date() },
+    });
+  }
+
+  return success({ marked: true, allComplete: allRequiredRead });
+});

--- a/app/api/reading-lists/[id]/route.ts
+++ b/app/api/reading-lists/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { validateBody } from "@/lib/validate";
+import { updateReadingListSchema } from "@/validators/reading-list-validators";
+import { success } from "@/lib/api-response";
+import { NotFoundError } from "@/services/errors";
+
+export const GET = withAuth(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+
+  const list = await prisma.readingList.findUnique({
+    where: { id },
+    include: {
+      creator: { select: { id: true, name: true } },
+      items: {
+        include: {
+          document: { select: { id: true, title: true, slug: true, status: true } },
+        },
+        orderBy: { sortOrder: "asc" },
+      },
+      assignments: {
+        include: {
+          user: { select: { id: true, name: true, avatar: true } },
+          assigner: { select: { id: true, name: true } },
+        },
+        orderBy: { createdAt: "desc" },
+      },
+    },
+  });
+
+  if (!list) throw new NotFoundError("閱讀清單不存在");
+  return success(list);
+});
+
+export const PATCH = withManager(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+  const raw = await req.json();
+  const body = validateBody(updateReadingListSchema, raw);
+
+  const existing = await prisma.readingList.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("閱讀清單不存在");
+
+  const list = await prisma.readingList.update({
+    where: { id },
+    data: {
+      ...(body.title !== undefined && { title: body.title }),
+      ...(body.description !== undefined && { description: body.description }),
+      ...(body.isDefault !== undefined && { isDefault: body.isDefault }),
+    },
+    include: {
+      creator: { select: { id: true, name: true } },
+      _count: { select: { items: true, assignments: true } },
+    },
+  });
+
+  return success(list);
+});
+
+export const DELETE = withManager(async (
+  _req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+
+  const existing = await prisma.readingList.findUnique({ where: { id } });
+  if (!existing) throw new NotFoundError("閱讀清單不存在");
+
+  await prisma.readingList.delete({ where: { id } });
+  return success({ deleted: true });
+});

--- a/app/api/reading-lists/my/route.ts
+++ b/app/api/reading-lists/my/route.ts
@@ -1,0 +1,76 @@
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+export const GET = withAuth(async () => {
+  const session = await requireAuth();
+
+  const assignments = await prisma.readingListAssignment.findMany({
+    where: { userId: session.user.id },
+    include: {
+      readingList: {
+        include: {
+          items: {
+            include: {
+              document: { select: { id: true, title: true, slug: true, status: true } },
+            },
+            orderBy: { sortOrder: "asc" },
+          },
+          creator: { select: { id: true, name: true } },
+        },
+      },
+      assigner: { select: { id: true, name: true } },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  // Fetch read records for all assigned reading lists
+  const readingListIds = assignments.map((a) => a.readingListId);
+
+  const readRecords = await prisma.readingListItemRead.findMany({
+    where: {
+      userId: session.user.id,
+      readingListId: { in: readingListIds },
+    },
+    select: { readingListId: true, documentId: true },
+  });
+
+  const readSet = new Set(
+    readRecords.map((r) => `${r.readingListId}:${r.documentId}`)
+  );
+
+  const result = assignments.map((a) => {
+    const totalItems = a.readingList.items.length;
+    const requiredItems = a.readingList.items.filter((i) => i.required);
+    const readCount = a.readingList.items.filter((i) =>
+      readSet.has(`${a.readingListId}:${i.documentId}`)
+    ).length;
+    const requiredReadCount = requiredItems.filter((i) =>
+      readSet.has(`${a.readingListId}:${i.documentId}`)
+    ).length;
+
+    return {
+      id: a.id,
+      readingList: {
+        ...a.readingList,
+        items: a.readingList.items.map((item) => ({
+          ...item,
+          isRead: readSet.has(`${a.readingListId}:${item.documentId}`),
+        })),
+      },
+      assigner: a.assigner,
+      completedAt: a.completedAt,
+      createdAt: a.createdAt,
+      progress: {
+        total: totalItems,
+        read: readCount,
+        requiredTotal: requiredItems.length,
+        requiredRead: requiredReadCount,
+        pct: totalItems > 0 ? Math.round((readCount / totalItems) * 100) : 0,
+      },
+    };
+  });
+
+  return success(result);
+});

--- a/app/api/reading-lists/route.ts
+++ b/app/api/reading-lists/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth, withManager } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { createReadingListSchema } from "@/validators/reading-list-validators";
+import { success } from "@/lib/api-response";
+
+export const GET = withAuth(async () => {
+  const lists = await prisma.readingList.findMany({
+    include: {
+      creator: { select: { id: true, name: true } },
+      _count: { select: { items: true, assignments: true } },
+    },
+    orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
+  });
+
+  return success(lists);
+});
+
+export const POST = withManager(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const raw = await req.json();
+  const body = validateBody(createReadingListSchema, raw);
+
+  const list = await prisma.readingList.create({
+    data: {
+      title: body.title,
+      description: body.description ?? null,
+      isDefault: body.isDefault ?? false,
+      createdBy: session.user.id,
+    },
+    include: {
+      creator: { select: { id: true, name: true } },
+      _count: { select: { items: true, assignments: true } },
+    },
+  });
+
+  return success(list, 201);
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,10 @@ model User {
   createdRecurringRules    RecurringRule[]       @relation("RecurringRuleCreator")
   createdSpaces            KnowledgeSpace[]     @relation("SpaceCreator")
   verifiedDocuments        Document[]           @relation("DocVerifier")
+  createdReadingLists      ReadingList[]         @relation("ReadingListCreator")
+  readingListAssignments   ReadingListAssignment[] @relation("ReadingListAssignee")
+  readingListAssigned      ReadingListAssignment[] @relation("ReadingListAssigner")
+  readingListItemReads     ReadingListItemRead[]   @relation("ReadingListItemReads")
 
   @@map("users")
 }
@@ -893,8 +897,10 @@ model Document {
   children Document[]        @relation("DocTree")
   creator  User              @relation("DocCreator", fields: [createdBy], references: [id])
   updater  User              @relation("DocUpdater", fields: [updatedBy], references: [id])
-  verifier User?             @relation("DocVerifier", fields: [verifierId], references: [id])
-  versions DocumentVersion[]
+  verifier          User?             @relation("DocVerifier", fields: [verifierId], references: [id])
+  versions          DocumentVersion[]
+  readingListItems  ReadingListItem[]
+  readingListReads  ReadingListItemRead[]
 
   @@index([spaceId])
   @@index([parentId])
@@ -1122,4 +1128,79 @@ model NotificationLog {
   @@index([notificationId])
   @@index([recipient])
   @@map("notification_logs")
+}
+
+// ═══════════════════════════════════════
+// 閱讀清單 (Issue #991)
+// ═══════════════════════════════════════
+
+model ReadingList {
+  id          String   @id @default(cuid())
+  title       String
+  description String?
+  createdBy   String
+  isDefault   Boolean  @default(false)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  creator     User                  @relation("ReadingListCreator", fields: [createdBy], references: [id])
+  items       ReadingListItem[]
+  assignments ReadingListAssignment[]
+  itemReads   ReadingListItemRead[]
+
+  @@index([createdBy])
+  @@map("reading_lists")
+}
+
+model ReadingListItem {
+  id            String   @id @default(cuid())
+  readingListId String
+  documentId    String
+  sortOrder     Int      @default(0)
+  required      Boolean  @default(true)
+  createdAt     DateTime @default(now())
+
+  readingList ReadingList @relation(fields: [readingListId], references: [id], onDelete: Cascade)
+  document    Document    @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@unique([readingListId, documentId])
+  @@index([readingListId])
+  @@index([documentId])
+  @@map("reading_list_items")
+}
+
+model ReadingListAssignment {
+  id            String    @id @default(cuid())
+  readingListId String
+  userId        String
+  assignedBy    String
+  completedAt   DateTime?
+  createdAt     DateTime  @default(now())
+
+  readingList ReadingList @relation(fields: [readingListId], references: [id], onDelete: Cascade)
+  user        User        @relation("ReadingListAssignee", fields: [userId], references: [id])
+  assigner    User        @relation("ReadingListAssigner", fields: [assignedBy], references: [id])
+
+  @@unique([readingListId, userId])
+  @@index([readingListId])
+  @@index([userId])
+  @@index([assignedBy])
+  @@map("reading_list_assignments")
+}
+
+/// 閱讀清單項目已讀紀錄
+model ReadingListItemRead {
+  id            String   @id @default(cuid())
+  readingListId String
+  documentId    String
+  userId        String
+  readAt        DateTime @default(now())
+
+  readingList ReadingList @relation(fields: [readingListId], references: [id], onDelete: Cascade)
+  document   Document    @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  user       User        @relation("ReadingListItemReads", fields: [userId], references: [id])
+
+  @@unique([readingListId, documentId, userId])
+  @@index([readingListId, userId])
+  @@map("reading_list_item_reads")
 }

--- a/validators/reading-list-validators.ts
+++ b/validators/reading-list-validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const createReadingListSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(1000).optional(),
+  isDefault: z.boolean().default(false),
+});
+
+export const updateReadingListSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(1000).nullable().optional(),
+  isDefault: z.boolean().optional(),
+});
+
+export const addReadingListItemSchema = z.object({
+  documentId: z.string().min(1),
+  sortOrder: z.number().int().min(0).default(0),
+  required: z.boolean().default(true),
+});
+
+export const assignReadingListSchema = z.object({
+  userId: z.string().min(1),
+});
+
+export type CreateReadingListInput = z.infer<typeof createReadingListSchema>;
+export type UpdateReadingListInput = z.infer<typeof updateReadingListSchema>;
+export type AddReadingListItemInput = z.infer<typeof addReadingListItemSchema>;
+export type AssignReadingListInput = z.infer<typeof assignReadingListSchema>;


### PR DESCRIPTION
## Summary
- Add 4 models: ReadingList, ReadingListItem, ReadingListAssignment, ReadingListItemRead
- Full CRUD APIs for lists, items management, user assignment, and read tracking
- Auto-completion: assignment marked complete when all required items are read
- `GET /api/reading-lists/my` returns user's assigned lists with progress stats

Closes #991

## QA 自審報告
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — all pass (1 pre-existing failure in jwt-auth-flow unrelated)
- [x] 4 models added: ReadingList, ReadingListItem, ReadingListAssignment, ReadingListItemRead
- [x] APIs: CRUD for lists, add/remove items, assign to user, mark as read, my lists with progress
- [x] Validators: reading-list-validators.ts with all schemas
- [x] Auto-complete assignment when all required items read
- [x] Backward compatible

## AC Verification
- [x] Models migration successful (prisma generate)
- [x] CRUD + assign + mark-read API correctly defined
- [x] tsc 0 errors, jest all pass