### PR TITLE
fix(T1277): critical security fixes — sanitization, RBAC, self-approval

### DIFF
--- a/app/(app)/approvals/page.tsx
+++ b/app/(app)/approvals/page.tsx
@@ -85,8 +85,11 @@ function ReviewDialog({
 
   async function handleConfirm() {
     setSubmitting(true);
-    await onConfirm(note);
-    setSubmitting(false);
+    try {
+      await onConfirm(note);
+    } finally {
+      setSubmitting(false);
+    }
   }
 
   return (
@@ -280,28 +283,30 @@ export default function ApprovalsPage() {
   const [showNewForm, setShowNewForm] = useState(false);
   const [reviewTarget, setReviewTarget] = useState<{ approval: Approval; action: "APPROVED" | "REJECTED" } | null>(null);
 
-  const fetchApprovals = useCallback(async () => {
+  const fetchApprovals = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
     try {
       const params = new URLSearchParams({ page: String(page), limit: "20" });
       if (statusFilter !== "ALL") params.set("status", statusFilter);
       if (typeFilter !== "ALL") params.set("type", typeFilter);
-      const res = await fetch(`/api/approvals?${params}`);
+      const res = await fetch(`/api/approvals?${params}`, { signal });
       if (!res.ok) throw new Error("載入失敗");
       const body = await res.json();
       setItems(extractItems<Approval>(body));
       if (body?.data?.pagination) setPagination(body.data.pagination);
     } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
       toast.error(err instanceof Error ? err.message : "載入失敗");
     } finally {
       setLoading(false);
     }
   }, [page, statusFilter, typeFilter]);
 
-  useEffect(() => { fetchApprovals(); }, [fetchApprovals]);
-
-  // Reset page when filters change
-  useEffect(() => { setPage(1); }, [statusFilter, typeFilter]);
+  useEffect(() => {
+    const controller = new AbortController();
+    fetchApprovals(controller.signal);
+    return () => controller.abort();
+  }, [fetchApprovals]);
 
   async function handleReview(approval: Approval, action: "APPROVED" | "REJECTED", reviewNote: string) {
     try {

--- a/app/(app)/knowledge/page.tsx
+++ b/app/(app)/knowledge/page.tsx
@@ -202,6 +202,9 @@ export default function KnowledgePage() {
           prev.map((d) => d.id === selectedId ? { ...d, title: updated.title } : d)
         );
         toast.success("文件已儲存");
+      } else {
+        const errBody = await res.json().catch(() => ({}));
+        toast.error(errBody?.message ?? "操作失敗");
       }
     } finally {
       setSaving(false);
@@ -217,6 +220,9 @@ export default function KnowledgePage() {
       setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
       loadDocs();
       toast.success("文件已發佈");
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      toast.error(errBody?.message ?? "操作失敗");
     }
   }
 
@@ -229,6 +235,9 @@ export default function KnowledgePage() {
       setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
       loadDocs();
       toast.success("已送出審核");
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      toast.error(errBody?.message ?? "操作失敗");
     }
   }
 
@@ -247,6 +256,9 @@ export default function KnowledgePage() {
       setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
       loadDocs();
       toast.success("文件已退役");
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      toast.error(errBody?.message ?? "操作失敗");
     }
   }
 
@@ -261,6 +273,9 @@ export default function KnowledgePage() {
       setDocDetail((prev) => prev ? { ...prev, status: updated.status } : prev);
       loadDocs();
       toast.success("文件已歸檔");
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      toast.error(errBody?.message ?? "操作失敗");
     }
   }
 
@@ -314,7 +329,12 @@ export default function KnowledgePage() {
     const ok = await confirmDialog({ title: "確定刪除此文件？", description: "子文件將一起刪除。此操作無法復原", confirmLabel: "確認", variant: "destructive" });
     if (!ok) return;
     const delRes = await fetch(`/api/documents/${id}`, { method: "DELETE" });
-    if (delRes.ok) toast.success("文件已刪除");
+    if (delRes.ok) {
+      toast.success("文件已刪除");
+    } else {
+      const errBody = await delRes.json().catch(() => ({}));
+      toast.error(errBody?.message ?? "操作失敗");
+    }
     if (selectedId === id) setSelectedId(null);
     await loadDocs();
   }

--- a/app/api/approvals/route.ts
+++ b/app/api/approvals/route.ts
@@ -26,7 +26,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   const statusFilter = searchParams.get("status");
   const typeFilter = searchParams.get("type");
 
