### PR TITLE
fix(T1257): enforce ENGINEER role task isolation in GET /api/tasks

### DIFF
--- a/app/api/tasks/gantt/route.ts
+++ b/app/api/tasks/gantt/route.ts
@@ -1,14 +1,19 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
 import { parseYear } from "@/lib/query-params";
 
 export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
 
   const { searchParams } = new URL(req.url);
   const year = parseYear(searchParams.get("year"));
-  const assignee = searchParams.get("assignee");
+  // Issue #1257: ENGINEER role must only see own tasks in gantt
+  const assignee = session.user.role === "ENGINEER"
+    ? session.user.id
+    : searchParams.get("assignee");
 
   const annualPlan = await prisma.annualPlan.findFirst({
     where: { year, archivedAt: null },

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -17,11 +17,12 @@ const VALID_CATEGORIES: TaskCategory[] = ["PLANNED", "ADDED", "INCIDENT", "SUPPO
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
+  const session = await requireAuth();
 
   // Resolve "me" to the actual session userId (CR-19 / Issue #284)
+  // Issue #1257: ENGINEER role must only see own tasks (RBAC data isolation)
   let assignee = searchParams.get("assignee") ?? undefined;
-  if (assignee === "me") {
-    const session = await requireAuth();
+  if (assignee === "me" || session.user.role === "ENGINEER") {
     assignee = session.user.id;
   }
 


### PR DESCRIPTION
## Summary
- `GET /api/tasks`: ENGINEER role now forced to only see own tasks (primaryAssignee or backupAssignee)
- `GET /api/tasks/gantt`: Same RBAC enforcement for gantt view
- Prevents data leakage where engineers could see other team members' tasks

## Test plan
- [x] `npx jest __tests__/api/rbac` — 33/33 pass
- [x] `npm run build` — clean
- [ ] E2E: verify RBAC-ENG-03 passes after deploy

Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)