### PR TITLE
feat(T1090): mobile minimum version check middleware (426 Upgrade Required)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,3 +155,7 @@ LDAP_BASE_DN=
 # PLANE_SECRET_KEY=
 # PLANE_DB_NAME=plane
 # PLANE_REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/1
+
+# ── Mobile App ─────────────────────────────────────────────
+# 最低支援的行動裝置 App 版本（低於此版本回 426 Upgrade Required）
+MIN_MOBILE_VERSION=1.0.0

--- a/__tests__/middleware/mobile-version.test.ts
+++ b/__tests__/middleware/mobile-version.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Mobile Version Check Middleware Tests — Issue #1090
+ *
+ * Tests the X-App-Version header check for mobile API endpoints.
+ * Ensures outdated mobile apps receive 426 Upgrade Required.
+ */
+
+import { NextRequest } from "next/server";
+import { checkMobileVersion } from "@/lib/middleware/mobile-version";
+
+function createRequest(pathname: string, appVersion?: string): NextRequest {
+  const url = `http://localhost:3100${pathname}`;
+  const headers: Record<string, string> = {};
+  if (appVersion !== undefined) {
+    headers["x-app-version"] = appVersion;
+  }
+  return new NextRequest(url, { headers });
+}
+
+describe("Mobile Version Check — Issue #1090", () => {
+  const originalEnv = process.env.MIN_MOBILE_VERSION;
+
+  beforeEach(() => {
+    process.env.MIN_MOBILE_VERSION = "1.2.0";
+  });
+
+  afterAll(() => {
+    if (originalEnv !== undefined) {
+      process.env.MIN_MOBILE_VERSION = originalEnv;
+    } else {
+      delete process.env.MIN_MOBILE_VERSION;
+    }
+  });
+
+  describe("non-mobile endpoints", () => {
+    it("passes through for web API routes", () => {
+      const req = createRequest("/api/tasks", "0.1.0");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+
+    it("passes through for page routes", () => {
+      const req = createRequest("/dashboard");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+
+    it("passes through for web auth routes", () => {
+      const req = createRequest("/api/auth/callback/credentials");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+  });
+
+  describe("mobile endpoints — version enforcement", () => {
+    it("returns 426 when X-App-Version header is missing", async () => {
+      const req = createRequest("/api/auth/mobile/login");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+      const body = await res!.json();
+      expect(body.error).toBe("UpgradeRequired");
+      expect(body.minimumVersion).toBe("1.2.0");
+    });
+
+    it("returns 426 when version is below minimum", async () => {
+      const req = createRequest("/api/auth/mobile/login", "1.1.9");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+      const body = await res!.json();
+      expect(body.error).toBe("UpgradeRequired");
+      expect(body.message).toContain("1.1.9");
+      expect(body.message).toContain("1.2.0");
+    });
+
+    it("returns 426 for major version below minimum", async () => {
+      const req = createRequest("/api/auth/mobile/logout", "0.9.0");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+
+    it("passes through when version equals minimum", () => {
+      const req = createRequest("/api/auth/mobile/login", "1.2.0");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+
+    it("passes through when version exceeds minimum", () => {
+      const req = createRequest("/api/auth/mobile/login", "1.3.0");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+
+    it("passes through for higher major version", () => {
+      const req = createRequest("/api/auth/mobile/login", "2.0.0");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+
+    it("passes through for higher patch version", () => {
+      const req = createRequest("/api/auth/mobile/login", "1.2.1");
+      expect(checkMobileVersion(req)).toBeNull();
+    });
+  });
+
+  describe("invalid version formats", () => {
+    it("returns 426 for non-semver version string", async () => {
+      const req = createRequest("/api/auth/mobile/login", "abc");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+      const body = await res!.json();
+      expect(body.message).toContain("無效的版本格式");
+    });
+
+    it("returns 426 for partial version (major only)", async () => {
+      const req = createRequest("/api/auth/mobile/login", "1");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+
+    it("returns 426 for version with pre-release suffix", async () => {
+      const req = createRequest("/api/auth/mobile/login", "1.2.0-beta");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+
+    it("returns 426 for empty version string", async () => {
+      const req = createRequest("/api/auth/mobile/login", "");
+      const res = checkMobileVersion(req);
+
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles version comparison at patch boundary", () => {
+      const req = createRequest("/api/auth/mobile/login", "1.1.999");
+      const res = checkMobileVersion(req);
+      // 1.1.999 < 1.2.0 → should be rejected
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+
+    it("applies to all mobile sub-paths", () => {
+      const req = createRequest("/api/auth/mobile/refresh", "0.1.0");
+      const res = checkMobileVersion(req);
+      expect(res).not.toBeNull();
+      expect(res!.status).toBe(426);
+    });
+  });
+});

--- a/lib/middleware/mobile-version.ts
+++ b/lib/middleware/mobile-version.ts
@@ -1,0 +1,105 @@
+/**
+ * Mobile version check middleware module — Issue #1090
+ *
+ * Reads `X-App-Version` header from mobile clients and returns 426 Upgrade Required
+ * when the version is below the configured minimum. This ensures security patches
+ * are enforced — outdated mobile apps cannot bypass fixes.
+ *
+ * Version comparison uses semver-style major.minor.patch (numeric only).
+ * The minimum version is configurable via `MIN_MOBILE_VERSION` env var.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+/** Mobile API path prefix — only mobile endpoints are checked */
+const MOBILE_API_PREFIX = "/api/auth/mobile/";
+
+/** Read minimum version at request time to support dynamic config updates */
+function getMinVersion(): string {
+  return process.env.MIN_MOBILE_VERSION ?? "1.0.0";
+}
+
+/**
+ * Parse a semver string into [major, minor, patch].
+ * Returns null if the string is not a valid version.
+ */
+function parseSemver(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+  return [parseInt(match[1], 10), parseInt(match[2], 10), parseInt(match[3], 10)];
+}
+
+/**
+ * Compare two semver tuples.
+ * Returns negative if a < b, 0 if equal, positive if a > b.
+ */
+function compareSemver(
+  a: [number, number, number],
+  b: [number, number, number]
+): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+/**
+ * Check mobile app version against the minimum required version.
+ *
+ * Only applies to requests with an `X-App-Version` header targeting mobile API
+ * endpoints. Non-mobile requests and requests without the header pass through.
+ *
+ * @returns NextResponse with 426 if version is too old
+ * @returns null if the request should proceed
+ */
+export function checkMobileVersion(req: NextRequest): NextResponse | null {
+  const pathname = req.nextUrl.pathname;
+
+  // Only check mobile API endpoints
+  if (!pathname.startsWith(MOBILE_API_PREFIX)) {
+    return null;
+  }
+
+  const appVersion = req.headers.get("x-app-version");
+
+  // No version header = not a mobile client or very old app → block
+  if (!appVersion) {
+    return NextResponse.json(
+      {
+        error: "UpgradeRequired",
+        message: "請更新至最新版本的 TITAN Mobile",
+        minimumVersion: getMinVersion(),
+      },
+      { status: 426 }
+    );
+  }
+
+  const clientVersion = parseSemver(appVersion);
+  const minVersion = parseSemver(getMinVersion());
+
+  // Invalid version format → block (fail-closed)
+  if (!clientVersion || !minVersion) {
+    return NextResponse.json(
+      {
+        error: "UpgradeRequired",
+        message: "無效的版本格式，請更新至最新版本",
+        minimumVersion: getMinVersion(),
+      },
+      { status: 426 }
+    );
+  }
+
+  // Version too old → 426
+  if (compareSemver(clientVersion, minVersion) < 0) {
+    return NextResponse.json(
+      {
+        error: "UpgradeRequired",
+        message: `目前版本 ${appVersion} 已不支援，請更新至 ${getMinVersion()} 或以上`,
+        minimumVersion: getMinVersion(),
+      },
+      { status: 426 }
+    );
+  }
+
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -16,11 +16,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { generateNonce, applyCsp } from "@/lib/middleware/csp";
 import { resolveCorrelationId, applyCorrelationId } from "@/lib/middleware/correlation";
 import { checkAuth } from "@/lib/middleware/auth";
+import { checkMobileVersion } from "@/lib/middleware/mobile-version";
 
 export async function middleware(req: NextRequest): Promise<NextResponse> {
   // 1. Generate per-request identifiers
   const requestId = resolveCorrelationId(req);
   const nonce = generateNonce();
+
+  // 1.5. Mobile version check — reject outdated mobile apps before auth (Issue #1090)
+  const versionResult = checkMobileVersion(req);
+  if (versionResult !== null) {
+    return versionResult;
+  }
 
   // 2. Auth check — may return redirect or 401
   const authResult = await checkAuth(req, requestId);


### PR DESCRIPTION
## Summary

- New Edge middleware module: `lib/middleware/mobile-version.ts`
- Checks `X-App-Version` header on `/api/auth/mobile/*` endpoints
- Returns **426 Upgrade Required** for outdated or missing versions
- `MIN_MOBILE_VERSION` env var — dynamic at request time, defaults to `1.0.0`
- **Fail-closed**: missing/invalid version header → 426 (security-first)

## Test plan

- [x] 16 unit tests covering version comparison, invalid formats, edge cases
- [ ] Manual: curl with `X-App-Version: 0.1.0` → 426
- [ ] Manual: curl with `X-App-Version: 1.0.0` → passes through

Closes #1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)