### PR TITLE
fix(test): mock next/headers globally — fix 70+ API tests 500 errors (#1112)

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -5,3 +5,25 @@ import "@testing-library/jest-dom";
 //   jest.mock("@/auth", () => ({ auth: jest.fn().mockResolvedValue(...) }))
 // or directly: (auth as jest.Mock).mockResolvedValue(...)
 jest.mock("@/auth");
+
+// Mock next/headers for all tests — Issue #1112
+//
+// requireAuth() calls `await headers()` to check for Bearer tokens.
+// Next.js `headers()` requires a Request Store context that doesn't exist
+// in Jest, causing `throwForMissingRequestStore` and 500 errors in all
+// route handler tests.
+//
+// Default: return null for Authorization header → web session path (via @/auth mock above).
+// Override per-test to simulate Bearer tokens:
+//   (headers as jest.Mock).mockResolvedValue({ get: jest.fn().mockReturnValue("Bearer <token>") })
+jest.mock("next/headers", () => ({
+  headers: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(null),
+    has: jest.fn().mockReturnValue(false),
+  }),
+  cookies: jest.fn().mockResolvedValue({
+    get: jest.fn().mockReturnValue(undefined),
+    has: jest.fn().mockReturnValue(false),
+    getAll: jest.fn().mockReturnValue([]),
+  }),
+}));


### PR DESCRIPTION
## 問題

PR #1109 (`lib/rbac.ts` Bearer token path) 引入 `await headers()`，
在 Jest 環境（無 Next.js Request Store）拋出 `throwForMissingRequestStore`，
導致所有使用 `requireAuth()` 的 route handler tests 回 500。

## 修正

在 `jest.setup.ts` 新增全域 `jest.mock("next/headers")`：

```typescript
jest.mock("next/headers", () => ({
  headers: jest.fn().mockResolvedValue({
    get: jest.fn().mockReturnValue(null),  // 預設無 Bearer → web session path
    has: jest.fn().mockReturnValue(false),
  }),
  cookies: jest.fn().mockResolvedValue({
    get: jest.fn().mockReturnValue(undefined),
    has: jest.fn().mockReturnValue(false),
    getAll: jest.fn().mockReturnValue([]),
  }),
}));
```

個別測試（如 `mobile-auth.test.ts`）可 override 回傳值測試 Bearer token path。

## 結果

- 修復前：70+ test suites 失敗（全部 500）
- 修復後：223 passed, 5 failed（剩餘 5 個為預存在的 TooltipProvider / auth mock 問題）
- `mobile-auth.test.ts` 76/76 ✅ 未受影響

## 關聯

Closes #1112
Caused by: #1085 / PR #1109
Related: PR #1111 (ESM transform fix)