### PR TITLE
feat: Excel 季報/單項目報告 + 甘特圖/報表/計畫整合

### DIFF
--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -311,6 +311,54 @@ function MilestoneMarker({ milestone, year, totalDays }: MilestoneMarkerProps) {
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
+type GanttView = "goals" | "projects";
+
+type ProjectRow = {
+  id: string;
+  code: string;
+  name: string;
+  status: string;
+  plannedStart: string | null;
+  plannedEnd: string | null;
+  progressPct: number;
+};
+
+const PROJECT_STATUS_BAR: Record<string, string> = {
+  PROPOSED: "bg-muted",
+  EVALUATING: "bg-blue-400/60",
+  APPROVED: "bg-blue-500/70",
+  SCHEDULED: "bg-indigo-500/70",
+  REQUIREMENTS: "bg-violet-500/70",
+  DESIGN: "bg-purple-500/70",
+  DEVELOPMENT: "bg-amber-500/80",
+  TESTING: "bg-orange-500/80",
+  DEPLOYMENT: "bg-rose-500/80",
+  WARRANTY: "bg-pink-400/70",
+  COMPLETED: "bg-emerald-500/80",
+  POST_REVIEW: "bg-teal-500/70",
+  CLOSED: "bg-gray-500/60",
+  ON_HOLD: "bg-muted",
+  CANCELLED: "bg-muted/50",
+};
+
+const PROJECT_STATUS_LABEL: Record<string, string> = {
+  PROPOSED: "提案",
+  EVALUATING: "評估中",
+  APPROVED: "已核准",
+  SCHEDULED: "已排程",
+  REQUIREMENTS: "需求分析",
+  DESIGN: "系統設計",
+  DEVELOPMENT: "開發中",
+  TESTING: "測試中",
+  DEPLOYMENT: "部署中",
+  WARRANTY: "保固期",
+  COMPLETED: "已完成",
+  POST_REVIEW: "後評價",
+  CLOSED: "已關閉",
+  ON_HOLD: "暫停",
+  CANCELLED: "已取消",
+};
+
 export default function GanttPage() {
   const { data: session } = useSession();
   const isManager = session?.user?.role === "MANAGER";
@@ -321,6 +369,9 @@ export default function GanttPage() {
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [users, setUsers] = useState<User[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [view, setView] = useState<GanttView>("goals");
+  const [projectRows, setProjectRows] = useState<ProjectRow[]>([]);
+  const [projectLoading, setProjectLoading] = useState(false);
 
   const handleDateChange = useCallback(async (taskId: string, startDate: string | null, dueDate: string | null) => {
     try {
@@ -365,6 +416,26 @@ export default function GanttPage() {
 
   useEffect(() => { fetchData(); }, [fetchData]);
 
+  // Fetch projects for project view
+  const fetchProjects = useCallback(async () => {
+    setProjectLoading(true);
+    try {
+      const res = await fetch(`/api/projects?year=${year}&limit=100`);
+      if (!res.ok) throw new Error("項目資料載入失敗");
+      const body = await res.json();
+      const items = body?.data?.items ?? body?.items ?? [];
+      setProjectRows(items);
+    } catch {
+      setProjectRows([]);
+    } finally {
+      setProjectLoading(false);
+    }
+  }, [year]);
+
+  useEffect(() => {
+    if (view === "projects") fetchProjects();
+  }, [view, fetchProjects]);
+
   useEffect(() => {
     fetch("/api/users").then((r) => r.json()).then((body) => setUsers(extractItems<User>(body))).catch(() => {});
   }, []);
@@ -384,7 +455,30 @@ export default function GanttPage() {
         </div>
 
         <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-          {/* Assignee filter */}
+          {/* View toggle */}
+          <div className="flex items-center bg-background border border-border rounded-md overflow-hidden">
+            <button
+              onClick={() => setView("goals")}
+              className={cn(
+                "px-3 py-1.5 text-sm transition-colors",
+                view === "goals" ? "bg-primary text-primary-foreground font-medium" : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              月度目標
+            </button>
+            <button
+              onClick={() => setView("projects")}
+              className={cn(
+                "px-3 py-1.5 text-sm transition-colors",
+                view === "projects" ? "bg-primary text-primary-foreground font-medium" : "text-muted-foreground hover:text-foreground"
+              )}
+            >
+              項目
+            </button>
+          </div>
+
+          {/* Assignee filter (only in goals view) */}
+          {view === "goals" && (
           <select
             aria-label="篩選負責人"
             value={assigneeFilter}
@@ -394,6 +488,7 @@ export default function GanttPage() {
             <option value="">全部成員</option>
             {users.map((u) => <option key={u.id} value={u.id}>{u.name}</option>)}
           </select>
+          )}
 
           {/* Year picker */}
           <div className="flex items-center gap-1 bg-background border border-border rounded-md">
@@ -414,7 +509,109 @@ export default function GanttPage() {
         </div>
       </div>
 
-      {loading ? (
+      {/* ── Project View ─────────────────────────────────────────────── */}
+      {view === "projects" ? (
+        projectLoading ? (
+          <div className="flex-1">
+            <PageLoading message="載入項目..." />
+          </div>
+        ) : projectRows.length === 0 ? (
+          <div className="flex-1">
+            <PageEmpty
+              icon={<BarChart2 className="h-10 w-10" />}
+              title={`${year} 年度無項目`}
+              description="請先在項目管理頁面建立項目"
+            />
+          </div>
+        ) : (
+          <div className="flex-1 overflow-auto">
+            <div className="min-w-[900px]">
+              {/* Month header */}
+              <div className="flex">
+                <div className="w-56 flex-shrink-0" />
+                <div className="flex-1 relative">
+                  <div className="flex border-b border-border">
+                    {MONTHS.map((m, i) => {
+                      const widthPct = ((new Date(year, i + 1, 0).getDate()) / totalDays) * 100;
+                      return (
+                        <div
+                          key={i}
+                          className="text-center text-xs text-muted-foreground py-2 border-r border-border/50 last:border-0"
+                          style={{ width: `${widthPct}%` }}
+                        >
+                          {m}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              {/* Project rows */}
+              {projectRows.map((proj) => {
+                const hasRange = proj.plannedStart || proj.plannedEnd;
+                const startDay = proj.plannedStart
+                  ? Math.max(0, dayOfYear(proj.plannedStart, year))
+                  : (proj.plannedEnd ? Math.max(0, dayOfYear(proj.plannedEnd, year) - 30) : 0);
+                const endDay = proj.plannedEnd
+                  ? Math.min(totalDays, dayOfYear(proj.plannedEnd, year))
+                  : Math.min(totalDays, startDay + 30);
+                const leftPct = (startDay / totalDays) * 100;
+                const widthPct = Math.max(0.5, ((endDay - startDay) / totalDays) * 100);
+
+                return (
+                  <div key={proj.id} className="flex border-b border-border/20 hover:bg-accent/20 transition-colors group">
+                    <div className="w-56 flex-shrink-0 px-3 py-1.5 flex items-center gap-2">
+                      <div className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", PROJECT_STATUS_BAR[proj.status] ?? "bg-muted")} />
+                      <span className="text-xs text-muted-foreground group-hover:text-foreground truncate transition-colors" title={`${proj.code} ${proj.name}`}>
+                        <span className="font-mono text-[10px] mr-1">{proj.code}</span>
+                        {proj.name}
+                      </span>
+                    </div>
+                    <div className="flex-1 relative py-1.5 px-1">
+                      {MONTHS.map((_, i) => (
+                        <div
+                          key={i}
+                          className="absolute top-0 bottom-0 w-px bg-border/20"
+                          style={{ left: `${(monthStartDay(i, year) / totalDays) * 100}%` }}
+                        />
+                      ))}
+                      {hasRange ? (
+                        <div className="h-5 relative">
+                          <div
+                            title={`${proj.name} — ${PROJECT_STATUS_LABEL[proj.status] ?? proj.status} (${proj.progressPct}%)`}
+                            className={cn(
+                              "absolute h-5 rounded-sm flex items-center px-1.5 overflow-hidden cursor-default",
+                              PROJECT_STATUS_BAR[proj.status] ?? "bg-muted"
+                            )}
+                            style={{ left: `${leftPct}%`, width: `${widthPct}%`, minWidth: "4px" }}
+                          >
+                            {widthPct > 5 && (
+                              <span className="text-[10px] text-white/80 font-medium truncate leading-none">
+                                {PROJECT_STATUS_LABEL[proj.status] ?? proj.status}
+                              </span>
+                            )}
+                            {proj.progressPct > 0 && (
+                              <div
+                                className="absolute inset-0 left-0 bg-white/10 rounded-sm"
+                                style={{ width: `${proj.progressPct}%` }}
+                              />
+                            )}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="h-5 flex items-center">
+                          <span className="text-xs text-muted-foreground/50 italic">無日期</span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )
+      ) : loading ? (
         <div className="flex-1">
           <PageLoading message="載入甘特圖..." />
         </div>

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -61,6 +61,98 @@ const statusColors: Record<TaskStatus, string> = {
 
 const monthNames = ["", "1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
 
+// ─── Linked Projects ─────────────────────────────────────────────────────────
+
+const PROJECT_STATUS_LABEL: Record<string, string> = {
+  PROPOSED: "提案", EVALUATING: "評估中", APPROVED: "已核准", SCHEDULED: "已排程",
+  REQUIREMENTS: "需求分析", DESIGN: "系統設計", DEVELOPMENT: "開發中", TESTING: "測試中",
+  DEPLOYMENT: "部署中", WARRANTY: "保固期", COMPLETED: "已完成", POST_REVIEW: "後評價",
+  CLOSED: "已關閉", ON_HOLD: "暫停", CANCELLED: "已取消",
+};
+
+const PROJECT_STATUS_COLOR: Record<string, string> = {
+  COMPLETED: "text-emerald-400", CLOSED: "text-muted-foreground", CANCELLED: "text-muted-foreground/50",
+  DEVELOPMENT: "text-amber-400", TESTING: "text-orange-400", DEPLOYMENT: "text-rose-400",
+};
+
+type LinkedProject = {
+  id: string;
+  code: string;
+  name: string;
+  status: string;
+  progressPct: number;
+};
+
+function LinkedProjects({ planYear, planTitle }: { planYear: number; planTitle: string }) {
+  const [projects, setProjects] = useState<LinkedProject[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/projects?year=${planYear}&limit=50`)
+      .then(r => r.json())
+      .then(d => {
+        const items = d?.data?.items ?? d?.items ?? [];
+        setProjects(items.map((p: Record<string, unknown>) => ({
+          id: p.id,
+          code: p.code,
+          name: p.name,
+          status: p.status,
+          progressPct: p.progressPct ?? 0,
+        })));
+      })
+      .catch(() => setProjects([]))
+      .finally(() => setLoading(false));
+  }, [planYear]);
+
+  if (loading || projects.length === 0) return null;
+
+  return (
+    <div className="bg-card border border-border rounded-xl">
+      <button
+        onClick={() => setExpanded(v => !v)}
+        className="flex items-center justify-between w-full px-4 py-3 hover:bg-accent/30 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <ChevronRight className={cn("h-3.5 w-3.5 text-muted-foreground transition-transform", expanded && "rotate-90")} />
+          <span className="text-sm font-medium">關聯項目</span>
+          <span className="text-xs text-muted-foreground">({planTitle} — {projects.length} 個項目)</span>
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border/50">
+                <th className="text-left py-1.5 px-2 text-muted-foreground font-medium">編號</th>
+                <th className="text-left py-1.5 px-2 text-muted-foreground font-medium">名稱</th>
+                <th className="text-left py-1.5 px-2 text-muted-foreground font-medium">狀態</th>
+                <th className="text-right py-1.5 px-2 text-muted-foreground font-medium">進度</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projects.map((p) => (
+                <tr key={p.id} className="border-b border-border/20 hover:bg-accent/20">
+                  <td className="py-1.5 px-2 font-mono">{p.code}</td>
+                  <td className="py-1.5 px-2">{p.name}</td>
+                  <td className={cn("py-1.5 px-2", PROJECT_STATUS_COLOR[p.status] ?? "text-blue-400")}>
+                    {PROJECT_STATUS_LABEL[p.status] ?? p.status}
+                  </td>
+                  <td className="text-right py-1.5 px-2 tabular-nums">{p.progressPct}%</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
 export default function PlansPage() {
   const [plans, setPlans] = useState<AnnualPlan[]>([]);
   const [loading, setLoading] = useState(true);
@@ -456,6 +548,11 @@ export default function PlansPage() {
           archivingId={archiving}
         />
       )}
+
+      {/* Linked projects */}
+      {!loading && plans.filter(p => !p.archivedAt).map((plan) => (
+        <LinkedProjects key={plan.id} planYear={plan.year} planTitle={plan.title} />
+      ))}
 
       {/* Goal detail panel */}
       {selectedGoal && (

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -33,7 +33,7 @@ import { safeFixed, safePct } from "@/lib/safe-number";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type ReportId = "utilization" | "velocity" | "kpi-trend" | "unplanned" | "time-summary" | "overtime" | "audit-summary" | "login-activity";
+type ReportId = "utilization" | "velocity" | "kpi-trend" | "unplanned" | "time-summary" | "overtime" | "audit-summary" | "login-activity" | "project-status" | "project-budget";
 
 interface ReportNav {
   id: ReportId;
@@ -62,6 +62,8 @@ const REPORT_CATEGORIES: ReportCategory[] = [
     icon: FolderKanban,
     reports: [
       { id: "unplanned", label: "計畫外工作趨勢", icon: AlertTriangle, description: "計畫外占比月趨勢" },
+      { id: "project-status", label: "項目狀態分佈", icon: FolderKanban, description: "按狀態統計項目數量" },
+      { id: "project-budget", label: "預算執行率", icon: TrendingUp, description: "各項目預算 vs 實際花費" },
     ],
   },
   {
@@ -898,6 +900,144 @@ function LoginActivityReport({ from, to }: { from: string; to: string }) {
   );
 }
 
+// ─── Project Status Distribution Report ────────────────────────────────────
+
+const PROJECT_STATUS_LABELS: Record<string, string> = {
+  PROPOSED: "提案", EVALUATING: "評估中", APPROVED: "已核准", SCHEDULED: "已排程",
+  REQUIREMENTS: "需求分析", DESIGN: "系統設計", DEVELOPMENT: "開發中", TESTING: "測試中",
+  DEPLOYMENT: "部署中", WARRANTY: "保固期", COMPLETED: "已完成", POST_REVIEW: "後評價",
+  CLOSED: "已關閉", ON_HOLD: "暫停", CANCELLED: "已取消",
+};
+
+function ProjectStatusReport() {
+  const [data, setData] = useState<{ status: string; count: number }[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [reportYear, setReportYear] = useState(new Date().getFullYear());
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/reports/project-status?year=${reportYear}`)
+      .then(r => r.json())
+      .then(d => { setData(d.data?.byStatus ?? []); setTotal(d.data?.total ?? 0); })
+      .catch(() => { setData([]); setTotal(0); })
+      .finally(() => setLoading(false));
+  }, [reportYear]);
+
+  const handleExport = () => exportCSV(
+    ["狀態", "數量"],
+    data.map(r => [PROJECT_STATUS_LABELS[r.status] ?? r.status, String(r.count)]),
+    `project-status-${reportYear}.csv`
+  );
+
+  if (loading) return <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
+
+  const maxCount = Math.max(1, ...data.map(d => d.count));
+
+  return (
+    <div>
+      <div className="flex flex-wrap justify-between items-center gap-2 mb-4">
+        <div>
+          <h3 className="font-semibold">項目狀態分佈</h3>
+          <p className="text-xs text-muted-foreground">共 {total} 個項目</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input type="number" value={reportYear} onChange={e => setReportYear(parseInt(e.target.value) || new Date().getFullYear())} className="text-sm px-2 py-1 border border-border rounded-md w-20 bg-background text-foreground" />
+          <button onClick={handleExport} className="flex items-center gap-1.5 text-xs px-3 py-1.5 border border-border rounded-md hover:bg-accent"><Download className="h-3.5 w-3.5" />CSV</button>
+        </div>
+      </div>
+      {data.length === 0 ? (
+        <div className="text-center text-muted-foreground py-12">此年度無項目資料</div>
+      ) : (
+        <div className="space-y-2">
+          {data.map(r => (
+            <div key={r.status} className="flex items-center gap-3">
+              <span className="text-xs w-20 flex-shrink-0 text-right text-muted-foreground">{PROJECT_STATUS_LABELS[r.status] ?? r.status}</span>
+              <div className="flex-1 h-6 bg-muted/30 rounded overflow-hidden">
+                <div className="h-full bg-primary/60 rounded transition-all" style={{ width: `${(r.count / maxCount) * 100}%` }} />
+              </div>
+              <span className="text-sm font-medium tabular-nums w-10">{r.count}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Project Budget Execution Report ──────────────────────────────────────
+
+interface BudgetRow { id: string; code: string; name: string; budgetTotal: number; budgetActual: number; executionRate: number; status: string; }
+
+function ProjectBudgetReport() {
+  const [data, setData] = useState<BudgetRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reportYear, setReportYear] = useState(new Date().getFullYear());
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/reports/project-budget?year=${reportYear}`)
+      .then(r => r.json())
+      .then(d => setData(d.data?.items ?? []))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [reportYear]);
+
+  const handleExport = () => exportCSV(
+    ["編號", "名稱", "預算", "實際花費", "執行率(%)", "狀態"],
+    data.map(r => [r.code, r.name, String(r.budgetTotal), String(r.budgetActual), String(r.executionRate), PROJECT_STATUS_LABELS[r.status] ?? r.status]),
+    `project-budget-${reportYear}.csv`
+  );
+
+  if (loading) return <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
+
+  return (
+    <div>
+      <div className="flex flex-wrap justify-between items-center gap-2 mb-4">
+        <div>
+          <h3 className="font-semibold">預算執行率</h3>
+          <p className="text-xs text-muted-foreground">各項目預算 vs 實際花費</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input type="number" value={reportYear} onChange={e => setReportYear(parseInt(e.target.value) || new Date().getFullYear())} className="text-sm px-2 py-1 border border-border rounded-md w-20 bg-background text-foreground" />
+          <button onClick={handleExport} className="flex items-center gap-1.5 text-xs px-3 py-1.5 border border-border rounded-md hover:bg-accent"><Download className="h-3.5 w-3.5" />CSV</button>
+        </div>
+      </div>
+      {data.length === 0 ? (
+        <div className="text-center text-muted-foreground py-12">此年度無項目資料</div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead><tr className="border-b bg-muted/30">
+              <th className="text-left py-2 px-2">編號</th>
+              <th className="text-left py-2 px-2">名稱</th>
+              <th className="text-right py-2 px-2">預算</th>
+              <th className="text-right py-2 px-2">實際花費</th>
+              <th className="text-right py-2 px-2">執行率</th>
+              <th className="text-left py-2 px-2">狀態</th>
+            </tr></thead>
+            <tbody>
+              {data.map(r => {
+                const rateColor = r.executionRate > 100 ? "text-red-600" : r.executionRate >= 80 ? "text-amber-600" : "text-foreground";
+                return (
+                  <tr key={r.id} className="border-b border-border/30 hover:bg-accent/30">
+                    <td className="py-1.5 px-2 font-mono">{r.code}</td>
+                    <td className="py-1.5 px-2">{r.name}</td>
+                    <td className="text-right py-1.5 px-2 tabular-nums">{r.budgetTotal.toLocaleString()}</td>
+                    <td className="text-right py-1.5 px-2 tabular-nums">{r.budgetActual.toLocaleString()}</td>
+                    <td className={`text-right py-1.5 px-2 font-bold tabular-nums ${rateColor}`}>{r.executionRate}%</td>
+                    <td className="py-1.5 px-2">{PROJECT_STATUS_LABELS[r.status] ?? r.status}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ─── Main Page ───────────────────────────────────────────────────────────────
 
 export default function ReportsV2Page() {
@@ -1006,6 +1146,12 @@ export default function ReportsV2Page() {
           )}
           {activeReport === "login-activity" && (
             <LoginActivityReport from={dateRange.from} to={dateRange.to} />
+          )}
+          {activeReport === "project-status" && (
+            <ProjectStatusReport />
+          )}
+          {activeReport === "project-budget" && (
+            <ProjectBudgetReport />
           )}
         </div>
       </div>

--- a/app/api/projects/[id]/export/route.ts
+++ b/app/api/projects/[id]/export/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { ProjectService } from "@/services/project-service";
+import { withManager } from "@/lib/auth-middleware";
+import { error as apiError } from "@/lib/api-response";
+import { generateProjectReport } from "@/lib/excel/project-templates";
+
+const projectService = new ProjectService(prisma);
+
+export const GET = withManager(async (
+  req: NextRequest,
+  context: { params: Promise<Record<string, string>> }
+) => {
+  const { id } = await context.params;
+  const project = await projectService.getProject(id);
+
+  if (!project) {
+    return apiError("NotFound", "項目不存在", 404);
+  }
+
+  const buffer = await generateProjectReport({
+    code: project.code,
+    name: project.name,
+    year: project.year,
+    category: project.category,
+    requestDept: project.requestDept,
+    status: project.status,
+    priority: project.priority,
+    owner: project.owner,
+    plannedStart: project.plannedStart,
+    plannedEnd: project.plannedEnd,
+    actualStart: project.actualStart,
+    actualEnd: project.actualEnd,
+    progressPct: project.progressPct,
+    riskLevel: project.riskLevel,
+    progressNote: project.progressNote,
+    mdProjectMgmt: project.mdProjectMgmt,
+    mdRequirements: project.mdRequirements,
+    mdDesign: project.mdDesign,
+    mdDevelopment: project.mdDevelopment,
+    mdTesting: project.mdTesting,
+    mdDeployment: project.mdDeployment,
+    mdDocumentation: project.mdDocumentation,
+    mdTraining: project.mdTraining,
+    mdMaintenance: project.mdMaintenance,
+    mdOther: project.mdOther,
+    mdTotalEstimated: project.mdTotalEstimated,
+    mdActualTotal: project.mdActualTotal,
+    budgetInternal: project.budgetInternal,
+    budgetExternal: project.budgetExternal,
+    budgetHardware: project.budgetHardware,
+    budgetLicense: project.budgetLicense,
+    budgetOther: project.budgetOther,
+    budgetTotal: project.budgetTotal,
+    budgetActual: project.budgetActual,
+    vendor: project.vendor,
+    vendorAmount: project.vendorAmount,
+    benefitScore: project.benefitScore,
+    postReviewSchedule: project.postReviewSchedule,
+    postReviewQuality: project.postReviewQuality,
+    postReviewBudget: project.postReviewBudget,
+    postReviewSatisfy: project.postReviewSatisfy,
+    postReviewScore: project.postReviewScore,
+    lessonsLearned: project.lessonsLearned,
+    improvements: project.improvements,
+    risks: project.risks.map((r) => ({
+      code: r.code,
+      title: r.title,
+      probability: r.probability,
+      impact: r.impact,
+      status: r.status,
+      mitigation: r.mitigation,
+    })),
+    issues: project.issues.map((i) => ({
+      code: i.code,
+      title: i.title,
+      severity: i.severity,
+      status: i.status,
+      resolution: i.resolution,
+    })),
+  });
+
+  const filename = `project-${project.code}-${new Date().toISOString().split("T")[0]}.xlsx`;
+
+  return new NextResponse(new Uint8Array(buffer), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+});

--- a/app/api/projects/export/route.ts
+++ b/app/api/projects/export/route.ts
@@ -2,20 +2,41 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { ProjectService } from "@/services/project-service";
 import { withManager } from "@/lib/auth-middleware";
-import { generateProjectExcel } from "@/lib/excel/project-templates";
+import { error as apiError } from "@/lib/api-response";
+import { generateProjectExcel, generateQuarterlyReport } from "@/lib/excel/project-templates";
 import type { ProjectStatus } from "@prisma/client";
 
 const projectService = new ProjectService(prisma);
 
 export const GET = withManager(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
-  const type = searchParams.get("type") as "full" | "summary" | null;
+  const type = searchParams.get("type") as "full" | "summary" | "quarterly" | null;
 
   const filter = {
     year: searchParams.get("year") ? parseInt(searchParams.get("year")!) : undefined,
     status: searchParams.get("status") as ProjectStatus | undefined,
     requestDept: searchParams.get("requestDept") ?? undefined,
   };
+
+  // Quarterly report (type=quarterly&quarter=1&year=2026)
+  if (type === "quarterly") {
+    const quarter = parseInt(searchParams.get("quarter") ?? "1");
+    const year = filter.year ?? new Date().getFullYear();
+    if (quarter < 1 || quarter > 4) {
+      return apiError("ValidationError", "quarter 必須為 1-4", 400);
+    }
+    const projects = await projectService.getProjectsForExport({ ...filter, year });
+    const buffer = await generateQuarterlyReport(projects, quarter, year);
+    const filename = `quarterly-report-${year}-Q${quarter}.xlsx`;
+
+    return new NextResponse(new Uint8Array(buffer), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  }
 
   // Excel export (type=full or type=summary)
   if (type === "full" || type === "summary") {

--- a/app/api/reports/project-budget/route.ts
+++ b/app/api/reports/project-budget/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { success } from "@/lib/api-response";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year")
+    ? parseInt(searchParams.get("year")!)
+    : new Date().getFullYear();
+
+  const projects = await prisma.project.findMany({
+    where: { year, archivedAt: null },
+    select: {
+      id: true,
+      code: true,
+      name: true,
+      budgetTotal: true,
+      budgetActual: true,
+      status: true,
+    },
+    orderBy: { code: "asc" },
+  });
+
+  const items = projects.map((p) => ({
+    id: p.id,
+    code: p.code,
+    name: p.name,
+    budgetTotal: p.budgetTotal ?? 0,
+    budgetActual: p.budgetActual ?? 0,
+    executionRate:
+      p.budgetTotal && p.budgetTotal > 0
+        ? Math.round(((p.budgetActual ?? 0) / p.budgetTotal) * 100)
+        : 0,
+    status: p.status,
+  }));
+
+  return success({ year, items });
+});

--- a/app/api/reports/project-status/route.ts
+++ b/app/api/reports/project-status/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { success } from "@/lib/api-response";
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const year = searchParams.get("year")
+    ? parseInt(searchParams.get("year")!)
+    : new Date().getFullYear();
+
+  const byStatus = await prisma.project.groupBy({
+    by: ["status"],
+    where: { year, archivedAt: null },
+    _count: { id: true },
+    orderBy: { _count: { id: "desc" } },
+  });
+
+  const total = byStatus.reduce((s, r) => s + r._count.id, 0);
+
+  return success({
+    year,
+    total,
+    byStatus: byStatus.map((r) => ({
+      status: r.status,
+      count: r._count.id,
+    })),
+  });
+});

--- a/lib/excel/project-templates.ts
+++ b/lib/excel/project-templates.ts
@@ -339,6 +339,508 @@ function buildSummarySheet(wb: ExcelJS.Workbook, projects: ProjectExportRow[]) {
   return ws;
 }
 
+// ── Quarterly Report ─────────────────────────────────────────────────────
+
+interface QuarterlyReportRow extends ProjectExportRow {
+  riskLevel: string | null;
+}
+
+export async function generateQuarterlyReport(
+  projects: QuarterlyReportRow[],
+  quarter: number,
+  year: number
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  wb.creator = "TITAN PMO";
+  wb.created = new Date();
+
+  const RISK_LABELS: Record<string, string> = {
+    LOW: "低", MEDIUM: "中", HIGH: "高", CRITICAL: "極高",
+  };
+
+  // ── Sheet 1: 摘要 ──────────────────────────────────────────────────────
+  const ws1 = wb.addWorksheet("摘要");
+
+  // Row 1: Title
+  ws1.mergeCells("A1:F1");
+  const titleCell = ws1.getCell("A1");
+  titleCell.value = "○○銀行 IT 項目管理季報";
+  titleCell.font = { bold: true, size: 16, color: { argb: "FFFFFFFF" } };
+  titleCell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1F4E79" } };
+  titleCell.alignment = { vertical: "middle", horizontal: "center" };
+  ws1.getRow(1).height = 36;
+
+  // Row 2: Subtitle
+  ws1.mergeCells("A2:F2");
+  const subtitleCell = ws1.getCell("A2");
+  subtitleCell.value = `${year} Q${quarter}`;
+  subtitleCell.font = { size: 12, color: { argb: "FF808080" } };
+  subtitleCell.alignment = { vertical: "middle", horizontal: "center" };
+  ws1.getRow(2).height = 24;
+
+  // Row 4-7: Summary stats
+  const completed = projects.filter((p) => ["COMPLETED", "CLOSED"].includes(p.status)).length;
+  const totalBudget = projects.reduce((s, p) => s + (p.budgetTotal ?? 0), 0);
+  const totalActual = projects.reduce((s, p) => s + (p.budgetActual ?? 0), 0);
+  const executionRate = totalBudget > 0 ? Math.round((totalActual / totalBudget) * 100) : 0;
+  const avgBenefit = projects.length > 0
+    ? Math.round(projects.reduce((s, p) => s + (p.benefitScore ?? 0), 0) / projects.length)
+    : 0;
+
+  const summaryStats: [string, string | number][] = [
+    ["項目總數", projects.length],
+    ["已完成", completed],
+    ["預算執行率", `${executionRate}%`],
+    ["平均效益分", avgBenefit],
+  ];
+
+  ws1.getColumn(1).width = 20;
+  ws1.getColumn(2).width = 20;
+
+  summaryStats.forEach(([label, value], i) => {
+    const row = ws1.getRow(4 + i);
+    row.getCell(1).value = label;
+    row.getCell(1).font = { bold: true };
+    row.getCell(2).value = value;
+  });
+
+  // Row 9: Status distribution table
+  const statusRow = 9;
+  ws1.getRow(statusRow).getCell(1).value = "狀態分佈";
+  ws1.getRow(statusRow).getCell(1).font = { bold: true, size: 11 };
+
+  const statusHeaderRow = ws1.getRow(statusRow + 1);
+  statusHeaderRow.getCell(1).value = "狀態";
+  statusHeaderRow.getCell(2).value = "數量";
+  statusHeaderRow.eachCell((cell) => {
+    cell.fill = HEADER_FILL;
+    cell.font = HEADER_FONT;
+    cell.alignment = HEADER_ALIGNMENT;
+  });
+
+  const statusCounts: Record<string, number> = {};
+  projects.forEach((p) => {
+    const label = STATUS_LABELS[p.status] ?? p.status;
+    statusCounts[label] = (statusCounts[label] ?? 0) + 1;
+  });
+  let currentRow = statusRow + 2;
+  Object.entries(statusCounts).forEach(([label, count]) => {
+    const row = ws1.getRow(currentRow++);
+    row.getCell(1).value = label;
+    row.getCell(2).value = count;
+  });
+
+  // High risk project list
+  currentRow += 1;
+  ws1.getRow(currentRow).getCell(1).value = "高風險項目清單";
+  ws1.getRow(currentRow).getCell(1).font = { bold: true, size: 11 };
+  currentRow++;
+
+  const highRiskProjects = projects.filter(
+    (p) => p.riskLevel === "HIGH" || p.riskLevel === "CRITICAL"
+  );
+
+  if (highRiskProjects.length > 0) {
+    const riskHeaderRow = ws1.getRow(currentRow++);
+    ["編號", "名稱", "風險等級", "狀態", "進度%"].forEach((h, i) => {
+      riskHeaderRow.getCell(i + 1).value = h;
+      riskHeaderRow.getCell(i + 1).fill = HEADER_FILL;
+      riskHeaderRow.getCell(i + 1).font = HEADER_FONT;
+      riskHeaderRow.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+    });
+    ws1.getColumn(3).width = 14;
+    ws1.getColumn(4).width = 14;
+    ws1.getColumn(5).width = 10;
+
+    highRiskProjects.forEach((p) => {
+      const row = ws1.getRow(currentRow++);
+      row.getCell(1).value = p.code;
+      row.getCell(2).value = p.name;
+      row.getCell(3).value = RISK_LABELS[p.riskLevel ?? ""] ?? p.riskLevel ?? "";
+      row.getCell(4).value = STATUS_LABELS[p.status] ?? p.status;
+      row.getCell(5).value = p.progressPct;
+    });
+  } else {
+    ws1.getRow(currentRow).getCell(1).value = "無高風險項目";
+    ws1.getRow(currentRow).getCell(1).font = { color: { argb: "FF808080" }, italic: true };
+  }
+
+  // ── Sheet 2: 項目明細 (reuse full sheet logic) ────────────────────────
+  buildFullSheet(wb, projects, year);
+
+  // ── Sheet 3: 效益追蹤 ─────────────────────────────────────────────────
+  const ws3 = wb.addWorksheet("效益追蹤");
+  ws3.columns = [
+    { header: "編號", key: "code", width: 14 },
+    { header: "名稱", key: "name", width: 30 },
+    { header: "效益分", key: "benefitScore", width: 10 },
+    { header: "預估人天", key: "mdTotalEstimated", width: 12 },
+    { header: "實際人天", key: "mdActualTotal", width: 12 },
+    { header: "差異", key: "diff", width: 10 },
+    { header: "預算", key: "budgetTotal", width: 14 },
+    { header: "實際花費", key: "budgetActual", width: 14 },
+  ];
+
+  const ws3HeaderRow = ws3.getRow(1);
+  ws3HeaderRow.height = 28;
+  ws3HeaderRow.eachCell((cell) => {
+    cell.fill = HEADER_FILL;
+    cell.font = HEADER_FONT;
+    cell.alignment = HEADER_ALIGNMENT;
+    cell.border = { bottom: { style: "thin", color: { argb: "FF000000" } } };
+  });
+
+  projects.forEach((p) => {
+    const est = p.mdTotalEstimated ?? 0;
+    const act = p.mdActualTotal ?? 0;
+    const diff = act - est;
+    const row = ws3.addRow({
+      code: p.code,
+      name: p.name,
+      benefitScore: p.benefitScore,
+      mdTotalEstimated: p.mdTotalEstimated,
+      mdActualTotal: p.mdActualTotal,
+      diff,
+      budgetTotal: p.budgetTotal,
+      budgetActual: p.budgetActual,
+    });
+
+    // Color diff: negative=green, positive=red
+    const diffCell = row.getCell("diff");
+    if (diff < 0) {
+      diffCell.font = { color: { argb: "FF008000" } };
+    } else if (diff > 0) {
+      diffCell.font = { color: { argb: "FFCC0000" } };
+    }
+  });
+
+  ws3.getColumn("benefitScore").numFmt = "#,##0";
+  ws3.getColumn("mdTotalEstimated").numFmt = "#,##0";
+  ws3.getColumn("mdActualTotal").numFmt = "#,##0";
+  ws3.getColumn("diff").numFmt = "#,##0";
+  ws3.getColumn("budgetTotal").numFmt = "#,##0";
+  ws3.getColumn("budgetActual").numFmt = "#,##0";
+
+  const buffer = await wb.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}
+
+// ── Single Project Report ────────────────────────────────────────────────
+
+interface ProjectReportData {
+  code: string;
+  name: string;
+  year: number;
+  category: string | null;
+  requestDept: string;
+  status: string;
+  priority: string;
+  owner: { name: string };
+  plannedStart: Date | string | null;
+  plannedEnd: Date | string | null;
+  actualStart: Date | string | null;
+  actualEnd: Date | string | null;
+  progressPct: number;
+  riskLevel: string | null;
+  progressNote: string | null;
+
+  // Man-days (10 stages)
+  mdProjectMgmt: number | null;
+  mdRequirements: number | null;
+  mdDesign: number | null;
+  mdDevelopment: number | null;
+  mdTesting: number | null;
+  mdDeployment: number | null;
+  mdDocumentation: number | null;
+  mdTraining: number | null;
+  mdMaintenance: number | null;
+  mdOther: number | null;
+  mdTotalEstimated: number | null;
+  mdActualTotal: number | null;
+
+  // Budget
+  budgetInternal: number | null;
+  budgetExternal: number | null;
+  budgetHardware: number | null;
+  budgetLicense: number | null;
+  budgetOther: number | null;
+  budgetTotal: number | null;
+  budgetActual: number | null;
+  vendor: string | null;
+  vendorAmount: number | null;
+
+  // Benefit
+  benefitScore: number | null;
+
+  // Post-review
+  postReviewSchedule: number | null;
+  postReviewQuality: number | null;
+  postReviewBudget: number | null;
+  postReviewSatisfy: number | null;
+  postReviewScore: number | null;
+  lessonsLearned: string | null;
+  improvements: string | null;
+
+  // Related
+  risks: Array<{
+    code: string;
+    title: string;
+    probability: string;
+    impact: string;
+    status: string;
+    mitigation: string | null;
+  }>;
+  issues: Array<{
+    code: string;
+    title: string;
+    severity: string;
+    status: string;
+    resolution: string | null;
+  }>;
+}
+
+export async function generateProjectReport(
+  project: ProjectReportData
+): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  wb.creator = "TITAN PMO";
+  wb.created = new Date();
+
+  // ── Sheet 1: 基本資訊 ─────────────────────────────────────────────────
+  const ws1 = wb.addWorksheet("基本資訊");
+  ws1.getColumn(1).width = 18;
+  ws1.getColumn(2).width = 40;
+
+  const kvPairs: [string, string | number | null][] = [
+    ["項目編號", project.code],
+    ["名稱", project.name],
+    ["年度", project.year],
+    ["類別", project.category],
+    ["需求部門", project.requestDept],
+    ["負責人", project.owner.name],
+    ["狀態", STATUS_LABELS[project.status] ?? project.status],
+    ["優先級", PRIORITY_LABELS[project.priority] ?? project.priority],
+    ["計劃開始", toDateStr(project.plannedStart)],
+    ["計劃結束", toDateStr(project.plannedEnd)],
+    ["實際開始", toDateStr(project.actualStart)],
+    ["實際結束", toDateStr(project.actualEnd)],
+    ["進度%", project.progressPct],
+    ["風險等級", project.riskLevel ?? ""],
+    ["效益分", project.benefitScore],
+    ["最新進展", project.progressNote],
+  ];
+
+  kvPairs.forEach(([label, value], i) => {
+    const row = ws1.getRow(i + 1);
+    row.getCell(1).value = label;
+    row.getCell(1).font = { bold: true };
+    row.getCell(1).fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFF0F0F0" } };
+    row.getCell(2).value = value ?? "";
+  });
+
+  // ── Sheet 2: 人天明細 ─────────────────────────────────────────────────
+  const ws2 = wb.addWorksheet("人天明細");
+  ws2.getColumn(1).width = 18;
+  ws2.getColumn(2).width = 14;
+  ws2.getColumn(3).width = 14;
+  ws2.getColumn(4).width = 14;
+
+  const headerRow2 = ws2.getRow(1);
+  ["階段", "預估", "實際", "差異"].forEach((h, i) => {
+    headerRow2.getCell(i + 1).value = h;
+    headerRow2.getCell(i + 1).fill = HEADER_FILL;
+    headerRow2.getCell(i + 1).font = HEADER_FONT;
+    headerRow2.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+  });
+  headerRow2.height = 28;
+
+  const mdStages: [string, number | null][] = [
+    ["專案管理", project.mdProjectMgmt],
+    ["需求分析", project.mdRequirements],
+    ["系統設計", project.mdDesign],
+    ["開發", project.mdDevelopment],
+    ["測試", project.mdTesting],
+    ["部署", project.mdDeployment],
+    ["文件", project.mdDocumentation],
+    ["教育訓練", project.mdTraining],
+    ["維護", project.mdMaintenance],
+    ["其他", project.mdOther],
+  ];
+
+  const totalActualMD = project.mdActualTotal ?? 0;
+  const totalEstMD = project.mdTotalEstimated ?? 0;
+  // We only have total actual, so put stages as estimated only
+  mdStages.forEach(([label, estimated]) => {
+    const est = estimated ?? 0;
+    const row = ws2.addRow([label, est, "", ""]);
+    row.getCell(2).numFmt = "#,##0";
+  });
+
+  // Total row
+  const totalMDRow = ws2.addRow(["合計", totalEstMD, totalActualMD, totalActualMD - totalEstMD]);
+  totalMDRow.font = { bold: true };
+  totalMDRow.eachCell((cell) => {
+    cell.border = { top: { style: "double", color: { argb: "FF000000" } } };
+  });
+  // Color diff
+  const diffVal = totalActualMD - totalEstMD;
+  const diffCell = totalMDRow.getCell(4);
+  if (diffVal < 0) {
+    diffCell.font = { bold: true, color: { argb: "FF008000" } };
+  } else if (diffVal > 0) {
+    diffCell.font = { bold: true, color: { argb: "FFCC0000" } };
+  }
+
+  // ── Sheet 3: 預算明細 ─────────────────────────────────────────────────
+  const ws3 = wb.addWorksheet("預算明細");
+  ws3.getColumn(1).width = 18;
+  ws3.getColumn(2).width = 18;
+
+  const budgetHeaderRow = ws3.getRow(1);
+  ["類別", "金額"].forEach((h, i) => {
+    budgetHeaderRow.getCell(i + 1).value = h;
+    budgetHeaderRow.getCell(i + 1).fill = HEADER_FILL;
+    budgetHeaderRow.getCell(i + 1).font = HEADER_FONT;
+    budgetHeaderRow.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+  });
+  budgetHeaderRow.height = 28;
+
+  const budgetItems: [string, number | null][] = [
+    ["內部人力", project.budgetInternal],
+    ["外包費用", project.budgetExternal],
+    ["硬體設備", project.budgetHardware],
+    ["軟體授權", project.budgetLicense],
+    ["其他", project.budgetOther],
+  ];
+
+  budgetItems.forEach(([label, amount]) => {
+    const row = ws3.addRow([label, amount ?? 0]);
+    row.getCell(2).numFmt = "#,##0";
+  });
+
+  const budgetTotalRow = ws3.addRow(["預算合計", project.budgetTotal ?? 0]);
+  budgetTotalRow.font = { bold: true };
+  budgetTotalRow.getCell(2).numFmt = "#,##0";
+  budgetTotalRow.eachCell((cell) => {
+    cell.border = { top: { style: "double", color: { argb: "FF000000" } } };
+  });
+
+  const actualRow = ws3.addRow(["實際花費", project.budgetActual ?? 0]);
+  actualRow.getCell(2).numFmt = "#,##0";
+
+  // Vendor info
+  if (project.vendor) {
+    ws3.addRow([]);
+    const vendorLabelRow = ws3.addRow(["廠商資訊", ""]);
+    vendorLabelRow.getCell(1).font = { bold: true, size: 11 };
+    ws3.addRow(["廠商名稱", project.vendor]);
+    ws3.addRow(["廠商金額", project.vendorAmount ?? 0]);
+    ws3.getRow(ws3.rowCount).getCell(2).numFmt = "#,##0";
+  }
+
+  // ── Sheet 4: 風險與議題 ───────────────────────────────────────────────
+  const ws4 = wb.addWorksheet("風險與議題");
+
+  // Risks section
+  ws4.getRow(1).getCell(1).value = "風險清單";
+  ws4.getRow(1).getCell(1).font = { bold: true, size: 12 };
+
+  if (project.risks.length > 0) {
+    const riskHeaders = ["編號", "標題", "可能性", "影響", "狀態", "緩解措施"];
+    const riskHeaderRow = ws4.getRow(2);
+    riskHeaders.forEach((h, i) => {
+      riskHeaderRow.getCell(i + 1).value = h;
+      riskHeaderRow.getCell(i + 1).fill = HEADER_FILL;
+      riskHeaderRow.getCell(i + 1).font = HEADER_FONT;
+      riskHeaderRow.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+    });
+    riskHeaderRow.height = 28;
+
+    ws4.getColumn(1).width = 12;
+    ws4.getColumn(2).width = 28;
+    ws4.getColumn(3).width = 10;
+    ws4.getColumn(4).width = 10;
+    ws4.getColumn(5).width = 10;
+    ws4.getColumn(6).width = 36;
+
+    project.risks.forEach((r) => {
+      ws4.addRow([r.code, r.title, r.probability, r.impact, r.status, r.mitigation ?? ""]);
+    });
+  } else {
+    ws4.getRow(2).getCell(1).value = "無風險紀錄";
+    ws4.getRow(2).getCell(1).font = { color: { argb: "FF808080" }, italic: true };
+  }
+
+  // Issues section
+  const issueStartRow = ws4.rowCount + 2;
+  ws4.getRow(issueStartRow).getCell(1).value = "議題清單";
+  ws4.getRow(issueStartRow).getCell(1).font = { bold: true, size: 12 };
+
+  if (project.issues.length > 0) {
+    const issueHeaders = ["編號", "標題", "嚴重度", "狀態", "解決方案"];
+    const issueHeaderRow = ws4.getRow(issueStartRow + 1);
+    issueHeaders.forEach((h, i) => {
+      issueHeaderRow.getCell(i + 1).value = h;
+      issueHeaderRow.getCell(i + 1).fill = HEADER_FILL;
+      issueHeaderRow.getCell(i + 1).font = HEADER_FONT;
+      issueHeaderRow.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+    });
+    issueHeaderRow.height = 28;
+
+    project.issues.forEach((iss) => {
+      ws4.addRow([iss.code, iss.title, iss.severity, iss.status, iss.resolution ?? ""]);
+    });
+  } else {
+    ws4.getRow(issueStartRow + 1).getCell(1).value = "無議題紀錄";
+    ws4.getRow(issueStartRow + 1).getCell(1).font = { color: { argb: "FF808080" }, italic: true };
+  }
+
+  // ── Sheet 5: 後評價 ───────────────────────────────────────────────────
+  const ws5 = wb.addWorksheet("後評價");
+  ws5.getColumn(1).width = 18;
+  ws5.getColumn(2).width = 14;
+
+  const postHeaderRow = ws5.getRow(1);
+  ["維度", "得分 (0-25)"].forEach((h, i) => {
+    postHeaderRow.getCell(i + 1).value = h;
+    postHeaderRow.getCell(i + 1).fill = HEADER_FILL;
+    postHeaderRow.getCell(i + 1).font = HEADER_FONT;
+    postHeaderRow.getCell(i + 1).alignment = HEADER_ALIGNMENT;
+  });
+  postHeaderRow.height = 28;
+
+  const dimensions: [string, number | null][] = [
+    ["時程", project.postReviewSchedule],
+    ["品質", project.postReviewQuality],
+    ["預算", project.postReviewBudget],
+    ["滿意度", project.postReviewSatisfy],
+  ];
+
+  dimensions.forEach(([label, score]) => {
+    ws5.addRow([label, score ?? ""]);
+  });
+
+  const totalPostRow = ws5.addRow(["總分", project.postReviewScore ?? ""]);
+  totalPostRow.font = { bold: true };
+  totalPostRow.eachCell((cell) => {
+    cell.border = { top: { style: "double", color: { argb: "FF000000" } } };
+  });
+
+  // Lessons learned & improvements
+  ws5.addRow([]);
+  const llRow = ws5.addRow(["經驗教訓", project.lessonsLearned ?? ""]);
+  llRow.getCell(1).font = { bold: true };
+  llRow.getCell(2).alignment = { wrapText: true };
+  ws5.getColumn(2).width = 50;
+
+  const impRow = ws5.addRow(["改善建議", project.improvements ?? ""]);
+  impRow.getCell(1).font = { bold: true };
+  impRow.getCell(2).alignment = { wrapText: true };
+
+  const buffer = await wb.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}
+
 // ── Main export function ──────────────────────────────────────────────────
 
 export async function generateProjectExcel(


### PR DESCRIPTION
## Excel 匯出（2 個新模版）
- 管理層季報：3 sheet（摘要+明細+效益追蹤）
- 單項目報告書：5 sheet（基本+人天+預算+風險+後評價）
- API: `?type=quarterly` + `/api/projects/[id]/export`

## 系統整合
- 甘特圖：「月度目標 | 項目」視圖切換
- 報表：項目狀態分佈 + 預算執行率
- 年度計畫：關聯項目區塊