### PR TITLE
feat(T1101): push token registration endpoint

### DIFF
--- a/app/api/push/register/route.ts
+++ b/app/api/push/register/route.ts
@@ -1,0 +1,60 @@
+/**
+ * POST /api/push/register — Issue #1101
+ *
+ * Register an Expo push token for a mobile device.
+ * Replaces any existing token for the same deviceId (token rotation).
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success, error } from "@/lib/api-response";
+import { requireAuth } from "@/lib/rbac";
+import { logger } from "@/lib/logger";
+
+export async function POST(req: NextRequest) {
+  const session = await requireAuth();
+
+  let body: { token?: string; platform?: string; deviceId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return error("ValidationError", "無效的請求格式", 400);
+  }
+
+  const { token, platform, deviceId } = body;
+
+  if (!token || typeof token !== "string") {
+    return error("ValidationError", "缺少或無效的 push token", 400);
+  }
+  if (!deviceId || typeof deviceId !== "string") {
+    return error("ValidationError", "缺少或無效的 deviceId", 400);
+  }
+  if (!platform || !["IOS", "ANDROID"].includes(platform)) {
+    return error("ValidationError", "platform 必須是 IOS 或 ANDROID", 400);
+  }
+
+  try {
+    // Upsert: update existing token or create new one
+    await prisma.pushToken.upsert({
+      where: { deviceId },
+      create: {
+        token,
+        platform: platform as "IOS" | "ANDROID",
+        deviceId,
+        userId: session.user.id,
+      },
+      update: {
+        token,
+        platform: platform as "IOS" | "ANDROID",
+        isActive: true,
+      },
+    });
+
+    logger.info({ userId: session.user.id, deviceId, platform }, "[push] Token registered");
+
+    return success({ ok: true });
+  } catch (err) {
+    logger.error({ err, userId: session.user.id }, "[push] Failed to register token");
+    return error("ServerError", "儲存推播 Token 失敗", 500);
+  }
+}

--- a/app/api/push/unregister/route.ts
+++ b/app/api/push/unregister/route.ts
@@ -1,0 +1,37 @@
+/**
+ * DELETE /api/push/unregister — Issue #1101
+ *
+ * Unregister a device's push token (logout or device reset).
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success, error } from "@/lib/api-response";
+import { requireAuth } from "@/lib/rbac";
+import { logger } from "@/lib/logger";
+
+export async function DELETE(req: NextRequest) {
+  const session = await requireAuth();
+
+  const deviceId = req.nextUrl.searchParams.get("deviceId");
+
+  if (!deviceId || typeof deviceId !== "string") {
+    return error("ValidationError", "缺少或無效的 deviceId", 400);
+  }
+
+  try {
+    const result = await prisma.pushToken.deleteMany({
+      where: {
+        deviceId,
+        userId: session.user.id,
+      },
+    });
+
+    logger.info({ userId: session.user.id, deviceId, deleted: result.count }, "[push] Token unregistered");
+
+    return success({ ok: true, deleted: result.count });
+  } catch (err) {
+    logger.error({ err, userId: session.user.id }, "[push] Failed to unregister token");
+    return error("ServerError", "移除推播 Token 失敗", 500);
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model User {
   passwordHistory          PasswordHistory[]
   notificationPreferences  NotificationPreference[]
   passwordResetTokens      PasswordResetToken[]
+  pushTokens               PushToken[]
   createdTemplates         TaskTemplate[]        @relation("TemplateCreator")
   uploadedAttachments      TaskAttachment[]     @relation("AttachmentUploader")
   approvalRequests         ApprovalRequest[]    @relation("ApprovalRequester")
@@ -1357,6 +1358,33 @@ model DocumentReadLog {
 enum LinkType {
   REFERENCE
   RELATED
+}
+
+// ═══════════════════════════════════════
+// Push Notification Tokens (Issue #1101)
+// ═══════════════════════════════════════
+
+enum PushPlatform {
+  IOS
+  ANDROID
+}
+
+model PushToken {
+  id        String       @id @default(cuid())
+  token     String       // Expo push token
+  platform  PushPlatform
+  deviceId  String       // Device unique identifier (UUID from mobile)
+  userId    String
+  isActive  Boolean      @default(true)
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([deviceId])
+  @@index([userId])
+  @@index([isActive])
+  @@map("push_tokens")
 }
 
 model DocumentLink {


### PR DESCRIPTION
## Summary
- Add `PushToken` Prisma model (IOS/ANDROID platform, deviceId binding, cascade delete)
- Add `User.pushTokens` relation
- `POST /api/push/register` — upsert push token with deviceId, requires auth
- `DELETE /api/push/unregister?deviceId=` — remove token, requires auth

## Test plan
- [ ] `POST /api/push/register` with valid token → 200
- [ ] `POST /api/push/register` with same deviceId → upserts (token rotation)
- [ ] `DELETE /api/push/unregister?deviceId=X` → 200
- [ ] Unauthenticated request → 401

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Closes #1101