### PR TITLE
fix(T1340): isSample filter coverage gap (14 query sites)

### DIFF
--- a/__tests__/integration/branch-coverage.test.ts
+++ b/__tests__/integration/branch-coverage.test.ts
@@ -704,7 +704,8 @@ describe("TaskService — listTasks filter branches", () => {
   it("applies no filters when none provided", async () => {
     await service.listTasks({});
     const call = (prisma.task.findMany as jest.Mock).mock.calls[0][0];
-    expect(call.where).toEqual({});
+    // T1340: listTasks now defaults to filtering out sample data
+    expect(call.where).toEqual({ isSample: false });
   });
 });
 

--- a/app/api/cockpit/route.ts
+++ b/app/api/cockpit/route.ts
@@ -62,7 +62,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
   // Fetch plan with goals, tasks, KPI links, time entries, milestones
   const plans = await prisma.annualPlan.findMany({
-    where: { year, archivedAt: null },
+    where: { isSample: false, year, archivedAt: null },
     include: {
       monthlyGoals: {
         include: {

--- a/app/api/my-day/route.ts
+++ b/app/api/my-day/route.ts
@@ -38,7 +38,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       await Promise.all([
         // Flagged tasks across team
         prisma.task.findMany({
-          where: { managerFlagged: true, status: { not: "DONE" } },
+          where: { isSample: false, managerFlagged: true, status: { not: "DONE" } },
           select: {
             id: true,
             title: true,
@@ -56,6 +56,7 @@ export const GET = withAuth(async (req: NextRequest) => {
         // Overdue tasks
         prisma.task.findMany({
           where: {
+            isSample: false,
             status: { not: "DONE" },
             dueDate: { lt: now },
           },
@@ -94,7 +95,7 @@ export const GET = withAuth(async (req: NextRequest) => {
         }),
         // Active plans for health snapshot
         prisma.annualPlan.findMany({
-          where: { year: now.getFullYear(), archivedAt: null },
+          where: { isSample: false, year: now.getFullYear(), archivedAt: null },
           select: {
             id: true,
             title: true,
@@ -182,6 +183,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       // Flagged tasks for this engineer
       prisma.task.findMany({
         where: {
+          isSample: false,
           managerFlagged: true,
           status: { not: "DONE" },
           OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
@@ -201,6 +203,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       // Due today
       prisma.task.findMany({
         where: {
+          isSample: false,
           status: { not: "DONE" },
           dueDate: { gte: todayStart, lt: todayEnd },
           OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
@@ -219,6 +222,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       // In progress
       prisma.task.findMany({
         where: {
+          isSample: false,
           status: "IN_PROGRESS",
           OR: [{ primaryAssigneeId: userId }, { backupAssigneeId: userId }],
         },
@@ -245,7 +249,7 @@ export const GET = withAuth(async (req: NextRequest) => {
       // Current month goals
       prisma.monthlyGoal.findMany({
         where: {
-          annualPlan: { year: now.getFullYear(), archivedAt: null },
+          annualPlan: { isSample: false, year: now.getFullYear(), archivedAt: null },
           month: now.getMonth() + 1,
         },
         select: {

--- a/app/api/retrospective/generate/route.ts
+++ b/app/api/retrospective/generate/route.ts
@@ -27,6 +27,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   // 1. Completed tasks
   const completedTasks = await prisma.task.findMany({
     where: {
+      isSample: false,
       status: "DONE",
       updatedAt: { gte: startDate, lt: endDate },
     },

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -69,6 +69,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     searchTasks
       ? prisma.task.findMany({
           where: {
+            isSample: false,
             OR: [
               { title: containsQuery },
               { description: containsQuery },

--- a/app/api/tasks/sla-check/route.ts
+++ b/app/api/tasks/sla-check/route.ts
@@ -15,6 +15,7 @@ export const GET = withAuth(async () => {
   // Find tasks with slaDeadline in the next 2 hours that are not DONE
   const tasks = await prisma.task.findMany({
     where: {
+      isSample: false,
       slaDeadline: {
         gte: now,
         lte: twoHoursLater,

--- a/app/api/tasks/tags/route.ts
+++ b/app/api/tasks/tags/route.ts
@@ -46,7 +46,7 @@ function hashColor(name: string): string {
 export const GET = withAuth(async (_req: NextRequest) => {
   // Fetch all unique tags from existing tasks
   const tasks = await prisma.task.findMany({
-    where: { tags: { isEmpty: false } },
+    where: { isSample: false, tags: { isEmpty: false } },
     select: { tags: true },
   });
 

--- a/app/api/users/[id]/workload/route.ts
+++ b/app/api/users/[id]/workload/route.ts
@@ -40,6 +40,7 @@ export const GET = withAuth(async (
   // Active tasks (exclude DONE) assigned to this user
   const activeTasks = await prisma.task.findMany({
     where: {
+      isSample: false,
       primaryAssigneeId: id,
       status: { notIn: ["DONE"] },
     },

--- a/services/__tests__/task-service.test.ts
+++ b/services/__tests__/task-service.test.ts
@@ -26,7 +26,7 @@ describe("TaskService", () => {
       const result = await service.listTasks({});
 
       expect(prisma.task.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: {} })
+        expect.objectContaining({ where: { isSample: false } })
       );
       expect(result).toEqual({ tasks: mockTasks, total: 2 });
     });

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -70,7 +70,7 @@ export class TaskService {
   }
 
   async listTasks(filter: ListTasksFilter) {
-    const where: Record<string, unknown> = {};
+    const where: Record<string, unknown> = { isSample: false };
 
     if (filter.assignee) {
       where.OR = [


### PR DESCRIPTION
Closes #1340

## Summary
Phase 1 missed 14 user-facing queries that didn't filter sample data.
This caused new users to see range tasks in their dashboards.

## Test plan
- [x] tsc 0 errors
- [x] jest baseline (50/4/2977)
- [x] task-service test updated for new default