### PR TITLE
fix(T1226): reject task creation when sanitized title is empty

### DIFF
--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -165,6 +165,11 @@ export class TaskService {
     const title = sanitizeHtml(input.title);
     const description = input.description ? sanitizeHtml(input.description) : input.description;
 
+    // Post-sanitize validation: title may become empty after stripping all tags (Issue #1226)
+    if (!title.trim()) {
+      throw new ValidationError("標題為必填");
+    }
+
     return this.prisma.task.create({
       data: {
         title,


### PR DESCRIPTION
## Summary
- Post-sanitize validation: if XSS payload like `<script>alert(1)</script>` gets sanitized to empty string, now returns 400 instead of creating empty-title task

## Test plan
- [x] Integration tests pass (20/20)
- POST /api/tasks with XSS title → 400
- POST /api/tasks with normal title → 201

Closes #1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)