### PR TITLE
fix(deploy): add sslmode=disable to Outline DATABASE_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       UTILS_SECRET: ${OUTLINE_UTILS_SECRET:?OUTLINE_UTILS_SECRET is required}
       URL: ${OUTLINE_URL:-http://localhost:3001}
       PORT: 3000
-      DATABASE_URL: postgres://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}
+      DATABASE_URL: postgres://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}?sslmode=disable
       DATABASE_CONNECTION_POOL_MIN: 1
       DATABASE_CONNECTION_POOL_MAX: 5
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379


### PR DESCRIPTION
## 問題

`titan-outline` 不斷重啟：`The server does not support SSL connections`

## 修法

Outline `DATABASE_URL` 加上 `?sslmode=disable`，適用於未設 SSL 的 PostgreSQL（air-gapped 預設部署）。

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)