### PR TITLE
fix: review round 2 — 1 CRITICAL + 4 HIGH + 3 MEDIUM + 1 LOW

### DIFF
--- a/app/(app)/gantt/page.tsx
+++ b/app/(app)/gantt/page.tsx
@@ -373,6 +373,23 @@ export default function GanttPage() {
   const [projectRows, setProjectRows] = useState<ProjectRow[]>([]);
   const [projectLoading, setProjectLoading] = useState(false);
 
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const params = new URLSearchParams({ year: year.toString() });
+      if (assigneeFilter) params.set("assignee", assigneeFilter);
+      const res = await fetch(`/api/tasks/gantt?${params}`);
+      if (!res.ok) throw new Error("甘特圖資料載入失敗");
+      const body = await res.json();
+      setData(extractData<{ annualPlan: AnnualPlan | null; year: number }>(body));
+    } catch (e) {
+      setFetchError(e instanceof Error ? e.message : "載入失敗");
+    } finally {
+      setLoading(false);
+    }
+  }, [year, assigneeFilter]);
+
   const handleDateChange = useCallback(async (taskId: string, startDate: string | null, dueDate: string | null) => {
     try {
       // Use dedicated dates endpoint — Issue #844 (G-3)
@@ -395,24 +412,7 @@ export default function GanttPage() {
     } catch {
       fetchData(); // Revert by re-fetching
     }
-  }, []);
-
-  const fetchData = useCallback(async () => {
-    setLoading(true);
-    setFetchError(null);
-    try {
-      const params = new URLSearchParams({ year: year.toString() });
-      if (assigneeFilter) params.set("assignee", assigneeFilter);
-      const res = await fetch(`/api/tasks/gantt?${params}`);
-      if (!res.ok) throw new Error("甘特圖資料載入失敗");
-      const body = await res.json();
-      setData(extractData<{ annualPlan: AnnualPlan | null; year: number }>(body));
-    } catch (e) {
-      setFetchError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }, [year, assigneeFilter]);
+  }, [fetchData]);
 
   useEffect(() => { fetchData(); }, [fetchData]);
 

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -106,7 +106,14 @@ function LinkedProjects({ planYear, planTitle }: { planYear: number; planTitle: 
       .finally(() => setLoading(false));
   }, [planYear]);
 
