### PR TITLE
feat(#1073): 駕駛艙 ECharts 視覺化 — 圓餅圖 + 雷達圖 + 折線圖

### DIFF
--- a/app/(app)/cockpit/page.tsx
+++ b/app/(app)/cockpit/page.tsx
@@ -10,6 +10,7 @@ import { PlanHealthCard } from "@/app/components/cockpit/plan-health-card";
 import { GoalProgressList } from "@/app/components/cockpit/goal-progress-list";
 import { KPIGaugeRow } from "@/app/components/cockpit/kpi-gauge-row";
 import { TaskDistributionChart } from "@/app/components/cockpit/task-distribution-chart";
+import { LazyTaskDistributionPie, LazyKPIRadarChart, LazyGoalTrendLine } from "@/app/components/lazy-echarts";
 import { TimeInvestmentBar } from "@/app/components/cockpit/time-investment-bar";
 import { extractData } from "@/lib/api-client";
 import { formatDate } from "@/lib/format";
@@ -163,6 +164,7 @@ export default function CockpitPage() {
                     交付績效
                   </h3>
                   <TaskDistributionChart distribution={plan.taskDistribution} />
+                  <LazyTaskDistributionPie data={plan.taskDistribution} />
                 </div>
                 {/* Q2: 品質指標 (Quality Metrics) */}
                 <div className="border border-border rounded-lg p-4" data-testid="bsc-q2-quality">
@@ -171,6 +173,7 @@ export default function CockpitPage() {
                     品質指標
                   </h3>
                   <KPIGaugeRow kpis={plan.kpis} />
+                  <LazyKPIRadarChart kpis={plan.kpis} />
                 </div>
                 {/* Q3: 效率分析 (Efficiency Analysis) */}
                 <div className="border border-border rounded-lg p-4" data-testid="bsc-q3-efficiency">
@@ -187,6 +190,7 @@ export default function CockpitPage() {
                     成長學習
                   </h3>
                   <GoalProgressList goals={plan.goals} />
+                  <LazyGoalTrendLine goals={plan.goals} />
                 </div>
               </div>
             </div>

--- a/app/components/cockpit/goal-trend-line.tsx
+++ b/app/components/cockpit/goal-trend-line.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+/**
+ * Goal Completion Trend Line Chart — Issue #1073 (UX-05)
+ *
+ * ECharts line chart showing monthly goal completion rate in cockpit Q4.
+ */
+
+import { useRef, useEffect } from "react";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import { CanvasRenderer } from "echarts/renderers";
+import { TooltipComponent, GridComponent } from "echarts/components";
+
+echarts.use([LineChart, CanvasRenderer, TooltipComponent, GridComponent]);
+
+interface GoalSummary {
+  month: number;
+  taskCount: number;
+  completedTaskCount: number;
+}
+
+export function GoalTrendLine({ goals }: { goals: GoalSummary[] }) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstance = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current || goals.length === 0) return;
+    if (!chartInstance.current) {
+      chartInstance.current = echarts.init(chartRef.current);
+    }
+
+    const sorted = [...goals].sort((a, b) => a.month - b.month);
+    const months = sorted.map((g) => `${g.month}月`);
+    const rates = sorted.map((g) =>
+      g.taskCount > 0 ? Math.round((g.completedTaskCount / g.taskCount) * 100) : 0
+    );
+
+    chartInstance.current.setOption({
+      tooltip: { trigger: "axis", formatter: "{b}: {c}%" },
+      grid: { top: 10, right: 10, bottom: 25, left: 35 },
+      xAxis: { type: "category", data: months, axisLabel: { fontSize: 10, color: "#888" }, axisLine: { lineStyle: { color: "#e2e8f0" } } },
+      yAxis: { type: "value", max: 100, axisLabel: { fontSize: 10, color: "#888", formatter: "{value}%" }, splitLine: { lineStyle: { color: "rgba(148,163,184,0.15)" } } },
+      series: [{
+        type: "line",
+        data: rates,
+        smooth: true,
+        symbol: "circle",
+        symbolSize: 6,
+        lineStyle: { color: "#8b5cf6", width: 2 },
+        itemStyle: { color: "#8b5cf6" },
+        areaStyle: { color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+          { offset: 0, color: "rgba(139,92,246,0.2)" },
+          { offset: 1, color: "rgba(139,92,246,0.02)" },
+        ]) },
+      }],
+    });
+
+    const handleResize = () => chartInstance.current?.resize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [goals]);
+
+  useEffect(() => () => chartInstance.current?.dispose(), []);
+
+  if (goals.length === 0) return null;
+
+  return <div ref={chartRef} className="w-full h-48" />;
+}

