### PR TITLE
fix(T1289): enforce daily 24hr limit in batch time-entry API

### DIFF
--- a/__tests__/api/time-entries-batch.test.ts
+++ b/__tests__/api/time-entries-batch.test.ts
@@ -191,6 +191,100 @@ describe("POST /api/time-entries/batch", () => {
 
     expect(res.status).toBe(400);
   });
+
+  // T-1: Daily 24hr limit enforcement in batch endpoint
+  test("rejects batch that exceeds daily 24hr limit against existing entries", async () => {
+    // User already has 20 hours on 2026-03-23
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([
+            { date: new Date("2026-03-23"), taskId: "t1", hours: 12 },
+            { date: new Date("2026-03-23"), taskId: "t2", hours: 8 },
+          ]),
+          create: jest.fn(),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          // Adding 5 hours would bring total to 25 — must be rejected
+          entries: [{ date: "2026-03-23", hours: 5, taskId: "t3", category: "PLANNED_TASK" }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.message).toMatch(/24/);
+  });
+
+  test("rejects batch where multiple entries on same day collectively exceed 24hr limit", async () => {
+    // No existing entries; batch itself totals 25 hours on one day
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: jest.fn(),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [
+            { date: "2026-03-23", hours: 12, taskId: "t1", category: "PLANNED_TASK" },
+            { date: "2026-03-23", hours: 8,  taskId: "t2", category: "SUPPORT" },
+            { date: "2026-03-23", hours: 5,  taskId: "t3", category: "MEETING" }, // 12+8+5 = 25
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  test("allows batch that exactly reaches 24hr limit", async () => {
+    // No existing entries; batch totals exactly 24 hours — should pass
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: jest.fn()
+            .mockResolvedValueOnce({ id: "e1", hours: 12 })
+            .mockResolvedValueOnce({ id: "e2", hours: 12 }),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [
+            { date: "2026-03-23", hours: 12, taskId: "t1", category: "PLANNED_TASK" },
+            { date: "2026-03-23", hours: 12, taskId: "t2", category: "SUPPORT" },
+          ],
+        },
+      })
+    );
+
+    expect(res.status).toBe(201);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/app/api/time-entries/batch/route.ts
+++ b/app/api/time-entries/batch/route.ts
@@ -18,6 +18,7 @@ import { requireAuth } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
 import { success, error } from "@/lib/api-response";
 import { TimeCategoryEnum } from "@/validators/shared/enums";
+import { validateDailyLimit } from "@/validators/shared/time-entry";
 import { ValidationError } from "@/services/errors";
 
 const batchEntrySchema = z.object({
@@ -53,20 +54,25 @@ export const POST = withAuth(async (req: NextRequest) => {
       where: {
         userId,
         date: { gte: minDate, lte: maxDate },
+        isDeleted: false,
       },
-      select: { date: true, taskId: true },
+      select: { date: true, taskId: true, hours: true },
     });
 
     // Build a set of existing date+taskId keys for overlap detection
-    const existingKeys = new Set(
-      existing.map((e) => {
-        const dateStr = formatLocalDate(new Date(e.date));
-        return `${dateStr}:${e.taskId ?? ""}`;
-      })
-    );
+    // Also build a map of existing hours per date for daily-limit validation
+    const existingKeys = new Set<string>();
+    const existingHoursByDate = new Map<string, number>();
+    for (const e of existing) {
+      const dateStr = formatLocalDate(new Date(e.date));
+      existingKeys.add(`${dateStr}:${e.taskId ?? ""}`);
+      existingHoursByDate.set(dateStr, (existingHoursByDate.get(dateStr) ?? 0) + e.hours);
+    }
 
     // Also detect duplicates within the batch itself
     const batchKeys = new Set<string>();
+    // Track batch hours added per date (accumulates as we validate each entry)
+    const batchHoursByDate = new Map<string, number>();
 
     for (const entry of entries) {
       const key = `${entry.date}:${entry.taskId ?? ""}`;
@@ -81,6 +87,15 @@ export const POST = withAuth(async (req: NextRequest) => {
         );
       }
       batchKeys.add(key);
+
+      // T-1: Enforce daily 24hr limit — existing + already-validated batch entries + this entry
+      const existingDay = existingHoursByDate.get(entry.date) ?? 0;
+      const batchDay = batchHoursByDate.get(entry.date) ?? 0;
+      const limitError = validateDailyLimit(existingDay + batchDay, entry.hours);
+      if (limitError) {
+        throw new ValidationError(limitError);
+      }
+      batchHoursByDate.set(entry.date, batchDay + entry.hours);
     }
 
     // Create entries one by one within the transaction (for include support)


### PR DESCRIPTION
## Summary

- `POST /api/time-entries/batch` was missing `validateDailyLimit()` check, allowing users to submit entries that exceed 24 hours in a single day via the batch endpoint
- Single-entry and update endpoints already enforced this correctly
- Added `isDeleted: false` filter to the `findMany` query for consistency

## Changes

- `app/api/time-entries/batch/route.ts`: import and call `validateDailyLimit()` per date within the transaction loop
- `__tests__/api/time-entries-batch.test.ts`: 3 new tests covering limit enforcement

## Test plan
- [x] `pnpm test __tests__/api/time-entries-batch.test.ts` — 15/15 pass
- [x] All 3 new daily-limit test cases pass

Closes #1291