### PR TITLE
ci: add DATABASE_URL to prisma generate steps (Prisma 7 compat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: npm ci
 
       - run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
 
       - name: Run database migrations
         run: npx prisma migrate deploy
@@ -42,6 +44,8 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
 
       - name: Unit + Integration tests
         run: npx jest --forceExit --coverage
@@ -72,6 +76,8 @@ jobs:
       - run: npm ci
 
       - run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://titan:dummy@localhost:5432/titan_dummy
 
       - name: Build Next.js app (produces .next/standalone for Dockerfile COPY)
         run: npm run build
@@ -186,6 +192,8 @@ jobs:
       - run: npm ci
 
       - run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
 
       - name: Run database migrations
         run: npx prisma migrate deploy


### PR DESCRIPTION
## Summary
- Add `DATABASE_URL` env to all 3 `prisma generate` steps (test, docker-build, e2e)
- Add `DATABASE_URL` env to `tsc --noEmit` step  
- Prisma 7.x resolves env vars during generate via `prisma.config.ts`, unlike 5.x

## Root cause
Prisma upgrade 5.22 → 7.6 (PR #1190) introduced `prisma.config.ts` which reads `DATABASE_URL` at generate time. CI workflow never set this env for the generate step.

## Test plan
- [x] CI should now pass the `prisma generate` step
- [x] All other steps unaffected (same env vars)

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)