### PR TITLE
feat(T1316,T1318): empty state CTAs + i18n cleanup

### DIFF
--- a/__tests__/pages/plans.test.tsx
+++ b/__tests__/pages/plans.test.tsx
@@ -114,9 +114,9 @@ describe("Plans Page", () => {
       render(<PlansPage />);
     });
     await waitFor(() => {
-      // 空資料時應顯示引導訊息，而非白屏或 PlanTree
-      expect(screen.getByText("尚無年度計畫")).toBeInTheDocument();
-      expect(screen.getByText("目前沒有任何計畫，請點擊「新增年度計畫」建立")).toBeInTheDocument();
+      // 空資料時應顯示引導訊息 + CTA（T1316: 空狀態 CTA 改版）
+      expect(screen.getByText("建立第一個年度計畫，把目標落實到月度行動")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "建立計畫" })).toBeInTheDocument();
     });
     // 空資料時不應渲染 PlanTree
     expect(screen.queryByTestId("plan-tree")).not.toBeInTheDocument();

--- a/__tests__/pages/timesheet.test.tsx
+++ b/__tests__/pages/timesheet.test.tsx
@@ -55,7 +55,8 @@ describe("Timesheet Page", () => {
   });
 
   it("renders timesheet grid", async () => {
-    // Provide mock time entries so the grid is rendered instead of the empty state
+    // Provide mock time entries with a real taskId so taskRows has a task-bound row
+    // (taskId: null is a free-row entry and does NOT add a task-bound row to taskRows)
     mockFetch.mockImplementation((url: string) => {
       if (url.includes("time-entries/stats")) {
         return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
@@ -63,7 +64,7 @@ describe("Timesheet Page", () => {
       return Promise.resolve({
         ok: true,
         json: async () => [
-          { id: "e1", userId: "u1", taskId: null, date: "2024-01-15", hours: 4, category: "PLANNED_TASK", description: null, task: null },
+          { id: "e1", userId: "u1", taskId: "task-1", date: "2024-01-15", hours: 4, category: "PLANNED_TASK", description: null, task: { title: "Task 1" } },
         ],
       } as Response);
     });
@@ -106,6 +107,27 @@ describe("Timesheet Page", () => {
       // Refactored page shows help text
       expect(screen.getByText(/點擊格子直接輸入數字/)).toBeInTheDocument();
     });
+  });
+
+  it("shows PageEmpty CTA when only FREE_ROW exists (no task-bound rows)", async () => {
+    // When fetch returns empty entries, taskRows = [FREE_ROW] only.
+    // The fixed condition filters out FREE_ROW (taskId === null), so length === 0 → PageEmpty renders.
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("time-entries/stats")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(screen.getByText("從看板選擇任務或先建立一個")).toBeInTheDocument();
+    });
+    const kanbanLink = screen.getByRole("link", { name: "前往看板" });
+    expect(kanbanLink).toBeInTheDocument();
+    expect(kanbanLink).toHaveAttribute("href", "/kanban");
   });
 
   it("renders without crash when hours fields are null in time entries", async () => {

--- a/app/(app)/kanban/page.tsx
+++ b/app/(app)/kanban/page.tsx
@@ -474,6 +474,30 @@ export default function KanbanPage() {
     [] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  // ── Create task (used by header button and empty state CTA) ──────────────
+
+  async function handleCreateTask() {
+    const res = await fetch("/api/tasks", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "新任務",
+        status: "BACKLOG",
+        priority: "P2",
+        category: "PLANNED",
+      }),
+    });
+    if (res.ok) {
+      const created = await res.json();
+      const newId = created.id ?? created.data?.id;
+      await fetchTasks();
+      if (newId) setSelectedTaskId(newId);
+    } else {
+      const errBody = await res.json().catch(() => ({}));
+      toast.error(errBody?.message ?? errBody?.error ?? "建立失敗");
+    }
+  }
+
   // ── Multi-select mode toggle (Issue #1023) ─────────────────────────────
 
   function toggleMultiSelectMode() {
@@ -656,29 +680,7 @@ export default function KanbanPage() {
           </button>
 
           <button
-            onClick={async () => {
-              const res = await fetch("/api/tasks", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  title: "新任務",
-                  status: "BACKLOG",
-                  priority: "P2",
-                  category: "PLANNED",
-                }),
-              });
-              if (res.ok) {
-                const created = await res.json();
-                const newId = created.id ?? created.data?.id;
-                await fetchTasks();
-                if (newId) setSelectedTaskId(newId);
-              } else {
-                const errBody = await res.json().catch(() => ({}));
-                toast.error(
-                  errBody?.message ?? errBody?.error ?? "建立失敗"
-                );
-              }
-            }}
+            onClick={handleCreateTask}
             className="flex items-center justify-center gap-1.5 text-sm font-medium px-3 py-1.5 bg-primary text-primary-foreground rounded-lg shadow-sm transition-all hover:opacity-90 flex-1 sm:flex-none"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -867,8 +869,17 @@ export default function KanbanPage() {
         <div className="flex-1">
           <PageEmpty
             icon={<Kanban className="h-10 w-10" />}
-            title="尚無任務"
-            description="目前沒有任何任務，請點擊「新增任務」開始"
+            title="建立第一個任務開始工作"
+            description="把待辦事項加入看板，拖曳卡片即可更新進度"
+            action={
+              <button
+                onClick={handleCreateTask}
+                className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-all"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                建立任務
+              </button>
+            }
           />
         </div>
       ) : (

--- a/app/(app)/plans/page.tsx
+++ b/app/(app)/plans/page.tsx
@@ -582,8 +582,17 @@ export default function PlansPage() {
       ) : plans.length === 0 ? (
         <PageEmpty
           icon={<Target className="h-10 w-10" />}
-          title="尚無年度計畫"
-          description="目前沒有任何計畫，請點擊「新增年度計畫」建立"
+          title="建立第一個年度計畫，把目標落實到月度行動"
+          description="設定年度願景與月度里程碑，追蹤全年進度"
+          action={
+            <button
+              onClick={() => { setShowPlanForm(true); setPlanError(""); }}
+              className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition-all"
+            >
+              <Target className="h-3.5 w-3.5" />
+              建立計畫
+            </button>
+          }
         />
       ) : (
 

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2, CalendarDays, TableProperties } from "lucide-react";
+import { Loader2, CalendarDays, TableProperties, Clock } from "lucide-react";
+import Link from "next/link";
 import {
   useTimesheet,
   TimesheetGrid,
@@ -17,7 +18,7 @@ import {
 } from "@/app/components/timesheet";
 import { TimesheetListView } from "@/app/components/timesheet-list-view";
 import { TimeSummary } from "@/app/components/time-summary";
-import { PageLoading, PageError } from "@/app/components/page-states";
+import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
 import { TimesheetPivotTable, type TimesheetPivotData } from "@/app/components/timesheet-pivot-table";
 import { cn } from "@/lib/utils";
 
@@ -220,6 +221,20 @@ export default function TimesheetPage() {
             <PageLoading message="載入工時..." className="py-12" />
           ) : ts.loadError ? (
             <PageError message={ts.loadError} onRetry={ts.refresh} className="py-12" />
+          ) : ts.taskRows.filter(r => r.taskId !== null).length === 0 && viewMode === "grid" ? (
+            <PageEmpty
+              icon={<Clock className="h-10 w-10" />}
+              title="從看板選擇任務或先建立一個"
+              description="工時紀錄會依照你在看板上的任務自動帶入"
+              action={
+                <Link
+                  href="/kanban"
+                  className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-card hover:bg-accent text-foreground rounded-lg border border-border shadow-sm hover:shadow transition-all"
+                >
+                  前往看板
+                </Link>
+              }
+            />
           ) : viewMode === "grid" ? (
             <TimesheetGrid
               weekStart={ts.weekStart}

--- a/app/components/command-palette.tsx
+++ b/app/components/command-palette.tsx
@@ -427,8 +427,9 @@ export function CommandPalette() {
             </li>
           ))}
           {allResults.length === 0 && !searching && (
-            <li className="px-4 py-6 text-sm text-muted-foreground text-center">
-              找不到符合的結果
+            <li className="px-4 py-6 text-center">
+              <p className="text-sm text-muted-foreground">找不到符合的結果</p>
+              <p className="text-xs text-muted-foreground/60 mt-1">試試其他關鍵字或切換搜尋範圍</p>
             </li>
           )}
           {allResults.length === 0 && searching && (

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -197,8 +197,9 @@ export function NotificationBell() {
                 載入中...
               </div>
             ) : notifications.length === 0 ? (
-              <div className="py-8 text-center text-sm text-muted-foreground">
-                目前沒有通知
+              <div className="py-8 text-center px-4">
+                <p className="text-sm text-muted-foreground">目前沒有通知</p>
+                <p className="text-xs text-muted-foreground/60 mt-1">任務被指派、留言、到期時會通知你</p>
               </div>
             ) : (
               notifications.map((n) => (

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -6,15 +6,15 @@
  */
 
 /** Supported locales */
-export const locales = ["zh-TW", "en"] as const;
+// NOTE: English support pending future release
+export const locales = ["zh-TW"] as const;
 
 /** Default locale — Traditional Chinese for banking environment */
 export const defaultLocale = "zh-TW" as const;
 
-/** Locale display names (for language switcher UI) */
+/** Locale display names */
 export const localeNames: Record<(typeof locales)[number], string> = {
   "zh-TW": "繁體中文",
-  en: "English",
 };
 
 export type Locale = (typeof locales)[number];


### PR DESCRIPTION
Closes #1316
Closes #1318

## Summary
- 5 empty states upgraded with action-oriented CTAs
- Timesheet condition bug fixed (was always false due to FREE_ROW)
- Removed unused 'en' locale from i18n config

## Review fix
- Timesheet empty check: filter r.taskId !== null
- New unit test covers timesheet empty state

## Test plan
- [x] tsc 0 errors
- [x] jest 0 regressions, +1 new test