--- a/app/components/cockpit/kpi-radar-chart.tsx
+++ b/app/components/cockpit/kpi-radar-chart.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * KPI Radar Chart — Issue #1073 (UX-05)
+ *
+ * ECharts radar chart showing multi-KPI achievement rates in cockpit Q2.
+ */
+
+import { useRef, useEffect } from "react";
+import * as echarts from "echarts/core";
+import { RadarChart } from "echarts/charts";
+import { CanvasRenderer } from "echarts/renderers";
+import { TooltipComponent } from "echarts/components";
+
+echarts.use([RadarChart, CanvasRenderer, TooltipComponent]);
+
+interface KPISummary {
+  name: string;
+  achievementRate: number;
+}
+
+export function KPIRadarChart({ kpis }: { kpis: KPISummary[] }) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstance = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current || kpis.length === 0) return;
+    if (!chartInstance.current) {
+      chartInstance.current = echarts.init(chartRef.current);
+    }
+
+    const indicators = kpis.map((k) => ({
+      name: k.name.length > 8 ? k.name.slice(0, 8) + "…" : k.name,
+      max: 100,
+    }));
+    const values = kpis.map((k) => Math.min(k.achievementRate, 100));
+
+    chartInstance.current.setOption({
+      tooltip: { trigger: "item" },
+      radar: {
+        indicator: indicators,
+        shape: "circle",
+        splitNumber: 4,
+        axisName: { color: "#888", fontSize: 10 },
+        splitArea: { areaStyle: { color: ["rgba(99,102,241,0.02)", "rgba(99,102,241,0.05)"] } },
+        splitLine: { lineStyle: { color: "rgba(148,163,184,0.2)" } },
+      },
+      series: [{
+        type: "radar",
+        data: [{
+          value: values,
+          name: "KPI 達成率",
+          areaStyle: { color: "rgba(99,102,241,0.15)" },
+          lineStyle: { color: "#6366f1", width: 2 },
+          itemStyle: { color: "#6366f1" },
+        }],
+      }],
+    });
+
+    const handleResize = () => chartInstance.current?.resize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [kpis]);
+
+  useEffect(() => () => chartInstance.current?.dispose(), []);
+
+  if (kpis.length < 3) return null;
+
+  return <div ref={chartRef} className="w-full h-48" />;
+}

