### PR TITLE
feat(T1062): CSRF SameSite=Lax + auto-append @titan.local

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -55,7 +55,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       name: "authjs.csrf-token",
       options: {
         httpOnly: true,
-        sameSite: "strict",
+        sameSite: "lax",
         path: "/",
         secure: process.env.NODE_ENV === "production",
       },
@@ -73,7 +73,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           return null;
         }
 
-        const username = credentials.username as string;
+        const rawUsername = credentials.username as string;
+        const username = rawUsername.includes("@") ? rawUsername : `${rawUsername}@titan.local`;
         const password = credentials.password as string;
 
         const ip =


### PR DESCRIPTION
## 修改

| 項目 | 變更 |
|------|------|
| CSRF cookie | `sameSite: strict` → `lax`（修復 MissingCSRF 登入失敗）|
| 帳號輸入 | 不含 `@` 時自動補 `@titan.local`（輸入 `admin` 即可登入）|

Closes #1062