### PR TITLE
fix(#1080): QA round 2 — 工時摘要 + 日曆新增 + 團隊快照點擊

### DIFF
--- a/app/components/team-overview.tsx
+++ b/app/components/team-overview.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { Users, AlertTriangle, Clock } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { extractData } from "@/lib/api-client";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
@@ -76,7 +77,7 @@ export function TeamOverview() {
 
 function MemberSummaryCard({ member }: { member: MemberSummary }) {
   return (
-    <div className="flex items-center gap-3 p-3 bg-accent/40 rounded-lg hover:bg-accent/60 transition-colors">
+    <Link href={`/kanban?assignee=${member.id}`} className="flex items-center gap-3 p-3 bg-accent/40 rounded-lg hover:bg-accent/60 transition-colors cursor-pointer">
       <div className="flex-shrink-0 h-8 w-8 rounded-full bg-muted flex items-center justify-center text-sm text-muted-foreground font-medium">
         {member.avatar ? (
           <img src={member.avatar} alt={member.name} className="h-8 w-8 rounded-full" />
@@ -114,6 +115,6 @@ function MemberSummaryCard({ member }: { member: MemberSummary }) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/app/components/time-summary.tsx
+++ b/app/components/time-summary.tsx
@@ -66,9 +66,9 @@ export function TimeSummary({ totalHours, breakdown, taskInvestmentRate, overtim
         </div>
       )}
 
-      {/* Category rows */}
-      <div className="space-y-2">
-        {breakdown.map((b) => {
+      {/* Category rows — only show categories with hours > 0 */}
+      <div className="space-y-2 max-h-[200px] overflow-y-auto">
+        {breakdown.filter((b) => b.hours > 0).map((b) => {
           const meta = CAT_META[b.category];
           if (!meta) return null;
           return (

--- a/app/components/timesheet/calendar-month-view.tsx
+++ b/app/components/timesheet/calendar-month-view.tsx
@@ -300,7 +300,7 @@ export function CalendarMonthView({ onDayClick }: CalendarMonthViewProps) {
                 key={cell.dateStr}
                 onClick={() => onDayClick(new Date(year, month, cell.day!))}
                 className={cn(
-                  "aspect-square rounded-lg border transition-all hover:ring-2 hover:ring-ring/30 flex flex-col items-center justify-center gap-0.5 p-1",
+                  "group aspect-square rounded-lg border transition-all hover:ring-2 hover:ring-ring/30 flex flex-col items-center justify-center gap-0.5 p-1",
                   hourColor(hours),
                   today && "ring-2 ring-primary/50",
                   weekend && hours <= 0 && "bg-muted/10 border-border/30"
@@ -317,11 +317,13 @@ export function CalendarMonthView({ onDayClick }: CalendarMonthViewProps) {
                 >
                   {cell.day}
                 </span>
-                {hours > 0 && (
+                {hours > 0 ? (
                   <span className={cn("text-[10px] font-semibold tabular-nums leading-none", hourBadgeColor(hours))}>
                     {hours.toFixed(1)}
                   </span>
-                )}
+                ) : !weekend ? (
+                  <span className="text-[10px] text-muted-foreground/30 group-hover:text-primary/60 transition-colors">+</span>
+                ) : null}
               </button>
             );
           })}

--- a/app/components/timesheet/calendar-week-view.tsx
+++ b/app/components/timesheet/calendar-week-view.tsx
@@ -612,12 +612,19 @@ export function CalendarWeekView({
             <div
               key={i}
               className={cn(
-                "p-2 text-center text-xs tabular-nums border-r border-border last:border-r-0",
+                "p-2 text-center text-xs tabular-nums border-r border-border last:border-r-0 flex items-center justify-center gap-1",
                 total > 8 ? "text-amber-500 font-medium" : "text-muted-foreground"
               )}
               data-testid={`day-total-cell-${i}`}
             >
               {total > 0 ? `${safeFixed(total, 1)}h` : "--"}
+              <button
+                onClick={() => setCreateForm({ dayIndex: i, startTime: "09:00", endTime: "10:00", taskId: "", category: "PLANNED_TASK", description: "" })}
+                className="text-[10px] text-muted-foreground/40 hover:text-primary transition-colors"
+                title="新增工時"
+              >
+                +
+              </button>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## QA 第二輪修復

| Bug | 修復 |
|-----|------|
| 工時摘要佔版過大 | 隱藏 0 工時分類 + `max-h-[200px] overflow-y-auto` |
| 月曆無新增入口 | 空日期格顯示 `+` 提示（hover 高亮），點擊進入 day view |
| 週曆無直覺新增 | totals row 每天加 `+` 按鈕，點擊開啟建立表單 |
| 團隊快照不可點擊 | `<div>` → `<Link href="/kanban?assignee={id}">` |

Closes #1080