### PR TITLE
fix(T1231): auto-open task detail modal from URL ?task= parameter

### DIFF
--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -128,6 +128,14 @@ export default function KanbanPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [showDragHint, setShowDragHint] = useState(false);
 
+  // Issue #1231: auto-open task detail modal from URL ?task= parameter
+  useEffect(() => {
+    const taskParam = searchParams.get("task");
+    if (taskParam) {
+      setSelectedTaskId(taskParam);
+    }
+  }, [searchParams]);
+
   useEffect(() => {
     if (typeof window !== "undefined" && !localStorage.getItem("titan-kanban-onboarded")) {
       setShowDragHint(true);


### PR DESCRIPTION
## Summary
- Kanban page now reads `?task=<id>` from URL search params
- Auto-opens TaskDetailModal when param present (e.g., from Dashboard overdue task links)

## Test plan
- Navigate to `/kanban?task=<validId>` → modal opens
- Navigate to `/kanban` (no param) → no change

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)