### PR TITLE
fix(T1275): security + code quality fixes from review

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -241,7 +241,7 @@ function AuditLogSection() {
   const pagedLogs = logs;
 
   // Derive unique actions for filter dropdown
-  const uniqueActions = Array.from(new Set(logs.map((l) => l.action))).sort();
+  const uniqueActions = Object.keys(ACTION_LABELS).sort();
 
   if (loading) return <PageLoading message="載入稽核日誌..." className="py-8" />;
   if (error) return <PageError message={error} onRetry={() => load(0)} className="py-8" />;
@@ -549,8 +549,12 @@ function UserManagementSection() {
         // Suspend: DELETE /api/users/:id
         res = await fetch(`/api/users/${user.id}`, { method: "DELETE" });
       } else {
-        // Unsuspend: DELETE /api/users/:id?action=unsuspend
-        res = await fetch(`/api/users/${user.id}?action=unsuspend`, { method: "DELETE" });
+        // Unsuspend: PATCH to reactivate
+        res = await fetch(`/api/users/${user.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ isActive: true }),
+        });
       }
       if (res.ok) {
         toast.success(user.isActive ? `已停用「${user.name}」` : `已啟用「${user.name}」`);
@@ -1367,7 +1371,7 @@ export default function AdminPage() {
       {activeTab === "system" && (
         <div className="space-y-10">
           <BackupStatusSection />
-          <AdminTools />
+          <AdminTools role={userRole} />
           <AuditLogSection />
         </div>
       )}

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -167,11 +167,19 @@ function defaultDateRange(): { from: string; to: string } {
 }
 
 function exportCSV(headers: string[], rows: string[][], filename: string) {
-  const sanitize = (s: string) => /^[=+\-@\t\r]/.test(s) ? `'${s}` : s;
+  const sanitize = (s: string) => /^[=+\-@\t\r|]/.test(s) ? `'${s}` : s;
+  const escapeCell = (v: string) => {
+    const s = sanitize(v);
+    // Quote if contains comma, double-quote, newline, or was sanitized (starts with ')
+    if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r") || s.startsWith("'")) {
+      return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+  };
   const bom = "\uFEFF";
   const csv = [
-    headers.map(sanitize).join(","),
-    ...rows.map(r => r.map(v => sanitize(v.includes(",") || v.includes('"') ? `"${v.replace(/"/g, '""')}"` : v)).join(","))
+    headers.map(escapeCell).join(","),
+    ...rows.map(r => r.map(escapeCell).join(","))
   ].join("\n");
   const blob = new Blob([bom + csv], { type: "text/csv;charset=utf-8" });
   const url = URL.createObjectURL(blob);
@@ -202,7 +210,7 @@ function UtilizationReport({ from, to }: { from: string; to: string }) {
     setError(null);
     try {
       const res = await fetch(
-        `/api/reports/time-distribution?from=${from}&to=${to}&view=utilization`
+        `/api/reports/time-distribution?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&view=utilization`
       );
       if (!res.ok) throw new Error("載入失敗");
       const body = await res.json();
@@ -648,16 +656,21 @@ interface TimeSummaryUser { userName: string; email: string; planned: number; ad
 function TimeSummaryReport({ from, to }: { from: string; to: string }) {
   const [data, setData] = useState<TimeSummaryUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     setLoading(true);
-    fetch(`/api/reports/time-summary?from=${from}&to=${to}&mode=by-user`)
-      .then(r => r.json()).then(d => setData(d.data?.users ?? d.data ?? []))
-      .catch(() => setData([]))
+    setError(null);
+    fetch(`/api/reports/time-summary?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&mode=by-user`)
+      .then(r => { if (!r.ok) throw new Error("載入失敗"); return r.json(); })
+      .then(d => setData(d.data?.users ?? d.data ?? []))
+      .catch((e) => { setData([]); setError(e instanceof Error ? e.message : "載入失敗"); })
       .finally(() => setLoading(false));
-  }, [from, to]);
+  }, [from, to, reloadKey]);
 
   if (loading) return <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
+  if (error) return <PageError message={error} onRetry={() => setReloadKey(k => k + 1)} className="py-8" />;
   if (!data.length) return <div className="text-center text-muted-foreground py-12">此期間無工時資料<br/><span className="text-xs">團隊成員開始登記工時後，摘要將自動產生</span></div>;
 
   // Aggregate totals
@@ -695,7 +708,7 @@ function TimeSummaryReport({ from, to }: { from: string; to: string }) {
               const pct = r.utilizationPct;
               const pctColor = pct >= 100 ? "text-green-600" : pct >= 80 ? "text-foreground" : pct >= 60 ? "text-amber-600" : "text-red-600";
               return (
-                <tr key={i} className="border-b border-border/30 hover:bg-accent/30">
+                <tr key={r.email || r.userName || i} className="border-b border-border/30 hover:bg-accent/30">
                   <td className="py-1.5 px-2 font-medium">{r.userName}</td>
                   <td className="text-right py-1.5 px-1">{r.planned || "-"}</td>
                   <td className="text-right py-1.5 px-1">{r.added || "-"}</td>
@@ -736,16 +749,21 @@ interface OvertimeUser { userName: string; email: string; normal: number; weekda
 function OvertimeReport({ from, to }: { from: string; to: string }) {
   const [data, setData] = useState<OvertimeUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     setLoading(true);
-    fetch(`/api/reports/overtime?from=${from}&to=${to}&mode=compliance`)
-      .then(r => r.json()).then(d => setData(d.data?.users ?? d.data ?? []))
-      .catch(() => setData([]))
+    setError(null);
+    fetch(`/api/reports/overtime?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&mode=compliance`)
+      .then(r => { if (!r.ok) throw new Error("載入失敗"); return r.json(); })
+      .then(d => setData(d.data?.users ?? d.data ?? []))
+      .catch((e) => { setData([]); setError(e instanceof Error ? e.message : "載入失敗"); })
       .finally(() => setLoading(false));
-  }, [from, to]);
+  }, [from, to, reloadKey]);
 
   if (loading) return <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>;
+  if (error) return <PageError message={error} onRetry={() => setReloadKey(k => k + 1)} className="py-8" />;
   if (!data.length) return <div className="text-center text-muted-foreground py-12">此期間無加班資料</div>;
 
   const overLimitCount = data.filter(r => r.overLimit).length;
@@ -787,7 +805,7 @@ function OvertimeReport({ from, to }: { from: string; to: string }) {
           </tr></thead>
           <tbody>
             {data.map((r, i) => (
-              <tr key={i} className={`border-b border-border/30 hover:bg-accent/30 ${r.overLimit ? "bg-red-50/50 dark:bg-red-950/20" : ""}`}>
+              <tr key={r.email || r.userName || i} className={`border-b border-border/30 hover:bg-accent/30 ${r.overLimit ? "bg-red-50/50 dark:bg-red-950/20" : ""}`}>
                 <td className="py-1.5 px-2 font-medium">{r.userName}</td>
                 <td className="text-right py-1.5 px-2">{r.normal}h</td>
                 <td className="text-right py-1.5 px-2 text-amber-600 dark:text-amber-400">{r.weekdayOT}h</td>

--- a/app/components/admin-tools.tsx
+++ b/app/components/admin-tools.tsx
@@ -124,6 +124,15 @@ function ResetTokenCard({ users }: { users: User[] }) {
     userName: string;
   } | null>(null);
 
+  // Auto-clear OTP from UI when it expires (security: don't leave OTP on screen indefinitely)
+  useEffect(() => {
+    if (!result) return;
+    const ms = new Date(result.expiresAt).getTime() - Date.now();
+    if (ms <= 0) { setResult(null); return; }
+    const timer = setTimeout(() => setResult(null), ms);
+    return () => clearTimeout(timer);
+  }, [result]);
+
   async function generateToken() {
     if (!selectedUserId) {
       toast.error("請選擇使用者");
@@ -282,7 +291,7 @@ function UnlockAccountCard({ users }: { users: User[] }) {
 
 // ─── Main Component ──────────────────────────────────────────────────────────
 
-export function AdminTools() {
+export function AdminTools({ role }: { role?: string }) {
   const [users, setUsers] = useState<User[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(true);
 
@@ -304,6 +313,9 @@ export function AdminTools() {
       }
     })();
   }, []);
+
+  // OTP generation and account unlock are ADMIN-only operations
+  if (role !== "ADMIN") return null;
 
   return (
     <div className="space-y-4">

--- a/app/components/reports-extended.tsx
+++ b/app/components/reports-extended.tsx
@@ -71,25 +71,31 @@ function useReportData<T>(url: string) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
-  const load = useCallback(async () => {
+  useEffect(() => {
+    const controller = new AbortController();
     setLoading(true);
     setError(null);
-    try {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = await res.json();
-      setData(extractData<T>(body));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "載入失敗");
-    } finally {
-      setLoading(false);
-    }
-  }, [url]);
+    fetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((body) => setData(extractData<T>(body)))
+      .catch((e) => {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        setError(e instanceof Error ? e.message : "載入失敗");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [url, reloadKey]);
 
-  useEffect(() => { load(); }, [load]);
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
 
-  return { data, loading, error, reload: load };
+  return { data, loading, error, reload };
 }
 
 // ─── Loading / Error wrappers ─────────────────────────────────────────────────
@@ -149,7 +155,7 @@ function flattenToTable(items: Record<string, unknown>[]): { headers: string[]; 
 // ─── Completion Rate ──────────────────────────────────────────────────────────
 
 function CompletionRateReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/completion-rate?granularity=month&from=${from}&to=${to}`;
+  const url = `/api/reports/completion-rate?granularity=month&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     points?: { month: string; total: number; completed: number; rate: number }[];
     summary?: { totalTasks: number; completedTasks: number; averageRate: number };
@@ -185,8 +191,21 @@ function CompletionRateReport({ from, to }: { from: string; to: string }) {
 function CustomReport({ from, to }: { from: string; to: string }) {
   const [category, setCategory] = useState("");
   const [status, setStatus] = useState("");
+  const [debouncedCategory, setDebouncedCategory] = useState("");
+  const [debouncedStatus, setDebouncedStatus] = useState("");
   const [page] = useState(1);
-  const url = `/api/reports/custom?category=${encodeURIComponent(category)}&status=${encodeURIComponent(status)}&from=${from}&to=${to}&page=${page}&limit=20`;
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedCategory(category), 400);
+    return () => clearTimeout(t);
+  }, [category]);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedStatus(status), 400);
+    return () => clearTimeout(t);
+  }, [status]);
+
+  const url = `/api/reports/custom?category=${encodeURIComponent(debouncedCategory)}&status=${encodeURIComponent(debouncedStatus)}&from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}&page=${page}&limit=20`;
   const { data, loading, error, reload } = useReportData<{
     items?: Record<string, unknown>[];
     total?: number;
@@ -246,7 +265,7 @@ function CustomReport({ from, to }: { from: string; to: string }) {
 // ─── Delay Change ─────────────────────────────────────────────────────────────
 
 function DelayChangeReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/delay-change?from=${from}&to=${to}`;
+  const url = `/api/reports/delay-change?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     items?: { taskId: string; title: string; originalDue: string; newDue: string; delayDays: number; reason?: string }[];
     summary?: { totalDelayed: number; avgDelayDays: number };
@@ -281,7 +300,7 @@ function DelayChangeReport({ from, to }: { from: string; to: string }) {
 function DepartmentTimesheetReport({ from }: { from: string }) {
   // Use the from date as weekStart
   const weekStart = from;
-  const url = `/api/reports/department-timesheet?weekStart=${weekStart}`;
+  const url = `/api/reports/department-timesheet?weekStart=${encodeURIComponent(weekStart)}`;
   const { data, loading, error, reload } = useReportData<{
     departments?: { department: string; members: number; totalHours: number; avgHours: number }[];
     weekStart?: string;
@@ -307,7 +326,7 @@ function DepartmentTimesheetReport({ from }: { from: string }) {
 // ─── KPI Report ───────────────────────────────────────────────────────────────
 
 function KpiReport({ year }: { year: number }) {
-  const url = `/api/reports/kpi?year=${year}`;
+  const url = `/api/reports/kpi?year=${encodeURIComponent(String(year))}`;
   const { data, loading, error, reload } = useReportData<{
     items?: { kpiId: string; title: string; category: string; target: number; actual: number; achievement: number; unit: string }[];
     year?: number;
@@ -344,7 +363,7 @@ function KpiReport({ year }: { year: number }) {
 function MonthlyReport({ from }: { from: string }) {
   // Derive YYYY-MM from the from date
   const month = from.substring(0, 7);
-  const url = `/api/reports/monthly?month=${month}`;
+  const url = `/api/reports/monthly?month=${encodeURIComponent(month)}`;
   const { data, loading, error, reload } = useReportData<{
     month?: string;
     summary?: Record<string, unknown>;
@@ -379,7 +398,7 @@ function MonthlyReport({ from }: { from: string }) {
 // ─── Time Distribution ────────────────────────────────────────────────────────
 
 function TimeDistributionReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/time-distribution?from=${from}&to=${to}`;
+  const url = `/api/reports/time-distribution?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     users?: string[];
     series?: Record<string, number[]>;
@@ -436,7 +455,7 @@ function TimeDistributionReport({ from, to }: { from: string; to: string }) {
 // ─── Timesheet Compliance ─────────────────────────────────────────────────────
 
 function TimesheetComplianceReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/timesheet-compliance?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/timesheet-compliance?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     items?: { userId: string; userName: string; submittedWeeks: number; totalWeeks: number; complianceRate: number }[];
     summary?: { avgComplianceRate: number; fullyCompliant: number; total: number };
@@ -497,7 +516,7 @@ function TrendsReport({ year }: { year: number }) {
 
 function WeeklyReport({ from }: { from: string }) {
   const weekStart = from;
-  const url = `/api/reports/weekly?weekStart=${weekStart}`;
+  const url = `/api/reports/weekly?weekStart=${encodeURIComponent(weekStart)}`;
   const { data, loading, error, reload } = useReportData<{
     weekStart?: string;
     weekEnd?: string;
@@ -532,7 +551,7 @@ function WeeklyReport({ from }: { from: string }) {
 // ─── Workload ─────────────────────────────────────────────────────────────────
 
 function WorkloadReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/workload?from=${from}&to=${to}`;
+  const url = `/api/reports/workload?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     items?: { userId: string; userName: string; assignedTasks: number; completedTasks: number; pendingTasks: number; overdueTasks: number }[];
     summary?: { totalAssigned: number; totalCompleted: number };
@@ -565,7 +584,7 @@ function WorkloadReport({ from, to }: { from: string; to: string }) {
 // ─── V2 Change Summary ────────────────────────────────────────────────────────
 
 function V2ChangeSummaryReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/change-summary?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/change-summary?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: { items?: Record<string, unknown>[]; summary?: Record<string, unknown> };
     meta?: { total?: number };
@@ -593,7 +612,14 @@ function V2ChangeSummaryReport({ from, to }: { from: string; to: string }) {
 
 function V2EarnedValueReport({ from }: { from: string }) {
   const [planId, setPlanId] = useState("");
-  const url = `/api/reports/v2/earned-value?asOfDate=${from}${planId ? `&planId=${encodeURIComponent(planId)}` : ""}`;
+  const [debouncedPlanId, setDebouncedPlanId] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedPlanId(planId), 400);
+    return () => clearTimeout(t);
+  }, [planId]);
+
+  const url = `/api/reports/v2/earned-value?asOfDate=${encodeURIComponent(from)}${debouncedPlanId ? `&planId=${encodeURIComponent(debouncedPlanId)}` : ""}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       planId?: string;
@@ -663,7 +689,7 @@ function V2EarnedValueReport({ from }: { from: string }) {
 // ─── V2 Incident SLA ─────────────────────────────────────────────────────────
 
 function V2IncidentSlaReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/incident-sla?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/incident-sla?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { incidentId: string; title: string; priority: string; openedAt: string; resolvedAt?: string; slaTarget: number; actualHours: number; slaMet: boolean }[];
@@ -710,7 +736,7 @@ function V2IncidentSlaReport({ from, to }: { from: string; to: string }) {
 // ─── V2 KPI Composite ────────────────────────────────────────────────────────
 
 function V2KpiCompositeReport({ year }: { year: number }) {
-  const url = `/api/reports/v2/kpi-composite?year=${year}`;
+  const url = `/api/reports/v2/kpi-composite?year=${encodeURIComponent(String(year))}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       year?: number;
@@ -747,7 +773,7 @@ function V2KpiCompositeReport({ year }: { year: number }) {
 // ─── V2 KPI Correlation ──────────────────────────────────────────────────────
 
 function V2KpiCorrelationReport({ year }: { year: number }) {
-  const url = `/api/reports/v2/kpi-correlation?year=${year}`;
+  const url = `/api/reports/v2/kpi-correlation?year=${encodeURIComponent(String(year))}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       year?: number;
@@ -774,7 +800,7 @@ function V2KpiCorrelationReport({ year }: { year: number }) {
 // ─── V2 Milestone Achievement ─────────────────────────────────────────────────
 
 function V2MilestoneAchievementReport({ year }: { year: number }) {
-  const url = `/api/reports/v2/milestone-achievement?year=${year}`;
+  const url = `/api/reports/v2/milestone-achievement?year=${encodeURIComponent(String(year))}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { milestoneId: string; title: string; planTitle: string; dueDate: string; status: string; achievedDate?: string; onTime: boolean }[];
@@ -819,7 +845,7 @@ function V2MilestoneAchievementReport({ year }: { year: number }) {
 // ─── V2 Overdue Analysis ─────────────────────────────────────────────────────
 
 function V2OverdueAnalysisReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/overdue-analysis?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/overdue-analysis?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { taskId: string; title: string; assignee: string; dueDate: string; overdueDays: number; status: string }[];
@@ -856,7 +882,7 @@ function V2OverdueAnalysisReport({ from, to }: { from: string; to: string }) {
 // ─── V2 Overtime Analysis ─────────────────────────────────────────────────────
 
 function V2OvertimeAnalysisReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/overtime-analysis?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/overtime-analysis?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { userId: string; userName: string; regularHours: number; overtimeHours: number; holidayHours: number; total: number }[];
@@ -892,7 +918,7 @@ function V2OvertimeAnalysisReport({ from, to }: { from: string; to: string }) {
 // ─── V2 Permission Audit ──────────────────────────────────────────────────────
 
 function V2PermissionAuditReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/permission-audit?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/permission-audit?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { userId: string; userName: string; role: string; action: string; resource: string; timestamp: string; result: string }[];
@@ -930,7 +956,7 @@ function V2PermissionAuditReport({ from, to }: { from: string; to: string }) {
 // ─── V2 Time Efficiency ───────────────────────────────────────────────────────
 
 function V2TimeEfficiencyReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/time-efficiency?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/time-efficiency?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { userId: string; userName: string; estimatedHours: number; actualHours: number; efficiency: number; completedTasks: number }[];
@@ -967,7 +993,7 @@ function V2TimeEfficiencyReport({ from, to }: { from: string; to: string }) {
 // ─── V2 Workload Distribution ─────────────────────────────────────────────────
 
 function V2WorkloadDistributionReport({ from, to }: { from: string; to: string }) {
-  const url = `/api/reports/v2/workload-distribution?startDate=${from}&endDate=${to}`;
+  const url = `/api/reports/v2/workload-distribution?startDate=${encodeURIComponent(from)}&endDate=${encodeURIComponent(to)}`;
   const { data, loading, error, reload } = useReportData<{
     data?: {
       items?: { userId: string; userName: string; department: string; taskCount: number; hoursBurden: number; score: number; level: string }[];


### PR DESCRIPTION
## Summary

- **ADMIN RBAC**: AdminTools (OTP generation, account unlock) now requires ADMIN role — MANAGER users no longer see these tools
- **OTP auto-expiry**: Reset token auto-clears from UI when expired (banking security)
- **Report URL injection**: All 19+ report URLs now use `encodeURIComponent` on date/year params
- **Fetch race condition**: `useReportData` hook uses `AbortController` to cancel stale requests
- **Input debounce**: CustomReport and V2EarnedValueReport text inputs debounced at 400ms
- **Audit log filter**: Action dropdown shows all known actions, not just current page's 20 records
- **Error handling**: TimeSummaryReport and OvertimeReport now show `PageError` instead of silent empty state
- **CSV injection defense**: Added pipe prefix, newline handling, and sanitized-value quoting
- **HTTP semantics**: Unsuspend changed from `DELETE ?action=unsuspend` to `PATCH { isActive: true }`
- **React keys**: Replaced array index keys with stable `email || userName` keys

## Test plan

- [ ] Login as MANAGER → admin page → verify AdminTools section is hidden
- [ ] Login as ADMIN → generate OTP → verify it auto-clears after expiry
- [ ] Open reports → verify no request flood when typing in filter inputs
- [ ] Audit log → verify action filter dropdown shows all 8 action types on any page
- [ ] Reports → simulate API error → verify error state renders with retry button
- [ ] Export CSV with special characters → verify no formula injection in Excel

Closes #1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)