### PR TITLE
fix(deploy): flatten Next.js standalone output before docker build

### DIFF
--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -8,14 +8,16 @@
 
 FROM node:20-alpine
 
+# Prisma schema engine requires OpenSSL
+RUN apk add --no-cache openssl
+
 WORKDIR /app
 
 # Copy only what prisma needs to generate and migrate
 COPY package.json package-lock.json ./
 COPY prisma/ ./prisma/
 
-# Install production prisma CLI + download Linux query engine binary
-# PRISMA_BINARY_TARGETS ensures the correct engine is fetched for linux-musl
+# Install prisma CLI + download Linux query engine binary
 RUN npm ci --ignore-scripts && \
     npx prisma generate
 

--- a/scripts/first-deploy.sh
+++ b/scripts/first-deploy.sh
@@ -213,6 +213,21 @@ build_titan_app() {
     exit 1
   fi
 
+  # Next.js standalone 會將輸出複製到 .next/standalone/<absolute-path>/server.js
+  # 需要拍平到 .next/standalone/server.js 供 Dockerfile COPY 使用
+  local standalone_server
+  standalone_server=$(find ".next/standalone" -name "server.js" -not -path "*/node_modules/*" | head -1)
+  if [[ -n "${standalone_server}" ]] && [[ "${standalone_server}" != ".next/standalone/server.js" ]]; then
+    local standalone_src
+    standalone_src=$(dirname "${standalone_server}")
+    log_info "拍平 standalone 輸出：${standalone_src} → .next/standalone/"
+    cp -rn "${standalone_src}/." ".next/standalone/"
+    # 移除嵌套的路徑目錄（保留 node_modules 和 .next）
+    local nested_top
+    nested_top=$(echo "${standalone_src#.next/standalone/}" | cut -d/ -f1)
+    [[ -n "${nested_top}" ]] && rm -rf ".next/standalone/${nested_top}"
+  fi
+
   # Docker build
   log_info "建構 Docker 映像 titan-app:latest..."
   docker build -t titan-app:latest . 2>&1 | tail -5

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -189,6 +189,19 @@ rebuild_titan_app() {
     return 1
   fi
 
+  # 拍平 standalone 輸出（Next.js 會將 server.js 複製到完整絕對路徑下）
+  local standalone_server
+  standalone_server=$(find ".next/standalone" -name "server.js" -not -path "*/node_modules/*" | head -1)
+  if [[ -n "${standalone_server}" ]] && [[ "${standalone_server}" != ".next/standalone/server.js" ]]; then
+    local standalone_src
+    standalone_src=$(dirname "${standalone_server}")
+    log_info "拍平 standalone 輸出：${standalone_src} → .next/standalone/"
+    cp -rn "${standalone_src}/." ".next/standalone/"
+    local nested_top
+    nested_top=$(echo "${standalone_src#.next/standalone/}" | cut -d/ -f1)
+    [[ -n "${nested_top}" ]] && rm -rf ".next/standalone/${nested_top}"
+  fi
+
   log_info "建構 Docker 映像..."
   docker build -t titan-app:latest . 2>&1 | tail -5
 


### PR DESCRIPTION
## 問題

`titan-app` 容器不斷重啟：`Error: Cannot find module '/app/server.js'`

## 根因

Next.js standalone 建構將 `server.js` 輸出至 `.next/standalone/<完整絕對路徑>/` 而非直接放在 `.next/standalone/` 根目錄。Dockerfile `COPY .next/standalone ./` 因此 copy 到了嵌套路徑，容器啟動找不到 `/app/server.js`。

## 修法

在 `npm run build` 和 `docker build` 之間，加入拍平步驟：找到實際的 `server.js` 位置，將其目錄內容複製到 `.next/standalone/` 根目錄，並移除嵌套路徑目錄。

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)