-  const isManager = session.user.role === "MANAGER";
+  const isManager = session.user.role === "MANAGER" || session.user.role === "ADMIN";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const where: any = {};
@@ -170,6 +170,9 @@ export const PATCH = withManager(async (req: NextRequest) => {
   const existing = await prisma.approvalRequest.findUnique({ where: { id } });
   if (!existing) {
     return error("NotFound", "Approval request not found", 404);
+  }
+  if (existing.requesterId === session.user.id) {
+    return error("FORBIDDEN", "審核人不得為申請人本身", 403);
   }
   if (existing.status !== "PENDING") {
     return error("ConflictError", "Only PENDING requests can be reviewed", 409);

--- a/app/api/document-templates/route.ts
+++ b/app/api/document-templates/route.ts
@@ -2,8 +2,9 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
 import { ValidationError } from "@/services/errors";
+import { sanitizeMarkdown } from "@/lib/security/sanitize";
 
 /**
  * GET /api/document-templates — List all document templates (Issue #1002)
@@ -43,11 +44,19 @@ export const POST = withAuth(async (req: NextRequest) => {
     throw new ValidationError("title, content, category 為必填欄位");
   }
 
+  const cleanTitle = sanitizeMarkdown(title);
+  const cleanContent = sanitizeMarkdown(content);
+  const cleanCategory = sanitizeMarkdown(category);
+
+  if (!cleanTitle || !cleanContent) {
+    return error("VALIDATION_ERROR", "標題和內容不可為空", 400);
+  }
+
   const template = await prisma.documentTemplate.create({
     data: {
-      title,
-      content,
-      category,
+      title: cleanTitle,
+      content: cleanContent,
+      category: cleanCategory,
       isSystem: false,
       createdBy: session.user.id,
     },

--- a/app/api/milestones/[id]/route.ts
+++ b/app/api/milestones/[id]/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { validateBody } from "@/lib/validate";
 import { updateMilestoneSchema } from "@/validators/milestone-validators";
 import { MilestoneService } from "@/services/milestone-service";
-import { withAuth } from "@/lib/auth-middleware";
+import { withAuth, withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 
 const getService = () => new MilestoneService(prisma);
@@ -41,7 +41,7 @@ export const PUT = withAuth(async (
   return success(milestone);
 });
 
-export const DELETE = withAuth(async (
+export const DELETE = withManager(async (
   _req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {

--- a/app/api/milestones/route.ts
+++ b/app/api/milestones/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { validateBody } from "@/lib/validate";
 import { createMilestoneSchema } from "@/validators/milestone-validators";
 import { MilestoneService } from "@/services/milestone-service";
-import { withAuth } from "@/lib/auth-middleware";
+import { withAuth, withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 
 const getService = () => new MilestoneService(prisma);
@@ -17,7 +17,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   return success(milestones);
 });
 
-export const POST = withAuth(async (req: NextRequest) => {
+export const POST = withManager(async (req: NextRequest) => {
 
   const raw = await req.json();
   const data = validateBody(createMilestoneSchema, raw);

--- a/app/api/monitoring-alerts/[id]/route.ts
+++ b/app/api/monitoring-alerts/[id]/route.ts
@@ -19,6 +19,9 @@ export const PATCH = withAuth(async (req: NextRequest, context: { params: Promis
   const raw = await req.json();
 
   if (raw.action === "acknowledge") {
+    if (session.user.role !== "MANAGER" && session.user.role !== "ADMIN") {
+      return error("FORBIDDEN", "僅限管理員可確認警報", 403);
+    }
     const alert = await service.acknowledgeAlert(id, session.user.id);
     return success(alert);
   }

--- a/app/api/recurring/[id]/route.ts
+++ b/app/api/recurring/[id]/route.ts
@@ -12,28 +12,44 @@ import { validateBody } from "@/lib/validate";
 import { updateRecurringRuleSchema } from "@/validators/recurring-validators";
 import { success, error } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
 
 const service = new RecurringService(prisma);
 
 export const PATCH = withAuth(async (req: NextRequest, context: { params: Promise<{ id: string }> }) => {
   const { id } = await context.params;
+  const session = await requireAuth();
   const raw = await req.json();
   const body = validateBody(updateRecurringRuleSchema, raw);
 
-  const rule = await service.updateRule(id, body);
-  if (!rule) {
+  const existing = await service.getRuleById(id);
+  if (!existing) {
     return error("NOT_FOUND", "RecurringRule not found", 404);
   }
 
+  const isOwner = existing.creatorId === session.user.id;
+  const isManager = session.user.role === "MANAGER" || session.user.role === "ADMIN";
+  if (!isOwner && !isManager) {
+    return error("FORBIDDEN", "僅限規則建立者或管理員可操作", 403);
+  }
+
+  const rule = await service.updateRule(id, body);
   return success(rule);
 });
 
 export const DELETE = withAuth(async (_req: NextRequest, context: { params: Promise<{ id: string }> }) => {
   const { id } = await context.params;
+  const session = await requireAuth();
 
   const existing = await service.getRuleById(id);
   if (!existing) {
     return error("NOT_FOUND", "RecurringRule not found", 404);
+  }
+
+  const isOwner = existing.creatorId === session.user.id;
+  const isManager = session.user.role === "MANAGER" || session.user.role === "ADMIN";
+  if (!isOwner && !isManager) {
+    return error("FORBIDDEN", "僅限規則建立者或管理員可操作", 403);
   }
 
   await service.deleteRule(id);

--- a/app/api/recurring/route.ts
+++ b/app/api/recurring/route.ts
@@ -13,6 +13,7 @@ import { createRecurringRuleSchema } from "@/validators/recurring-validators";
 import { success } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { sanitizeMarkdown } from "@/lib/security/sanitize";
 
 const service = new RecurringService(prisma);
 
@@ -28,6 +29,8 @@ export const POST = withAuth(async (req: NextRequest) => {
 
   const rule = await service.createRule({
     ...body,
+    title: sanitizeMarkdown(body.title),
+    description: body.description !== undefined ? sanitizeMarkdown(body.description) : body.description,
     creatorId: session.user.id,
   });
 

--- a/app/api/task-templates/route.ts
+++ b/app/api/task-templates/route.ts
@@ -6,6 +6,7 @@ import { success } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
+import { sanitizeMarkdown } from "@/lib/security/sanitize";
 
 /**
  * GET /api/task-templates
@@ -45,6 +46,8 @@ export const POST = withAuth(async (req: NextRequest) => {
   const template = await prisma.taskTemplate.create({
     data: {
       ...body,
+      title: sanitizeMarkdown(body.title),
+      description: body.description !== undefined ? sanitizeMarkdown(body.description) : body.description,
       creatorId: session.user.id,
     },
     include: {

--- a/app/components/milestone-section.tsx
+++ b/app/components/milestone-section.tsx
@@ -58,6 +58,9 @@ export function MilestoneSection({ plans }: MilestoneSectionProps) {
 
   // Form state
   const [formPlanId, setFormPlanId] = useState(plans[0]?.id ?? "");
+  useEffect(() => {
+    if (!formPlanId && plans.length > 0) setFormPlanId(plans[0].id);
+  }, [plans, formPlanId]);
   const [formTitle, setFormTitle] = useState("");
   const [formType, setFormType] = useState<MilestoneType>("CUSTOM");
   const [formPlannedEnd, setFormPlannedEnd] = useState("");
@@ -209,7 +212,7 @@ export function MilestoneSection({ plans }: MilestoneSectionProps) {
               {creating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "建立"}
             </button>
           </div>
-          {formError && <p className="text-xs text-danger">{formError}</p>}
+          {formError && <p className="text-xs text-destructive">{formError}</p>}
         </div>
       )}
 

--- a/app/components/reading-list-section.tsx
+++ b/app/components/reading-list-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Plus, Loader2, X, ChevronRight, BookOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { extractItems } from "@/lib/api-client";
@@ -213,9 +213,8 @@ export function ReadingListSection() {
               </thead>
               <tbody>
                 {lists.map((list) => (
-                  <>
+                  <React.Fragment key={list.id}>
                     <tr
-                      key={list.id}
                       className="border-b border-border/20 hover:bg-accent/20 cursor-pointer"
                       onClick={() => toggleExpand(list.id)}
                     >
@@ -289,7 +288,7 @@ export function ReadingListSection() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary

### CRITICAL (P0)
- **Stored XSS prevention**: Added `sanitizeMarkdown()` to document-templates, recurring-rules, and task-templates API routes before DB writes
- **Auth bypass fix**: Added ownership + MANAGER role check to `PATCH/DELETE /api/recurring/[id]` (was any-user)

### HIGH
- **ADMIN visibility**: Fixed `GET /api/approvals` excluding ADMIN from full-list view
- **Self-approval block**: Added guard preventing requester from approving their own request (403)
- **Milestone RBAC**: POST/DELETE now require `withManager`
- **Alert acknowledge RBAC**: Added MANAGER/ADMIN role check

### Code Quality
- Error handling added to 6 silent API operations in `knowledge/page.tsx`
- Race condition fixed in `approvals/page.tsx` with `AbortController`
- `ReviewDialog` try/finally for submitting state
- `React.Fragment` key fix in `reading-list-section.tsx`
- `text-danger` → `text-destructive` in `milestone-section.tsx`
- `formPlanId` sync when plans prop loads async

## Test plan

- [ ] POST document-template with `<script>alert(1)</script>` → stored content is sanitized
- [ ] ENGINEER tries DELETE /api/recurring/[id] on another user's rule → 403
- [ ] ADMIN views GET /api/approvals → sees all requests (not just own)
- [ ] MANAGER tries to approve own request → 403
- [ ] ENGINEER tries DELETE /api/milestones/[id] → 403
- [ ] ENGINEER tries PATCH acknowledge alert → 403
- [ ] Knowledge page: save fails → toast.error shown

Closes #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)