### PR TITLE
fix(deploy): give Outline its own outline database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       UTILS_SECRET: ${OUTLINE_UTILS_SECRET:?OUTLINE_UTILS_SECRET is required}
       URL: ${OUTLINE_URL:-http://localhost:3001}
       PORT: 3000
-      DATABASE_URL: postgres://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-titan}?sslmode=disable
+      DATABASE_URL: postgres://${POSTGRES_USER:-titan}:${POSTGRES_PASSWORD}@postgres:5432/outline?sslmode=disable
       DATABASE_CONNECTION_POOL_MIN: 1
       DATABASE_CONNECTION_POOL_MAX: 5
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379

--- a/scripts/init/01-postgres-init.sql
+++ b/scripts/init/01-postgres-init.sql
@@ -4,6 +4,10 @@
 -- 用途：建立共用資料庫使用者、擴展、功能
 -- ═══════════════════════════════════════════════════════════
 
+-- 建立 Outline 專用資料庫（與 TITAN App 的 titan DB 分離）
+SELECT 'CREATE DATABASE outline'
+  WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'outline')\gexec
+
 -- 建立應用程式專用使用者（非超級使用者）
 -- 注意：實際建立使用者時，請確保使用強密碼
 DO $$


### PR DESCRIPTION
## 問題

Outline migration 失敗：`column "urlId" does not exist`

## 根因

Outline 和 TITAN App 共用 `titan` DB，Prisma schema 和 Outline Sequelize migrations 互相衝突。

## 修法

- `scripts/init/01-postgres-init.sql`：PostgreSQL 啟動時自動建立 `outline` 資料庫
- `docker-compose.yml`：Outline `DATABASE_URL` 改連 `outline` 資料庫

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)