### PR TITLE
fix(T1146): Outline iframe integration — CSP, Dockerfile, scope fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy pre-built standalone output from host
+# standalone output nests under relativeAppDir (.openclaw/shared/projects/titan)
 COPY --chown=nextjs:nodejs public ./public
-COPY --chown=nextjs:nodejs .next/standalone ./
+COPY --chown=nextjs:nodejs .next/standalone/.openclaw/shared/projects/titan/ ./
 COPY --chown=nextjs:nodejs .next/static ./.next/static
 
 USER nextjs

--- a/lib/middleware/csp.ts
+++ b/lib/middleware/csp.ts
@@ -32,6 +32,7 @@ export function buildCspWithNonce(nonce: string): string {
     "font-src 'self' data:",
     "connect-src 'self' wss: ws:",
     "worker-src 'self' blob:",
+    `frame-src 'self' ${process.env.NEXT_PUBLIC_OUTLINE_URL ?? ""}`.trim(),
     "object-src 'none'",
     "base-uri 'self'",
     "form-action 'self'",

--- a/lib/security-middleware.ts
+++ b/lib/security-middleware.ts
@@ -191,12 +191,12 @@ export function withAuditLog<T extends AnyHandler>(fn: T): T {
     const response = await fn(req, context);
 
     if (MUTATING_METHODS.has(method) && response.status >= 200 && response.status < 300) {
+      const { pathname } = new URL(req.url);
+      const resourceType = resourceTypeFromPath(pathname);
+      const action = `${method}_${resourceType.toUpperCase()}`;
       try {
-        const { pathname } = new URL(req.url);
         const userId = await getSessionUserId(req);
-        const resourceType = resourceTypeFromPath(pathname);
         const resourceId = resourceIdFromPath(pathname);
-        const action = `${method}_${resourceType.toUpperCase()}`;
 
         await auditService.log({
           userId,
@@ -207,7 +207,7 @@ export function withAuditLog<T extends AnyHandler>(fn: T): T {
       } catch (auditErr) {
         // Audit failures must never block the response — log and continue.
         // Tagged with auditFailure:true for log-based alerting (Grafana/Loki/PagerDuty).
-        logger.error({ err: auditErr, auditFailure: true, type: "audit_failure", userId, action, resourceType }, "[withAuditLog] Failed to write audit log");
+        logger.error({ err: auditErr, auditFailure: true, type: "audit_failure", action, resourceType }, "[withAuditLog] Failed to write audit log");
       }
     }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -121,11 +121,12 @@ http {
         listen [::]:8443 ssl;
         server_name titan.bank.local mac-mini.tailde842d.ts.net localhost;
 
-        add_header X-Frame-Options SAMEORIGIN always;
         add_header X-Content-Type-Options nosniff always;
         add_header Referrer-Policy strict-origin-when-cross-origin always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
+        # 允許 TITAN 主站 iframe 嵌入 Outline（跨 port = 跨 origin）
+        proxy_hide_header X-Frame-Options;
         # 移除 Outline 自帶 CSP（URL env 為 localhost，會阻擋外部主機）
         proxy_hide_header Content-Security-Policy;
 


### PR DESCRIPTION
## Summary

- CSP 加 `frame-src` 允許 Outline `:8443` iframe 嵌入
- Outline nginx server block 移除 `X-Frame-Options`（跨 port = 跨 origin）
- Dockerfile 修正 standalone copy path（Next.js nested `relativeAppDir`）
- `security-middleware.ts` 修正 `withAuditLog` catch block 變數 scope

## Test plan

- [x] Chrome DevTools 驗證：Outline iframe 正常顯示 "Create workspace"
- [x] Console 零 CSP error
- [x] `npm run build` 成功（TS error 已修）
- [x] Docker image 重建成功，app healthy

Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)