### PR TITLE
fix(deploy): remove invalid user: minio/outline from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,6 @@ services:
     container_name: titan-minio
     restart: unless-stopped
     command: server /data --console-address ":9001"
-    user: minio
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
@@ -129,7 +128,6 @@ services:
     image: outlinewiki/outline:1.6.1
     container_name: titan-outline
     restart: unless-stopped
-    user: outline
     environment:
       SECRET_KEY: ${OUTLINE_SECRET_KEY:?OUTLINE_SECRET_KEY is required}
       UTILS_SECRET: ${OUTLINE_UTILS_SECRET:?OUTLINE_UTILS_SECRET is required}


### PR DESCRIPTION
## 問題

MinIO 容器啟動失敗：`unable to find user minio: no matching entries in passwd file`

## 根因

`minio/minio:latest` 和 `outlinewiki/outline:1.6.1` 映像內沒有 `minio`/`outline` 系統使用者。`user:` 設定導致容器無法啟動。

（`postgres` 和 `redis` 的 `user:` 保留，因為它們的官方映像確實定義了這些使用者。）

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)