### PR TITLE
fix(T1281): import XSS, settle-month auth, upload bypass, KPI formula

### DIFF
--- a/app/api/kpi/[id]/route.ts
+++ b/app/api/kpi/[id]/route.ts
@@ -49,8 +49,10 @@ export const DELETE = withManager(async (
   const existing = await prisma.kPI.findUnique({ where: { id } });
   if (!existing) throw new NotFoundError("找不到 KPI");
 
-  await prisma.kPITaskLink.deleteMany({ where: { kpiId: id } });
-  await prisma.kPI.delete({ where: { id } });
+  await prisma.$transaction([
+    prisma.kPITaskLink.deleteMany({ where: { kpiId: id } }),
+    prisma.kPI.delete({ where: { id } }),
+  ]);
   return success({ deleted: true });
 });
 

--- a/app/api/tasks/import/route.ts
+++ b/app/api/tasks/import/route.ts
@@ -46,6 +46,10 @@ export const POST = withManager(async (req: NextRequest) => {
     return error("ValidationError", "Only .xlsx files are supported", 400);
   }
 
+  if (file.size > 10 * 1024 * 1024) {
+    return error("ValidationError", "檔案大小不得超過 10MB", 400);
+  }
+
   const buffer = Buffer.from(await file.arrayBuffer());
 
   // Determine import type from query parameter

--- a/app/api/time-entries/approve/route.ts
+++ b/app/api/time-entries/approve/route.ts
@@ -19,7 +19,7 @@ import { validateBody } from "@/lib/validate";
 import { success, error } from "@/lib/api-response";
 
 const approveSchema = z.object({
-  entryIds: z.array(z.string()).min(1, "至少需選擇一筆工時記錄"),
+  entryIds: z.array(z.string()).min(1, "至少需選擇一筆工時記錄").max(500, "單次最多核准 500 筆工時記錄"),
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/time-entries/copy-week/route.ts
+++ b/app/api/time-entries/copy-week/route.ts
@@ -37,11 +37,13 @@ export const POST = withAuth(async (req: NextRequest) => {
   const tgtEnd = new Date(tgtStart);
   tgtEnd.setDate(tgtEnd.getDate() + 6);
 
-  // Fetch source week entries
+  // Fetch source week entries — exclude deleted and actively running entries
   const sourceEntries = await prisma.timeEntry.findMany({
     where: {
       userId,
       date: { gte: srcStart, lte: srcEnd },
+      isDeleted: false,
+      isRunning: false,
     },
   });
 

--- a/app/api/time-entries/monthly-summary/route.ts
+++ b/app/api/time-entries/monthly-summary/route.ts
@@ -10,7 +10,8 @@ import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
+import { formatLocalDate } from "@/lib/utils/date";
 
 const monthParamSchema = z.string().regex(/^\d{4}-\d{2}$/, "格式須為 YYYY-MM");
 
@@ -43,7 +44,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
   const monthResult = monthParamSchema.safeParse(monthRaw);
   if (!monthResult.success) {
-    return success({ error: "month 參數格式須為 YYYY-MM" }, 400) as never;
+    return error("ValidationError", "month 參數格式須為 YYYY-MM", 400) as never;
   }
   const month = monthResult.data;
 
@@ -87,7 +88,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
     // Days with entries
     const datesWithEntries = new Set(
-      userEntries.map((e) => e.date.toISOString().split("T")[0])
+      userEntries.map((e) => formatLocalDate(e.date))
     );
 
     // Missing workdays (no entries filed)
@@ -95,7 +96,7 @@ export const GET = withManager(async (req: NextRequest) => {
     for (let d = 1; d <= daysInMonth; d++) {
       const date = new Date(year, mon - 1, d);
       if (isWeekend(date)) continue;
-      const dateStr = date.toISOString().split("T")[0];
+      const dateStr = formatLocalDate(date);
       if (!datesWithEntries.has(dateStr)) {
         missingDays.push(dateStr);
       }

--- a/app/api/time-entries/monthly/route.ts
+++ b/app/api/time-entries/monthly/route.ts
@@ -11,6 +11,7 @@ import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { success, error as apiError } from "@/lib/api-response";
+import { formatLocalDate } from "@/lib/utils/date";
 
 const monthParamSchema = z.string().regex(/^\d{4}-\d{2}$/, "格式須為 YYYY-MM");
 
@@ -63,7 +64,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
     for (const entry of userEntries) {
       // Use local date string from the Date object
-      const dateKey = entry.date.toISOString().split("T")[0];
+      const dateKey = formatLocalDate(entry.date);
       if (!days[dateKey]) {
         days[dateKey] = { totalHours: 0, entries: [], approvalStatus: "PENDING" };
       }

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { TimeCategory } from "@prisma/client";
 import { ForbiddenError, ValidationError } from "@/services/errors";
+import { sanitizeHtml } from "@/lib/security/sanitize";
 import { validateBody } from "@/lib/validate";
 import { createTimeEntrySchema } from "@/validators/time-entry-validators";
 import { validateDailyLimit } from "@/validators/shared/time-entry";
@@ -106,6 +107,7 @@ export const POST = withAuth(async (req: NextRequest) => {
   // Always create entries owned by the caller — ignores any userId in body.
   // #928: Manager time entries auto-approve (no approval workflow needed)
   const isManager = session.user.role === "MANAGER" || session.user.role === "ADMIN";
+  const cleanDescription = description ? sanitizeHtml(description) || null : null;
   const entry = await prisma.timeEntry.create({
     data: {
       taskId: taskId || null,
@@ -114,7 +116,7 @@ export const POST = withAuth(async (req: NextRequest) => {
       date: new Date(date),
       hours,
       category: (category as TimeCategory) ?? "PLANNED_TASK",
-      description: description || null,
+      description: cleanDescription,
       ...(isManager ? { approvalStatus: "APPROVED", locked: true } : {}),
     },
     include: {

--- a/app/api/time-entries/settle-month/route.ts
+++ b/app/api/time-entries/settle-month/route.ts
@@ -1,8 +1,8 @@
 /**
  * POST /api/time-entries/settle-month — Monthly settlement (TS-25)
  *
- * Locks all time entries for a given year/month.
- * Only MANAGER role may call this endpoint.
+ * Locks all APPROVED time entries for a given year/month.
+ * Only ADMIN role may call this endpoint.
  * Returns 409 if the month is already fully settled.
  *
  * Body: { year: number, month: number }
@@ -11,19 +11,20 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { withManager } from "@/lib/auth-middleware";
+import { withAdmin } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
 import { success } from "@/lib/api-response";
 import { ConflictError } from "@/services/errors";
+import { AuditService } from "@/services/audit-service";
 
 const settleMonthSchema = z.object({
   year: z.number().int().min(2000).max(2100),
   month: z.number().int().min(1).max(12),
 });
 
-export const POST = withManager(async (req: NextRequest) => {
-  await requireRole("MANAGER");
+export const POST = withAdmin(async (req: NextRequest) => {
+  const session = await requireRole("ADMIN");
 
   const raw = await req.json();
   const { year, month } = validateBody(settleMonthSchema, raw);
@@ -32,27 +33,39 @@ export const POST = withManager(async (req: NextRequest) => {
   const monthStart = new Date(year, month - 1, 1);
   const monthEnd = new Date(year, month, 0, 23, 59, 59, 999);
 
-  // Find all entries in this month
+  // Find all APPROVED entries in this month
   const entries = await prisma.timeEntry.findMany({
     where: {
       date: { gte: monthStart, lte: monthEnd },
+      approvalStatus: "APPROVED",
     },
     select: { id: true, locked: true },
   });
 
-  // Check if already fully settled (all locked or no entries)
+  // Check if already fully settled (all locked or no approved entries)
   const unlocked = entries.filter((e) => !e.locked);
   if (unlocked.length === 0) {
     throw new ConflictError("該月份已全部結算完成");
   }
 
-  // Lock all unlocked entries
+  // Lock all unlocked APPROVED entries
   const result = await prisma.timeEntry.updateMany({
     where: {
       date: { gte: monthStart, lte: monthEnd },
       locked: false,
+      approvalStatus: "APPROVED",
     },
     data: { locked: true },
+  });
+
+  // Audit log for compliance
+  const auditService = new AuditService(prisma);
+  await auditService.log({
+    userId: session.user.id,
+    action: "SETTLE_MONTH",
+    resourceType: "TimeEntry",
+    detail: `結算 ${year}/${month}，鎖定 ${result.count} 筆工時記錄`,
+    ipAddress: null,
   });
 
   return success({

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -67,6 +67,14 @@ export const POST = withAuth(async (req: NextRequest) => {
     return error("ValidationError", "檔案內容與宣告的類型不符", 400);
   }
 
+  // WebP requires 'WEBP' at offset 8-11 (RIFF container subtype)
+  if (ext === ".webp") {
+    const webpMarker = [0x57, 0x45, 0x42, 0x50]; // 'WEBP'
+    if (buffer.length < 12 || !webpMarker.every((b, i) => buffer[8 + i] === b)) {
+      return error("ValidationError", "無效的 WebP 檔案格式", 400);
+    }
+  }
+
   // Generate unique filename
   const filename = `${crypto.randomUUID()}${ext}`;
   const uploadDir = path.join(process.cwd(), "public", "uploads");

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -4,8 +4,9 @@ import { UserService } from "@/services/user-service";
 import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { updateUserSchema } from "@/validators/user-validators";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
+import { sanitizeHtml } from "@/lib/security/sanitize";
 import { requireAuth, requireRole } from "@/lib/rbac";
 import { getClientIp } from "@/lib/get-client-ip";
 
@@ -66,15 +67,20 @@ export const PATCH = withAuth(async (
 
   const raw = await req.json();
   // Only allow name updates via self-edit
-  const name = typeof raw.name === "string" ? raw.name.trim() : undefined;
-  if (!name || name.length === 0) {
+  const rawName = typeof raw.name === "string" ? raw.name.trim() : undefined;
+  if (!rawName || rawName.length === 0) {
     return NextResponse.json(
       { ok: false, error: "ValidationError", message: "姓名為必填" },
       { status: 400 }
     );
   }
 
-  const user = await userService.updateUser(id, { name });
+  const cleanName = sanitizeHtml(rawName);
+  if (!cleanName) {
+    return error("ValidationError", "姓名不可為空", 400);
+  }
+
+  const user = await userService.updateUser(id, { name: cleanName });
   return success(user);
 });
 

--- a/lib/kpi-calculator.ts
+++ b/lib/kpi-calculator.ts
@@ -19,7 +19,7 @@ export function calculateAchievement(kpi: KPILike): number {
       const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
       return s + (prog * l.weight) / 100;
     }, 0);
-    return Math.min((weighted / totalWeight) * kpi.target, 100);
+    return Math.min(weighted / totalWeight, 100);
   }
   return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
 }

--- a/services/import-service.ts
+++ b/services/import-service.ts
@@ -1,5 +1,6 @@
 import ExcelJS from "exceljs";
 import { PrismaClient } from "@prisma/client";
+import { sanitizeHtml } from "@/lib/security/sanitize";
 
 // Valid enum values mirrored from Prisma schema
 const VALID_STATUSES = ["BACKLOG", "TODO", "IN_PROGRESS", "REVIEW", "DONE"] as const;
@@ -222,23 +223,30 @@ export class ImportService {
       }
     }
 
-    // Build task data for batch creation
-    const taskData = validRows.map(({ row }) => ({
-      title: row.title,
-      description: row.description || undefined,
-      status: (row.status ?? "BACKLOG") as never,
-      priority: (row.priority ?? "P2") as never,
-      category: (row.category ?? "PLANNED") as never,
-      primaryAssigneeId: row.assigneeEmail
-        ? emailToUserId.get(row.assigneeEmail) ?? null
-        : null,
-      creatorId,
-      dueDate: row.dueDate ? new Date(row.dueDate) : null,
-      estimatedHours:
-        row.estimatedHours !== undefined && !isNaN(row.estimatedHours)
-          ? row.estimatedHours
+    // Build task data for batch creation, sanitizing text fields against XSS
+    const taskData = validRows.flatMap(({ row, index }) => {
+      const title = sanitizeHtml(row.title?.trim() ?? "");
+      if (!title) {
+        errors.push({ rowIndex: index, message: "title 清洗後為空（可能含有不允許的內容）" });
+        return [];
+      }
+      return [{
+        title,
+        description: row.description ? sanitizeHtml(row.description.trim()) || null : undefined,
+        status: (row.status ?? "BACKLOG") as never,
+        priority: (row.priority ?? "P2") as never,
+        category: (row.category ?? "PLANNED") as never,
+        primaryAssigneeId: row.assigneeEmail
+          ? emailToUserId.get(row.assigneeEmail) ?? null
           : null,
-    }));
+        creatorId,
+        dueDate: row.dueDate ? new Date(row.dueDate) : null,
+        estimatedHours:
+          row.estimatedHours !== undefined && !isNaN(row.estimatedHours)
+            ? row.estimatedHours
+            : null,
+      }];
+    });
 
     // Batch create all tasks in a single transaction
     const result = await this.prisma.$transaction(async (tx) => {
@@ -303,9 +311,9 @@ export class ImportService {
     }
 
     const kpiData = validRows.map((row) => ({
-      code: row.code,
-      title: row.title,
-      description: row.description ?? null,
+      code: sanitizeHtml(row.code),
+      title: sanitizeHtml(row.title),
+      description: row.description ? sanitizeHtml(row.description) || null : null,
       year: row.year,
       target: row.target,
       actual: row.actual ?? 0,
@@ -363,9 +371,9 @@ export class ImportService {
 
     const planData = validRows.map((row) => ({
       year: row.year,
-      title: row.title,
-      description: row.description ?? null,
-      implementationPlan: row.implementationPlan ?? null,
+      title: sanitizeHtml(row.title),
+      description: row.description ? sanitizeHtml(row.description) || null : null,
+      implementationPlan: row.implementationPlan ? sanitizeHtml(row.implementationPlan) || null : null,
       createdBy: creatorId,
     }));
 


### PR DESCRIPTION
## Summary

### CRITICAL
- **Import stored XSS**: `importTasks/KPIs/Plans` now sanitize all text fields before `createMany`; rows with empty titles after sanitization are skipped
- **Zip bomb prevention**: Excel import rejects files > 10MB before `arrayBuffer()`
- **Settle-month hardened**: Elevated to ADMIN-only, added audit log, filters only APPROVED entries

### HIGH
- **WebP upload bypass**: Added secondary WEBP marker check at offset 8 (RIFF alone accepted .wav/.avi)
- **User name XSS**: Self-edit PATCH now sanitizes name + validates non-empty
- **Copy-week safety**: Source query now excludes `isDeleted: true` and `isRunning: true` entries
- **Approve batch cap**: `entryIds` array capped at 500 to prevent DoS

### MEDIUM
- **KPI formula fix**: `calculateAchievement` removed erroneous `* kpi.target` multiplication — was producing 100% for any autoCalc KPI with target < 100
- **Timezone fix**: Monthly/monthly-summary views use `formatLocalDate()` instead of `toISOString().split("T")[0]`
- **Time entry description**: Sanitized before DB write
- **KPI delete atomic**: Wrapped in `$transaction`
- **monthly-summary 400**: Changed `success({error}, 400)` → `error("ValidationError", msg, 400)`

## Test plan

- [ ] Import xlsx with `<script>` in title → sanitized, no XSS
- [ ] Import 15MB xlsx → 400 "檔案大小不得超過 10MB"
- [ ] MANAGER calls settle-month → 403
- [ ] ADMIN calls settle-month → only APPROVED entries locked + audit log created
- [ ] Upload .wav renamed to .webp → rejected
- [ ] Self-edit name with HTML → sanitized
- [ ] KPI autoCalc=true, target=80, 50% task progress → achievement = 50% (not 100%)

Closes #1281

🤖 Generated with [Claude Code](https://claude.com/claude-code)