### PR TITLE
feat(T1315,T1317): wire OnboardingGuide + sample data for new users

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,6 +7,7 @@ import { KeyboardShortcutsDialog } from "@/app/components/keyboard-shortcuts-dia
 import { NextAuthSessionProvider } from "@/app/components/session-provider";
 import { SessionTimeoutWarning } from "@/app/components/session-timeout-warning";
 import { PasswordChangeGuard } from "@/app/components/password-change-guard";
+import { OnboardingController } from "@/app/components/onboarding/onboarding-controller";
 import { Toaster } from "sonner";
 import { TooltipProvider } from "@/app/components/ui/tooltip";
 // GlobalAlertBanner removed — alerts now consolidated into NotificationBell
@@ -32,6 +33,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <FeedbackButton />
         <Toaster richColors position="top-right" />
         <SessionTimeoutWarning />
+        <OnboardingController />
       </PasswordChangeGuard>
       </TooltipProvider>
     </NextAuthSessionProvider>

--- a/app/api/users/me/onboarding/route.ts
+++ b/app/api/users/me/onboarding/route.ts
@@ -1,0 +1,47 @@
+/**
+ * POST /api/users/me/onboarding — Issue #1315
+ *
+ * Marks the current user's onboarding as completed and seeds sample data.
+ * Called when the user clicks "開始使用" in the OnboardingGuide.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { success, error } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { seedSampleDataForUser } from "@/lib/seed-sample-data";
+import { logger } from "@/lib/logger";
+
+export const POST = withAuth(async (_req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  // Guard: do not re-seed if already completed
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { hasCompletedOnboarding: true },
+  });
+
+  if (!user) {
+    return error("NotFoundError", "使用者不存在", 404);
+  }
+
+  if (!user.hasCompletedOnboarding) {
+    // Seed sample data first, then mark onboarding complete
+    try {
+      await seedSampleDataForUser(prisma, userId);
+    } catch (err) {
+      logger.error({ err, userId }, "[onboarding] Failed to seed sample data");
+      // Non-fatal: continue to mark onboarding complete even if seeding fails
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { hasCompletedOnboarding: true },
+    });
+
+    logger.info({ userId }, "[onboarding] Onboarding completed and sample data seeded");
+  }
+
+  return success({ completed: true });
+});

--- a/app/api/users/me/sample-data/route.ts
+++ b/app/api/users/me/sample-data/route.ts
@@ -1,0 +1,45 @@
+/**
+ * DELETE /api/users/me/sample-data — Issue #1317
+ *
+ * Removes all sample data records belonging to the current user.
+ * Allows users to clean up tutorial data once they start real work.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { logger } from "@/lib/logger";
+
+export const DELETE = withAuth(async (_req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  // Delete sample tasks created by this user
+  const deletedTasks = await prisma.task.deleteMany({
+    where: {
+      isSample: true,
+      creatorId: userId,
+    },
+  });
+
+  // Delete sample annual plans created by this user
+  const deletedPlans = await prisma.annualPlan.deleteMany({
+    where: {
+      isSample: true,
+      createdBy: userId,
+    },
+  });
+
+  logger.info(
+    { userId, deletedTasks: deletedTasks.count, deletedPlans: deletedPlans.count },
+    "[sample-data] Sample data deleted"
+  );
+
+  return success({
+    deleted: {
+      tasks: deletedTasks.count,
+      plans: deletedPlans.count,
+    },
+  });
+});

--- a/app/components/onboarding/onboarding-controller.tsx
+++ b/app/components/onboarding/onboarding-controller.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+/**
+ * OnboardingController — Issue #1315
+ *
+ * Client component that checks whether the current user has completed
+ * onboarding and conditionally renders the OnboardingGuide overlay.
+ *
+ * Reads `hasCompletedOnboarding` from the Next-Auth session extended field.
+ * Calls POST /api/users/me/onboarding when the user completes or dismisses.
+ */
+
+import { useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { OnboardingGuide } from "./onboarding-guide";
+
+export function OnboardingController() {
+  const { data: session, status, update } = useSession();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+
+    const user = session?.user as
+      | { hasCompletedOnboarding?: boolean; mustChangePassword?: boolean }
+      | undefined;
+
+    // Do not show onboarding if the user must change their password first
+    if (user?.mustChangePassword) return;
+
+    if (user?.hasCompletedOnboarding === false) {
+      setVisible(true);
+    }
+  }, [session, status]);
+
+  const handleComplete = async () => {
+    setVisible(false);
+    try {
+      await fetch("/api/users/me/onboarding", { method: "POST" });
+      // Refresh session so hasCompletedOnboarding reflects the new state
+      await update({ hasCompletedOnboarding: true });
+    } catch {
+      // Non-fatal: guide is already hidden
+    }
+  };
+
+  const handleDismiss = async () => {
+    setVisible(false);
+    try {
+      await fetch("/api/users/me/onboarding", { method: "POST" });
+      await update({ hasCompletedOnboarding: true });
+    } catch {
+      // Non-fatal
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+      <OnboardingGuide onComplete={handleComplete} onDismiss={handleDismiss} />
+    </div>
+  );
+}

