### PR TITLE
fix(deploy): uncomment titan-app build section in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,9 +263,9 @@ services:
   # ── TITAN Next.js App（Issue #185）────────────────────────
   titan-app:
     image: titan-app:latest
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: titan-app
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## 問題

`first-deploy.sh` 執行 `docker compose pull --ignore-buildable` 時：
`Error response from daemon: pull access denied for titan-app`

## 根因

`build:` 被注釋掉 → Docker Compose 不知道 titan-app 是本地建構的 → `--ignore-buildable` 無法跳過 → 嘗試從 registry 拉取而失敗。

## 修法

取消注釋 `build: context/dockerfile`，讓 `--ignore-buildable` 正確運作。

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)