### PR TITLE
fix(T1293): batch time-entry XSS, date key mismatch, schema parity

### DIFF
--- a/__tests__/api/time-entries-batch.test.ts
+++ b/__tests__/api/time-entries-batch.test.ts
@@ -256,6 +256,84 @@ describe("POST /api/time-entries/batch", () => {
     expect(body.ok).toBe(false);
   });
 
+  test("rejects zero hours (shared hoursSchema: gt(0))", async () => {
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [{ date: "2026-03-23", hours: 0, category: "PLANNED_TASK" }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects non-0.5-increment hours (shared hoursSchema)", async () => {
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [{ date: "2026-03-23", hours: 1.3, category: "PLANNED_TASK" }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects future dates (shared pastOrTodayDate)", async () => {
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [{ date: "2099-12-31", hours: 4, category: "PLANNED_TASK" }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  test("sanitizes description to prevent XSS", async () => {
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const tx = {
+        timeEntry: {
+          findMany: jest.fn().mockResolvedValue([]),
+          create: jest.fn().mockImplementation((args: { data: { description: unknown } }) => ({
+            id: "e1",
+            ...args.data,
+          })),
+        },
+      };
+      return fn(tx);
+    });
+
+    const { POST } = await import("@/app/api/time-entries/batch/route");
+    const res = await POST(
+      createMockRequest("/api/time-entries/batch", {
+        method: "POST",
+        body: {
+          entries: [{
+            date: "2026-03-23",
+            hours: 4,
+            category: "PLANNED_TASK",
+            description: '<script>alert("xss")</script>Legit text',
+          }],
+        },
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    // Description should have script tag stripped
+    const desc = body.data?.[0]?.description ?? "";
+    expect(desc).not.toContain("<script>");
+  });
+
   test("allows batch that exactly reaches 24hr limit", async () => {
     // No existing entries; batch totals exactly 24 hours — should pass
     mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {

--- a/__tests__/api/time-entries-daily-limit.test.ts
+++ b/__tests__/api/time-entries-daily-limit.test.ts
@@ -38,9 +38,9 @@ describe("Time Entry Validator — 0.5hr minimum unit", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts 0 hours", () => {
+  it("rejects 0 hours (must be gt(0))", () => {
     const result = createTimeEntrySchema.safeParse({ date: "2026-03-26", hours: 0 });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 
   it("rejects 0.3 hours (not 0.5 increment)", () => {

--- a/app/api/time-entries/batch/route.ts
+++ b/app/api/time-entries/batch/route.ts
@@ -18,15 +18,16 @@ import { requireAuth } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
 import { success, error } from "@/lib/api-response";
 import { TimeCategoryEnum } from "@/validators/shared/enums";
-import { validateDailyLimit } from "@/validators/shared/time-entry";
+import { validateDailyLimit, hoursSchema, pastOrTodayDate } from "@/validators/shared/time-entry";
+import { sanitizeHtml } from "@/lib/security/sanitize";
 import { ValidationError } from "@/services/errors";
 
 const batchEntrySchema = z.object({
-  date: z.string().date(),
-  hours: z.number().min(0).max(24),
+  date: pastOrTodayDate,
+  hours: hoursSchema,
   taskId: z.string().optional(),
   category: TimeCategoryEnum.optional().default("PLANNED_TASK"),
-  description: z.string().optional(),
+  description: z.string().max(2000).optional(),
 });
 
 const batchCreateSchema = z.object({
@@ -75,7 +76,9 @@ export const POST = withAuth(async (req: NextRequest) => {
     const batchHoursByDate = new Map<string, number>();
 
     for (const entry of entries) {
-      const key = `${entry.date}:${entry.taskId ?? ""}`;
+      // Normalize date key the same way existing entries are keyed
+      const dateKey = formatLocalDate(new Date(entry.date));
+      const key = `${dateKey}:${entry.taskId ?? ""}`;
       if (existingKeys.has(key)) {
         throw new ValidationError(
           `重複：${entry.date} 的任務 ${entry.taskId ?? "(無任務)"} 已有工時記錄`
@@ -89,18 +92,19 @@ export const POST = withAuth(async (req: NextRequest) => {
       batchKeys.add(key);
 
       // T-1: Enforce daily 24hr limit — existing + already-validated batch entries + this entry
-      const existingDay = existingHoursByDate.get(entry.date) ?? 0;
-      const batchDay = batchHoursByDate.get(entry.date) ?? 0;
+      const existingDay = existingHoursByDate.get(dateKey) ?? 0;
+      const batchDay = batchHoursByDate.get(dateKey) ?? 0;
       const limitError = validateDailyLimit(existingDay + batchDay, entry.hours);
       if (limitError) {
         throw new ValidationError(limitError);
       }
-      batchHoursByDate.set(entry.date, batchDay + entry.hours);
+      batchHoursByDate.set(dateKey, batchDay + entry.hours);
     }
 
     // Create entries one by one within the transaction (for include support)
     const results = [];
     for (const entry of entries) {
+      const cleanDescription = entry.description ? sanitizeHtml(entry.description) || null : null;
       const result = await tx.timeEntry.create({
         data: {
           userId,
@@ -108,7 +112,7 @@ export const POST = withAuth(async (req: NextRequest) => {
           date: new Date(entry.date),
           hours: entry.hours,
           category: (entry.category as TimeCategory) ?? "PLANNED_TASK",
-          description: entry.description || null,
+          description: cleanDescription,
         },
         include: {
           task: { select: { id: true, title: true, category: true } },

--- a/validators/shared/time-entry.ts
+++ b/validators/shared/time-entry.ts
@@ -13,7 +13,7 @@ import { TimeCategoryEnum } from "./enums";
  * Validate hours is in 0.5hr increments.
  * Rounds to nearest 0.5 if within a small tolerance, else rejects.
  */
-const hoursSchema = z.number().gt(0, "工時必須大於 0").max(24).refine(
+export const hoursSchema = z.number().gt(0, "工時必須大於 0").max(24).refine(
   (val) => {
     // Allow exact 0.5 increments (with floating-point tolerance)
     const remainder = (val * 10) % 5;
@@ -23,7 +23,7 @@ const hoursSchema = z.number().gt(0, "工時必須大於 0").max(24).refine(
 );
 
 /** Date must be today or earlier — no future date entries (Issue #1157) */
-const pastOrTodayDate = z.string().date().refine(
+export const pastOrTodayDate = z.string().date().refine(
   (val) => val <= new Date().toISOString().slice(0, 10),
   { message: "工時日期不可為未來日期" }
 );


### PR DESCRIPTION
## Summary

Follow-up fixes from code review + security review of #1292.

### P0 fixes
- **Date key mismatch**: `existingHoursByDate` keyed by `formatLocalDate()` but looked up with raw `entry.date` — daily limit silently bypassed on non-UTC servers. Now all keys normalized through `formatLocalDate(new Date(...))`.
- **Stored XSS**: batch endpoint did not sanitize `description`. Added `sanitizeHtml()` before DB write.

### P1 fixes
- **Schema parity**: replaced inline `z.number().min(0).max(24)` with shared `hoursSchema` (`gt(0)` + 0.5 increments). Replaced `z.string().date()` with shared `pastOrTodayDate` (blocks future dates). Added `.max(2000)` to description.
- **Exported shared schemas**: `hoursSchema` and `pastOrTodayDate` now exported from `validators/shared/time-entry.ts`.
- **Fixed pre-existing wrong test**: `hours: 0` was expected to pass but `hoursSchema` uses `gt(0)`.

## Test plan
- [x] 19/19 batch tests pass (4 new: zero hours, non-0.5, future date, XSS sanitization)
- [x] 19/19 daily-limit tests pass (1 corrected)
- [x] 38/38 total

Closes #1293