### PR TITLE
fix: basePath-aware login redirect + root / → /titan

### DIFF
--- a/lib/middleware/auth.ts
+++ b/lib/middleware/auth.ts
@@ -48,7 +48,9 @@ export async function checkAuth(
     const cookieHeader = req.headers.get("cookie") ?? "";
     const hasSession = cookieHeader.includes("authjs.session-token");
     if (!hasSession) {
-      const loginUrl = new URL("/login", req.url);
+      // Use req.nextUrl.clone() so NextURL preserves basePath in the redirect
+      const loginUrl = req.nextUrl.clone();
+      loginUrl.pathname = "/login";
       loginUrl.searchParams.set("callbackUrl", pathname);
       const redirectRes = NextResponse.redirect(loginUrl);
       redirectRes.headers.set("x-request-id", requestId);

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -51,13 +51,9 @@ http {
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
 
-        # ── Homepage（根路徑）────────────────────────────────────────────────
-        location / {
-            proxy_pass http://titan-homepage:3000;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+        # ── 根路徑 → 重導至 TITAN App ────────────────────────────────────────
+        location = / {
+            return 301 /titan;
         }
 
         # ── TITAN App（/titan 路徑，保留前綴）──────────────────────────────────


### PR DESCRIPTION
## 問題

1. `https://mac-mini.tailde842d.ts.net/` 顯示舊系統（Homepage 服務）
2. `/titan` 點進去報錯 — unauthenticated redirect 到 `/login`（無 basePath），造成 404

## 根本原因

`lib/middleware/auth.ts` 使用 `new URL("/login", req.url)` 構建 redirect URL。`req.url` 含完整路徑，`/login` 解析到 origin root，得到 `/login` 而非 `/titan/login`。

## 修復

| 檔案 | 修改 |
|------|------|
| `nginx/nginx.conf` | `location /` 從 proxy homepage 改為 `301 /titan` |
| `lib/middleware/auth.ts` | `new URL("/login", req.url)` → `req.nextUrl.clone()` + 設 `.pathname`（NextURL 自動保留 basePath）|

## 驗證

```
https://mac-mini.tailde842d.ts.net/       → 301 → /titan ✅
https://mac-mini.tailde842d.ts.net/titan  → 307 → /titan/dashboard → 302 → /titan/login ✅
https://mac-mini.tailde842d.ts.net/titan/login → HTTP 200 ✅
```