--- a/auth.ts
+++ b/auth.ts
@@ -172,6 +172,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           role: user.role,
           mustChangePassword: needsPasswordChange,
           passwordChangedAt: user.passwordChangedAt?.toISOString(),
+          hasCompletedOnboarding: user.hasCompletedOnboarding, // Issue #1315
         };
       },
     }),
@@ -181,16 +182,21 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     maxAge: 15 * 60, // 15 minutes (Issue #795: short-lived access token)
   },
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         token.id = user.id;
         token.role = (user as { id: string; role: string }).role;
         token.mustChangePassword = (user as { mustChangePassword?: boolean }).mustChangePassword ?? false;
         token.passwordChangedAt = (user as { passwordChangedAt?: string | null }).passwordChangedAt ?? null;
+        token.hasCompletedOnboarding = (user as { hasCompletedOnboarding?: boolean }).hasCompletedOnboarding ?? false; // Issue #1315
         // Issue #184: generate session ID and register (invalidates previous session)
         const sessionId = crypto.randomUUID();
         token.sessionId = sessionId;
         registerSession(user.id!, sessionId).catch(() => {});
+      }
+      // Issue #1315: persist update() call so hasCompletedOnboarding survives token rotation
+      if (trigger === "update" && session && "hasCompletedOnboarding" in session) {
+        token.hasCompletedOnboarding = session.hasCompletedOnboarding as boolean;
       }
       return token;
     },
@@ -200,6 +206,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.role = token.role as string;
         session.user.mustChangePassword = token.mustChangePassword as boolean;
         session.user.passwordChangedAt = (token.passwordChangedAt as string) ?? null;
+        session.user.hasCompletedOnboarding = (token.hasCompletedOnboarding as boolean) ?? false; // Issue #1315
       }
       return session;
     },

