### PR TITLE
feat(T1137): activate session timeout warning + cross-tab sync

### DIFF
--- a/__tests__/api/session-timeout.test.ts
+++ b/__tests__/api/session-timeout.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 /**
- * Session Timeout tests — Issue #798 (AU-4)
+ * Session Timeout tests — Issue #798 (AU-4), extended for Issue #1137
  */
 import path from "path";
 
@@ -52,5 +52,67 @@ describe("Session timeout configuration", () => {
     expect(content).toContain("mousedown");
     expect(content).toContain("keydown");
     expect(content).toContain("resetTimers");
+  });
+});
+
+describe("Cross-tab session sync (Issue #1137)", () => {
+  it("uses BroadcastChannel for cross-tab communication", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync(
+      path.resolve(ROOT, "app/components/session-timeout-warning.tsx"), "utf8"
+    );
+    expect(content).toContain("BroadcastChannel");
+    expect(content).toContain("titan-session-sync");
+  });
+
+  it("SSR safety: checks typeof BroadcastChannel before usage", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync(
+      path.resolve(ROOT, "app/components/session-timeout-warning.tsx"), "utf8"
+    );
+    expect(content).toContain('typeof BroadcastChannel');
+  });
+
+  it("broadcasts session_extended when user extends session", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync(
+      path.resolve(ROOT, "app/components/session-timeout-warning.tsx"), "utf8"
+    );
+    expect(content).toContain("session_extended");
+    expect(content).toMatch(/broadcast.*session_extended/s);
+  });
+
+  it("broadcasts session_timeout when session expires", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync(
+      path.resolve(ROOT, "app/components/session-timeout-warning.tsx"), "utf8"
+    );
+    expect(content).toContain("session_timeout");
+    expect(content).toMatch(/broadcast.*session_timeout/s);
+  });
+
+  it("cleans up BroadcastChannel on unmount", async () => {
+    const fs = await import("fs");
+    const content = fs.readFileSync(
+      path.resolve(ROOT, "app/components/session-timeout-warning.tsx"), "utf8"
+    );
+    expect(content).toContain("channel.close()");
+    expect(content).toContain("channelRef.current = null");
+  });
+
+  it("is rendered inside NextAuthSessionProvider in app layout", async () => {
+    const fs = await import("fs");
+    const layout = fs.readFileSync(
+      path.resolve(ROOT, "app/(app)/layout.tsx"), "utf8"
+    );
+    expect(layout).toContain("SessionTimeoutWarning");
+    // Verify it's imported from the correct module
+    expect(layout).toContain("session-timeout-warning");
+    // Verify it appears after NextAuthSessionProvider open and before its close
+    const providerOpen = layout.indexOf("NextAuthSessionProvider>");
+    const componentPos = layout.indexOf("<SessionTimeoutWarning");
+    const providerClose = layout.indexOf("</NextAuthSessionProvider>");
+    expect(providerOpen).toBeLessThan(componentPos);
+    expect(componentPos).toBeLessThan(providerClose);
   });
 });

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { CommandPalette } from "@/app/components/command-palette";
 import { FeedbackButton } from "@/app/components/feedback-button";
 import { KeyboardShortcutsDialog } from "@/app/components/keyboard-shortcuts-dialog";
 import { NextAuthSessionProvider } from "@/app/components/session-provider";
+import { SessionTimeoutWarning } from "@/app/components/session-timeout-warning";
 import { PasswordChangeGuard } from "@/app/components/password-change-guard";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/app/components/ui/tooltip";
@@ -30,6 +31,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <KeyboardShortcutsDialog />
         <FeedbackButton />
         <Toaster richColors position="top-right" />
+        <SessionTimeoutWarning />
       </PasswordChangeGuard>
       </TooltipProvider>
     </NextAuthSessionProvider>

--- a/app/components/session-timeout-warning.tsx
+++ b/app/components/session-timeout-warning.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 /**
- * Session Timeout Warning — Issue #798 (AU-4)
+ * Session Timeout Warning — Issue #798 (AU-4), enhanced by Issue #1137
  *
  * Displays a warning modal 5 minutes before session expires.
  * User can click "延長" to extend the session.
  * On timeout, redirects to login page.
+ *
+ * Cross-tab sync via BroadcastChannel (Issue #1137):
+ * - When a tab extends the session, all tabs reset their timers.
+ * - When a tab times out, all tabs redirect to login.
  */
 
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -15,6 +19,13 @@ import { useSession } from "next-auth/react";
 const DEFAULT_TIMEOUT_MINUTES = 30;
 const WARNING_BEFORE_MINUTES = 5;
 
