### PR TITLE
feat(#1082): 跨頁面雙向連結 + Drill Down

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -256,7 +256,7 @@ function EngineerMyDay({ data }: { data: EngineerData }) {
             </h2>
             <div className="space-y-3">
               {data.monthlyGoals.map((g) => (
-                <div key={g.id} className="space-y-1">
+                <Link key={g.id} href="/plans" className="block space-y-1 hover:bg-accent/40 -mx-2 px-2 py-1 rounded transition-colors">
                   <div className="flex justify-between text-xs">
                     <span className="text-foreground truncate">{g.title}</span>
                     <span className="tabular-nums text-muted-foreground ml-2">{Math.round(g.progressPct)}%</span>
@@ -270,7 +270,7 @@ function EngineerMyDay({ data }: { data: EngineerData }) {
                       style={{ width: `${Math.min(g.progressPct, 100)}%` }}
                     />
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </div>
@@ -388,7 +388,7 @@ function ManagerMyDay({ data }: { data: ManagerData }) {
               </h2>
               <div className="space-y-3">
                 {data.planSummaries.map((p) => (
-                  <div key={p.id} className="space-y-1.5">
+                  <Link key={p.id} href="/plans" className="block space-y-1.5 hover:bg-accent/40 -mx-2 px-2 py-1 rounded transition-colors">
                     <div className="flex justify-between text-xs">
                       <span className="text-foreground truncate">{p.title}</span>
                       <span className="tabular-nums text-muted-foreground ml-2">{Math.round(p.progressPct)}%</span>
@@ -405,7 +405,7 @@ function ManagerMyDay({ data }: { data: ManagerData }) {
                         {p.flaggedCount} 個標記任務
                       </p>
                     )}
-                  </div>
+                  </Link>
                 ))}
               </div>
             </div>

--- a/app/(app)/kpi/page.tsx
+++ b/app/(app)/kpi/page.tsx
@@ -10,6 +10,7 @@ import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states"
 import { FormError, FormBanner } from "@/app/components/form-error";
 import { safePct } from "@/lib/safe-number";
 import { calculateAchievement } from "@/lib/kpi-calculator";
+import Link from "next/link";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -484,9 +485,10 @@ function KPICard({ kpi, isManager, onUnlink, onStatusChange }: KPICardProps) {
             <p className="text-sm text-muted-foreground">尚未連結任務</p>
           ) : (
             kpi.taskLinks.map((link) => (
-              <div
+              <Link
                 key={link.taskId}
-                className="flex items-center gap-3 p-2.5 bg-accent/40 rounded-md"
+                href={`/kanban?task=${link.taskId}`}
+                className="flex items-center gap-3 p-2.5 bg-accent/40 rounded-md hover:bg-accent/70 transition-colors"
               >
                 <div className="flex-1 min-w-0">
                   <p className="text-sm text-foreground truncate">{link.task.title}</p>
@@ -518,7 +520,7 @@ function KPICard({ kpi, isManager, onUnlink, onStatusChange }: KPICardProps) {
                     </button>
                   )}
                 </div>
-              </div>
+              </Link>
             ))
           )}
         </div>

--- a/app/components/cockpit/goal-progress-list.tsx
+++ b/app/components/cockpit/goal-progress-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CheckCircle2, Circle } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 export interface GoalSummary {
@@ -40,8 +41,9 @@ export function GoalProgressList({ goals, currentMonth }: GoalProgressListProps)
           const isCurrent = goal.month === month;
 
           return (
-            <div
+            <Link
               key={goal.id}
+              href="/plans"
               className={cn(
                 "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors",
                 isCurrent && "bg-primary/5 ring-1 ring-primary/20",
@@ -89,7 +91,7 @@ export function GoalProgressList({ goals, currentMonth }: GoalProgressListProps)
                   {goal.completedTaskCount}/{goal.taskCount}
                 </span>
               </div>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/app/components/cockpit/kpi-gauge-row.tsx
+++ b/app/components/cockpit/kpi-gauge-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 export interface KPISummary {
@@ -42,7 +43,7 @@ export function KPIGaugeRow({ kpis }: KPIGaugeRowProps) {
       <h3 className="text-sm font-semibold text-foreground mb-3">KPI 達成</h3>
       <div className="space-y-2.5">
         {kpis.map((kpi) => (
-          <div key={kpi.id} className="group">
+          <Link key={kpi.id} href="/kpi" className="group block hover:bg-accent/40 -mx-1 px-1 rounded transition-colors">
             <div className="flex items-center justify-between text-sm mb-1">
               <span className="text-muted-foreground truncate mr-2">
                 <span className="font-mono text-xs">{kpi.code}</span>{" "}
@@ -58,7 +59,7 @@ export function KPIGaugeRow({ kpis }: KPIGaugeRowProps) {
                 style={{ width: `${Math.min(100, kpi.achievementRate)}%` }}
               />
             </div>
-          </div>
+          </Link>
         ))}
       </div>
     </div>

--- a/app/components/cockpit/task-distribution-chart.tsx
+++ b/app/components/cockpit/task-distribution-chart.tsx
@@ -1,6 +1,11 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
+
+const STATUS_MAP: Record<string, string> = {
+  done: "DONE", review: "REVIEW", inProgress: "IN_PROGRESS", todo: "TODO", backlog: "BACKLOG",
+};
 
 export interface TaskDistribution {
   backlog: number;
@@ -62,19 +67,19 @@ export function TaskDistributionChart({ distribution }: TaskDistributionChartPro
               const count = distribution[key];
               if (count === 0) return null;
               return (
-                <div key={key} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Link key={key} href={`/kanban?status=${STATUS_MAP[key] ?? key}`} className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
                   <span className={cn("w-2.5 h-2.5 rounded-sm", color)} />
                   <span>{label}</span>
                   <span className="font-medium text-foreground tabular-nums">{count}</span>
-                </div>
+                </Link>
               );
             })}
             {distribution.overdue > 0 && (
-              <div className="flex items-center gap-1.5 text-xs text-red-600 dark:text-red-400">
+              <Link href="/kanban?overdue=true" className="flex items-center gap-1.5 text-xs text-red-600 dark:text-red-400 hover:text-red-500 transition-colors">
                 <span className="w-2.5 h-2.5 rounded-sm bg-red-500 ring-1 ring-red-300" />
                 <span>逾期</span>
                 <span className="font-medium tabular-nums">{distribution.overdue}</span>
-              </div>
+              </Link>
             )}
           </div>
         </>

--- a/app/components/cockpit/time-investment-bar.tsx
+++ b/app/components/cockpit/time-investment-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 
 export interface TimeInvestment {
@@ -63,11 +64,11 @@ export function TimeInvestmentBar({ time }: TimeInvestmentBarProps) {
         </div>
       </div>
 
-      {/* Utilization rate */}
+      {/* Utilization rate — link to timesheet */}
       {time.planned > 0 && (
-        <p className="text-xs text-muted-foreground mt-2">
-          投入率 {Math.round((time.actual / time.planned) * 100)}%
-        </p>
+        <Link href="/timesheet" className="block text-xs text-muted-foreground mt-2 hover:text-primary transition-colors">
+          投入率 {Math.round((time.actual / time.planned) * 100)}% →
+        </Link>
       )}
     </div>
   );

--- a/app/components/task-detail/task-form-fields.tsx
+++ b/app/components/task-detail/task-form-fields.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Link2, Tag, X, Plus } from "lucide-react";
+import { Link2, Tag, X, Plus, ExternalLink } from "lucide-react";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { extractData } from "@/lib/api-client";
 
@@ -346,6 +347,11 @@ export function TaskFormFields({ form, onFieldChange, users, goals, errors }: Ta
           <span className="flex items-center gap-1">
             <Link2 className="h-3 w-3" />
             連結月度目標
+            {form.monthlyGoalId && (
+              <Link href="/plans" className="text-primary hover:text-primary/80 transition-colors" title="前往年度計畫">
+                <ExternalLink className="h-3 w-3" />
+              </Link>
+            )}
           </span>
         </Label>
         <select value={form.monthlyGoalId} onChange={(e) => onFieldChange("monthlyGoalId", e.target.value)} className={selectCls}>

--- a/app/components/timesheet/timesheet-grid.tsx
+++ b/app/components/timesheet/timesheet-grid.tsx
@@ -6,6 +6,7 @@ import { safeFixed } from "@/lib/safe-number";
 import { TimesheetCell } from "./timesheet-cell";
 import { type TimeEntry, type TaskRow, type OvertimeType, type TaskOption, type SubTaskOption } from "./use-timesheet";
 import { Plus } from "lucide-react";
+import Link from "next/link";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -186,16 +187,20 @@ export function TimesheetGrid({
                         : "";
                     const fullLabel = `${row.label}${subLabel}`;
                     return (
-                      <span
-                        className="text-xs text-muted-foreground truncate block max-w-[168px]"
-                        title={fullLabel}
-                      >
-                        {row.taskId ? "# " : ""}
-                        {row.label}
-                        {subLabel && (
-                          <span className="text-muted-foreground/60">{subLabel}</span>
-                        )}
-                      </span>
+                      {row.taskId ? (
+                        <Link
+                          href={`/kanban?task=${row.taskId}`}
+                          className="text-xs text-muted-foreground truncate block max-w-[168px] hover:text-primary transition-colors"
+                          title={fullLabel}
+                        >
+                          # {row.label}
+                          {subLabel && <span className="text-muted-foreground/60">{subLabel}</span>}
+                        </Link>
+                      ) : (
+                        <span className="text-xs text-muted-foreground truncate block max-w-[168px]" title={fullLabel}>
+                          {row.label}
+                        </span>
+                      )}
                     );
                   })()}
                 </td>


### PR DESCRIPTION
## 跨頁面連結全面實施

所有匯總資料現在都可以 drill down 到來源頁面：

| 來源 | → 目標 | 連結方式 |
|------|--------|---------|
| 駕駛艙 KPI 指標 | KPI 頁面 | 每行 KPI 可點擊 |
| 駕駛艙月度目標 | 年度計畫 | 每個目標可點擊 |
| 駕駛艙任務分佈 | 看板篩選 | 每個狀態 legend 連到 `/kanban?status=` |
| 駕駛艙工時投入 | 工時頁面 | 投入率連到 `/timesheet` |
| KPI 關聯任務 | 看板任務 | 每個任務連到 `/kanban?task=` |
| Dashboard 計畫摘要 | 年度計畫 | 每個計畫可點擊 |
| Dashboard 月目標 | 年度計畫 | 每個目標可點擊 |
| 工時表任務名稱 | 看板任務 | `#` 開頭的任務名可點擊 |
| 任務 Modal 月目標 | 年度計畫 | 外部連結 icon |

### 修改檔案（8 檔）
cockpit: kpi-gauge-row, goal-progress-list, task-distribution-chart, time-investment-bar
pages: kpi/page, dashboard/page
components: timesheet-grid, task-form-fields

Closes #1082