### PR TITLE
fix(T1225): enforce RBAC on reports + break circular dep (#1223)

### DIFF
--- a/app/api/reports/overtime/route.ts
+++ b/app/api/reports/overtime/route.ts
@@ -6,13 +6,13 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/auth";
+import { requireManagerOrAbove as requireManager } from "@/lib/auth";
 import { success, error } from "@/lib/api-response";
 
 const MONTHLY_OT_LIMIT = 46; // Taiwan Labor Standards Act
 
 export async function GET(req: NextRequest) {
-  try { await requireAuth(); } catch { return error("UnauthorizedError", "未授權", 401); }
+  try { await requireManager(); } catch { return error("ForbiddenError", "權限不足", 403); }
 
   const { searchParams } = new URL(req.url);
   const from = searchParams.get("from");

--- a/app/api/reports/time-summary/route.ts
+++ b/app/api/reports/time-summary/route.ts
@@ -6,7 +6,7 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth } from "@/lib/auth";
+import { requireManagerOrAbove as requireManager } from "@/lib/auth";
 import { success, error } from "@/lib/api-response";
 
 const HOURS_PER_DAY = 8;
@@ -23,7 +23,7 @@ function countWorkdays(from: Date, to: Date): number {
 }
 
 export async function GET(req: NextRequest) {
-  try { await requireAuth(); } catch { return error("UnauthorizedError", "未授權", 401); }
+  try { await requireManager(); } catch { return error("ForbiddenError", "權限不足", 403); }
 
   const { searchParams } = new URL(req.url);
   const from = searchParams.get("from");

--- a/services/audit-service.ts
+++ b/services/audit-service.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from "@prisma/client";
 import { ForbiddenError } from "./errors";
 import { getRedisClient } from "@/lib/redis";
 import { logger } from "@/lib/logger";
-import { isManagerOrAbove } from "@/lib/middleware/role-guard";
+import { hasMinimumRole } from "@/lib/auth/permissions";
 
 const AUDIT_QUEUE_KEY = "titan:audit:failed:queue";
 const MAX_QUEUE_SIZE = 10000;
@@ -182,7 +182,7 @@ export class AuditService {
    * Audit logs are read-only — no update or delete methods are exposed.
    */
   async queryLogs(input: QueryAuditLogsInput) {
-    if (!isManagerOrAbove(input.callerRole)) {
+    if (!hasMinimumRole(input.callerRole, "MANAGER")) {
       throw new ForbiddenError("權限不足：僅限管理員查詢稽核日誌");
     }
 


### PR DESCRIPTION
## Summary
- **P0 Security**: `time-summary` and `overtime` report APIs now require MANAGER role (was `requireAuth` — ENGINEER could see all team data)
- **P0 Bug**: Break circular dependency `auth.ts → audit-service → role-guard → rbac → auth.ts` that crashed login

## Changes
- `app/api/reports/time-summary/route.ts`: `requireAuth()` → `requireManager()`
- `app/api/reports/overtime/route.ts`: `requireAuth()` → `requireManager()`
- `services/audit-service.ts`: import from `permissions.ts` instead of `role-guard.ts`

## Test plan
- [x] Build passes
- [x] ENGINEER calls GET /api/reports/time-summary → 403
- [x] ENGINEER calls GET /api/reports/overtime → 403
- [x] MANAGER calls both → 200
- [x] Login works (circular dep fixed)

Closes #1225
Closes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)