### PR TITLE
feat: UX Phase 1 — 版本號統一 + 密碼強度 + 報表引導 + 活動日誌

### DIFF
--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -27,7 +27,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractData } from "@/lib/api-client";
-import { PageLoading, PageError } from "@/app/components/page-states";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { safeFixed, safePct } from "@/lib/safe-number";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -164,7 +164,7 @@ function UtilizationReport({ from, to }: { from: string; to: string }) {
       </div>
 
       {data.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">此期間無工時資料</p>
+        <PageEmpty icon={<Users className="h-5 w-5" />} title="此期間無工時資料" description="團隊成員開始登記工時後，利用率數據將自動產生" />
       ) : (
         <div className="grid gap-2" role="table" aria-label="團隊利用率">
           <div className="grid grid-cols-4 gap-2 text-xs font-medium text-muted-foreground px-3 py-2" role="row">
@@ -267,7 +267,7 @@ function VelocityReport({ from, to }: { from: string; to: string }) {
       </div>
 
       {data.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">此期間無完成任務</p>
+        <PageEmpty icon={<TrendingUp className="h-5 w-5" />} title="此期間無完成任務" description="任務完成後將自動統計速率趨勢" />
       ) : (
         <div className="space-y-3">
           <div className="flex items-end gap-1 h-48 px-2" role="img" aria-label="任務速率長條圖">
@@ -367,7 +367,7 @@ function KPITrendReport({ from, to }: { from: string; to: string }) {
       </div>
 
       {data.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">此期間無 KPI 資料</p>
+        <PageEmpty icon={<Target className="h-5 w-5" />} title="此期間無 KPI 資料" description="建立 KPI 指標並連結任務後，達成率將自動計算" />
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-sm" role="table">
@@ -496,7 +496,7 @@ function UnplannedTrendReport({ from, to }: { from: string; to: string }) {
       </div>
 
       {data.length === 0 ? (
-        <p className="text-sm text-muted-foreground py-8 text-center">此期間無資料</p>
+        <PageEmpty icon={<AlertTriangle className="h-5 w-5" />} title="此期間無計畫外事件" description="當任務被標記為計畫外時，趨勢數據將自動產生" />
       ) : (
         <div className="space-y-3">
           {data.map((point) => (

--- a/app/(auth)/change-password/page.tsx
+++ b/app/(auth)/change-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
+import { PasswordStrengthIndicator } from "@/app/components/password-strength-indicator";
 import { PASSWORD_POLICY_DESCRIPTION } from "@/lib/password-policy";
 
 export default function ChangePasswordPage() {
@@ -92,6 +93,7 @@ export default function ChangePasswordPage() {
               minLength={12}
               autoComplete="new-password"
             />
+            {newPassword && <PasswordStrengthIndicator password={newPassword} />}
           </div>
 
           <div className="space-y-1.5">

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -68,7 +68,7 @@ export default function LoginPage() {
           </button>
         </form>
       </div>
-      <p className="text-center text-[11px] text-muted-foreground/50 mt-6">&copy; 2026 TITAN v1.0</p>
+      <p className="text-center text-[11px] text-muted-foreground/50 mt-6">&copy; 2026 TITAN v{process.env.NEXT_PUBLIC_APP_VERSION}</p>
     </div>
   );
 }

--- a/app/components/sidebar.tsx
+++ b/app/components/sidebar.tsx
@@ -114,7 +114,7 @@ export function Sidebar() {
             </button>
           </SimpleTooltip>
         ) : (
-          <p className="font-mono text-[11px] text-muted-foreground/60 tabular-nums px-3 py-1">v2.0.0</p>
+          <p className="font-mono text-[11px] text-muted-foreground/60 tabular-nums px-3 py-1">v{process.env.NEXT_PUBLIC_APP_VERSION}</p>
         )}
       </div>
     </aside>

--- a/lib/utils/activity-formatter.ts
+++ b/lib/utils/activity-formatter.ts
@@ -8,21 +8,56 @@
 // ── Action → Label mapping ─────────────────────────────────────────────────
 
 const ACTION_LABELS: Record<string, string> = {
+  // General CRUD
   CREATE: "建立了",
   UPDATE: "更新了",
   DELETE: "刪除了",
+  // Task
   STATUS_CHANGE: "變更了狀態",
   STATUS_CHANGED: "變更了狀態",
+  PRIORITY_CHANGED: "變更了優先度",
+  ASSIGNEE_CHANGED: "變更了負責人",
+  DUE_DATE_CHANGED: "變更了截止日",
   COMMENT: "留言於",
   ASSIGN: "指派了",
   POST_TASKS: "建立了任務",
   PATCH_TASKS: "更新了任務",
   DELETE_TASK: "刪除了任務",
-  ROLE_CHANGE: "變更了角色",
-  PASSWORD_CHANGE: "變更了密碼",
-  LOGIN_FAILURE: "登入失敗",
+  GANTT_DATE_CHANGE: "調整了甘特圖日期",
+  // Auth / User
   LOGIN: "登入了系統",
   LOGOUT: "登出了系統",
+  LOGIN_FAILURE: "登入失敗",
+  ROLE_CHANGE: "變更了角色",
+  PASSWORD_CHANGE: "變更了密碼",
+  PASSWORD_RESET_TOKEN_GENERATED: "產生了密碼重設連結",
+  PASSWORD_RESET_COMPLETED: "完成了密碼重設",
+  ACCOUNT_UNLOCK: "解鎖了帳號",
+  CREATE_USER: "建立了使用者",
+  UPDATE_USER: "更新了使用者",
+  SUSPEND_USER: "停用了使用者",
+  UNSUSPEND_USER: "恢復了使用者",
+  // Time entries
+  UPDATE_TIME_ENTRY: "更新了工時",
+  DELETE_TIME_ENTRY: "刪除了工時",
+  BATCH_APPROVE_TIME_ENTRIES: "批次核准了工時",
+  BATCH_REJECT_TIME_ENTRIES: "批次退回了工時",
+  REQUEST_UNLOCK_TIME_ENTRY: "申請了工時解鎖",
+  // Documents
+  DELETE_DOCUMENT: "刪除了文件",
+  APPROVE: "核准了",
+  REJECT: "退回了",
+  // KPI / Permissions / Incidents
+  UPSERT_KPI_ACHIEVEMENT: "更新了 KPI 達成紀錄",
+  GRANT_PERMISSION: "授予了權限",
+  REVOKE_PERMISSION: "撤銷了權限",
+  CREATE_INCIDENT_RECORD: "建立了事件紀錄",
+  UPDATE_INCIDENT_RECORD: "更新了事件紀錄",
+  CREATE_CHANGE_RECORD: "建立了變更紀錄",
+  UPDATE_CHANGE_RECORD: "更新了變更紀錄",
+  // Other
+  KUDOS: "給了讚",
+  FRONTEND_ERROR: "回報了前端錯誤",
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -82,6 +117,25 @@ export function formatActivityDescription(item: ActivityData): string {
     if (to) {
       const toLabel = STATUS_LABELS[to as string] ?? to;
       return `${who} 將${resourceLabel}${resourceName}狀態改為 ${toLabel}`;
+    }
+  }
+
+  // Priority change with detail
+  if (item.action === "PRIORITY_CHANGED" && item.detail && typeof item.detail === "object") {
+    const d = item.detail as Record<string, unknown>;
+    const from = d.from || d.oldPriority;
+    const to = d.to || d.priority || d.newPriority;
+    if (from && to) {
+      return `${who} 將${resourceLabel}${resourceName}優先度從 ${from} 改為 ${to}`;
+    }
+  }
+
+  // Assignee change with detail
+  if (item.action === "ASSIGNEE_CHANGED" && item.detail && typeof item.detail === "object") {
+    const d = item.detail as Record<string, unknown>;
+    const to = d.assigneeName || d.to;
+    if (to) {
+      return `${who} 將${resourceLabel}${resourceName}指派給 ${to}`;
     }
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,7 @@ const nextConfig: NextConfig = {
   // Feature flag: TITAN_V2_ENABLED — toggle new vs old UI (Issue #970)
   env: {
     NEXT_PUBLIC_TITAN_V2_ENABLED: process.env.TITAN_V2_ENABLED ?? "true",
+    NEXT_PUBLIC_APP_VERSION: require("./package.json").version ?? "0.0.0",
   },
 
   async headers() {


### PR DESCRIPTION
## Phase 1 Quick Wins（4 項）

| Issue | 修改 | 複雜度 |
|-------|------|--------|
| #1064 UX-08 | 版本號從 package.json 讀取，替換 sidebar/login 硬編碼 | S |
| #1065 UX-09 | change-password 頁面引用已存在的 PasswordStrengthIndicator | S |
| #1066 UX-02 | 4 個報表空狀態改用 PageEmpty + icon + 操作引導文字 | S |
| #1067 UX-01 | activity-formatter 補齊 25+ action type + priority/assignee 格式化 | S |

Closes #1064, Closes #1065, Closes #1066, Closes #1067