### PR TITLE
fix(T1249): accept taskId=null in time-entry update validator

### DIFF
--- a/validators/shared/time-entry.ts
+++ b/validators/shared/time-entry.ts
@@ -40,7 +40,7 @@ export const createTimeEntrySchema = z.object({
 export const updateTimeEntrySchema = z.object({
   date: pastOrTodayDate.optional(),
   hours: hoursSchema.optional(),
-  taskId: z.string().optional(),
+  taskId: z.string().nullish(),             // Issue #1249: accept null for free-time entries
   subTaskId: z.string().nullish(),          // Issue #933: optional subtask
   category: TimeCategoryEnum.optional(),
   description: z.string().optional(),


### PR DESCRIPTION
## Summary
- Changed `updateTimeEntrySchema.taskId` from `z.string().optional()` to `z.string().nullish()` to accept `null` for free-time entries
- Matches existing `createTimeEntrySchema` pattern and route handler behavior

## Test plan
- [x] `npx jest __tests__/api/time-entry` — 10/10 pass
- [x] `npm run build` — clean

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)