### PR TITLE
fix(T1230): require blockerNote for BLOCKED gates and checklistPassed for PASSED

### DIFF
--- a/services/project-service.ts
+++ b/services/project-service.ts
@@ -776,9 +776,26 @@ export class ProjectService {
     }
 
     if (input.status !== undefined) {
+      // BLOCKED requires a non-empty blockerNote (from request body or already stored)
+      if (input.status === "BLOCKED") {
+        const note = (input.blockerNote as string | null | undefined) ?? (existing.blockerNote as string | null | undefined);
+        if (!note?.trim()) {
+          throw new ValidationError("狀態為 BLOCKED 時必須填寫 blockerNote");
+        }
+      }
+
       // CRITICAL: enforce sequential gate order — cannot PASS a gate unless
       // all previous gates (lower order) are already PASSED or WAIVED
       if (input.status === "PASSED") {
+        // Checklist must be fully completed before passing
+        const effectiveChecklistPassed =
+          input.checklist !== undefined
+            ? data.checklistPassed  // just computed above from the incoming checklist
+            : (existing.checklistPassed as boolean | null);
+        if (!effectiveChecklistPassed) {
+          throw new ValidationError("無法通過此 Gate：Checklist 尚未全部勾選完成");
+        }
+
         const previousGates = await this.prisma.projectGate.findMany({
           where: {
             projectId: existing.projectId,


### PR DESCRIPTION
## Summary
- BLOCKED gate now requires `blockerNote` (checks both input and existing DB value)
- PASSED gate now requires `checklistPassed === true`

## Test plan
- [x] 20/20 integration tests pass
- PATCH gate status=BLOCKED without blockerNote → 400
- PATCH gate status=PASSED with checklistPassed=false → 400

Closes #1230

🤖 Generated with [Claude Code](https://claude.com/claude-code)