### PR TITLE
fix(T1232): fix timesheet monthly endpoint status code consistency

### DIFF
--- a/app/api/time-entries/monthly/route.ts
+++ b/app/api/time-entries/monthly/route.ts
@@ -10,8 +10,7 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
-import { success } from "@/lib/api-response";
-import { validateBody } from "@/lib/validate";
+import { success, error as apiError } from "@/lib/api-response";
 
 const monthParamSchema = z.string().regex(/^\d{4}-\d{2}$/, "格式須為 YYYY-MM");
 
@@ -24,7 +23,7 @@ export const GET = withManager(async (req: NextRequest) => {
   // Validate month param
   const monthResult = monthParamSchema.safeParse(monthRaw);
   if (!monthResult.success) {
-    return success({ error: "month 參數格式須為 YYYY-MM" }, 400) as never;
+    return apiError("INVALID_PARAM", "month 參數格式須為 YYYY-MM", 400) as never;
   }
   const month = monthResult.data;
 


### PR DESCRIPTION
## Summary
- Changed `success()` to `error()` helper for invalid month param validation
- Now returns `{ok:false, error:"INVALID_PARAM"}` with HTTP 400 (was `{ok:true}` with 400)

## Test plan
- [x] 14/14 time-entries tests pass
- GET /api/time-entries/monthly?year=2026&month=4 → 400 with `ok:false`

Closes #1232

🤖 Generated with [Claude Code](https://claude.com/claude-code)