### PR TITLE
fix(T1171): add Redis TTL to JWT blacklist entries

### DIFF
--- a/__tests__/api/mobile-auth.test.ts
+++ b/__tests__/api/mobile-auth.test.ts
@@ -1391,7 +1391,7 @@ describe("Mobile Auth — POST /api/auth/mobile/logout", () => {
     const req = createLogoutRequest({ deviceId: "device-abc" });
     await POST(req as never);
 
-    expect(mockClearSession).toHaveBeenCalledWith("user-mobile-1", "sess-logout-1");
+    expect(mockClearSession).toHaveBeenCalledWith("user-mobile-1", "sess-logout-1", "mobile");
   });
 
   it("blacklists the JWT session", async () => {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -42,6 +42,7 @@ const config: Config = {
   transformIgnorePatterns: [
     "/node_modules/(?!(next-auth|@auth/core|@panva/hkdf|jose|oauth4webapi|preact-render-to-string|preact)/)",
   ],
+  modulePathIgnorePatterns: ["<rootDir>/.claude/worktrees/"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   // Allow Docker/CI to override the default test timeout
   testTimeout: parseInt(process.env.TEST_TIMEOUT ?? "10000", 10),

--- a/lib/jwt-blacklist.ts
+++ b/lib/jwt-blacklist.ts
@@ -15,6 +15,7 @@ import { logger } from "@/lib/logger";
 
 const REDIS_KEY_PREFIX = "titan:jwt:blacklist:";
 const MEM_TTL_MS = 60 * 60 * 1000; // 1 hour — tokens expire from memory after this
+const REDIS_TTL_SECONDS = 60 * 60; // 1 hour — matches in-memory TTL; exceeds 15min access token max age
 
 export class JwtBlacklist {
   /** In-memory fallback — used when Redis circuit-breaker is open. */
@@ -27,11 +28,18 @@ export class JwtBlacklist {
 
     const redis = getRedisClient();
     if (redis) {
-      // Fire-and-forget Redis add — do not await
+      const key = `${REDIS_KEY_PREFIX}${token}`;
+      // Fire-and-forget Redis add with TTL — do not await
+      // Pipeline ensures SADD + EXPIRE are sent as a single round-trip
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      redis.sadd(`${REDIS_KEY_PREFIX}${token}`, "1").catch((err) => {
-        logger.warn({ err, token }, "[jwt-blacklist] Redis SADD failed");
-      });
+      redis
+        .pipeline()
+        .sadd(key, "1")
+        .expire(key, REDIS_TTL_SECONDS)
+        .exec()
+        .catch((err) => {
+          logger.warn({ err, token }, "[jwt-blacklist] Redis pipeline failed");
+        });
     }
   }
 
@@ -93,7 +101,7 @@ export class JwtBlacklist {
   /** Clear all entries — used in tests. */
   static clear(): void {
     this._memMap.clear();
-    // Note: Redis keys are not cleared here as they are TTL-managed
+    // Redis keys auto-expire via REDIS_TTL_SECONDS (set in add())
     // For test isolation, tests should use unique session/user IDs
   }
 


### PR DESCRIPTION
## Summary

- JWT blacklist Redis entries (`SADD`) had no `EXPIRE`, causing unbounded memory growth
- Now uses `pipeline()` (`SADD` + `EXPIRE`) with 1-hour TTL matching in-memory TTL
- Fixes mobile-auth test: `clearSession` expects platform param `"mobile"`
- Adds `modulePathIgnorePatterns` to jest.config.ts to exclude stale `.claude/worktrees/`

## Test plan

- [x] `npx jest --testPathPatterns="jwt-blacklist|mobile-auth"` — 91 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Verify Redis keys have TTL in staging: `redis-cli TTL titan:jwt:blacklist:<token>`

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)