-  if (loading || projects.length === 0) return null;
+  if (loading && projects.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+  if (projects.length === 0) return null;
 
   return (
     <div className="bg-card border border-border rounded-xl">

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -106,8 +106,12 @@ function defaultDateRange(): { from: string; to: string } {
 }
 
 function exportCSV(headers: string[], rows: string[][], filename: string) {
+  const sanitize = (s: string) => /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
   const bom = "\uFEFF";
-  const csv = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
+  const csv = [
+    headers.map(sanitize).join(","),
+    ...rows.map(r => r.map(v => sanitize(v.includes(",") || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)).join(","))
+  ].join("\n");
   const blob = new Blob([bom + csv], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/app/api/projects/[id]/export/route.ts
+++ b/app/api/projects/[id]/export/route.ts
@@ -18,6 +18,10 @@ export const GET = withManager(async (
     return apiError("NotFound", "項目不存在", 404);
   }
 
+  if (project.archivedAt) {
+    return apiError("NotFoundError", "項目不存在", 404);
+  }
+
   const buffer = await generateProjectReport({
     code: project.code,
     name: project.name,
@@ -81,12 +85,13 @@ export const GET = withManager(async (
   });
 
   const filename = `project-${project.code}-${new Date().toISOString().split("T")[0]}.xlsx`;
+  const safeName = filename.replace(/[^\w\-\.]/g, "_");
 
   return new NextResponse(new Uint8Array(buffer), {
     status: 200,
     headers: {
       "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Disposition": `attachment; filename="${safeName}"`,
     },
   });
 });

--- a/app/api/projects/export/route.ts
+++ b/app/api/projects/export/route.ts
@@ -12,8 +12,13 @@ export const GET = withManager(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const type = searchParams.get("type") as "full" | "summary" | "quarterly" | null;
 
+  const rawYear = parseInt(searchParams.get("year") ?? "", 10);
+  const parsedYear = Number.isFinite(rawYear) && rawYear > 2000 && rawYear < 2100
+    ? rawYear
+    : undefined;
+
   const filter = {
-    year: searchParams.get("year") ? parseInt(searchParams.get("year")!) : undefined,
+    year: parsedYear,
     status: searchParams.get("status") as ProjectStatus | undefined,
     requestDept: searchParams.get("requestDept") ?? undefined,
   };
@@ -28,12 +33,13 @@ export const GET = withManager(async (req: NextRequest) => {
     const projects = await projectService.getProjectsForExport({ ...filter, year });
     const buffer = await generateQuarterlyReport(projects, quarter, year);
     const filename = `quarterly-report-${year}-Q${quarter}.xlsx`;
+    const safeName = filename.replace(/[^\w\-\.]/g, "_");
 
     return new NextResponse(new Uint8Array(buffer), {
       status: 200,
       headers: {
         "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Content-Disposition": `attachment; filename="${safeName}"`,
       },
     });
   }
@@ -46,12 +52,13 @@ export const GET = withManager(async (req: NextRequest) => {
     const filename = type === "full"
       ? `projects-full-${dateStr}.xlsx`
       : `projects-summary-${dateStr}.xlsx`;
+    const safeName = filename.replace(/[^\w\-\.]/g, "_");
 
     return new NextResponse(new Uint8Array(buffer), {
       status: 200,
       headers: {
         "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Content-Disposition": `attachment; filename="${safeName}"`,
       },
     });
   }
@@ -63,7 +70,7 @@ export const GET = withManager(async (req: NextRequest) => {
     status: 200,
     headers: {
       "Content-Type": "text/csv; charset=utf-8",
-      "Content-Disposition": `attachment; filename="projects-${new Date().toISOString().split("T")[0]}.csv"`,
+      "Content-Disposition": `attachment; filename="projects-${new Date().toISOString().split("T")[0].replace(/[^\w\-\.]/g, "_")}.csv"`,
     },
   });
 });

--- a/app/api/reports/project-budget/route.ts
+++ b/app/api/reports/project-budget/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { withAuth } from "@/lib/auth-middleware";
+import { withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 
-export const GET = withAuth(async (req: NextRequest) => {
+export const GET = withManager(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
-  const year = searchParams.get("year")
-    ? parseInt(searchParams.get("year")!)
+  const rawYear = parseInt(searchParams.get("year") ?? "", 10);
+  const year = Number.isFinite(rawYear) && rawYear > 2000 && rawYear < 2100
+    ? rawYear
     : new Date().getFullYear();
 
   const projects = await prisma.project.findMany({

--- a/app/api/reports/project-status/route.ts
+++ b/app/api/reports/project-status/route.ts
@@ -5,8 +5,9 @@ import { success } from "@/lib/api-response";
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
-  const year = searchParams.get("year")
-    ? parseInt(searchParams.get("year")!)
+  const rawYear = parseInt(searchParams.get("year") ?? "", 10);
+  const year = Number.isFinite(rawYear) && rawYear > 2000 && rawYear < 2100
+    ? rawYear
     : new Date().getFullYear();
 
   const byStatus = await prisma.project.groupBy({

--- a/lib/excel/project-templates.ts
+++ b/lib/excel/project-templates.ts
@@ -350,6 +350,19 @@ export async function generateQuarterlyReport(
   quarter: number,
   year: number
 ): Promise<Buffer> {
+  // Filter projects that overlap with the quarter date range
+  const quarterStart = new Date(year, (quarter - 1) * 3, 1);
+  const quarterEnd = new Date(year, quarter * 3, 0, 23, 59, 59);
+  const filtered = projects.filter(p => {
+    const start = p.plannedStart ? new Date(p.plannedStart) : null;
+    const end = p.plannedEnd ? new Date(p.plannedEnd) : null;
+    // Include if project's date range overlaps with the quarter
+    if (!start && !end) return true; // no dates = include
+    if (start && start > quarterEnd) return false;
+    if (end && end < quarterStart) return false;
+    return true;
+  });
+
   const wb = new ExcelJS.Workbook();
   wb.creator = "TITAN PMO";
   wb.created = new Date();
@@ -379,16 +392,16 @@ export async function generateQuarterlyReport(
   ws1.getRow(2).height = 24;
 
   // Row 4-7: Summary stats
-  const completed = projects.filter((p) => ["COMPLETED", "CLOSED"].includes(p.status)).length;
-  const totalBudget = projects.reduce((s, p) => s + (p.budgetTotal ?? 0), 0);
-  const totalActual = projects.reduce((s, p) => s + (p.budgetActual ?? 0), 0);
+  const completed = filtered.filter((p) => ["COMPLETED", "CLOSED"].includes(p.status)).length;
+  const totalBudget = filtered.reduce((s, p) => s + (p.budgetTotal ?? 0), 0);
+  const totalActual = filtered.reduce((s, p) => s + (p.budgetActual ?? 0), 0);
   const executionRate = totalBudget > 0 ? Math.round((totalActual / totalBudget) * 100) : 0;
-  const avgBenefit = projects.length > 0
-    ? Math.round(projects.reduce((s, p) => s + (p.benefitScore ?? 0), 0) / projects.length)
+  const avgBenefit = filtered.length > 0
+    ? Math.round(filtered.reduce((s, p) => s + (p.benefitScore ?? 0), 0) / filtered.length)
     : 0;
 
   const summaryStats: [string, string | number][] = [
-    ["項目總數", projects.length],
+    ["項目總數", filtered.length],
     ["已完成", completed],
     ["預算執行率", `${executionRate}%`],
     ["平均效益分", avgBenefit],
@@ -419,7 +432,7 @@ export async function generateQuarterlyReport(
   });
 
   const statusCounts: Record<string, number> = {};
-  projects.forEach((p) => {
+  filtered.forEach((p) => {
     const label = STATUS_LABELS[p.status] ?? p.status;
     statusCounts[label] = (statusCounts[label] ?? 0) + 1;
   });
@@ -436,7 +449,7 @@ export async function generateQuarterlyReport(
   ws1.getRow(currentRow).getCell(1).font = { bold: true, size: 11 };
   currentRow++;
 
-  const highRiskProjects = projects.filter(
+  const highRiskProjects = filtered.filter(
     (p) => p.riskLevel === "HIGH" || p.riskLevel === "CRITICAL"
   );
 
@@ -466,7 +479,7 @@ export async function generateQuarterlyReport(
   }
 
   // ── Sheet 2: 項目明細 (reuse full sheet logic) ────────────────────────
-  buildFullSheet(wb, projects, year);
+  buildFullSheet(wb, filtered, year);
 
   // ── Sheet 3: 效益追蹤 ─────────────────────────────────────────────────
   const ws3 = wb.addWorksheet("效益追蹤");
@@ -490,7 +503,7 @@ export async function generateQuarterlyReport(
     cell.border = { bottom: { style: "thin", color: { argb: "FF000000" } } };
   });
 
-  projects.forEach((p) => {
+  filtered.forEach((p) => {
     const est = p.mdTotalEstimated ?? 0;
     const act = p.mdActualTotal ?? 0;
     const diff = act - est;

--- a/services/project-service.ts
+++ b/services/project-service.ts
@@ -836,6 +836,7 @@ export class ProjectService {
         owner: { select: { name: true } },
       },
       orderBy: { code: "asc" },
+      take: 5000,
     });
   }
 


### PR DESCRIPTION
## 修復 9 個 review 問題

### CRITICAL (1)
- Content-Disposition filename sanitization

### HIGH (4)
- getProjectsForExport take:5000 limit
- year NaN guard (3 files)
- Quarterly report filters by quarter date range
- Archived project export blocked

### MEDIUM (3)
- Budget report withAuth→withManager
- Gantt fetchData stale closure
- Plans LinkedProjects loading spinner

### LOW (1)
- Client-side CSV injection protection

Review round 2: 9/9 全修 ✅