--- a/lib/seed-sample-data.ts
+++ b/lib/seed-sample-data.ts
@@ -1,0 +1,84 @@
+/**
+ * seedSampleDataForUser — Issue #1317
+ *
+ * Creates tutorial/sample records for a newly onboarded user so they see
+ * a non-empty interface instead of blank pages.
+ *
+ * All records are tagged with isSample: true so they can be bulk-deleted
+ * via DELETE /api/users/me/sample-data once the user is ready.
+ */
+import type { PrismaClient } from "@prisma/client";
+
+/**
+ * Seeds sample tasks and an annual plan for the given user.
+ * Idempotent: checks for existing sample data before inserting.
+ *
+ * @param prisma - PrismaClient instance
+ * @param userId - The ID of the user to seed data for
+ */
+export async function seedSampleDataForUser(
+  prisma: PrismaClient,
+  userId: string
+): Promise<void> {
+  const currentYear = new Date().getFullYear();
+
+  // Guard: skip if sample tasks already exist for this user
+  const existingSampleCount = await prisma.task.count({
+    where: { isSample: true, creatorId: userId },
+  });
+  if (existingSampleCount > 0) {
+    return;
+  }
+
+  // Create a sample annual plan
+  const samplePlan = await prisma.annualPlan.create({
+    data: {
+      year: currentYear,
+      title: `${currentYear} 年度計畫（範例）`,
+      description:
+        "這是一份範例年度計畫，幫助您了解 TITAN 的年度計畫功能。您可以刪除此範例或直接編輯使用。",
+      isSample: true,
+      createdBy: userId,
+    },
+  });
+
+  // Create 3 sample tasks in different statuses
+  const sampleTasks = [
+    {
+      title: "熟悉 TITAN — 建立第一個任務",
+      description:
+        "探索看板（Kanban）功能：建立任務、設定優先級、指派負責人。完成後將此任務拖曳到「完成」欄位。",
+      status: "TODO" as const,
+      priority: "P2" as const,
+    },
+    {
+      title: "熟悉 TITAN — 記錄第一筆工時",
+      description:
+        "前往工時表頁面，點選今天的儲存格並輸入工時。支援鍵盤快速操作：Tab 切換儲存格、Enter 儲存。",
+      status: "IN_PROGRESS" as const,
+      priority: "P2" as const,
+    },
+    {
+      title: "熟悉 TITAN — 瀏覽年度計畫",
+      description:
+        "查看年度計畫頁面，了解如何建立月度目標、追蹤里程碑與交付物。",
+      status: "DONE" as const,
+      priority: "P3" as const,
+    },
+  ];
+
+  await prisma.task.createMany({
+    data: sampleTasks.map((t) => ({
+      title: t.title,
+      description: t.description,
+      status: t.status,
+      priority: t.priority,
+      category: "PLANNED" as const,
+      creatorId: userId,
+      primaryAssigneeId: userId,
+      annualPlanId: samplePlan.id,
+      isSample: true,
+      progressPct: t.status === "DONE" ? 100 : t.status === "IN_PROGRESS" ? 50 : 0,
+    })),
+  });
+}

