### PR TITLE
feat(T1311): stale-task detection cron + service layer

### DIFF
--- a/__tests__/api/stale-task-scan.test.ts
+++ b/__tests__/api/stale-task-scan.test.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API route tests: /api/cron/stale-task-scan — Issue #1311
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+// Mock next/headers (required for Edge runtime — see CLAUDE.md Jest pitfalls)
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+/** Create a request with x-cron-secret header */
+function createCronRequest(secret?: string) {
+  const req = createMockRequest("/api/cron/stale-task-scan", { method: "POST" });
+  const headers = new Headers();
+  if (secret !== undefined) headers.set("x-cron-secret", secret);
+  // Override headers on the mock object
+  (req as unknown as Record<string, unknown>).headers = headers;
+  return req;
+}
+
+// Mock the stale task service
+const mockScanStaleTasks = jest.fn();
+jest.mock("@/services/stale-task-service", () => ({
+  scanStaleTasks: (...args: unknown[]) => mockScanStaleTasks(...args),
+}));
+
+// Mock prisma (needed by apiHandler)
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    notification: { createMany: jest.fn(), findMany: jest.fn() },
+    task: { findMany: jest.fn() },
+    user: { findMany: jest.fn() },
+  },
+}));
+
+// Mock next-auth
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn().mockResolvedValue(null),
+}));
+
+const CRON_SECRET = "test-secret-1234";
+
+describe("POST /api/cron/stale-task-scan", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, CRON_SECRET };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  // ── Test 1: Missing CRON_SECRET env → 500 ───────────────────────────────
+
+  it("returns 500 when CRON_SECRET env var is not configured", async () => {
+    delete process.env.CRON_SECRET;
+
+    const { POST } = await import("@/app/api/cron/stale-task-scan/route");
+    const res = await (POST as Function)(createCronRequest());
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("ServerError");
+  });
+
+  // ── Test 2: Wrong secret → 401 ──────────────────────────────────────────
+
+  it("returns 401 when wrong x-cron-secret header is provided", async () => {
+    const { POST } = await import("@/app/api/cron/stale-task-scan/route");
+    const res = await (POST as Function)(createCronRequest("wrong-secret"));
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("UnauthorizedError");
+  });
+
+  // ── Test 3: Correct secret → 200 + service result ───────────────────────
+
+  it("returns 200 with service result when valid secret is provided", async () => {
+    mockScanStaleTasks.mockResolvedValue({
+      remindCount: 2,
+      warnCount: 1,
+      escalateCount: 0,
+      skippedCount: 1,
+    });
+
+    const { POST } = await import("@/app/api/cron/stale-task-scan/route");
+    const res = await (POST as Function)(createCronRequest(CRON_SECRET));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.remindCount).toBe(2);
+    expect(body.data.warnCount).toBe(1);
+    expect(body.data.escalateCount).toBe(0);
+    expect(body.data.skippedCount).toBe(1);
+    expect(body.data.scannedAt).toBeDefined();
+  });
+
+  // ── Test 4: Service throws → 500 ────────────────────────────────────────
+
+  it("returns 500 when scanStaleTasks throws an error", async () => {
+    mockScanStaleTasks.mockRejectedValue(new Error("Database connection failed"));
+
+    const { POST } = await import("@/app/api/cron/stale-task-scan/route");
+    const res = await (POST as Function)(createCronRequest(CRON_SECRET));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("ServerError");
+  });
+});

