### PR TITLE
fix(T1054): broaden Prisma binary copy to cover debian-* (x86) targets

### DIFF
--- a/scripts/first-deploy.sh
+++ b/scripts/first-deploy.sh
@@ -234,7 +234,7 @@ build_titan_app() {
   local prisma_dst=".next/standalone/node_modules/.prisma/client"
   if [[ -d "${prisma_src}" ]] && [[ -d "${prisma_dst}" ]]; then
     log_info "補充 Linux Prisma binaries 到 standalone..."
-    for f in "${prisma_src}"/libquery_engine-linux-*.so.node; do
+    for f in "${prisma_src}"/libquery_engine-*.so.node; do
       [[ -f "${f}" ]] && cp -n "${f}" "${prisma_dst}/" && log_info "  已複製 $(basename "${f}")"
     done
   fi

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -208,7 +208,7 @@ rebuild_titan_app() {
   local prisma_dst=".next/standalone/node_modules/.prisma/client"
   if [[ -d "${prisma_src}" ]] && [[ -d "${prisma_dst}" ]]; then
     log_info "補充 Linux Prisma binaries 到 standalone..."
-    for f in "${prisma_src}"/libquery_engine-linux-*.so.node; do
+    for f in "${prisma_src}"/libquery_engine-*.so.node; do
       [[ -f "${f}" ]] && cp -n "${f}" "${prisma_dst}/" && log_info "  已複製 $(basename "${f}")"
     done
   fi


### PR DESCRIPTION
## 問題

#1053 的 copy pattern `libquery_engine-linux-*.so.node` 只匹配 ARM64，不匹配 x86 Debian binary（`libquery_engine-debian-openssl-3.0.x.so.node`）。

x86 機器部署時 `titan-app` 會報：
```
Prisma Client could not locate the Query Engine for runtime "debian-openssl-3.0.x"
```

## 修復

兩個部署腳本的 copy pattern：
- 舊：`libquery_engine-linux-*.so.node`
- 新：`libquery_engine-*.so.node`

`.so.node` = 所有 Linux variants（ARM64 + x86 + musl）
`.dylib.node` = macOS → 不匹配，不會被錯誤複製進容器

Closes #1054