### PR TITLE
feat(T1138): audit queue monitoring API + queue status

### DIFF
--- a/app/api/admin/audit-queue/route.ts
+++ b/app/api/admin/audit-queue/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest } from "next/server";
+import { withManager } from "@/lib/auth-middleware";
+import { success } from "@/lib/api-response";
+import { AuditService } from "@/services/audit-service";
+import { prisma } from "@/lib/prisma";
+
+const auditService = new AuditService(prisma);
+
+/**
+ * GET /api/admin/audit-queue
+ * Returns audit failure queue status (depth, oldest entry timestamp).
+ * MANAGER only.
+ */
+export const GET = withManager(async (_req: NextRequest) => {
+  const status = await auditService.getQueueStatus();
+  return success(status);
+});
+
+/**
+ * POST /api/admin/audit-queue
+ * Triggers processing of the audit failure queue (retry failed entries).
+ * Returns the number of entries successfully processed.
+ * MANAGER only.
+ */
+export const POST = withManager(async (_req: NextRequest) => {
+  const processed = await auditService.processAuditQueue();
+  return success({ processed });
+});

--- a/services/audit-service.ts
+++ b/services/audit-service.ts
@@ -143,6 +143,40 @@ export class AuditService {
   }
 
   /**
+   * Returns the current audit failure queue status.
+   * Useful for monitoring whether audit writes are failing.
+   */
+  async getQueueStatus(): Promise<{ depth: number; oldestEntryAt: string | null }> {
+    const redis = getRedisClient();
+    if (!redis) {
+      return { depth: 0, oldestEntryAt: null };
+    }
+
+    try {
+      const depth = await redis.llen(AUDIT_QUEUE_KEY);
+      let oldestEntryAt: string | null = null;
+
+      if (depth > 0) {
+        // LINDEX -1 returns the oldest entry (rpop processes from tail)
+        const oldest = await redis.lindex(AUDIT_QUEUE_KEY, -1);
+        if (oldest) {
+          try {
+            const parsed = JSON.parse(oldest) as { failedAt?: string };
+            oldestEntryAt = parsed.failedAt ?? null;
+          } catch {
+            // Malformed entry — report depth but no timestamp
+          }
+        }
+      }
+
+      return { depth, oldestEntryAt };
+    } catch (err) {
+      logger.error({ err }, "[audit] Failed to read queue status");
+      return { depth: 0, oldestEntryAt: null };
+    }
+  }
+
+  /**
    * Query audit logs. Only MANAGER role may call this.
    * Audit logs are read-only — no update or delete methods are exposed.
    */


### PR DESCRIPTION
## Summary
- Add `GET /api/admin/audit-queue` endpoint returning queue depth and oldest entry timestamp (MANAGER only)
- Add `POST /api/admin/audit-queue` endpoint to trigger retry processing of failed audit entries (MANAGER only)
- Add `getQueueStatus()` method to `AuditService` for Redis queue introspection

Both endpoints use `withManager` auth middleware, consistent with existing admin routes.

Closes #1138

## Test plan
- [x] All 56 existing audit tests pass (`npx jest -- audit`)
- [ ] Manual test: `GET /api/admin/audit-queue` returns `{ ok: true, data: { depth: 0, oldestEntryAt: null } }` when queue is empty
- [ ] Manual test: `POST /api/admin/audit-queue` returns `{ ok: true, data: { processed: 0 } }` when queue is empty
- [ ] Verify 401/403 for non-MANAGER users on both endpoints
- [ ] Verify graceful degradation when Redis is unavailable (returns depth: 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)