### PR TITLE
fix(test): TooltipProvider wrapper for component tests

### DIFF
--- a/__tests__/components/responsive.test.tsx
+++ b/__tests__/components/responsive.test.tsx
@@ -2,8 +2,9 @@
  * Tests for responsive improvements (Task 25 — Issue #785)
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 // We test that the mobile nav includes all necessary items
 // by checking the Topbar's MOBILE_NAV constant coverage

--- a/__tests__/components/sidebar.test.tsx
+++ b/__tests__/components/sidebar.test.tsx
@@ -2,8 +2,9 @@
  * Component tests: Sidebar — Updated for 5-experience-group restructure (Issue #970)
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 jest.mock("next-auth/react", () => ({
   useSession: () => ({ data: { user: { id: "u1", role: "MANAGER" } }, status: "authenticated" }),

--- a/__tests__/components/topbar.test.tsx
+++ b/__tests__/components/topbar.test.tsx
@@ -2,8 +2,9 @@
  * Component tests: Topbar
  */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 // Mock next/navigation
 jest.mock("next/navigation", () => ({

--- a/__tests__/utils/test-utils.tsx
+++ b/__tests__/utils/test-utils.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
+import { TooltipProvider } from "@/app/components/ui/tooltip";
 
 // Wrapper with any necessary providers
 function AllProviders({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <TooltipProvider delayDuration={300}>{children}</TooltipProvider>;
 }
 
 function renderWithProviders(


### PR DESCRIPTION
## Summary

- 新增 \`TooltipProvider\` 到 \`AllProviders\` (\`__tests__/utils/test-utils.tsx\`)
- 更新 \`sidebar.test.tsx\`, \`topbar.test.tsx\`, \`responsive.test.tsx\` 使用 \`test-utils\` 的 \`render\`

## Fixes

\Closes #1117

## Test plan

- [x] \`npx jest __tests__/components/topbar.test.tsx --forceExit\` ✅
- [x] \`npx jest __tests__/components/responsive.test.tsx --forceExit\` ✅
- [x] \`npx jest __tests__/components/sidebar.test.tsx --forceExit\` (1 pre-existing failure unrelated to this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)