### PR TITLE
fix(deploy): rename docker-compose.override.yml to docker-compose.kimai.yml

### DIFF
--- a/docker-compose.kimai.yml
+++ b/docker-compose.kimai.yml
@@ -1,7 +1,7 @@
 # TITAN 平台 — Kimai 工時追蹤整合擴充設定
 # Issue: #64 — Kimai Time Tracking Deep Integration
 # 此檔案覆寫 docker-compose.yml 的預設設定，新增 Kimai + MySQL 服務
-# 使用方式：docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+# 使用方式：docker compose -f docker-compose.yml -f docker-compose.kimai.yml up -d
 #
 # 架構說明：
 #   Kimai 使用獨立的 MySQL 8.0（與 TITAN 的 PostgreSQL 16 分開）


### PR DESCRIPTION
## 問題

`first-deploy.sh` 因 `KIMAI_MYSQL_ROOT_PASSWORD` 缺失而失敗。

根因：`docker-compose.override.yml` 被 Docker Compose **自動載入**，強制要求所有 Kimai 必填變數，即使未啟用 Kimai。

## 修法

重新命名為 `docker-compose.kimai.yml`（不再自動載入）。啟用 Kimai 需明確指定：

```bash
docker compose -f docker-compose.yml -f docker-compose.kimai.yml up -d
```

同時更新 `docker-compose.kimai.yml`、`docs/pg-failover.md`、`DOCKER_COMPOSE_README.md` 中的舊檔名引用。

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)