### PR TITLE
fix(T1279): P0 auth security — OTP hardening, CSRF, session blacklist

### DIFF
--- a/app/api/admin/generate-reset-token/route.ts
+++ b/app/api/admin/generate-reset-token/route.ts
@@ -12,7 +12,7 @@
  * Authorization: MANAGER only
  */
 import { NextRequest } from "next/server";
-import { randomInt } from "crypto";
+import { randomBytes, createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
@@ -25,8 +25,8 @@ const TOKEN_EXPIRY_MINUTES = 30;
 const auditService = new AuditService(prisma);
 
 function generateOTP(): string {
-  // 6-digit numeric OTP
-  return String(randomInt(100000, 999999));
+  // Cryptographically secure 32-byte hex token (256 bits of entropy)
+  return randomBytes(32).toString("hex");
 }
 
 export const POST = withManager(async (req: NextRequest) => {
@@ -66,12 +66,13 @@ export const POST = withManager(async (req: NextRequest) => {
 
   // Generate new OTP
   const token = generateOTP();
+  const tokenHash = createHash("sha256").update(token).digest("hex");
   const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MINUTES * 60 * 1000);
 
   await prisma.passwordResetToken.create({
     data: {
       userId: body.userId,
-      token,
+      token: tokenHash,   // Store hash, not plaintext
       expiresAt,
       createdBy: adminId,
     },

--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -14,10 +14,11 @@ import { isPasswordValid, PASSWORD_POLICY_DESCRIPTION } from "@/lib/password-pol
 import { AuditService } from "@/services/audit-service";
 import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/get-client-ip";
+import { apiHandler } from "@/lib/api-handler";
 
 const auditService = new AuditService(prisma);
 
-export async function POST(req: NextRequest) {
+export const POST = apiHandler(async (req: NextRequest) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const session = await getCachedSession(req) as any;
   const userId = session?.user?.id as string | undefined;
@@ -68,9 +69,11 @@ export async function POST(req: NextRequest) {
     select: { hash: true },
   });
 
-  for (const entry of recentHashes) {
-    if (await compare(newPassword, entry.hash)) {
-      return error("ValidationError", `新密碼不得與最近 ${PASSWORD_HISTORY_LIMIT} 組密碼相同`, 400);
+  // Check against current password hash AND recent history
+  const allHashes = [user.password, ...recentHashes.map(e => e.hash)];
+  for (const h of allHashes) {
+    if (await compare(newPassword, h)) {
+      return error("ValidationError", `新密碼不得與目前或最近 ${PASSWORD_HISTORY_LIMIT} 組密碼相同`, 400);
     }
   }
 
@@ -103,4 +106,4 @@ export async function POST(req: NextRequest) {
   logger.info({ userId }, "[auth] Password changed successfully");
 
   return success({ message: "密碼變更成功" });
-}
+});

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -12,6 +12,7 @@ import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { AuditService } from "@/services/audit-service";
+import { JwtBlacklist } from "@/lib/jwt-blacklist";
 
 export async function POST(req: NextRequest) {
   let body: { refreshToken?: string } = {};
@@ -33,6 +34,12 @@ export async function POST(req: NextRequest) {
   }
 
   if (userId) {
+    // Blacklist the current session JWT to prevent use during the 15-min access token window
+    const sessionId = (session as { sessionId?: string })?.sessionId;
+    if (sessionId) {
+      JwtBlacklist.add(`session:${sessionId}`);
+    }
+
     logger.info({ userId }, "[auth] User logged out");
 
     // Banking compliance: audit trail for logout events

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -13,6 +13,7 @@
  */
 import { NextRequest } from "next/server";
 import { hash } from "bcryptjs";
+import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { success, error } from "@/lib/api-response";
 import { isPasswordValid, PASSWORD_POLICY_DESCRIPTION } from "@/lib/password-policy";
@@ -51,11 +52,14 @@ export async function POST(req: NextRequest) {
     return error("InvalidTokenError", "重設碼無效或已過期", 400);
   }
 
+  // Hash submitted token before querying — tokens are stored as SHA-256 hashes
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+
   // Find valid, unused token
   const resetToken = await prisma.passwordResetToken.findFirst({
     where: {
       userId: user.id,
-      token,
+      token: tokenHash,   // Compare by hash
       usedAt: null,
       expiresAt: { gt: new Date() },
     },

--- a/lib/security-middleware.ts
+++ b/lib/security-middleware.ts
@@ -109,9 +109,11 @@ function extractBearer(req: NextRequest): string | null {
 
 /** Extract userId from the session (null if unauthenticated). */
 async function getSessionUserId(req: NextRequest): Promise<string | null> {
-  // Prefer X-User-Id header injected by tests / other middleware.
-  const override = req.headers.get("x-user-id");
-  if (override) return override;
+  // X-User-Id header override — test environments only (security: prevents rate-limit spoofing)
+  if (process.env.NODE_ENV === "test") {
+    const override = req.headers.get("x-user-id");
+    if (override) return override;
+  }
 
   const session = await getCachedSession(req);
   return ((session as { user?: { id?: string } } | null)?.user)?.id ?? null;


### PR DESCRIPTION
## Summary

### CRITICAL (P0)
- **CSRF bypass fixed**: `change-password` route now wrapped in `apiHandler()` — restores CSRF validation, IP rate limiting, and audit logging
- **X-User-Id spoofing blocked**: `getSessionUserId()` only trusts `X-User-Id` header in `NODE_ENV=test` — prevents rate-limit and JWT blacklist manipulation
- **OTP brute-force eliminated**: Upgraded from 6-digit numeric (900k keyspace) to `randomBytes(32)` hex (2^256 keyspace)
- **OTP stored as SHA-256 hash**: DB breach no longer exposes pending reset tokens

### HIGH
- **Zombie token window closed**: Logout now calls `JwtBlacklist.add("session:<id>")` — prevents 15-min post-logout token reuse
- **Password rotate-back blocked**: History check now includes current `user.password` hash alongside last 5 history entries

## Test plan

- [ ] `POST /api/auth/change-password` without CSRF token → 403
- [ ] Send `X-User-Id: fake` header in production → ignored (rate limit uses real session)
- [ ] Generate OTP → token is 64-char hex string (not 6 digits)
- [ ] Check DB → `passwordResetToken.token` is SHA-256 hash, not plaintext
- [ ] Reset password with correct OTP → success
- [ ] Logout → immediately try authenticated endpoint with old token → 401
- [ ] Change password to same as current → rejected

Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)