### PR TITLE
feat(T1089): type generation script from Prisma schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:migrate:deploy": "prisma migrate deploy",
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "generate:mobile-types": "tsx scripts/generate-mobile-types.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/generate-mobile-types.ts
+++ b/scripts/generate-mobile-types.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env npx ts-node
+/**
+ * Generate Mobile TypeScript Types from Prisma Schema — Issue #1089
+ *
+ * Parses prisma/schema.prisma and produces types/mobile-api.ts containing:
+ * - All enums as string union types (lightweight, no runtime import needed)
+ * - Key model interfaces (fields relevant to mobile API responses)
+ * - API response wrapper types
+ *
+ * Usage:
+ *   npx ts-node scripts/generate-mobile-types.ts
+ *   npm run generate:mobile-types
+ *
+ * The output file is committed to the repo so mobile devs can import directly.
+ * CI runs a diff check to ensure it stays in sync with the schema.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const SCHEMA_PATH = path.join(__dirname, "..", "prisma", "schema.prisma");
+const OUTPUT_PATH = path.join(__dirname, "..", "types", "mobile-api.ts");
+
+// Models to include in mobile types (others are internal/server-only)
+const MOBILE_MODELS = new Set([
+  "User",
+  "Task",
+  "SubTask",
+  "TaskComment",
+  "TaskActivity",
+  "TimeEntry",
+  "TimeEntryTemplate",
+  "TimeEntryTemplateItem",
+  "Notification",
+  "NotificationPreference",
+  "KPI",
+  "KPIAchievement",
+  "AnnualPlan",
+  "MonthlyGoal",
+  "Milestone",
+  "Deliverable",
+  "Document",
+  "KnowledgeSpace",
+]);
+
+// Fields to exclude from mobile types (server-internal, sensitive)
+const EXCLUDED_FIELDS = new Set([
+  "password",
+  "passwordChangedAt",
+  "mustChangePassword",
+  "passwordHistory",
+  "tokenHash",
+  "revokedAt",
+  "ipAddress",
+]);
+
+// Prisma → TypeScript type mapping
+const TYPE_MAP: Record<string, string> = {
+  String: "string",
+  Int: "number",
+  Float: "number",
+  Decimal: "number",
+  Boolean: "boolean",
+  DateTime: "string", // ISO 8601 in API responses
+  Json: "unknown",
+  BigInt: "number",
+};
+
+interface ParsedEnum {
+  name: string;
+  values: string[];
+}
+
+interface ParsedField {
+  name: string;
+  type: string;
+  isOptional: boolean;
+  isList: boolean;
+  isRelation: boolean;
+}
+
+interface ParsedModel {
+  name: string;
+  fields: ParsedField[];
+}
+
+function parseSchema(content: string): { enums: ParsedEnum[]; models: ParsedModel[] } {
+  const enums: ParsedEnum[] = [];
+  const models: ParsedModel[] = [];
+  const lines = content.split("\n");
+
+  let currentEnum: ParsedEnum | null = null;
+  let currentModel: ParsedModel | null = null;
+  let braceDepth = 0;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    // Track enum blocks
+    if (line.startsWith("enum ") && line.endsWith("{")) {
+      const name = line.replace("enum ", "").replace(" {", "").trim();
+      currentEnum = { name, values: [] };
+      braceDepth = 1;
+      continue;
+    }
+
+    // Track model blocks
+    if (line.startsWith("model ") && line.endsWith("{")) {
+      const name = line.replace("model ", "").replace(" {", "").trim();
+      currentModel = { name, fields: [] };
+      braceDepth = 1;
+      continue;
+    }
+
+    if (line === "}") {
+      if (currentEnum) {
+        enums.push(currentEnum);
+        currentEnum = null;
+      }
+      if (currentModel) {
+        models.push(currentModel);
+        currentModel = null;
+      }
+      braceDepth = 0;
+      continue;
+    }
+
+    // Parse enum values — strip inline comments and whitespace
+    if (currentEnum && line && !line.startsWith("//") && !line.startsWith("@@")) {
+      const enumValue = line.split("//")[0].trim().replace(/,\s*$/, "");
+      if (enumValue) {
+        currentEnum.values.push(enumValue);
+      }
+      continue;
+    }
+
+    // Parse model fields
+    if (currentModel && line && !line.startsWith("//") && !line.startsWith("@@")) {
+      const field = parseField(line);
+      if (field) {
+        currentModel.fields.push(field);
+      }
+    }
+  }
+
+  return { enums, models };
+}
+
+function parseField(line: string): ParsedField | null {
+  // Match: fieldName TypeName? @relation(...) etc.
+  const match = line.match(/^(\w+)\s+(\w+)(\[\])?([\?])?/);
+  if (!match) return null;
+
+  const [, name, rawType, listMarker, optionalMarker] = match;
+
+  // Skip Prisma directives lines like @@id, @@unique, @@index
+  if (name.startsWith("@@")) return null;
+
+  const isExplicitRelation = line.includes("@relation(");
+  const isList = listMarker === "[]";
+  const isOptional = optionalMarker === "?" || isList;
+  // A field is a relation if it has @relation() or its type starts with uppercase
+  // and is not a known scalar/enum type (relations reference other models)
+  const isScalarOrEnum = rawType in TYPE_MAP || rawType.match(/^[A-Z]/) === null;
+  const isRelation = isExplicitRelation || (isList && !isScalarOrEnum);
+
+  return {
+    name,
+    type: rawType,
+    isOptional,
+    isList,
+    isRelation,
+  };
+}
+
+function mapType(field: ParsedField, enumNames: Set<string>): string {
+  const baseType = TYPE_MAP[field.type] ?? (enumNames.has(field.type) ? field.type : field.type);
+
+  if (field.isList) return `${baseType}[]`;
+  return baseType;
+}
+
+function generate(enums: ParsedEnum[], models: ParsedModel[]): string {
+  const enumNames = new Set(enums.map((e) => e.name));
+  const modelNames = new Set(models.map((m) => m.name));
+  const lines: string[] = [];
+
+  lines.push("/**");
+  lines.push(" * TITAN Mobile API Types — Auto-generated from prisma/schema.prisma");
+  lines.push(` * Generated: ${new Date().toISOString().slice(0, 10)}`);
+  lines.push(" *");
+  lines.push(" * DO NOT EDIT MANUALLY — run `npm run generate:mobile-types` to regenerate.");
+  lines.push(" * See scripts/generate-mobile-types.ts for the generator.");
+  lines.push(" */");
+  lines.push("");
+  lines.push("/* eslint-disable @typescript-eslint/no-empty-interface */");
+  lines.push("");
+
+  // Generate enums as string union types
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("// Enums (string unions — no runtime overhead)");
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("");
+
+  for (const e of enums) {
+    lines.push(`export type ${e.name} = ${e.values.map((v) => `"${v}"`).join(" | ")};`);
+  }
+
+  lines.push("");
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("// Models (mobile-facing fields only)");
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("");
+
+  // Generate model interfaces
+  const mobileModels = models.filter((m) => MOBILE_MODELS.has(m.name));
+
+  for (const model of mobileModels) {
+    lines.push(`export interface ${model.name} {`);
+
+    for (const field of model.fields) {
+      // Skip excluded fields
+      if (EXCLUDED_FIELDS.has(field.name)) continue;
+      // Skip relation fields — types referencing other models
+      if (field.isRelation || modelNames.has(field.type)) continue;
+
+      const tsType = mapType(field, enumNames);
+      const optional = field.isOptional ? "?" : "";
+      lines.push(`  ${field.name}${optional}: ${tsType};`);
+    }
+
+    lines.push("}");
+    lines.push("");
+  }
+
+  // Generate API response wrappers
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("// API Response Types");
+  lines.push("// ═══════════════════════════════════════════════════════════");
+  lines.push("");
+  lines.push("export interface ApiResponse<T> {");
+  lines.push("  success: boolean;");
+  lines.push("  data?: T;");
+  lines.push("  error?: string;");
+  lines.push("  message?: string;");
+  lines.push("}");
+  lines.push("");
+  lines.push("export interface PaginatedResponse<T> extends ApiResponse<T[]> {");
+  lines.push("  total: number;");
+  lines.push("  page: number;");
+  lines.push("  pageSize: number;");
+  lines.push("}");
+  lines.push("");
+  lines.push("export interface MobileLoginResponse {");
+  lines.push("  token: string;");
+  lines.push("  refreshToken: string;");
+  lines.push("  expiresAt: number;");
+  lines.push("  user: Pick<User, \"id\" | \"name\" | \"email\" | \"role\">;");
+  lines.push("}");
+  lines.push("");
+  lines.push("export interface MobileRefreshResponse {");
+  lines.push("  token?: string;");
+  lines.push("  refreshToken: string;");
+  lines.push("  expiresAt?: number;");
+  lines.push("  expiresIn: number;");
+  lines.push("  user: Pick<User, \"id\" | \"name\" | \"email\" | \"role\">;");
+  lines.push("}");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// Main
+const schema = fs.readFileSync(SCHEMA_PATH, "utf-8");
+const { enums, models } = parseSchema(schema);
+
+const output = generate(enums, models);
+fs.writeFileSync(OUTPUT_PATH, output, "utf-8");
+
+const mobileModelCount = models.filter((m) => MOBILE_MODELS.has(m.name)).length;
+console.log(`✓ Generated ${OUTPUT_PATH}`);
+console.log(`  ${enums.length} enums, ${mobileModelCount}/${models.length} models`);

