### PR TITLE
feat: UX Phase 2 — drag hint, Outline error, prompt→dialog, timer, bulk deadline, B角

### DIFF
--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -22,6 +22,7 @@ import {
   X,
   MousePointerSquareDashed,
   Check,
+  GripVertical,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -120,6 +121,13 @@ export default function KanbanPage() {
   >([]);
   const [filters, setFilters] = useState<FiltersType>({ ...emptyFilters });
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [showDragHint, setShowDragHint] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && !localStorage.getItem("titan-kanban-onboarded")) {
+      setShowDragHint(true);
+    }
+  }, []);
   const [dragOver, setDragOver] = useState<TaskStatus | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [movingTask, setMovingTask] = useState<string | null>(null);
@@ -575,6 +583,25 @@ export default function KanbanPage() {
           </button>
         </div>
       </div>
+
+      {/* Drag-and-drop onboarding hint (Issue #1068) */}
+      {showDragHint && (
+        <div className="flex items-center gap-3 px-4 py-2.5 bg-primary/5 border border-primary/20 rounded-lg text-sm flex-shrink-0">
+          <GripVertical className="h-4 w-4 text-primary shrink-0" />
+          <span className="text-foreground/80">
+            <strong>拖曳卡片</strong>到不同欄位即可變更任務狀態
+          </span>
+          <button
+            onClick={() => {
+              setShowDragHint(false);
+              localStorage.setItem("titan-kanban-onboarded", "1");
+            }}
+            className="ml-auto text-muted-foreground hover:text-foreground shrink-0"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
 
       {/* Filters */}
       <div className="flex-shrink-0">

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -546,21 +546,21 @@ export default function KanbanPage() {
           </button>
           <button
             onClick={async () => {
-              const title = prompt("任務標題：");
-              if (!title?.trim()) return;
               const res = await fetch("/api/tasks", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                  title: title.trim(),
+                  title: "新任務",
                   status: "BACKLOG",
                   priority: "P2",
                   category: "PLANNED",
                 }),
               });
               if (res.ok) {
-                toast.success("任務已建立");
-                fetchTasks();
+                const created = await res.json();
+                const newId = created.id ?? created.data?.id;
+                await fetchTasks();
+                if (newId) setSelectedTaskId(newId);
               } else {
                 const errBody = await res.json().catch(() => ({}));
                 toast.error(

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -695,6 +695,19 @@ export default function KanbanPage() {
             ))}
           </select>
 
+          {/* Bulk deadline (Issue #1071) */}
+          <input
+            type="date"
+            onChange={(e) => {
+              if (e.target.value) {
+                executeBulkAction({ dueDate: new Date(e.target.value).toISOString() });
+                e.target.value = "";
+              }
+            }}
+            className="h-7 px-2 text-xs border border-border rounded-md bg-background text-foreground cursor-pointer"
+            title="批次設定截止日"
+          />
+
           {bulkLoading && (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           )}

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -7,7 +7,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
-import { useConfirmDialog } from "@/app/components/ui/alert-dialog";
+import { useConfirmDialog, usePromptDialog } from "@/app/components/ui/alert-dialog";
 import { extractItems, extractData } from "@/lib/api-client";
 import { DocumentTree, type DocNode } from "@/app/components/document-tree";
 import { MarkdownEditor } from "@/app/components/markdown-editor";
@@ -67,8 +67,58 @@ const TEMPLATE_OPTIONS = [
   { key: "tech-doc", label: "技術文件", icon: Monitor },
 ] as const;
 
+/** Outline iframe wrapper with loading + timeout error handling (Issue #1069) */
+function OutlineIframeWrapper({ url, onFallback }: { url: string; onFallback: () => void }) {
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setStatus((s) => (s === "loading" ? "error" : s));
+    }, 15000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (status === "error") {
+    return (
+      <div className="flex-1 min-h-0 border border-border rounded-xl flex items-center justify-center">
+        <div className="text-center max-w-sm">
+          <AlertCircle className="h-10 w-10 text-destructive/40 mx-auto mb-3" />
+          <h2 className="text-base font-medium text-foreground mb-1">無法連線至 Outline</h2>
+          <p className="text-sm text-muted-foreground">
+            Outline 服務可能尚未啟動或網路不可達，請確認服務狀態後重試。
+          </p>
+          <button
+            onClick={onFallback}
+            className="mt-4 text-sm font-medium px-4 py-2 bg-accent hover:bg-accent/80 text-accent-foreground rounded-md transition-colors"
+          >
+            切換至文件編輯器
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 min-h-0 border border-border rounded-xl overflow-hidden relative">
+      {status === "loading" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/80 z-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      <iframe
+        src={url}
+        title="Outline 知識庫"
+        className="w-full h-full border-0"
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
+        onLoad={() => setStatus("ready")}
+      />
+    </div>
+  );
+}
+
 export default function KnowledgePage() {
   const { confirmDialog, ConfirmDialog } = useConfirmDialog();
+  const { promptDialog, PromptDialog } = usePromptDialog();
   const [docs, setDocs] = useState<DocNode[]>([]);
   const [loadingDocs, setLoadingDocs] = useState(true);
   const [docsError, setDocsError] = useState<string | null>(null);
@@ -213,7 +263,7 @@ export default function KnowledgePage() {
   }
 
   async function createDoc(parentId: string | null, templateType?: string) {
-    const title = templateType ? "" : prompt("新文件標題：");
+    const title = templateType ? "" : await promptDialog({ title: "新文件標題", placeholder: "輸入文件名稱" });
     if (!templateType && !title?.trim()) return;
     setShowTemplates(false);
 
@@ -241,7 +291,7 @@ export default function KnowledgePage() {
   }
 
   async function createSpace() {
-    const name = prompt("Space 名稱：");
+    const name = await promptDialog({ title: "新增 Space", placeholder: "輸入空間名稱" });
     if (!name?.trim()) return;
     const res = await fetch("/api/spaces", {
       method: "POST",
@@ -378,16 +428,9 @@ export default function KnowledgePage() {
         </div>
       </div>
 
-      {/* Outline iframe view */}
+      {/* Outline iframe view with error handling (Issue #1069) */}
       {viewMode === "outline" && isOutlineConfigured && (
-        <div className="flex-1 min-h-0 border border-border rounded-xl overflow-hidden">
-          <iframe
-            src={OUTLINE_URL}
-            title="Outline 知識庫"
-            className="w-full h-full border-0"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox"
-          />
-        </div>
+        <OutlineIframeWrapper url={OUTLINE_URL} onFallback={() => setViewMode("editor")} />
       )}
 
       {/* Outline not configured fallback */}
@@ -645,6 +688,7 @@ export default function KnowledgePage() {
         </div>
       )}
       <ConfirmDialog />
+      <PromptDialog />
     </div>
   );
 }

--- a/app/(app)/work/page.tsx
+++ b/app/(app)/work/page.tsx
@@ -136,20 +136,22 @@ function WorkspaceContent() {
           {/* Add task */}
           <button
             onClick={async () => {
-              const title = prompt("任務標題：");
-              if (!title?.trim()) return;
               const res = await fetch("/api/tasks", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                  title: title.trim(),
+                  title: "新任務",
                   status: "BACKLOG",
                   priority: "P2",
                   category: "PLANNED",
                 }),
               });
-              if (res.ok) { toast.success("任務已建立"); ws.refresh(); }
-              else {
+              if (res.ok) {
+                const created = await res.json();
+                const newId = created.id ?? created.data?.id;
+                ws.refresh();
+                if (newId) setSelectedTaskId(newId);
+              } else {
                 const errBody = await res.json().catch(() => ({}));
                 toast.error(errBody?.message ?? errBody?.error ?? "建立失敗");
               }

--- a/app/components/task-detail/task-form-fields.tsx
+++ b/app/components/task-detail/task-form-fields.tsx
@@ -198,6 +198,25 @@ export function TaskFormFields({ form, onFieldChange, users, goals, errors }: Ta
             <option value="">未指派</option>
             {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
           </select>
+          {/* Auto-suggest B角 (Issue #1072) */}
+          {form.primaryAssigneeId && !form.backupAssigneeId && (() => {
+            const suggestions = users.filter((u) => u.id !== form.primaryAssigneeId).slice(0, 3);
+            return suggestions.length > 0 ? (
+              <div className="flex items-center gap-1 mt-1">
+                <span className="text-[11px] text-muted-foreground">建議：</span>
+                {suggestions.map((u) => (
+                  <button
+                    key={u.id}
+                    type="button"
+                    onClick={() => onFieldChange("backupAssigneeId", u.id)}
+                    className="text-[11px] px-1.5 py-0.5 rounded bg-accent hover:bg-accent/80 text-accent-foreground transition-colors"
+                  >
+                    {u.name}
+                  </button>
+                ))}
+              </div>
+            ) : null;
+          })()}
         </div>
       </div>
 

--- a/app/components/topbar-timer-indicator.tsx
+++ b/app/components/topbar-timer-indicator.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * Topbar Timer Indicator — Issue #1070 (UX-06)
+ *
+ * Shows a mini elapsed-time badge when a time entry is running.
+ * Polls /api/time-entries/running on mount and every 30s.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { Timer, Square } from "lucide-react";
+import Link from "next/link";
+import { SimpleTooltip } from "@/app/components/ui/tooltip";
+import { toast } from "sonner";
+
+function formatElapsed(startIso: string): string {
+  const diff = Math.max(0, Math.floor((Date.now() - new Date(startIso).getTime()) / 1000));
+  const h = Math.floor(diff / 3600);
+  const m = Math.floor((diff % 3600) / 60);
+  const s = diff % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+export function TopbarTimerIndicator() {
+  const [running, setRunning] = useState<{ id: string; startTime: string; description?: string } | null>(null);
+  const [display, setDisplay] = useState("00:00:00");
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  async function fetchRunning() {
+    try {
+      const res = await fetch("/api/time-entries/running");
+      if (res.ok) {
+        const body = await res.json();
+        const entry = body.data ?? body;
+        if (entry?.id && entry?.startTime) {
+          setRunning(entry);
+        } else {
+          setRunning(null);
+        }
+      } else {
+        setRunning(null);
+      }
+    } catch {
+      setRunning(null);
+    }
+  }
+
+  useEffect(() => {
+    fetchRunning();
+    const poll = setInterval(fetchRunning, 30000);
+    return () => clearInterval(poll);
+  }, []);
+
+  useEffect(() => {
+    if (running) {
+      setDisplay(formatElapsed(running.startTime));
+      intervalRef.current = setInterval(() => {
+        setDisplay(formatElapsed(running.startTime));
+      }, 1000);
+    } else {
+      setDisplay("00:00:00");
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  async function stopTimer() {
+    if (!running) return;
+    try {
+      const res = await fetch(`/api/time-entries/${running.id}/stop`, { method: "PATCH" });
+      if (res.ok) {
+        setRunning(null);
+        toast.success("計時已停止");
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (!running) return null;
+
+  return (
+    <SimpleTooltip content={running.description ?? "計時中 — 點擊前往工時頁面"} side="bottom">
+      <div className="flex items-center gap-1.5">
+        <Link
+          href="/timesheet"
+          className="flex items-center gap-1.5 px-2 py-1 rounded-md bg-destructive/10 text-destructive text-xs font-mono tabular-nums hover:bg-destructive/20 transition-colors"
+        >
+          <Timer className="h-3 w-3 animate-pulse" />
+          {display}
+        </Link>
+        <button
+          onClick={stopTimer}
+          className="p-1 rounded hover:bg-destructive/20 text-destructive transition-colors"
+          aria-label="停止計時"
+        >
+          <Square className="h-3 w-3 fill-current" />
+        </button>
+      </div>
+    </SimpleTooltip>
+  );
+}

--- a/app/components/topbar.tsx
+++ b/app/components/topbar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { SimpleTooltip } from "@/app/components/ui/tooltip";
 import { useState, useEffect, useMemo } from "react";
 import { NotificationBell } from "@/app/components/notification-bell";
+import { TopbarTimerIndicator } from "@/app/components/topbar-timer-indicator";
 import { getFlatNavItems, buildLabelMap } from "@/lib/nav-config";
 
 /** Page titles derived from shared nav-config (Issue #1019) */
@@ -94,6 +95,7 @@ export function Topbar() {
         </SimpleTooltip>
         <ThemeToggle />
         <NotificationBell />
+        <TopbarTimerIndicator />
         <div className="w-px h-6 bg-border mx-2" />
         <div className="flex items-center gap-2.5">
           <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center">

--- a/app/components/ui/alert-dialog.tsx
+++ b/app/components/ui/alert-dialog.tsx
@@ -177,6 +177,90 @@ export function useConfirmDialog() {
   return { confirmDialog, ConfirmDialog: ConfirmDialogComponent };
 }
 
+/* ------------------------------------------------------------------ */
+/*  usePromptDialog — async replacement for window.prompt()            */
+/* ------------------------------------------------------------------ */
+
+interface PromptDialogOptions {
+  title: string;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+interface PromptDialogState extends PromptDialogOptions {
+  open: boolean;
+}
+
+/**
+ * Hook that provides an async `prompt()` replacement using TITAN UI.
+ *
+ * Usage:
+ *   const { promptDialog, PromptDialog } = usePromptDialog();
+ *   const value = await promptDialog({ title: "名稱：" });
+ *   if (value) { ... }
+ *   // render <PromptDialog /> somewhere in JSX
+ */
+export function usePromptDialog() {
+  const [state, setState] = React.useState<PromptDialogState>({ open: false, title: "" });
+  const [inputValue, setInputValue] = React.useState("");
+  const resolveRef = React.useRef<((v: string | null) => void) | null>(null);
+
+  const promptDialog = React.useCallback((options: PromptDialogOptions) => {
+    return new Promise<string | null>((resolve) => {
+      resolveRef.current = resolve;
+      setInputValue(options.defaultValue ?? "");
+      setState({ ...options, open: true });
+    });
+  }, []);
+
+  const handleClose = React.useCallback(() => {
+    resolveRef.current?.(null);
+    resolveRef.current = null;
+    setState((s) => ({ ...s, open: false }));
+  }, []);
+
+  const handleConfirm = React.useCallback(() => {
+    resolveRef.current?.(inputValue);
+    resolveRef.current = null;
+    setState((s) => ({ ...s, open: false }));
+  }, [inputValue]);
+
+  const PromptDialogComponent = React.useCallback(
+    () => (
+      <AlertDialog open={state.open} onOpenChange={(open) => { if (!open) handleClose(); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{state.title}</AlertDialogTitle>
+            {state.description && <AlertDialogDescription>{state.description}</AlertDialogDescription>}
+          </AlertDialogHeader>
+          <div className="px-0 py-2">
+            <input
+              autoFocus
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") handleConfirm(); }}
+              placeholder={state.placeholder}
+              className="w-full h-10 px-3 bg-background border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground/60 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/10 transition-all"
+            />
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleClose}>{state.cancelLabel ?? "取消"}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm} className="bg-primary text-primary-foreground hover:bg-primary/90">
+              {state.confirmLabel ?? "確定"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ),
+    [state, inputValue, handleClose, handleConfirm],
+  );
+
+  return { promptDialog, PromptDialog: PromptDialogComponent };
+}
+
 export {
   AlertDialog,
   AlertDialogTrigger,


### PR DESCRIPTION
## Phase 2 Medium Effort（6 項 + 1 額外修正）

| Issue | 修改 |
|-------|------|
| #1068 UX-03 | 看板首次拖拉 onboarding 提示（localStorage 記憶） |
| #1069 UX-04 | Outline iframe 載入超時 15s → 錯誤訊息 + fallback 按鈕 |
| #1075 | **消除全部 `window.prompt()`**：新增 `usePromptDialog` hook + 任務建立改用 TaskDetailModal |
| #1071 UX-10 | 看板批次操作增加截止日 date picker |
| #1070 UX-06 | Topbar 計時器指示器（紅色 badge + 停止按鈕） |
| #1072 UX-07 | B 角自動建議（A 角指定時顯示快速選取按鈕） |

### 新增檔案
- `app/components/topbar-timer-indicator.tsx`

### 修改檔案
- `app/components/ui/alert-dialog.tsx` — 新增 `usePromptDialog`
- `app/(app)/kanban/page.tsx` — drag hint + prompt→modal + bulk deadline
- `app/(app)/knowledge/page.tsx` — Outline wrapper + prompt→dialog
- `app/(app)/work/page.tsx` — prompt→modal
- `app/components/topbar.tsx` — timer indicator
- `app/components/task-detail/task-form-fields.tsx` — B 角建議

Closes #1068, Closes #1069, Closes #1070, Closes #1071, Closes #1072, Closes #1075