### PR TITLE
fix(T1233): validate task filter enum values, return 400 for invalid

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -4,12 +4,16 @@ import { TaskStatus, Priority, TaskCategory } from "@prisma/client";
 import { TaskService } from "@/services/task-service";
 import { validateBody } from "@/lib/validate";
 import { createTaskSchema } from "@/validators/task-validators";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 
 const taskService = new TaskService(prisma);
+
+const VALID_PRIORITIES: Priority[] = ["P0", "P1", "P2", "P3"];
+const VALID_STATUSES: TaskStatus[] = ["BACKLOG", "TODO", "IN_PROGRESS", "REVIEW", "DONE"];
+const VALID_CATEGORIES: TaskCategory[] = ["PLANNED", "ADDED", "INCIDENT", "SUPPORT", "ADMIN", "LEARNING"];
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
@@ -19,6 +23,30 @@ export const GET = withAuth(async (req: NextRequest) => {
   if (assignee === "me") {
     const session = await requireAuth();
     assignee = session.user.id;
+  }
+
+  // Validate enum query params before passing to Prisma (Issue #1239)
+  const priorityParam = searchParams.get("priority");
+  if (priorityParam && !VALID_PRIORITIES.includes(priorityParam as Priority)) {
+    return error("ValidationError", `無效的優先度值：${priorityParam}，允許值為 ${VALID_PRIORITIES.join(", ")}`, 400);
+  }
+
+  const statusParam = searchParams.get("status");
+  if (statusParam && !statusParam.includes(",")) {
+    if (!VALID_STATUSES.includes(statusParam as TaskStatus)) {
+      return error("ValidationError", `無效的狀態值：${statusParam}，允許值為 ${VALID_STATUSES.join(", ")}`, 400);
+    }
+  } else if (statusParam?.includes(",")) {
+    const statuses = statusParam.split(",");
+    const invalidStatus = statuses.find(s => !VALID_STATUSES.includes(s as TaskStatus));
+    if (invalidStatus) {
+      return error("ValidationError", `無效的狀態值：${invalidStatus}，允許值為 ${VALID_STATUSES.join(", ")}`, 400);
+    }
+  }
+
+  const categoryParam = searchParams.get("category");
+  if (categoryParam && !VALID_CATEGORIES.includes(categoryParam as TaskCategory)) {
+    return error("ValidationError", `無效的類別值：${categoryParam}，允許值為 ${VALID_CATEGORIES.join(", ")}`, 400);
   }
 
   const { page, limit, skip } = parsePagination(searchParams);


### PR DESCRIPTION
## Summary
- Validate `priority`, `status`, `category` query params against allowed enums
- Invalid values now return 400 ValidationError instead of 500

## Test plan
- [x] 21/22 task tests pass (1 pre-existing failure unrelated)
- GET /api/tasks?priority=P9 → 400
- GET /api/tasks?priority=P0 → 200

Closes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)