### PR TITLE
fix(T1058): add basePath /titan + fix middleware public route bypass

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     ports:
       - "${TITAN_PORT:-3100}:3100"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/api/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/titan/api/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -34,7 +34,8 @@ export async function checkAuth(
   req: NextRequest,
   requestId: string
 ): Promise<NextResponse | null> {
-  const { pathname } = new URL(req.url);
+  // req.nextUrl.pathname strips basePath automatically (unlike new URL(req.url).pathname)
+  const pathname = req.nextUrl.pathname;
 
   if (shouldBypassAuth(pathname)) {
     return null; // allow — CSP/correlation still applied by caller

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   poweredByHeader: false,
+  basePath: "/titan",
 
   // Feature flag: TITAN_V2_ENABLED — toggle new vs old UI (Issue #970)
   env: {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,7 +44,7 @@ http {
     server {
         listen 443 ssl;
         listen [::]:443 ssl;
-        server_name titan.bank.local localhost;
+        server_name titan.bank.local mac-mini.tailde842d.ts.net localhost;
 
         # 通用安全 headers
         add_header X-Frame-Options SAMEORIGIN always;
@@ -60,12 +60,9 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # ── TITAN App（/titan 路徑，strip prefix）────────────────────────────
+        # ── TITAN App（/titan 路徑，保留前綴）──────────────────────────────────
+        # basePath: "/titan" 已設定於 next.config.ts，不需 strip prefix
         location /titan {
-            # Rewrite /titan → / before proxying
-            rewrite ^/titan(/.*)$ $1 break;
-            rewrite ^/titan$ / break;
-
             proxy_pass http://titan-app:3100;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -273,7 +273,7 @@ rolling_update() {
   local waited=0
 
   while [[ ${waited} -lt ${max_wait} ]]; do
-    if docker compose exec -T titan-app wget -qO- http://localhost:3100/api/health &>/dev/null 2>&1; then
+    if docker compose exec -T titan-app wget -qO- http://localhost:3100/titan/api/health &>/dev/null 2>&1; then
       log_ok "titan-app 健康檢查通過（${waited}s）"
       return 0
     fi
@@ -310,7 +310,7 @@ run_health_check() {
   fi
 
   # TITAN App
-  if docker compose exec -T titan-app wget -qO- http://localhost:3100/api/health &>/dev/null 2>&1; then
+  if docker compose exec -T titan-app wget -qO- http://localhost:3100/titan/api/health &>/dev/null 2>&1; then
     log_ok "TITAN App：正常"
   else
     log_error "TITAN App：無回應"


### PR DESCRIPTION
## 問題

\`basePath: \"/titan\"\` 未設定，導致 Next.js 所有 asset/API 路徑缺少 \`/titan\` 前綴，造成 client-side exception。

## 根本原因連鎖

1. **無 basePath** → \`/_next/static/...\` 被 nginx 路由到 Homepage 而非 titan-app
2. **加了 basePath 後**，middleware 的 \`new URL(req.url).pathname\` 返回 \`/titan/api/health\`，但 \`AUTH_BYPASS_EXACT\` 只有 \`/api/health\` → health endpoint 被 auth 攔截 → Docker healthcheck unhealthy
3. **healthcheck URL** 也需更新：\`/api/health\` → \`/titan/api/health\`

## 修復

| 檔案 | 修改 |
|------|------|
| \`next.config.ts\` | 加入 \`basePath: \"/titan\"\` |
| \`lib/middleware/auth.ts\` | \`new URL(req.url).pathname\` → \`req.nextUrl.pathname\`（自動去掉 basePath）|
| \`docker-compose.yml\` | healthcheck URL 加 \`/titan\` 前綴 |
| \`scripts/upgrade.sh\` | 同上 |
| \`nginx/nginx.conf\` | 移除 \`/titan\` rewrite strip（app 自行處理前綴）|

## 驗證

```
https://mac-mini.tailde842d.ts.net/titan/api/health → {"status":"ok",...} ✅
titan-app container: healthy ✅
```

Closes #1058