### PR TITLE
fix(T1273): move ENGINEER ownership check inside $transaction to prevent TOCTOU race

### DIFF
--- a/__tests__/api/bulk-operations.test.ts
+++ b/__tests__/api/bulk-operations.test.ts
@@ -16,12 +16,20 @@ import { createMockRequest } from "../utils/test-utils";
 const mockTaskFindMany = jest.fn();
 const mockTaskUpdateMany = jest.fn();
 
+const mockTx = {
+  task: {
+    findMany: (...args: unknown[]) => mockTaskFindMany(...args),
+    updateMany: (...args: unknown[]) => mockTaskUpdateMany(...args),
+  },
+};
+
 jest.mock("@/lib/prisma", () => ({
   prisma: {
     task: {
       findMany: (...args: unknown[]) => mockTaskFindMany(...args),
       updateMany: (...args: unknown[]) => mockTaskUpdateMany(...args),
     },
+    $transaction: (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx),
   },
 }));
 
@@ -63,8 +71,7 @@ describe("PATCH /api/tasks/bulk", () => {
     expect(res.status).toBe(401);
   });
 
-  // TODO: #775 — prisma.$transaction mock missing after dependency update
-  it.skip("manager can bulk update any tasks", async () => {
+  it("manager can bulk update any tasks", async () => {
     mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
     mockTaskUpdateMany.mockResolvedValue({ count: 2 });
     const req = createMockRequest("/api/tasks/bulk", {
@@ -78,8 +85,7 @@ describe("PATCH /api/tasks/bulk", () => {
     expect(json.data.updated).toBe(2);
   });
 
-  // TODO: #775 — prisma.$transaction mock missing after dependency update
-  it.skip("engineer can update own tasks", async () => {
+  it("engineer can update own tasks", async () => {
     mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
     mockTaskFindMany.mockResolvedValue([
       { id: "t1", primaryAssigneeId: "eng-1", backupAssigneeId: null },
@@ -106,6 +112,25 @@ describe("PATCH /api/tasks/bulk", () => {
     });
     const res = await PATCH(req);
     expect(res.status).toBe(403);
+  });
+
+  it("admin can bulk update any tasks (skips ownership check)", async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { id: "adm-1", name: "Admin", email: "admin@test.com", role: "ADMIN" },
+      expires: "2099-01-01",
+    });
+    mockTaskUpdateMany.mockResolvedValue({ count: 3 });
+    const req = createMockRequest("/api/tasks/bulk", {
+      method: "PATCH",
+      body: { taskIds: ["t1", "t2", "t3"], updates: { status: "DONE" } },
+    });
+    const res = await PATCH(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.data.updated).toBe(3);
+    // ADMIN should NOT trigger findMany ownership check
+    expect(mockTaskFindMany).not.toHaveBeenCalled();
   });
 
   it("rejects empty taskIds array", async () => {

--- a/app/api/tasks/bulk/route.ts
+++ b/app/api/tasks/bulk/route.ts
@@ -5,6 +5,7 @@ import { success } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { ForbiddenError } from "@/services/errors";
+import { hasMinimumRole } from "@/lib/auth/permissions";
 import { z } from "zod";
 
 const bulkUpdateSchema = z.object({
@@ -29,30 +30,31 @@ export const PATCH = withAuth(async (req: NextRequest) => {
   const raw = await req.json();
   const { taskIds, updates } = validateBody(bulkUpdateSchema, raw);
 
-  // ENGINEER ownership check: verify all tasks are assigned to them
-  if (session.user.role !== "MANAGER") {
-    const tasks = await prisma.task.findMany({
-      where: { id: { in: taskIds } },
-      select: { id: true, primaryAssigneeId: true, backupAssigneeId: true },
-    });
-
-    const unauthorized = tasks.filter(
-      (t) => t.primaryAssigneeId !== session.user.id && t.backupAssigneeId !== session.user.id
-    );
-
-    if (unauthorized.length > 0) {
-      throw new ForbiddenError("包含未被指派給你的任務，無法批量修改");
-    }
-  }
-
   // Build the update data object, only including defined fields
   const data: Record<string, unknown> = {};
   if (updates.status !== undefined) data.status = updates.status;
   if (updates.priority !== undefined) data.priority = updates.priority;
   if (updates.primaryAssigneeId !== undefined) data.primaryAssigneeId = updates.primaryAssigneeId;
 
-  // Wrap ownership check + update in a transaction for atomicity
+  const isManagerOrAbove = hasMinimumRole(session.user.role, "MANAGER");
+
+  // Atomic ownership check + update inside a single transaction to prevent TOCTOU race
   const result = await prisma.$transaction(async (tx) => {
+    if (!isManagerOrAbove) {
+      const tasks = await tx.task.findMany({
+        where: { id: { in: taskIds } },
+        select: { id: true, primaryAssigneeId: true, backupAssigneeId: true },
+      });
+
+      const unauthorized = tasks.filter(
+        (t) => t.primaryAssigneeId !== session.user.id && t.backupAssigneeId !== session.user.id
+      );
+
+      if (unauthorized.length > 0) {
+        throw new ForbiddenError("包含未被指派給你的任務，無法批量修改");
+      }
+    }
+
     return tx.task.updateMany({
       where: { id: { in: taskIds } },
       data,


### PR DESCRIPTION
## Summary

- 將 ENGINEER 所有權檢查從 `$transaction` 外部移入內部，消除 TOCTOU 競爭條件
- 使用 `hasMinimumRole()` 替代硬編碼角色字串比較，ADMIN 角色也正確跳過 ownership check
- 修復 `$transaction` mock（解決 #775 TODO），恢復 2 個被 skip 的測試
- 新增 ADMIN 角色批量更新測試

## 問題

`PATCH /api/tasks/bulk` 的所有權檢查（`findMany`）和實際更新（`updateMany`）在不同的 DB 操作中執行。在兩者之間有時間窗口，另一個請求可能將 task 重新指派，導致 ENGINEER 修改不屬於自己的任務。

## 修復

將 `findMany` + `updateMany` 包在同一個 Prisma interactive transaction 中，確保原子性。

## Test plan

- [x] 7/7 tests pass（含 2 個之前被 skip 的 + 1 個新增 ADMIN test）
- [x] `npx jest __tests__/api/bulk-operations.test.ts --forceExit` 全部通過

Closes #1273