+/** BroadcastChannel name for cross-tab session sync */
+const CHANNEL_NAME = "titan-session-sync";
+
+type SyncMessage =
+  | { type: "session_extended" }
+  | { type: "session_timeout" };
+
 export function SessionTimeoutWarning() {
   const { data: session, update } = useSession();
   const [showWarning, setShowWarning] = useState(false);
@@ -23,17 +34,34 @@ export function SessionTimeoutWarning() {
   const warningRef = useRef<NodeJS.Timeout | null>(null);
   const countdownRef = useRef<NodeJS.Timeout | null>(null);
   const lastActivityRef = useRef(Date.now());
+  const channelRef = useRef<BroadcastChannel | null>(null);
 
   const timeoutMs = DEFAULT_TIMEOUT_MINUTES * 60 * 1000;
   const warningMs = (DEFAULT_TIMEOUT_MINUTES - WARNING_BEFORE_MINUTES) * 60 * 1000;
 
-  const resetTimers = useCallback(() => {
-    lastActivityRef.current = Date.now();
-    setShowWarning(false);
+  /** Broadcast a message to other tabs (no-op if BroadcastChannel unavailable) */
+  const broadcast = useCallback((msg: SyncMessage) => {
+    try {
+      channelRef.current?.postMessage(msg);
+    } catch {
+      // Silently ignore — channel may be closed
+    }
+  }, []);
 
+  const clearAllTimers = useCallback(() => {
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     if (warningRef.current) clearTimeout(warningRef.current);
     if (countdownRef.current) clearInterval(countdownRef.current);
+  }, []);
+
+  const redirectToLogin = useCallback(() => {
+    window.location.href = "/login?reason=session_timeout";
+  }, []);
+
+  const resetTimers = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    setShowWarning(false);
+    clearAllTimers();
 
     // Set warning timer
     warningRef.current = setTimeout(() => {
@@ -44,8 +72,8 @@ export function SessionTimeoutWarning() {
       countdownRef.current = setInterval(() => {
         setRemainingSeconds((prev) => {
           if (prev <= 1) {
-            // Session expired — redirect to login
-            window.location.href = "/login?reason=session_timeout";
+            broadcast({ type: "session_timeout" });
+            redirectToLogin();
             return 0;
           }
           return prev - 1;
@@ -55,15 +83,43 @@ export function SessionTimeoutWarning() {
 
     // Set absolute timeout
     timeoutRef.current = setTimeout(() => {
-      window.location.href = "/login?reason=session_timeout";
+      broadcast({ type: "session_timeout" });
+      redirectToLogin();
     }, timeoutMs);
-  }, [timeoutMs, warningMs]);
+  }, [timeoutMs, warningMs, clearAllTimers, broadcast, redirectToLogin]);
 
   const handleExtend = useCallback(async () => {
     // Extend session via NextAuth update
     await update();
     resetTimers();
-  }, [update, resetTimers]);
+    broadcast({ type: "session_extended" });
+  }, [update, resetTimers, broadcast]);
+
+  // BroadcastChannel setup for cross-tab sync
+  useEffect(() => {
+    // SSR safety: BroadcastChannel is browser-only
+    if (typeof BroadcastChannel === "undefined") return;
+
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+
+    channel.onmessage = (event: MessageEvent<SyncMessage>) => {
+      const msg = event.data;
+      if (msg.type === "session_extended") {
+        // Another tab extended the session — reset our timers
+        resetTimers();
+      } else if (msg.type === "session_timeout") {
+        // Another tab detected timeout — redirect immediately
+        clearAllTimers();
+        redirectToLogin();
+      }
+    };
+
+    return () => {
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [resetTimers, clearAllTimers, redirectToLogin]);
 
   // Track user activity
   useEffect(() => {
@@ -84,11 +140,9 @@ export function SessionTimeoutWarning() {
 
     return () => {
       events.forEach((e) => window.removeEventListener(e, onActivity));
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      if (warningRef.current) clearTimeout(warningRef.current);
-      if (countdownRef.current) clearInterval(countdownRef.current);
+      clearAllTimers();
     };
-  }, [session, resetTimers]);
+  }, [session, resetTimers, clearAllTimers]);
 
   if (!session || !showWarning) return null;
 
@@ -97,11 +151,11 @@ export function SessionTimeoutWarning() {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white rounded-lg p-6 shadow-xl max-w-md w-full mx-4">
-        <h2 className="text-lg font-semibold text-gray-900">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-xl max-w-md w-full mx-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Session 即將逾時
         </h2>
-        <p className="mt-2 text-gray-600">
+        <p className="mt-2 text-gray-600 dark:text-gray-300">
           您的 Session 將在{" "}
           <span className="font-mono font-bold text-red-600">
             {minutes}:{seconds.toString().padStart(2, "0")}
@@ -113,7 +167,7 @@ export function SessionTimeoutWarning() {
             onClick={() => {
               window.location.href = "/login";
             }}
-            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
+            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
           >
             登出
           </button>


### PR DESCRIPTION
## Summary
- **Activate** the existing `SessionTimeoutWarning` component by importing and rendering it in `app/(app)/layout.tsx` inside `NextAuthSessionProvider` (required for `useSession()`)
- **Add BroadcastChannel cross-tab sync**: when one tab extends the session, all tabs reset timers; when one tab times out, all tabs redirect to login
- **SSR safety**: `typeof BroadcastChannel` guard prevents server-side errors; channel is cleaned up on unmount

## Changes
| File | What |
|------|------|
| `app/components/session-timeout-warning.tsx` | Add BroadcastChannel sync, SSR guard, dark mode, refactor timer cleanup |
| `app/(app)/layout.tsx` | Import + render `<SessionTimeoutWarning />` inside provider |
| `__tests__/api/session-timeout.test.ts` | 6 new tests for cross-tab sync, SSR safety, cleanup, layout integration |

## Test plan
- [x] `npx jest __tests__/api/session-timeout.test.ts --forceExit` — 11/11 pass
- [ ] Manual: open 2 tabs, extend session in tab A, verify tab B warning dismisses
- [ ] Manual: let session expire in tab A, verify tab B redirects to login
- [ ] Manual: verify SSR renders without error (no `BroadcastChannel is not defined`)

Closes #1137

🤖 Generated with [Claude Code](https://claude.com/claude-code)