### PR TITLE
fix(nginx): Outline sub-path proxy blank page — sub_filter rewrite

### DIFF
--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     ports:
       - "${NGINX_HTTP_PORT:-8080}:80"
       - "${NGINX_HTTPS_PORT:-8443}:443"
+      - "${NGINX_OUTLINE_PORT:-8444}:8443"
     volumes:
       - ../nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ../nginx/ssl:/etc/nginx/ssl:ro

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -67,37 +67,6 @@ http {
             proxy_read_timeout 86400;
         }
 
-        # ── Outline Wiki（/outline 路徑，strip prefix + 路徑改寫）────────────
-        location /outline {
-            rewrite ^/outline(/.*)$ $1 break;
-            rewrite ^/outline$ / break;
-
-            proxy_pass http://titan-outline:3000;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-
-            # 禁用 upstream 壓縮，讓 sub_filter 可處理回應內容
-            proxy_set_header Accept-Encoding "";
-
-            # 改寫 Outline 回應中的絕對路徑 → 加上 /outline 前綴
-            sub_filter_once off;
-            sub_filter_types application/javascript text/css;
-            sub_filter '"/static/'   '"/outline/static/';
-            sub_filter '"/images/'   '"/outline/images/';
-            sub_filter '"/api/'      '"/outline/api/';
-            sub_filter '"/auth/'     '"/outline/auth/';
-            sub_filter '"/realtime'  '"/outline/realtime';
-            sub_filter "'/static/"   "'/outline/static/";
-            sub_filter "'/images/"   "'/outline/images/";
-            sub_filter "'/api/"      "'/outline/api/";
-            sub_filter "'/auth/"     "'/outline/auth/";
-        }
-
         # ── MinIO Console（/minio-console 路徑）─────────────────────────────
         location /minio-console/ {
             proxy_pass http://titan-minio:9001/;
@@ -142,6 +111,38 @@ http {
             }
             add_header Content-Type text/plain;
             return 200 "healthy\n";
+        }
+    }
+
+    # ── Outline Wiki 獨立虛擬主機（:8443）─────────────────────────────────
+    # Outline 不支援 sub-path 部署，用獨立 port 避免路徑衝突
+    server {
+        listen 8443 ssl;
+        listen [::]:8443 ssl;
+        server_name titan.bank.local mac-mini.tailde842d.ts.net localhost;
+
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy strict-origin-when-cross-origin always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        # 移除 Outline 自帶 CSP（URL env 為 localhost，會阻擋外部主機）
+        proxy_hide_header Content-Security-Policy;
+
+        location / {
+            proxy_pass http://titan-outline:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            # WebSocket（Outline realtime collaboration）
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
+
+            client_max_body_size 50m;
         }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -67,7 +67,7 @@ http {
             proxy_read_timeout 86400;
         }
 
-        # ── Outline Wiki（/outline 路徑，strip prefix）───────────────────────
+        # ── Outline Wiki（/outline 路徑，strip prefix + 路徑改寫）────────────
         location /outline {
             rewrite ^/outline(/.*)$ $1 break;
             rewrite ^/outline$ / break;
@@ -80,6 +80,22 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+
+            # 禁用 upstream 壓縮，讓 sub_filter 可處理回應內容
+            proxy_set_header Accept-Encoding "";
+
+            # 改寫 Outline 回應中的絕對路徑 → 加上 /outline 前綴
+            sub_filter_once off;
+            sub_filter_types application/javascript text/css;
+            sub_filter '"/static/'   '"/outline/static/';
+            sub_filter '"/images/'   '"/outline/images/';
+            sub_filter '"/api/'      '"/outline/api/';
+            sub_filter '"/auth/'     '"/outline/auth/';
+            sub_filter '"/realtime'  '"/outline/realtime';
+            sub_filter "'/static/"   "'/outline/static/";
+            sub_filter "'/images/"   "'/outline/images/";
+            sub_filter "'/api/"      "'/outline/api/";
+            sub_filter "'/auth/"     "'/outline/auth/";
         }
 
         # ── MinIO Console（/minio-console 路徑）─────────────────────────────
@@ -93,9 +109,21 @@ http {
             proxy_set_header Connection "upgrade";
         }
 
-        # ── AI Trader（/ai-trader 路徑，直接代理）──────────────────────────────
+        # ── AI Trader API（/ai-trader/api → FastAPI backend）────────────────────
+        location /ai-trader/api/ {
+            proxy_pass https://host.docker.internal:8080/api/;
+            proxy_ssl_verify off;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 86400;
+        }
+
+        # ── AI Trader 前端（/ai-trader 路徑，直接代理）─────────────────────────
         location /ai-trader/ {
-            proxy_pass http://host.docker.internal:3000/ai-trader/;
+            proxy_pass http://host.docker.internal:3012/ai-trader/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Outline 在 sub-path `/outline` 下顯示空白頁（SPA 不支援 sub-path 部署）
- 嘗試 `sub_filter` 改寫路徑後發現 JS runtime 有多重 URL 構建模式（template literal、dynamic import、window.env），無法完全攔截
- **最終方案：** 獨立 nginx server block on port 8443，透過 Tailscale serve 暴露
- 同時包含 AI Trader 路由更新（port 3012、API 路由分離）

## Access

- TITAN: `https://mac-mini.tailde842d.ts.net/`
- Outline: `https://mac-mini.tailde842d.ts.net:8443/`

## Test plan

- [x] Outline "Create workspace" 頁面正常顯示（Playwright 截圖驗證）
- [x] Console error 僅 1 個（auth 401，未登入正常）
- [x] TITAN 主站不受影響（正常重導至 /login）
- [x] nginx -t 語法驗證通過

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)