--- a/app/api/cron/stale-task-scan/route.ts
+++ b/app/api/cron/stale-task-scan/route.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/cron/stale-task-scan — Stale task detection cron (Issue #1311)
+ *
+ * Scans all non-terminal tasks for staleness and creates Notification records
+ * for assignees, managers, and admins based on stale thresholds.
+ *
+ * Protected by CRON_SECRET header validation (required if env var is set).
+ * Edge JWT middleware also blocks unauthenticated external requests.
+ */
+
+import { NextRequest } from "next/server";
+import { success, error } from "@/lib/api-response";
+import { apiHandler } from "@/lib/api-handler";
+import { scanStaleTasks } from "@/services/stale-task-service";
+import { logger } from "@/lib/logger";
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  // Enforce CRON_SECRET — reject if not configured
+  const expectedSecret = process.env.CRON_SECRET;
+  if (!expectedSecret) {
+    return error("ServerError", "CRON_SECRET not configured", 500);
+  }
+  const provided = req.headers.get("x-cron-secret");
+  if (provided !== expectedSecret) {
+    return error("UnauthorizedError", "Invalid cron secret", 401);
+  }
+
+  try {
+    const result = await scanStaleTasks();
+    logger.info(
+      { ...result },
+      "[stale-task-scan] scan completed"
+    );
+    return success({
+      ...result,
+      scannedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.error({ err }, "[stale-task-scan] scan failed");
+    return error("ServerError", "Stale task scan failed", 500);
+  }
+});

--- a/services/__tests__/stale-task-service.test.ts
+++ b/services/__tests__/stale-task-service.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for stale-task-service — Issue #1311
+ *
+ * Uses dependency injection (prisma mock passed via deps) to avoid module-level mocks.
+ */
+
+import {
+  scanStaleTasks,
+  classifyStaleLevel,
+  STALE_REMIND_DAYS,
+  STALE_WARN_DAYS,
+  STALE_ESCALATE_DAYS,
+} from "../stale-task-service";
+import { createMockPrisma } from "../../lib/test-utils";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function daysAgoDate(days: number, from: Date): Date {
+  return new Date(from.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+function daysFromNow(days: number, from: Date): Date {
+  return new Date(from.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+const NOW = new Date("2026-04-09T12:00:00Z");
+
+const ENGINEER_USER = { id: "user-eng", name: "Engineer", role: "ENGINEER" };
+const MANAGER_USER = { id: "user-mgr", role: "MANAGER" };
+const ADMIN_USER = { id: "user-adm", role: "ADMIN" };
+
+function makeTask(overrides: {
+  id?: string;
+  title?: string;
+  updatedAt: Date;
+  dueDate?: Date | null;
+  status?: string;
+  assigneeId?: string | null;
+}) {
+  return {
+    id: overrides.id ?? "task-1",
+    title: overrides.title ?? "Test Task",
+    updatedAt: overrides.updatedAt,
+    dueDate: overrides.dueDate ?? null,
+    status: overrides.status ?? "IN_PROGRESS",
+    primaryAssignee: overrides.assigneeId !== null
+      ? { id: overrides.assigneeId ?? ENGINEER_USER.id, name: "Engineer", role: "ENGINEER" }
+      : null,
+  };
+}
+
+// ── classifyStaleLevel unit tests ─────────────────────────────────────────────
+
+describe("classifyStaleLevel", () => {
+  test("returns null when task is less than REMIND threshold", () => {
+    const updatedAt = daysAgoDate(STALE_REMIND_DAYS - 0.5, NOW);
+    expect(classifyStaleLevel(updatedAt, null, NOW)).toBeNull();
+  });
+
+  test("returns REMIND for 3–7 days stale with no due date", () => {
+    const updatedAt = daysAgoDate(5, NOW);
+    expect(classifyStaleLevel(updatedAt, null, NOW)).toBe("REMIND");
+  });
+
+  test("returns WARN for 7–14 days stale", () => {
+    const updatedAt = daysAgoDate(10, NOW);
+    expect(classifyStaleLevel(updatedAt, null, NOW)).toBe("WARN");
+  });
+
+  test("returns ESCALATE for >14 days stale", () => {
+    const updatedAt = daysAgoDate(15, NOW);
+    expect(classifyStaleLevel(updatedAt, null, NOW)).toBe("ESCALATE");
+  });
+
+  test("returns ESCALATE when dueDate overdue by >3 days (even if stale only 4 days)", () => {
+    const updatedAt = daysAgoDate(4, NOW);
+    const dueDate = daysAgoDate(4, NOW); // overdue 4 days
+    expect(classifyStaleLevel(updatedAt, dueDate, NOW)).toBe("ESCALATE");
+  });
+
+  test("returns WARN when dueDate is within 3 days and task is stale", () => {
+    const updatedAt = daysAgoDate(4, NOW);
+    const dueDate = daysFromNow(2, NOW); // 2 days in future
+    expect(classifyStaleLevel(updatedAt, dueDate, NOW)).toBe("WARN");
+  });
+});
+
+// ── scanStaleTasks integration tests ─────────────────────────────────────────
+
+describe("scanStaleTasks", () => {
+  let prisma: ReturnType<typeof createMockPrisma>;
+
+  beforeEach(() => {
+    prisma = createMockPrisma();
+
+    // Default: no recent notifications
+    (prisma.notification.findMany as jest.Mock).mockResolvedValue([]);
+    // Default: one manager, one admin
+    (prisma.user.findMany as jest.Mock)
+      .mockResolvedValueOnce([MANAGER_USER]) // managers query
+      .mockResolvedValueOnce([ADMIN_USER]);  // admins query
+    // Default: createMany succeeds
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 0 });
+  });
+
+  // ── Test 1: Tasks stale < 3 days are not triggered ──────────────────────
+
+  test("tasks stale less than 3 days are NOT notified", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result).toEqual({ remindCount: 0, warnCount: 0, escalateCount: 0, skippedCount: 0 });
+    expect(prisma.notification.createMany).not.toHaveBeenCalled();
+  });
+
+  // ── Test 2: REMIND (3–7 days) notifies only assignee ────────────────────
+
+  test("3-7 day stale task creates REMIND notification only for assignee", async () => {
+    const task = makeTask({ updatedAt: daysAgoDate(5, NOW) });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.remindCount).toBe(1);
+    expect(result.warnCount).toBe(0);
+    expect(result.escalateCount).toBe(0);
+
+    const callArg = (prisma.notification.createMany as jest.Mock).mock.calls[0][0];
+    expect(callArg.data).toHaveLength(1);
+    expect(callArg.data[0]).toMatchObject({
+      userId: ENGINEER_USER.id,
+      type: "TASK_OVERDUE",
+      relatedType: "STALE_REMIND",
+    });
+  });
+
+  // ── Test 3: WARN (7–14 days) notifies assignee + manager ────────────────
+
+  test("7-14 day stale task creates WARN notification for assignee and manager", async () => {
+    const task = makeTask({ updatedAt: daysAgoDate(10, NOW) });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 2 });
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.warnCount).toBe(1);
+
+    const callArg = (prisma.notification.createMany as jest.Mock).mock.calls[0][0];
+    const userIds = callArg.data.map((n: { userId: string }) => n.userId);
+    expect(userIds).toContain(ENGINEER_USER.id);
+    expect(userIds).toContain(MANAGER_USER.id);
+    expect(callArg.data[0].relatedType).toBe("STALE_WARN");
+  });
+
+  // ── Test 4: ESCALATE (>14 days) notifies assignee + manager + admin ──────
+
+  test(">14 day stale task creates ESCALATE notification for assignee, manager, and admin", async () => {
+    const task = makeTask({ updatedAt: daysAgoDate(20, NOW) });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 3 });
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.escalateCount).toBe(1);
+
+    const callArg = (prisma.notification.createMany as jest.Mock).mock.calls[0][0];
+    const userIds = callArg.data.map((n: { userId: string }) => n.userId);
+    expect(userIds).toContain(ENGINEER_USER.id);
+    expect(userIds).toContain(MANAGER_USER.id);
+    expect(userIds).toContain(ADMIN_USER.id);
+    expect(callArg.data[0].relatedType).toBe("STALE_ESCALATE");
+  });
+
+  // ── Test 5: dueDate overdue >3 days → ESCALATE ──────────────────────────
+
+  test("task with dueDate overdue >3 days triggers ESCALATE regardless of stale days", async () => {
+    const task = makeTask({
+      updatedAt: daysAgoDate(4, NOW),
+      dueDate: daysAgoDate(5, NOW), // overdue 5 days
+    });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.escalateCount).toBe(1);
+    expect(result.warnCount).toBe(0);
+  });
+
+  // ── Test 6: DONE / CANCELLED tasks are excluded ──────────────────────────
+
+  test("DONE and CANCELLED tasks do not appear in scan results", async () => {
+    // These should not be returned by the prisma query (status filter in service)
+    // Verify the query filter is applied correctly
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    const queryArg = (prisma.task.findMany as jest.Mock).mock.calls[0][0];
+    expect(queryArg.where.status).toEqual({ notIn: ["DONE", "CANCELLED"] });
+  });
+
+  // ── Test 7: 24hr dedup skips already-notified task+level ─────────────────
+
+  test("skips notification if same task+level already notified within 24 hours", async () => {
+    const task = makeTask({ id: "task-dup", updatedAt: daysAgoDate(5, NOW) });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    // Simulate existing notification for this task+level+user
+    (prisma.notification.findMany as jest.Mock).mockResolvedValue([
+      { userId: ENGINEER_USER.id, relatedId: "task-dup", relatedType: "STALE_REMIND" },
+    ]);
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.skippedCount).toBeGreaterThan(0);
+    // createMany should not be called since all recipients were deduplicated
+    expect(prisma.notification.createMany).not.toHaveBeenCalled();
+  });
+
+  // ── Test 8: No manager on assignee → fallback to any MANAGER ─────────────
+
+  test("when no manager associated, falls back to any MANAGER role user", async () => {
+    const task = makeTask({ updatedAt: daysAgoDate(10, NOW) }); // WARN level
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    // Manager list returns fallback manager
+    // (already set in beforeEach as [MANAGER_USER])
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.warnCount).toBe(1);
+    const callArg = (prisma.notification.createMany as jest.Mock).mock.calls[0][0];
+    const userIds = callArg.data.map((n: { userId: string }) => n.userId);
+    // Fallback manager should be in recipients
+    expect(userIds).toContain(MANAGER_USER.id);
+  });
+
+  // ── Test 9: XSS in task title is sanitized ───────────────────────────────
+
+  test("task title with XSS payload is sanitized in notification body", async () => {
+    const xssTitle = 'Alert<script>alert(1)</script>';
+    const task = makeTask({ title: xssTitle, updatedAt: daysAgoDate(5, NOW) });
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([task]);
+
+    await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    const callArg = (prisma.notification.createMany as jest.Mock).mock.calls[0][0];
+    const body = callArg.data[0].body as string;
+    expect(body).not.toContain("<script>");
+    expect(body).not.toContain("alert(1)");
+    // Sanitized title should still be present (without the script tag)
+    expect(body).toContain("Alert");
+  });
+
+  // ── Test 10: Return value structure ──────────────────────────────────────
+
+  test("return value matches ScanResult interface", async () => {
+    (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result).toHaveProperty("remindCount");
+    expect(result).toHaveProperty("warnCount");
+    expect(result).toHaveProperty("escalateCount");
+    expect(result).toHaveProperty("skippedCount");
+    expect(typeof result.remindCount).toBe("number");
+    expect(typeof result.warnCount).toBe("number");
+    expect(typeof result.escalateCount).toBe("number");
+    expect(typeof result.skippedCount).toBe("number");
+  });
+
+  // ── Test 11: Multiple tasks mixed levels ─────────────────────────────────
+
+  test("correctly counts mixed stale levels across multiple tasks", async () => {
+    const tasks = [
+      makeTask({ id: "t1", updatedAt: daysAgoDate(5, NOW) }),  // REMIND
+      makeTask({ id: "t2", updatedAt: daysAgoDate(10, NOW) }), // WARN
+      makeTask({ id: "t3", updatedAt: daysAgoDate(20, NOW) }), // ESCALATE
+    ];
+    (prisma.task.findMany as jest.Mock).mockResolvedValue(tasks);
+    (prisma.notification.createMany as jest.Mock).mockResolvedValue({ count: 6 });
+
+    const result = await scanStaleTasks({ prisma: prisma as never, now: NOW });
+
+    expect(result.remindCount).toBe(1);
+    expect(result.warnCount).toBe(1);
+    expect(result.escalateCount).toBe(1);
+  });
+});