--- a/types/mobile-api.ts
+++ b/types/mobile-api.ts
@@ -1,0 +1,360 @@
+/**
+ * TITAN Mobile API Types — Auto-generated from prisma/schema.prisma
+ * Generated: 2026-04-02
+ *
+ * DO NOT EDIT MANUALLY — run `npm run generate:mobile-types` to regenerate.
+ * See scripts/generate-mobile-types.ts for the generator.
+ */
+
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+// ═══════════════════════════════════════════════════════════
+// Enums (string unions — no runtime overhead)
+// ═══════════════════════════════════════════════════════════
+
+export type Role = "ADMIN" | "MANAGER" | "ENGINEER";
+export type KPIStatus = "DRAFT" | "ACTIVE" | "ACHIEVED" | "MISSED" | "CANCELLED";
+export type KPIFrequency = "MONTHLY" | "QUARTERLY" | "YEARLY";
+export type KPIVisibility = "ALL" | "MANAGER";
+export type GoalStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+export type MilestoneStatus = "PENDING" | "IN_PROGRESS" | "COMPLETED" | "DELAYED" | "CANCELLED";
+export type MilestoneType = "LAUNCH" | "AUDIT" | "CUSTOM";
+export type TaskStatus = "BACKLOG" | "TODO" | "IN_PROGRESS" | "REVIEW" | "DONE";
+export type Priority = "P0" | "P1" | "P2" | "P3";
+export type TaskCategory = "PLANNED" | "ADDED" | "INCIDENT" | "SUPPORT" | "ADMIN" | "LEARNING";
+export type IncidentSeverity = "SEV1" | "SEV2" | "SEV3" | "SEV4";
+export type CMChangeType = "NORMAL" | "STANDARD" | "EMERGENCY";
+export type RiskLevel = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+export type ChangeStatus = "DRAFT" | "PENDING_APPROVAL" | "APPROVED" | "IN_PROGRESS" | "VERIFYING" | "COMPLETED" | "ROLLED_BACK" | "CANCELLED";
+export type ChangeType = "DELAY" | "SCOPE_CHANGE";
+export type DeliverableType = "DOCUMENT" | "SYSTEM" | "REPORT" | "APPROVAL";
+export type DeliverableStatus = "NOT_STARTED" | "IN_PROGRESS" | "DELIVERED" | "ACCEPTED";
+export type TimeCategory = "PLANNED_TASK" | "ADDED_TASK" | "INCIDENT" | "SUPPORT" | "ADMIN" | "LEARNING";
+export type OvertimeType = "NONE" | "WEEKDAY" | "REST_DAY" | "HOLIDAY";
+export type TimesheetApprovalStatus = "PENDING" | "APPROVED" | "REJECTED";
+export type NotificationType = "TASK_ASSIGNED" | "TASK_DUE_SOON" | "TASK_OVERDUE" | "TASK_COMMENTED" | "MILESTONE_DUE" | "BACKUP_ACTIVATED" | "TASK_CHANGED" | "TIMESHEET_REMINDER" | "TIMESHEET_REJECTED" | "SLA_EXPIRING" | "VERIFICATION_DUE" | "MANAGER_FLAG";
+export type DocumentStatus = "DRAFT" | "IN_REVIEW" | "PUBLISHED" | "ARCHIVED" | "RETIRED";
+export type RecurrenceFrequency = "DAILY" | "WEEKLY" | "BIWEEKLY" | "MONTHLY" | "QUARTERLY" | "YEARLY";
+export type ApprovalStatus = "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
+export type ApprovalType = "TASK_STATUS_CHANGE" | "DELIVERABLE_ACCEPTANCE" | "PLAN_MODIFICATION" | "CHANGE_REQUEST";
+export type AlertStatus = "FIRING" | "RESOLVED" | "ACKNOWLEDGED";
+export type SpaceRole = "OWNER" | "EDITOR" | "VIEWER";
+export type LinkType = "REFERENCE" | "RELATED";
+export type PushPlatform = "IOS" | "ANDROID";
+
+// ═══════════════════════════════════════════════════════════
+// Models (mobile-facing fields only)
+// ═══════════════════════════════════════════════════════════
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: Role;
+  avatar?: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface KPI {
+  id: string;
+  year: number;
+  code: string;
+  title: string;
+  description?: string;
+  measureMethod?: string;
+  target: number;
+  actual: number;
+  weight: number;
+  frequency: KPIFrequency;
+  minValue?: number;
+  maxValue?: number;
+  unit?: string;
+  visibility: KPIVisibility;
+  status: KPIStatus;
+  autoCalc: boolean;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface KPIAchievement {
+  id: string;
+  kpiId: string;
+  period: string;
+  actualValue: number;
+  note?: string;
+  reportedBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AnnualPlan {
+  id: string;
+  year: number;
+  title: string;
+  description?: string;
+  vision?: string;
+  implementationPlan?: string;
+  progressPct: number;
+  copiedFromYear?: number;
+  archivedAt?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MonthlyGoal {
+  id: string;
+  annualPlanId: string;
+  month: number;
+  title: string;
+  description?: string;
+  assigneeId?: string;
+  retrospectiveNote?: string;
+  status: GoalStatus;
+  progressPct: number;
+  completedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Milestone {
+  id: string;
+  annualPlanId: string;
+  title: string;
+  description?: string;
+  type: MilestoneType;
+  plannedStart?: string;
+  plannedEnd: string;
+  actualStart?: string;
+  actualEnd?: string;
+  status: MilestoneStatus;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Task {
+  id: string;
+  annualPlanId?: string;
+  monthlyGoalId?: string;
+  title: string;
+  description?: string;
+  category: TaskCategory;
+  primaryAssigneeId?: string;
+  backupAssigneeId?: string;
+  creatorId: string;
+  status: TaskStatus;
+  priority: Priority;
+  dueDate?: string;
+  startDate?: string;
+  estimatedHours?: number;
+  actualHours: number;
+  progressPct: number;
+  position: number;
+  tags?: string[];
+  addedDate?: string;
+  addedReason?: string;
+  addedSource?: string;
+  slaDeadline?: string;
+  managerFlagged: boolean;
+  flagReason?: string;
+  flaggedAt?: string;
+  flaggedBy?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SubTask {
+  id: string;
+  taskId: string;
+  title: string;
+  done: boolean;
+  order: number;
+  assigneeId?: string;
+  dueDate?: string;
+  notes?: string;
+  result?: string;
+  completedAt?: string;
+  createdAt: string;
+}
+
+export interface TaskComment {
+  id: string;
+  taskId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskActivity {
+  id: string;
+  taskId: string;
+  userId: string;
+  action: string;
+  detail?: unknown;
+  createdAt: string;
+}
+
+export interface Deliverable {
+  id: string;
+  title: string;
+  type: DeliverableType;
+  status: DeliverableStatus;
+  attachmentUrl?: string;
+  acceptedBy?: string;
+  acceptedAt?: string;
+  kpiId?: string;
+  annualPlanId?: string;
+  monthlyGoalId?: string;
+  taskId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TimeEntry {
+  id: string;
+  taskId?: string;
+  userId: string;
+  date: string;
+  hours: number;
+  category: TimeCategory;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  startTime?: string;
+  endTime?: string;
+  overtime: boolean;
+  overtimeType: OvertimeType;
+  locked: boolean;
+  approvalStatus: TimesheetApprovalStatus;
+  isRunning: boolean;
+  sortOrder: number;
+  isDeleted: boolean;
+  deletedAt?: string;
+  subTaskId?: string;
+}
+
+export interface TimeEntryTemplate {
+  id: string;
+  name: string;
+  userId: string;
+  entries: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TimeEntryTemplateItem {
+  id: string;
+  templateId: string;
+  taskId?: string;
+  hours: number;
+  category: TimeCategory;
+  description?: string;
+  sortOrder: number;
+}
+
+export interface Notification {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  body?: string;
+  relatedId?: string;
+  relatedType?: string;
+  isRead: boolean;
+  createdAt: string;
+}
+
+export interface NotificationPreference {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  enabled: boolean;
+  emailEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface KnowledgeSpace {
+  id: string;
+  name: string;
+  description?: string;
+  slug?: string;
+  icon?: string;
+  color?: string;
+  visibility: string;
+  sortOrder: number;
+  updatedBy?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Document {
+  id: string;
+  spaceId?: string;
+  parentId?: string;
+  title: string;
+  content: string;
+  slug: string;
+  tags?: string[];
+  status: DocumentStatus;
+  createdBy: string;
+  updatedBy: string;
+  version: number;
+  verifierId?: string;
+  verifiedAt?: string;
+  verifyIntervalDays?: number;
+  verifyByDate?: string;
+  categoryId?: string;
+  summary?: string;
+  pinned: boolean;
+  coverImage?: string;
+  publishedVersion?: number;
+  publishedAt?: string;
+  publishedBy?: string;
+  archivedAt?: string;
+  archivedBy?: string;
+  wordCount: number;
+  readTimeMin: number;
+  visibility: string;
+  replacedById?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ═══════════════════════════════════════════════════════════
+// API Response Types
+// ═══════════════════════════════════════════════════════════
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  message?: string;
+}
+
+export interface PaginatedResponse<T> extends ApiResponse<T[]> {
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface MobileLoginResponse {
+  token: string;
+  refreshToken: string;
+  expiresAt: number;
+  user: Pick<User, "id" | "name" | "email" | "role">;
+}
+
+export interface MobileRefreshResponse {
+  token?: string;
+  refreshToken: string;
+  expiresAt?: number;
+  expiresIn: number;
+  user: Pick<User, "id" | "name" | "email" | "role">;
+}


### PR DESCRIPTION
## Summary

- New script: `scripts/generate-mobile-types.ts` — parses Prisma schema, generates mobile TypeScript types
- New npm command: `npm run generate:mobile-types`
- Output: `types/mobile-api.ts` — 29 enums + 18 model interfaces + API response types
- Strips inline comments from enum values, excludes relation fields and sensitive fields

## Test plan

- [x] `npm run generate:mobile-types` — produces clean output
- [x] `npx tsc --noEmit types/mobile-api.ts` — compiles without errors
- [ ] CI diff check: regenerate and verify no drift from committed version

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)