### PR TITLE
chore: upgrade zod 3→4 (2 API migrations)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "sonner": "2.0.7",
         "tailwind-merge": "^2.6.0",
         "uuid": "^11.1.0",
-        "zod": "^3.24.4"
+        "zod": "4.3.6"
       },
       "devDependencies": {
         "@axe-core/playwright": "4.11.1",
@@ -12115,9 +12115,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "sonner": "2.0.7",
     "tailwind-merge": "^2.6.0",
     "uuid": "^11.1.0",
-    "zod": "^3.24.4"
+    "zod": "4.3.6"
   },
   "overrides": {
     "handlebars": "^4.7.9",

--- a/validators/monitoring-validators.ts
+++ b/validators/monitoring-validators.ts
@@ -4,7 +4,7 @@ export const webhookPayloadSchema = z.object({
   alertName: z.string().min(1),
   severity: z.string().min(1),
   status: z.enum(["firing", "resolved"]),
-  labels: z.record(z.unknown()).optional(),
+  labels: z.record(z.string(), z.unknown()).optional(),
   annotations: z.object({
     summary: z.string().optional(),
     description: z.string().optional(),

--- a/validators/shared/kpi.ts
+++ b/validators/shared/kpi.ts
@@ -59,7 +59,7 @@ export const updateKpiSchema = z.object({
 /** Schema for KPI achievement reporting (KP-2: Issue #822) */
 export const createKpiAchievementSchema = z.object({
   period: z.string().min(1, "填報週期為必填"),
-  actualValue: z.number({ required_error: "實際值為必填" }),
+  actualValue: z.number({ error: "實際值為必填" }),
   note: z.string().optional(),
 });
 


### PR DESCRIPTION
z.record() 2 args + required_error→error