### PR TITLE
fix(T1052): add linux-arm64-openssl-3.0.x binaryTarget + auto-copy Linux Prisma binaries

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x"]
+  binaryTargets = ["native", "debian-openssl-1.1.x", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {

--- a/scripts/first-deploy.sh
+++ b/scripts/first-deploy.sh
@@ -228,6 +228,17 @@ build_titan_app() {
     [[ -n "${nested_top}" ]] && rm -rf ".next/standalone/${nested_top}"
   fi
 
+  # 補充 Linux Prisma binaries 到 standalone
+  # Next.js standalone 僅追蹤 host native binary；Linux target binaries 需手動複製
+  local prisma_src="node_modules/.prisma/client"
+  local prisma_dst=".next/standalone/node_modules/.prisma/client"
+  if [[ -d "${prisma_src}" ]] && [[ -d "${prisma_dst}" ]]; then
+    log_info "補充 Linux Prisma binaries 到 standalone..."
+    for f in "${prisma_src}"/libquery_engine-linux-*.so.node; do
+      [[ -f "${f}" ]] && cp -n "${f}" "${prisma_dst}/" && log_info "  已複製 $(basename "${f}")"
+    done
+  fi
+
   # Docker build
   log_info "建構 Docker 映像 titan-app:latest..."
   docker build -t titan-app:latest . 2>&1 | tail -5

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -202,6 +202,17 @@ rebuild_titan_app() {
     [[ -n "${nested_top}" ]] && rm -rf ".next/standalone/${nested_top}"
   fi
 
+  # 補充 Linux Prisma binaries 到 standalone
+  # Next.js standalone 僅追蹤 host native binary；Linux target binaries 需手動複製
+  local prisma_src="node_modules/.prisma/client"
+  local prisma_dst=".next/standalone/node_modules/.prisma/client"
+  if [[ -d "${prisma_src}" ]] && [[ -d "${prisma_dst}" ]]; then
+    log_info "補充 Linux Prisma binaries 到 standalone..."
+    for f in "${prisma_src}"/libquery_engine-linux-*.so.node; do
+      [[ -f "${f}" ]] && cp -n "${f}" "${prisma_dst}/" && log_info "  已複製 $(basename "${f}")"
+    done
+  fi
+
   log_info "建構 Docker 映像..."
   docker build -t titan-app:latest . 2>&1 | tail -5
 


### PR DESCRIPTION
## 問題

`titan-app` 容器（`aarch64` / OpenSSL 3.0）啟動時報錯：
```
Prisma Client could not locate the Query Engine for runtime "linux-arm64-openssl-3.0.x"
```

根本原因：
1. `schema.prisma` 的 `binaryTargets` 缺少 `linux-arm64-openssl-3.0.x`
2. Next.js standalone 建構只透過 Node File Tracing 追蹤 host-native binary（`darwin-arm64`），Linux binaries 不會自動複製到 `.next/standalone/node_modules/.prisma/client/`

## 修復

- `prisma/schema.prisma`: 加入 `linux-arm64-openssl-3.0.x` binaryTarget
- `scripts/first-deploy.sh`: 在 standalone flatten 後，補充複製所有 `libquery_engine-linux-*.so.node` 到 standalone
- `scripts/upgrade.sh`: 同上

## 驗證

- `docker compose ps titan-app` → `Up ... (healthy)` ✅

Closes #1052