### PR TITLE
fix(T1283): KPI formula regression + update tests for security changes

### DIFF
--- a/__tests__/api/password-routes.test.ts
+++ b/__tests__/api/password-routes.test.ts
@@ -228,7 +228,8 @@ describe("POST /api/auth/change-password", () => {
     // All compare calls for history check return false (no match)
     mockCompare
       .mockResolvedValueOnce(true)   // currentPassword valid
-      .mockResolvedValueOnce(false); // no history match
+      .mockResolvedValueOnce(false)  // current hash check (allHashes[0])
+      .mockResolvedValueOnce(false); // history entry check (allHashes[1])
     mockPasswordHistory.findMany.mockResolvedValue([
       { hash: "$2a$10$oldhash1" },
     ]);
@@ -511,15 +512,15 @@ describe("POST /api/admin/generate-reset-token", () => {
     expect(body.data.userName).toBe("Bob");
   });
 
-  it("generates a 6-digit numeric OTP", async () => {
+  it("generates a cryptographic hex token (SHA-256 hash stored)", async () => {
     const { POST } = await import("@/app/api/admin/generate-reset-token/route");
     const req = createMockRequest("/api/admin/generate-reset-token", {
       method: "POST",
       body: { userId: "target-1" },
     });
     await POST(req);
-    // Verify the token created in DB is a 6-digit string
+    // Verify the token stored in DB is a 64-char hex SHA-256 hash (not plaintext)
     const createCall = mockPasswordResetToken.create.mock.calls[0][0];
-    expect(createCall.data.token).toMatch(/^\d{6}$/);
+    expect(createCall.data.token).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/__tests__/api/time-entries-settle-month.test.ts
+++ b/__tests__/api/time-entries-settle-month.test.ts
@@ -35,10 +35,21 @@ const SESSION_MANAGER = {
   user: { id: "mgr-1", name: "Manager", email: "mgr@t.com", role: "MANAGER" },
   expires: "2099",
 };
+const SESSION_ADMIN = {
+  user: { id: "adm-1", name: "Admin", email: "admin@t.com", role: "ADMIN" },
+  expires: "2099",
+};
 const SESSION_ENGINEER = {
   user: { id: "eng-1", name: "Engineer", email: "e@t.com", role: "ENGINEER" },
   expires: "2099",
 };
+
+// ── AuditService mock ───────────────────────────────────────────────────────
+jest.mock("@/services/audit-service", () => ({
+  AuditService: jest.fn().mockImplementation(() => ({
+    log: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
 
 // Suppress console.error from apiHandler
 jest.spyOn(console, "error").mockImplementation(() => {});
@@ -49,8 +60,8 @@ describe("POST /api/time-entries/settle-month (TS-25)", () => {
     jest.resetModules();
   });
 
-  it("locks all entries for the given month when called by MANAGER", async () => {
-    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+  it("locks all entries for the given month when called by ADMIN", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_ADMIN);
     // Unsettled entries exist
     mockTimeEntry.findMany.mockResolvedValue([
       { id: "e1", locked: false },
@@ -75,6 +86,20 @@ describe("POST /api/time-entries/settle-month (TS-25)", () => {
         data: { locked: true },
       })
     );
+  });
+
+  it("returns 403 when MANAGER tries to settle (ADMIN only)", async () => {
+    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+
+    const { POST } = await import("@/app/api/time-entries/settle-month/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/settle-month", {
+        method: "POST",
+        body: { year: 2026, month: 3 },
+      })
+    );
+
+    expect(res.status).toBe(403);
   });
 
   it("returns 403 when ENGINEER tries to settle", async () => {
@@ -106,7 +131,7 @@ describe("POST /api/time-entries/settle-month (TS-25)", () => {
   });
 
   it("returns 409 when month is already fully settled", async () => {
-    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockGetServerSession.mockResolvedValue(SESSION_ADMIN);
     // All entries are already locked
     mockTimeEntry.findMany.mockResolvedValue([
       { id: "e1", locked: true },
@@ -125,7 +150,7 @@ describe("POST /api/time-entries/settle-month (TS-25)", () => {
   });
 
   it("returns 400 for invalid year/month", async () => {
-    mockGetServerSession.mockResolvedValue(SESSION_MANAGER);
+    mockGetServerSession.mockResolvedValue(SESSION_ADMIN);
 
     const { POST } = await import("@/app/api/time-entries/settle-month/route");
     const res = await POST(

--- a/lib/kpi-calculator.ts
+++ b/lib/kpi-calculator.ts
@@ -19,7 +19,7 @@ export function calculateAchievement(kpi: KPILike): number {
       const prog = l.task.status === "DONE" ? 100 : l.task.progressPct;
       return s + (prog * l.weight) / 100;
     }, 0);
-    return Math.min(weighted / totalWeight, 100);
+    return Math.min((weighted / totalWeight) * 100, 100);
   }
   return kpi.target > 0 ? Math.min((kpi.actual / kpi.target) * 100, 100) : 0;
 }


### PR DESCRIPTION
## Summary

- **KPI formula fix**: `calculateAchievement` autoCalc path now correctly returns percentage (0-100) instead of fraction (0-1)
- **Test updates**: Align tests with security changes from #1279 (OTP hash) and #1281 (ADMIN-only settle)

## Test plan

- [x] `kpi-service.test.ts` — 53/53 PASS
- [x] `password-routes.test.ts` — all PASS
- [x] `time-entries-settle-month.test.ts` — all PASS (including new MANAGER→403 test)

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)