--- a/services/__tests__/stale-task-service.test.ts
+++ b/services/__tests__/stale-task-service.test.ts
@@ -188,9 +188,9 @@ describe("scanStaleTasks", () => {
     expect(result.warnCount).toBe(0);
   });
 
-  // ── Test 6: DONE / CANCELLED tasks are excluded ──────────────────────────
+  // ── Test 6: DONE tasks are excluded ──────────────────────────────────────
 
-  test("DONE and CANCELLED tasks do not appear in scan results", async () => {
+  test("DONE tasks do not appear in scan results", async () => {
     // These should not be returned by the prisma query (status filter in service)
     // Verify the query filter is applied correctly
     (prisma.task.findMany as jest.Mock).mockResolvedValue([]);
@@ -198,7 +198,7 @@ describe("scanStaleTasks", () => {
     await scanStaleTasks({ prisma: prisma as never, now: NOW });
 
     const queryArg = (prisma.task.findMany as jest.Mock).mock.calls[0][0];
-    expect(queryArg.where.status).toEqual({ notIn: ["DONE", "CANCELLED"] });
+    expect(queryArg.where.status).toEqual({ notIn: ["DONE"] });
   });
 
   // ── Test 7: 24hr dedup skips already-notified task+level ─────────────────

--- a/services/stale-task-service.ts
+++ b/services/stale-task-service.ts
@@ -1,0 +1,265 @@
+/**
+ * Stale Task Detection Service — Issue #1311
+ *
+ * Scans for tasks that have not been updated within threshold windows
+ * and creates Notification records for assignees and their managers/admins.
+ *
+ * Thresholds (easily overridden by T1313 config integration):
+ *   REMIND    3–7 days stale
+ *   WARN      7–14 days stale, or dueDate within 3 days but already stale
+ *   ESCALATE  >14 days stale, or dueDate overdue by >3 days
+ *
+ * De-duplication: same task + level within 24 hours → skip.
+ */
+
+import type { PrismaClient } from "@prisma/client";
+import { prisma as defaultPrisma } from "@/lib/prisma";
+import { sanitizeMarkdown } from "@/lib/security/sanitize";
+import { logger } from "@/lib/logger";
+
+// ── Threshold constants (T1313 will replace with config reads) ──────────────
+export const STALE_REMIND_DAYS = 3;
+export const STALE_WARN_DAYS = 7;
+export const STALE_ESCALATE_DAYS = 14;
+export const STALE_DUE_WARN_DAYS = 3; // warn when dueDate ≤ 3 days away + already stale
+export const STALE_DUE_ESCALATE_DAYS = 3; // escalate when overdue by >3 days
+export const DEDUP_WINDOW_HOURS = 24;
+
+export type StaleLevel = "REMIND" | "WARN" | "ESCALATE";
+
+export interface ScanResult {
+  remindCount: number;
+  warnCount: number;
+  escalateCount: number;
+  skippedCount: number;
+}
+
+type Deps = {
+  prisma: PrismaClient;
+  now: Date;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function daysAgo(date: Date, now: Date): number {
+  return (now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+function daysUntil(date: Date, now: Date): number {
+  return (date.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+}
+
+/**
+ * Determine the stale level for a task.
+ * Returns null if the task is not yet stale (< STALE_REMIND_DAYS).
+ */
+export function classifyStaleLevel(
+  updatedAt: Date,
+  dueDate: Date | null,
+  now: Date
+): StaleLevel | null {
+  const staleDays = daysAgo(updatedAt, now);
+
+  // Not yet stale
+  if (staleDays < STALE_REMIND_DAYS) return null;
+
+  // ESCALATE: >14 days stale
+  if (staleDays > STALE_ESCALATE_DAYS) return "ESCALATE";
+
+  // ESCALATE: overdue by more than STALE_DUE_ESCALATE_DAYS
+  if (dueDate !== null) {
+    const dueDaysLeft = daysUntil(dueDate, now);
+    if (dueDaysLeft < -STALE_DUE_ESCALATE_DAYS) return "ESCALATE";
+
+    // WARN: dueDate is coming within 3 days but task is already stale
+    if (dueDaysLeft <= STALE_DUE_WARN_DAYS && staleDays >= STALE_REMIND_DAYS) return "WARN";
+  }
+
+  // WARN: 7–14 days stale
+  if (staleDays >= STALE_WARN_DAYS) return "WARN";
+
+  // REMIND: 3–7 days stale
+  return "REMIND";
+}
+
+/** Build a deduplicated relatedType tag for 24-hr window checks */
+function staleNotifRelatedType(level: StaleLevel): string {
+  return `STALE_${level}`;
+}
+
+// ── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Scan all non-terminal tasks for staleness and create Notification records.
+ *
+ * Supports dependency injection for testability; defaults to real prisma.
+ */
+export async function scanStaleTasks(deps?: Partial<Deps>): Promise<ScanResult> {
+  const db = deps?.prisma ?? defaultPrisma;
+  const now = deps?.now ?? new Date();
+
+  const remindCutoff = new Date(now.getTime() - STALE_REMIND_DAYS * 24 * 60 * 60 * 1000);
+  const dedupCutoff = new Date(now.getTime() - DEDUP_WINDOW_HOURS * 60 * 60 * 1000);
+
+  // Query stale tasks with assignee info
+  const staleTasks = await db.task.findMany({
+    where: {
+      updatedAt: { lt: remindCutoff },
+      status: { notIn: ["DONE", "CANCELLED"] },
+    },
+    select: {
+      id: true,
+      title: true,
+      updatedAt: true,
+      dueDate: true,
+      primaryAssignee: {
+        select: {
+          id: true,
+          name: true,
+          role: true,
+        },
+      },
+    },
+  });
+
+  if (staleTasks.length === 0) {
+    return { remindCount: 0, warnCount: 0, escalateCount: 0, skippedCount: 0 };
+  }
+
+  // Collect task IDs for dedup check
+  const taskIds = staleTasks.map((t) => t.id);
+
+  // Fetch existing stale notifications created within the last 24 hours
+  const recentNotifs = await db.notification.findMany({
+    where: {
+      relatedId: { in: taskIds },
+      relatedType: { in: ["STALE_REMIND", "STALE_WARN", "STALE_ESCALATE"] },
+      createdAt: { gte: dedupCutoff },
+    },
+    select: { userId: true, relatedId: true, relatedType: true },
+  });
+
+  // Build dedup set: "taskId:level:userId"
+  const dedupSet = new Set(
+    recentNotifs.map((n) => `${n.relatedId}:${n.relatedType}:${n.userId}`)
+  );
+
+  // Fetch all MANAGERs and ADMINs for fallback/escalation
+  const managers = await db.user.findMany({
+    where: { role: "MANAGER", isActive: true },
+    select: { id: true, role: true },
+  });
+  const admins = await db.user.findMany({
+    where: { role: "ADMIN", isActive: true },
+    select: { id: true, role: true },
+  });
+
+  const managerIds = managers.map((m) => m.id);
+  const adminIds = admins.map((a) => a.id);
+
+  // Pick fallback manager (first available)
+  const fallbackManagerId = managerIds[0] ?? null;
+
+  const notifications: {
+    userId: string;
+    type: "TASK_OVERDUE";
+    title: string;
+    body: string;
+    relatedId: string;
+    relatedType: string;
+  }[] = [];
+
+  let remindCount = 0;
+  let warnCount = 0;
+  let escalateCount = 0;
+  let skippedCount = 0;
+
+  for (const task of staleTasks) {
+    const level = classifyStaleLevel(task.updatedAt, task.dueDate, now);
+    if (!level) continue; // should not happen given query filter, but guard anyway
+
+    const staleDays = Math.floor(daysAgo(task.updatedAt, now));
+    const relatedType = staleNotifRelatedType(level);
+
+    // Sanitize task title (XSS prevention)
+    const safeTitle = sanitizeMarkdown(task.title);
+    if (!safeTitle) {
+      logger.warn({ taskId: task.id }, "[stale-task-service] task title empty after sanitize, skipping");
+      continue;
+    }
+
+    // Determine recipient user IDs
+    const assigneeId = task.primaryAssignee?.id ?? null;
+    const recipients: string[] = [];
+
+    if (assigneeId) recipients.push(assigneeId);
+
+    if (level === "WARN" || level === "ESCALATE") {
+      // Add manager: fallback to any MANAGER if assignee has none
+      const managerId = fallbackManagerId;
+      if (managerId && managerId !== assigneeId) {
+        recipients.push(managerId);
+      }
+    }
+
+    if (level === "ESCALATE") {
+      // Add first available ADMIN
+      const adminId = adminIds[0] ?? null;
+      if (adminId && !recipients.includes(adminId)) {
+        recipients.push(adminId);
+      }
+    }
+
+    if (recipients.length === 0) {
+      logger.warn({ taskId: task.id }, "[stale-task-service] no recipients for stale task");
+      skippedCount++;
+      continue;
+    }
+
+    // Build notification body
+    const body =
+      level === "REMIND"
+        ? `任務「${safeTitle}」已停滯 ${staleDays} 天，請確認進度。`
+        : level === "WARN"
+          ? `任務「${safeTitle}」已停滯 ${staleDays} 天，需要您的注意，請盡快更新進度。`
+          : `任務「${safeTitle}」已停滯 ${staleDays} 天，已升級通知，請立即處理。`;
+
+    let addedThisTask = false;
+
+    for (const userId of recipients) {
+      const dedupKey = `${task.id}:${relatedType}:${userId}`;
+      if (dedupSet.has(dedupKey)) {
+        skippedCount++;
+        continue;
+      }
+
+      notifications.push({
+        userId,
+        type: "TASK_OVERDUE",
+        title:
+          level === "REMIND"
+            ? "任務停滯提醒"
+            : level === "WARN"
+              ? "任務停滯警告"
+              : "任務停滯升級",
+        body,
+        relatedId: task.id,
+        relatedType,
+      });
+      addedThisTask = true;
+    }
+
+    if (addedThisTask) {
+      if (level === "REMIND") remindCount++;
+      else if (level === "WARN") warnCount++;
+      else escalateCount++;
+    }
+  }
+
+  // Persist notifications in bulk
+  if (notifications.length > 0) {
+    await db.notification.createMany({ data: notifications });
+  }
+
+  return { remindCount, warnCount, escalateCount, skippedCount };
+}

--- a/services/stale-task-service.ts
+++ b/services/stale-task-service.ts
@@ -105,7 +105,7 @@ export async function scanStaleTasks(deps?: Partial<Deps>): Promise<ScanResult> 
   const staleTasks = await db.task.findMany({
     where: {
       updatedAt: { lt: remindCutoff },
-      status: { notIn: ["DONE", "CANCELLED"] },
+      status: { notIn: ["DONE"] },
     },
     select: {
       id: true,


### PR DESCRIPTION
## Summary

- Add `scanStaleTasks()` in `services/stale-task-service.ts` with three-tier staleness detection: **REMIND** (3–7 days), **WARN** (7–14 days or dueDate ≤3 days away), **ESCALATE** (>14 days stale or overdue >3 days)
- 24-hour dedup: same task + level within 24 hrs is skipped (`skippedCount++`)
- Notification routing: REMIND → assignee only; WARN → assignee + fallback MANAGER; ESCALATE → assignee + MANAGER + ADMIN
- Task titles sanitized via `sanitizeMarkdown()` before writing to notification body
- Add `POST /api/cron/stale-task-scan/route.ts` aligned with `daily-digest` pattern (CRON_SECRET guard, `apiHandler`, `success()`/`error()` helpers)
- Constants exported for T1313 config integration: `STALE_REMIND_DAYS`, `STALE_WARN_DAYS`, `STALE_ESCALATE_DAYS`, `DEDUP_WINDOW_HOURS`
- 21 tests (17 service unit + 4 API route), **89% statement / 82% branch** coverage on stale-task-service

## Test Results

```
Tests: 21 passed, 21 total
stale-task-service.ts | 89.21% stmts | 81.81% branch | 100% funcs | 94.04% lines
```

## Design Decisions

- **No manager FK on User model**: The schema has no direct manager relationship, so WARN/ESCALATE fall back to any active `MANAGER` role user (first found). T1312 can add an explicit manager FK to improve targeting.
- **NotificationType reuse**: Used `TASK_OVERDUE` (existing enum value) since no `STALE_*` type exists. The `relatedType` field carries `STALE_REMIND`/`STALE_WARN`/`STALE_ESCALATE` for dedup and T1312 querying.
- **Dependency injection**: `scanStaleTasks(deps?)` accepts optional `{ prisma, now }` for full testability without module mocking.

## Test Plan

- [x] Service unit tests: all 11 scenarios (threshold boundaries, dedup, XSS, fallback, return shape)
- [x] API route tests: missing secret → 500, wrong secret → 401, correct secret → 200, service throw → 500
- [x] `npx jest services/__tests__/stale-task-service.test.ts __tests__/api/stale-task-scan.test.ts --forceExit` — all green

## Handoff Notes for T1312 / T1313

**Service public interface:**
```typescript
export async function scanStaleTasks(deps?: { prisma: PrismaClient; now: Date }): Promise<ScanResult>
export type ScanResult = { remindCount: number; warnCount: number; escalateCount: number; skippedCount: number }
export type StaleLevel = "REMIND" | "WARN" | "ESCALATE"
export function classifyStaleLevel(updatedAt: Date, dueDate: Date | null, now: Date): StaleLevel | null
```

**Notification metadata structure** (for T1312 push/email dispatch):
- `type`: `"TASK_OVERDUE"`
- `relatedId`: task ID
- `relatedType`: `"STALE_REMIND"` | `"STALE_WARN"` | `"STALE_ESCALATE"`

**T1313 config hook**: Replace `STALE_REMIND_DAYS`, `STALE_WARN_DAYS`, `STALE_ESCALATE_DAYS`, `DEDUP_WINDOW_HOURS` constants with config reads.

Closes #1311