### PR TITLE
feat(T1250): increase login rate limit to 20/60s and add E2E_TESTING bypass

### DIFF
--- a/app/api/auth/ldap/route.ts
+++ b/app/api/auth/ldap/route.ts
@@ -16,9 +16,11 @@ import { getRedisClient } from "@/lib/redis";
 import { getClientIp } from "@/lib/get-client-ip";
 
 const redis = getRedisClient();
+const isTestEnv = process.env.NODE_ENV === "test" || process.env.E2E_TESTING === "true";
 const ldapRateLimiter = createLoginRateLimiter({
   redisClient: redis ?? undefined,
   useMemory: !redis,
+  points: isTestEnv ? 10000 : undefined,
 });
 
 export async function POST(request: NextRequest) {

--- a/app/api/auth/mobile/login/route.ts
+++ b/app/api/auth/mobile/login/route.ts
@@ -25,9 +25,11 @@ import { AuditService } from "@/services/audit-service";
 import { getClientIp } from "@/lib/get-client-ip";
 
 const redis = getRedisClient();
+const isTestEnv = process.env.NODE_ENV === "test" || process.env.E2E_TESTING === "true";
 const loginRateLimiter = createLoginRateLimiter({
   redisClient: redis ?? undefined,
   useMemory: !redis,
+  points: isTestEnv ? 10000 : undefined,
 });
 const accountLockService = new AccountLockService({
   maxFailures: 5,

--- a/auth.ts
+++ b/auth.ts
@@ -29,9 +29,11 @@ import { registerSession } from "@/lib/session-limiter";
  * Issue #178: Use Redis when available, fallback to in-memory.
  */
 const redis = getRedisClient();
+const isTestEnv = process.env.NODE_ENV === "test" || process.env.E2E_TESTING === "true";
 const loginRateLimiter = createLoginRateLimiter({
   redisClient: redis ?? undefined,
   useMemory: !redis,
+  points: isTestEnv ? 10000 : undefined,
 });
 const accountLockService = new AccountLockService({
   maxFailures: 5,           // Issue #797: 5 consecutive failures

--- a/lib/__tests__/rate-limiter.test.ts
+++ b/lib/__tests__/rate-limiter.test.ts
@@ -46,11 +46,11 @@ describe("createLoginRateLimiter", () => {
     expect(typeof limiter.consume).toBe("function");
   });
 
-  test("allows up to 5 attempts per minute for unique IP+username key", async () => {
-    const limiter = createLoginRateLimiter({ useMemory: true, points: 5, duration: 60 });
+  test("allows up to 20 attempts per minute for unique IP+username key", async () => {
+    const limiter = createLoginRateLimiter({ useMemory: true, points: 20, duration: 60 });
     const key = "192.168.1.1_testuser";
 
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 20; i++) {
       await expect(limiter.consume(key)).resolves.toBeDefined();
     }
   });

--- a/lib/rate-limiter.ts
+++ b/lib/rate-limiter.ts
@@ -4,7 +4,7 @@
  * Uses rate-limiter-flexible for both Redis and in-memory modes.
  *
  * Strategies:
- *   - Login:  5 attempts / 60s per IP+username key
+ *   - Login:  20 attempts / 60s per IP+username key
  *   - API:    100 requests / 60s per userId
  *
  * When Redis is unavailable the factory falls back to RateLimiterMemory and
@@ -61,12 +61,12 @@ export interface ApiRateLimiterOptions {
 
 /**
  * Creates a rate limiter for login endpoints.
- * Default: 5 attempts per 60 seconds, keyed by IP+username.
+ * Default: 20 attempts per 60 seconds, keyed by IP+username.
  */
 export function createLoginRateLimiter(
   opts: LoginRateLimiterOptions = {}
 ): RateLimiterMemory | RateLimiterRedis {
-  const points = opts.points ?? 5;
+  const points = opts.points ?? 20;
   const duration = opts.duration ?? 60;
   const keyPrefix = "login";
 


### PR DESCRIPTION
## Summary

- Raise default login rate limit from 5 → 20 attempts per 60 seconds to reduce false-positive lockouts
- Add `E2E_TESTING` bypass (points: 10000) in `auth.ts`, mobile login route, and LDAP route so Playwright E2E suites are never blocked by rate limits
- Update JSDoc comments and the corresponding Jest test to reflect the new 20/60s default

## Files Changed

- `lib/rate-limiter.ts` — default points 5 → 20; updated JSDoc
- `auth.ts` — `isTestEnv` check + `points: 10000` override in test/E2E environments
- `app/api/auth/mobile/login/route.ts` — same E2E bypass pattern
- `app/api/auth/ldap/route.ts` — same E2E bypass pattern
- `lib/__tests__/rate-limiter.test.ts` — update test from 5 → 20 attempts

## Test plan

- [x] `npx jest lib/__tests__/rate-limiter.test.ts --forceExit` — 16 passed, 4 skipped (pre-existing `test.skip` for #775)
- [x] `npm run build` — compiled successfully (152 static pages generated)
- [ ] E2E login flows pass without rate-limit 429 errors when `E2E_TESTING=true`

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)