### PR TITLE
fix(deploy): align .env.example to use NEXTAUTH_SECRET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,8 @@ REDIS_URL=redis://:changeme_redis_password_here@titan-redis:6379
 
 # ── TITAN Next.js App（Issue #185, #200）─────────────────────
 # 必填：Auth.js v5 JWT 簽名密鑰（使用 openssl rand -hex 32 產生）
-# Auth.js v5 使用 AUTH_SECRET（向下相容 NEXTAUTH_SECRET）
-AUTH_SECRET=changeme_auth_secret_here
+# docker-compose.yml 以 NEXTAUTH_SECRET 為主；AUTH_SECRET 由 compose 自動設為相同值
+NEXTAUTH_SECRET=changeme_nextauth_secret_here
 # TITAN 對外 URL（Nginx 反向代理後的完整 URL）
 TITAN_URL=https://titan.bank.local/titan
 # TITAN App 資料庫連線字串（含連線池上限）


### PR DESCRIPTION
## 問題

`first-deploy.sh` 第一步驟成功，但 docker compose 啟動時報錯：
`required variable NEXTAUTH_SECRET is missing a value`

根因：`.env.example` 用 `AUTH_SECRET`，但 `first-deploy.sh` sed 替換的是 `NEXTAUTH_SECRET`，靜默失敗，`.env` 中該變數從未被寫入。

## 修法

將 `.env.example` 的 `AUTH_SECRET` 改為 `NEXTAUTH_SECRET`，對齊：
- `first-deploy.sh`（`sed -e "s|^NEXTAUTH_SECRET=...`）
- `docker-compose.yml`（`${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required}`）

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)