--- a/app/components/cockpit/task-distribution-pie.tsx
+++ b/app/components/cockpit/task-distribution-pie.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+/**
+ * Task Distribution Pie Chart — Issue #1073 (UX-05)
+ *
+ * ECharts pie chart showing task status distribution in cockpit Q1.
+ */
+
+import { useRef, useEffect } from "react";
+import * as echarts from "echarts/core";
+import { PieChart } from "echarts/charts";
+import { CanvasRenderer } from "echarts/renderers";
+import { TooltipComponent, LegendComponent } from "echarts/components";
+
+echarts.use([PieChart, CanvasRenderer, TooltipComponent, LegendComponent]);
+
+interface TaskDistribution {
+  backlog: number;
+  todo: number;
+  inProgress: number;
+  review: number;
+  done: number;
+  overdue: number;
+}
+
+const STATUS_MAP: { key: keyof TaskDistribution; label: string; color: string }[] = [
+  { key: "backlog", label: "待排", color: "#94a3b8" },
+  { key: "todo", label: "待辦", color: "#60a5fa" },
+  { key: "inProgress", label: "進行中", color: "#fbbf24" },
+  { key: "review", label: "審核中", color: "#a78bfa" },
+  { key: "done", label: "已完成", color: "#34d399" },
+  { key: "overdue", label: "逾期", color: "#f87171" },
+];
+
+export function TaskDistributionPie({ data }: { data: TaskDistribution }) {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const chartInstance = useRef<echarts.ECharts | null>(null);
+
+  useEffect(() => {
+    if (!chartRef.current) return;
+    if (!chartInstance.current) {
+      chartInstance.current = echarts.init(chartRef.current);
+    }
+
+    const seriesData = STATUS_MAP
+      .filter((s) => data[s.key] > 0)
+      .map((s) => ({ name: s.label, value: data[s.key], itemStyle: { color: s.color } }));
+
+    chartInstance.current.setOption({
+      tooltip: { trigger: "item", formatter: "{b}: {c} ({d}%)" },
+      legend: { bottom: 0, textStyle: { fontSize: 11, color: "#888" } },
+      series: [{
+        type: "pie",
+        radius: ["40%", "70%"],
+        center: ["50%", "42%"],
+        avoidLabelOverlap: true,
+        label: { show: false },
+        emphasis: { label: { show: true, fontSize: 12, fontWeight: "bold" } },
+        data: seriesData,
+      }],
+    });
+
+    const handleResize = () => chartInstance.current?.resize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [data]);
+
+  useEffect(() => () => chartInstance.current?.dispose(), []);
+
+  return <div ref={chartRef} className="w-full h-48" />;
+}

--- a/app/components/lazy-echarts.tsx
+++ b/app/components/lazy-echarts.tsx
@@ -35,3 +35,19 @@ export const LazyTimesheetDistributionChart = dynamic(
   () => import("@/app/components/timesheet-distribution-chart").then((mod) => ({ default: mod.TimesheetDistributionChart })),
   { loading: ChartLoading, ssr: false }
 );
+
+// Cockpit charts (Issue #1073 — UX-05)
+export const LazyTaskDistributionPie = dynamic(
+  () => import("@/app/components/cockpit/task-distribution-pie").then((mod) => ({ default: mod.TaskDistributionPie })),
+  { loading: ChartLoading, ssr: false }
+);
+
+export const LazyKPIRadarChart = dynamic(
+  () => import("@/app/components/cockpit/kpi-radar-chart").then((mod) => ({ default: mod.KPIRadarChart })),
+  { loading: ChartLoading, ssr: false }
+);
+
+export const LazyGoalTrendLine = dynamic(
+  () => import("@/app/components/cockpit/goal-trend-line").then((mod) => ({ default: mod.GoalTrendLine })),
+  { loading: ChartLoading, ssr: false }
+);


### PR DESCRIPTION
## Phase 3 — 駕駛艙視覺化圖表 (UX-05)

### 新增 3 個 ECharts 元件

| 象限 | 元件 | 圖表類型 | 資料來源 |
|------|------|---------|---------|
| Q1 交付績效 | `TaskDistributionPie` | 環形圓餅圖 | `taskDistribution`（6 種狀態色彩） |
| Q2 品質指標 | `KPIRadarChart` | 雷達圖 | `kpis[].achievementRate`（≥3 項 KPI 才顯示）|
| Q4 成長學習 | `GoalTrendLine` | 折線圖 | `goals[].month + completedTaskCount/taskCount` |

### 架構

- 全部透過 `lazy-echarts.tsx` 動態載入（`ssr: false`）
- 放在現有文字/數字元件下方（additive，不取代）
- 遵循既有 ECharts pattern（ref + init + resize + dispose）

### 新增檔案
- `app/components/cockpit/task-distribution-pie.tsx`
- `app/components/cockpit/kpi-radar-chart.tsx`
- `app/components/cockpit/goal-trend-line.tsx`

Closes #1073