### PR TITLE
fix(T1228): prefer non-archived plans with goals in Gantt API

### DIFF
--- a/app/api/tasks/gantt/route.ts
+++ b/app/api/tasks/gantt/route.ts
@@ -11,7 +11,7 @@ export const GET = withAuth(async (req: NextRequest) => {
 
   const annualPlan = await prisma.annualPlan.findFirst({
     where: { year, archivedAt: null },
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ monthlyGoals: { _count: "desc" } }, { createdAt: "desc" }],
     include: {
       milestones: { orderBy: { plannedEnd: "asc" } },
       monthlyGoals: {


### PR DESCRIPTION
## Summary
- Change `orderBy` in Gantt API from `{ createdAt: 'desc' }` to `[{ monthlyGoals: { _count: 'desc' } }, { createdAt: 'desc' }]`
- Plans with goals are now preferred over empty plans

## Test plan
- Gantt API with multiple same-year plans → selects plan with goals

Closes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)