--- a/prisma/migrations/20260407010000_add_onboarding_flag_and_sample_data/migration.sql
+++ b/prisma/migrations/20260407010000_add_onboarding_flag_and_sample_data/migration.sql
@@ -1,0 +1,12 @@
+-- Migration: 20260407010000_add_onboarding_flag_and_sample_data
+-- Issue #1315: Add hasCompletedOnboarding flag to User
+-- Issue #1317: Add isSample flag to Task, AnnualPlan, Project
+
+-- User: onboarding completion flag
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "hasCompletedOnboarding" BOOLEAN NOT NULL DEFAULT false;
+
+-- Task: sample data flag
+ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "isSample" BOOLEAN NOT NULL DEFAULT false;
+
+-- AnnualPlan: sample data flag
+ALTER TABLE "annual_plans" ADD COLUMN IF NOT EXISTS "isSample" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,9 @@ model User {
   role                Role     @default(ENGINEER)
   avatar              String?  // base64 or filename
   isActive            Boolean  @default(true)
-  mustChangePassword  Boolean  @default(true)   // Issue #182: 首次登入強制變更
-  passwordChangedAt   DateTime @default(now())  // Issue #182: 密碼到期追蹤（90天）
+  mustChangePassword        Boolean  @default(true)   // Issue #182: 首次登入強制變更
+  passwordChangedAt         DateTime @default(now())  // Issue #182: 密碼到期追蹤（90天）
+  hasCompletedOnboarding    Boolean  @default(false)  // Issue #1315: 新手導覽完成旗標
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
@@ -221,6 +222,7 @@ model AnnualPlan {
   progressPct        Float     @default(0)
   copiedFromYear     Int?
   archivedAt         DateTime? // 封存時間（不可硬刪除，僅封存）
+  isSample           Boolean   @default(false) // Issue #1317: 範例資料旗標
   createdBy          String
   createdAt          DateTime  @default(now())
   updatedAt          DateTime  @updatedAt
@@ -358,6 +360,7 @@ model Task {
   addedReason       String?
   addedSource       String?
   slaDeadline       DateTime?    // Issue #860: SLA 截止時間
+  isSample          Boolean      @default(false) // Issue #1317: 範例資料旗標
   managerFlagged    Boolean      @default(false) // Issue #960: 主管標記
   flagReason        String?      // Issue #960: 標記原因
   flaggedAt         DateTime?    // Issue #960: 標記時間

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -80,6 +80,7 @@ export class AlertService {
 
     const overdueTasks = await this.prisma.task.findMany({
       where: {
+        isSample: false,
         status: { not: "DONE" },
         dueDate: { lt: threeDaysAgo },
       },

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -60,6 +60,7 @@ export class NotificationService {
 
     const tasks = await this.prisma.task.findMany({
       where: {
+        isSample: false,
         status: { notIn: ["DONE"] },
         dueDate: { gte: now, lte: cutoff },
       },
@@ -170,6 +171,7 @@ export class NotificationService {
   ): Promise<NotificationInput[]> {
     const tasks = await this.prisma.task.findMany({
       where: {
+        isSample: false,
         status: { notIn: ["DONE"] },
         dueDate: { lt: now },
       },

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -147,6 +147,7 @@ export class ReportService {
     const completedTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
+        isSample: false,
         status: "DONE",
         updatedAt: { gte: weekStart, lte: weekEnd },
       },
@@ -184,6 +185,7 @@ export class ReportService {
     const overdueTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
+        isSample: false,
         status: { notIn: ["DONE"] },
         dueDate: { lt: new Date() },
       },
@@ -241,6 +243,7 @@ export class ReportService {
     const allTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
+        isSample: false,
         createdAt: { lte: monthEnd },
         OR: [
           { dueDate: { gte: monthStart, lte: monthEnd } },
@@ -432,6 +435,7 @@ export class ReportService {
         ...(filter.isManager
           ? {}
           : { primaryAssigneeId: filter.userId }),
+        isSample: false,
         category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
         createdAt: { gte: startDate, lte: endDate },
       },

--- a/services/report-v2-service.ts
+++ b/services/report-v2-service.ts
@@ -153,6 +153,7 @@ export class ReportV2Service {
 
     const tasks = await this.prisma.task.findMany({
       where: {
+        isSample: false,
         OR: [
           { status: "DONE", updatedAt: { gte: start, lte: end } },
           { createdAt: { gte: start, lte: end } },
@@ -202,7 +203,7 @@ export class ReportV2Service {
     });
 
     const completedTasks = await this.prisma.task.findMany({
-      where: { status: "DONE", updatedAt: { gte: start, lte: end } },
+      where: { isSample: false, status: "DONE", updatedAt: { gte: start, lte: end } },
       select: { id: true, primaryAssigneeId: true },
     });
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -15,6 +15,7 @@ declare module "next-auth" {
       role: string;
       mustChangePassword?: boolean;
       passwordChangedAt?: string | null; // Issue #834: password expiry tracking
+      hasCompletedOnboarding?: boolean;  // Issue #1315: onboarding flow
     } & DefaultSession["user"];
   }
 
@@ -23,6 +24,7 @@ declare module "next-auth" {
     role: string;
     mustChangePassword?: boolean;
     passwordChangedAt?: string; // Issue #834
+    hasCompletedOnboarding?: boolean; // Issue #1315
   }
 }
 
@@ -32,6 +34,7 @@ declare module "next-auth/jwt" {
     role: string;
     mustChangePassword?: boolean;
     passwordChangedAt?: string | null; // Issue #834
+    hasCompletedOnboarding?: boolean;  // Issue #1315
     sessionId?: string;
   }
 }


### PR DESCRIPTION
Closes #1315
Closes #1317

## Summary
- Wire up the existing but unmounted OnboardingGuide component
- New users get 4-step intro + sample AnnualPlan/Tasks auto-seeded
- Exclude sample data from reports/alerts/notifications

## Review fixes applied
- JWT update() propagation for hasCompletedOnboarding
- report-v2-service, alert-service, notification-service: isSample filter
- Dropped Project.isSample dead field
- Use withAuth wrapper per project convention

## Test plan
- [x] tsc 0 errors
- [x] jest 0 regressions (50 failed on both branches = baseline)
- [ ] Mac Mini deploy verification