### PR TITLE
fix(ci): correct Auth.js version check regex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,8 @@ jobs:
       - name: Verify Auth.js version is pinned (no caret/tilde)
         run: |
           AUTHJS_VERSION=$(node -e "console.log(require('./package.json').dependencies['next-auth'])")
-          if [[ "$AUTHJS_VERSION" =~ ^[\^~] ]]; then
+          FIRST_CHAR="${AUTHJS_VERSION:0:1}"
+          if [[ "$FIRST_CHAR" == "^" ]] || [[ "$FIRST_CHAR" == "~" ]]; then
             echo "::error::next-auth version must be pinned (no ^ or ~). Current: $AUTHJS_VERSION"
             echo "See docs/auth-upgrade-sop.md for upgrade procedure."
             exit 1

--- a/__tests__/components/responsive.test.tsx
+++ b/__tests__/components/responsive.test.tsx
@@ -2,8 +2,9 @@
  * Tests for responsive improvements (Task 25 — Issue #785)
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 // We test that the mobile nav includes all necessary items
 // by checking the Topbar's MOBILE_NAV constant coverage

--- a/__tests__/components/sidebar.test.tsx
+++ b/__tests__/components/sidebar.test.tsx
@@ -2,8 +2,9 @@
  * Component tests: Sidebar — Updated for 5-experience-group restructure (Issue #970)
  */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 jest.mock("next-auth/react", () => ({
   useSession: () => ({ data: { user: { id: "u1", role: "MANAGER" } }, status: "authenticated" }),

--- a/__tests__/components/topbar.test.tsx
+++ b/__tests__/components/topbar.test.tsx
@@ -2,8 +2,9 @@
  * Component tests: Topbar
  */
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { render } from "@/__tests__/utils/test-utils";
 
 // Mock next/navigation
 jest.mock("next/navigation", () => ({

--- a/__tests__/utils/test-utils.tsx
+++ b/__tests__/utils/test-utils.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
+import { TooltipProvider } from "@/app/components/ui/tooltip";
 
 // Wrapper with any necessary providers
 function AllProviders({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return <TooltipProvider delayDuration={300}>{children}</TooltipProvider>;
 }
 
 function renderWithProviders(


### PR DESCRIPTION
## Summary

The bash regex pattern `^[\^~]` in `[[ ]]` conditional behaves unexpectedly, causing false positives for versions like `5.0.0-beta.30`.

**Root cause**: In bash's built-in regex, `[\^~]` is interpreted differently than expected. The escaped caret doesn't work as intended inside character classes.

**Fix**: Use explicit first-character check: \`\${AUTHJS_VERSION:0:1}\`

## Test plan

- [ ] CI \`dependency-audit\` passes with \`5.0.0-beta.30\`

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)