### PR TITLE
fix(T1058): remove basePath, serve titan-app at root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     ports:
       - "${TITAN_PORT:-3100}:3100"
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/titan/api/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/api/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,7 +16,6 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   output: "standalone",
   poweredByHeader: false,
-  basePath: "/titan",
 
   // Feature flag: TITAN_V2_ENABLED — toggle new vs old UI (Issue #970)
   env: {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -51,14 +51,8 @@ http {
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
 
-        # ── 根路徑 → 重導至 TITAN App ────────────────────────────────────────
-        location = / {
-            return 301 /titan;
-        }
-
-        # ── TITAN App（/titan 路徑，保留前綴）──────────────────────────────────
-        # basePath: "/titan" 已設定於 next.config.ts，不需 strip prefix
-        location /titan {
+        # ── TITAN App（根路徑，直接代理）─────────────────────────────────────
+        location / {
             proxy_pass http://titan-app:3100;
             proxy_http_version 1.1;
             proxy_set_header Host $host;

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -273,7 +273,7 @@ rolling_update() {
   local waited=0
 
   while [[ ${waited} -lt ${max_wait} ]]; do
-    if docker compose exec -T titan-app wget -qO- http://localhost:3100/titan/api/health &>/dev/null 2>&1; then
+    if docker compose exec -T titan-app wget -qO- http://localhost:3100/api/health &>/dev/null 2>&1; then
       log_ok "titan-app 健康檢查通過（${waited}s）"
       return 0
     fi
@@ -310,7 +310,7 @@ run_health_check() {
   fi
 
   # TITAN App
-  if docker compose exec -T titan-app wget -qO- http://localhost:3100/titan/api/health &>/dev/null 2>&1; then
+  if docker compose exec -T titan-app wget -qO- http://localhost:3100/api/health &>/dev/null 2>&1; then
     log_ok "TITAN App：正常"
   else
     log_error "TITAN App：無回應"


### PR DESCRIPTION
## 問題

`basePath: "/titan"` 與 Auth.js v5 不相容：

1. Next.js strip basePath → route handler 的 `req.url` 不含 `/titan`
2. Auth.js 從 `AUTH_URL` 路徑自動讀取 basePath → 設為 `/titan`
3. Auth.js 嘗試匹配 `^/titan(.+)` vs 實際路徑 `/api/auth/csrf` → 永遠失敗 → "Bad request."

## 方案

移除 basePath，titan-app 直接服務在 root：

| 修改 | 說明 |
|------|------|
| `next.config.ts` | 移除 `basePath: "/titan"` |
| `auth.ts` | 移除 `trustHost`、還原 route handler |
| `nginx.conf` | `/` → titan-app:3100（直接 proxy） |
| `docker-compose.yml` | healthcheck 回 `/api/health` |
| `scripts/upgrade.sh` | 同上 |
| `.env` | `TITAN_URL=https://mac-mini.tailde842d.ts.net`（無路徑） |

## 驗證

```
Auth CSRF: {"csrfToken":"..."} ✅
Health:    {"status":"ok"} ✅
Login:     HTTP 200 → /login?callbackUrl=%2Fdashboard ✅
```

Closes #1058