### PR TITLE
fix(#1078): QA bugs — task ownership, nullable description, clickable tasks

### DIFF
--- a/app/(app)/cockpit/page.tsx
+++ b/app/(app)/cockpit/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import { Gauge, BarChart3, FileText, Flame, AlertTriangle } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { PageLoading, PageError } from "@/app/components/page-states";
 import { HealthAlerts } from "@/app/components/cockpit/health-alerts";
@@ -67,13 +68,13 @@ function RootCauseList({ tasks }: { tasks: RootCauseTask[] }) {
         {tasks.slice(0, 10).map((t) => {
           const isOverdue = t.dueDate && new Date(t.dueDate) < new Date();
           return (
-            <div key={t.id} className="flex items-center gap-2 p-2 bg-accent/40 rounded text-sm">
+            <Link key={t.id} href={`/kanban?task=${t.id}`} className="flex items-center gap-2 p-2 bg-accent/40 rounded text-sm hover:bg-accent/70 transition-colors cursor-pointer">
               {t.managerFlagged && <Flame className="h-3.5 w-3.5 text-red-500 fill-red-500 flex-shrink-0" />}
               <span className={cn("text-[11px] font-medium w-6 flex-shrink-0", PRIORITY_COLOR[t.priority] ?? "text-gray-500")}>{t.priority}</span>
               <span className="flex-1 text-foreground truncate min-w-0">{t.title}</span>
               {t.assignee && <span className="text-[11px] text-muted-foreground flex-shrink-0">{t.assignee}</span>}
               {t.dueDate && <span className={cn("text-[11px] tabular-nums flex-shrink-0", isOverdue ? "text-red-500" : "text-muted-foreground")}>{formatDate(t.dueDate)}</span>}
-            </div>
+            </Link>
           );
         })}
         {tasks.length > 10 && <p className="text-xs text-muted-foreground">還有 {tasks.length - 10} 個根因任務...</p>}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -17,6 +17,7 @@ import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states"
 import { extractData } from "@/lib/api-client";
 import { formatDate } from "@/lib/format";
 import { safeFixed } from "@/lib/safe-number";
+import Link from "next/link";
 
 // ── Skeleton loader ─────────────────────────────────────────────────────
 
@@ -123,7 +124,7 @@ function TaskRow({ task }: { task: TaskItem }) {
   const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && task.status !== "DONE";
 
   return (
-    <div className="flex items-center gap-2 p-2.5 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors">
+    <Link href={`/kanban?task=${task.id}`} className="flex items-center gap-2 p-2.5 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors cursor-pointer">
       {task.managerFlagged && (
         <Flame className="h-3.5 w-3.5 text-red-500 fill-red-500 flex-shrink-0" />
       )}
@@ -138,7 +139,7 @@ function TaskRow({ task }: { task: TaskItem }) {
           {formatDate(task.dueDate)}
         </span>
       )}
-    </div>
+    </Link>
   );
 }
 

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -22,15 +22,18 @@ async function enforceTaskOwnership(userId: string, role: string, taskId: string
 
   const task = await prisma.task.findUnique({
     where: { id: taskId },
-    select: { primaryAssigneeId: true, backupAssigneeId: true },
+    select: { primaryAssigneeId: true, backupAssigneeId: true, creatorId: true },
   });
 
   if (!task) {
     throw new NotFoundError("任務不存在");
   }
 
-  if (task.primaryAssigneeId !== userId && task.backupAssigneeId !== userId) {
-    throw new ForbiddenError("僅能修改自己被指派的任務");
+  const isOwner = task.primaryAssigneeId === userId
+    || task.backupAssigneeId === userId
+    || (task as Record<string, unknown>).creatorId === userId;
+  if (!isOwner) {
+    throw new ForbiddenError("僅能修改自己被指派或建立的任務");
   }
 }
 

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -38,7 +38,7 @@ export interface CreateTaskInput {
 
 export interface UpdateTaskInput {
   title?: string;
-  description?: string;
+  description?: string | null;
   status?: string;
   priority?: string;
   category?: string;

--- a/validators/shared/task.ts
+++ b/validators/shared/task.ts
@@ -60,9 +60,9 @@ export const createTaskFullSchema = z.object({
 
 export const updateTaskSchema = z.object({
   title: z.string().min(1, "標題為必填").max(200, "標題不得超過 200 字元").optional(),
-  description: z.string().max(10000, "描述不得超過 10,000 字元").optional(),
+  description: z.string().max(10000, "描述不得超過 10,000 字元").nullable().optional(),
   annualPlanId: z.string().nullable().optional(), // Issue #835
-  monthlyGoalId: z.string().optional(),
+  monthlyGoalId: z.string().nullable().optional(),
   primaryAssigneeId: z.string().nullable().optional(),
   backupAssigneeId: z.string().nullable().optional(),
   status: TaskStatusEnum.optional(),


### PR DESCRIPTION
## QA 測試修復

| Bug | 修復 |
|-----|------|
| 工程師新增任務後無法編輯 | `enforceTaskOwnership` 加入 `creatorId` 檢查 |
| 任務描述 null → 400 | `updateTaskSchema` + `UpdateTaskInput` 加 `.nullable()` |
| 駕駛艙/今日總覽任務不可點擊 | `<div>` → `<Link href="/kanban?task={id}">` |
| OUTLINE_URL type error | 加 `!` non-null assertion |

Closes #1078