### PR TITLE
fix(T1343): repair pre-existing test rot (13 files)

### DIFF
--- a/__tests__/api/cron-daily-reminder.test.ts
+++ b/__tests__/api/cron-daily-reminder.test.ts
@@ -47,7 +47,28 @@ jest.mock("@/auth", () => ({
 // Suppress console.error
 jest.spyOn(console, "error").mockImplementation(() => {});
 
+// Helper: create a mock request with the CRON_SECRET header
+function createCronRequest(url: string) {
+  return {
+    url: `http://localhost${url}`,
+    method: "POST",
+    json: jest.fn(() => Promise.resolve({})),
+    headers: {
+      get: (name: string) =>
+        name === "x-cron-secret" ? "test-cron-secret" : null,
+    },
+    nextUrl: new URL(`http://localhost${url}`),
+  } as unknown as import("next/server").NextRequest;
+}
+
 describe("POST /api/cron/daily-reminder (TS-29)", () => {
+  beforeAll(() => {
+    process.env.CRON_SECRET = "test-cron-secret";
+  });
+  afterAll(() => {
+    delete process.env.CRON_SECRET;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
@@ -65,7 +86,7 @@ describe("POST /api/cron/daily-reminder (TS-29)", () => {
 
     const { POST } = await import("@/app/api/cron/daily-reminder/route");
     const res = await POST(
-      createMockRequest("/api/cron/daily-reminder", { method: "POST" })
+      createCronRequest("/api/cron/daily-reminder")
     );
 
     expect(res.status).toBe(200);
@@ -86,7 +107,7 @@ describe("POST /api/cron/daily-reminder (TS-29)", () => {
 
     const { POST } = await import("@/app/api/cron/daily-reminder/route");
     const res = await POST(
-      createMockRequest("/api/cron/daily-reminder", { method: "POST" })
+      createCronRequest("/api/cron/daily-reminder")
     );
 
     // The endpoint itself should succeed (200) even on weekends
@@ -106,7 +127,7 @@ describe("POST /api/cron/daily-reminder (TS-29)", () => {
 
     const { POST } = await import("@/app/api/cron/daily-reminder/route");
     const res = await POST(
-      createMockRequest("/api/cron/daily-reminder", { method: "POST" })
+      createCronRequest("/api/cron/daily-reminder")
     );
 
     expect(res.status).toBe(200);
@@ -120,7 +141,7 @@ describe("POST /api/cron/daily-reminder (TS-29)", () => {
 
     const { POST } = await import("@/app/api/cron/daily-reminder/route");
     const res = await POST(
-      createMockRequest("/api/cron/daily-reminder", { method: "POST" })
+      createCronRequest("/api/cron/daily-reminder")
     );
 
     expect(res.status).toBe(200);

--- a/__tests__/api/daily-digest.test.ts
+++ b/__tests__/api/daily-digest.test.ts
@@ -23,7 +23,31 @@ jest.mock("next-auth", () => ({
   getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
 }));
 
+// Mock @/auth for apiHandler audit logging (Auth.js v5)
+jest.mock("@/auth", () => ({ auth: jest.fn().mockResolvedValue(null) }));
+
+// Helper: create a mock request with the CRON_SECRET header
+function createCronRequest(url: string) {
+  return {
+    url: `http://localhost${url}`,
+    method: "POST",
+    json: jest.fn(() => Promise.resolve({})),
+    headers: {
+      get: (name: string) =>
+        name === "x-cron-secret" ? "test-cron-secret" : null,
+    },
+    nextUrl: new URL(`http://localhost${url}`),
+  } as unknown as import("next/server").NextRequest;
+}
+
 describe("POST /api/cron/daily-digest", () => {
+  beforeAll(() => {
+    process.env.CRON_SECRET = "test-cron-secret";
+  });
+  afterAll(() => {
+    delete process.env.CRON_SECRET;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     // No session needed for cron endpoint
@@ -40,7 +64,7 @@ describe("POST /api/cron/daily-digest", () => {
 
     const { POST } = await import("@/app/api/cron/daily-digest/route");
     const res = await (POST as Function)(
-      createMockRequest("/api/cron/daily-digest", { method: "POST" })
+      createCronRequest("/api/cron/daily-digest")
     );
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -69,7 +93,7 @@ describe("POST /api/cron/daily-digest", () => {
 
     const { POST } = await import("@/app/api/cron/daily-digest/route");
     const res = await (POST as Function)(
-      createMockRequest("/api/cron/daily-digest", { method: "POST" })
+      createCronRequest("/api/cron/daily-digest")
     );
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/__tests__/api/plans-archive.test.ts
+++ b/__tests__/api/plans-archive.test.ts
@@ -93,10 +93,10 @@ describe("Plan archive validation", () => {
   });
 });
 
-describe("Plan API -- no DELETE, has PATCH", () => {
-  it("plans/[id]/route.ts does not export DELETE", async () => {
+describe("Plan API -- has PATCH and DELETE", () => {
+  it("plans/[id]/route.ts exports DELETE (manager-only hard delete)", async () => {
     const mod = await import("@/app/api/plans/[id]/route");
-    expect(mod).not.toHaveProperty("DELETE");
+    expect(mod).toHaveProperty("DELETE");
   });
 
   it("plans/[id]/route.ts exports PATCH", async () => {

--- a/__tests__/api/plans.test.ts
+++ b/__tests__/api/plans.test.ts
@@ -6,12 +6,15 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockAnnualPlan = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockAnnualPlan = { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
 
 jest.mock("@/lib/prisma", () => ({ prisma: { annualPlan: mockAnnualPlan } }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));
+
+// Mock @/auth for requireAuth() (Auth.js v5 uses auth() not getServerSession)
+jest.mock("@/auth", () => ({ auth: (...args: unknown[]) => mockGetServerSession(...args) }));
 
 const MANAGER_SESSION = { user: { id: "mgr-1", name: "Mgr", email: "m@e.com", role: "MANAGER" }, expires: "2099" };
 
@@ -67,6 +70,7 @@ describe("POST /api/plans", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
+    mockAnnualPlan.findFirst.mockResolvedValue(null); // no existing plan (conflict check)
     mockAnnualPlan.create.mockResolvedValue(MOCK_PLAN);
   });
 

--- a/__tests__/api/reports-extended.test.ts
+++ b/__tests__/api/reports-extended.test.ts
@@ -41,6 +41,9 @@ jest.mock("next-auth", () => ({
   getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
 }));
 
+// Mock @/auth for requireAuth() (Auth.js v5 uses auth() not getServerSession)
+jest.mock("@/auth", () => ({ auth: (...args: unknown[]) => mockGetServerSession(...args) }));
+
 // ── Service mocks ────────────────────────────────────────────────────────────
 const mockGetWeeklyReport = jest.fn();
 const mockGetMonthlyReport = jest.fn();
@@ -335,10 +338,11 @@ describe("GET /api/reports/trends", () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.metric).toBe("kpi");
-    expect(body.years).toEqual([2024, 2025]);
-    expect(body.data).toHaveProperty("2024");
-    expect(body.data).toHaveProperty("2025");
+    // Response is wrapped: { ok: true, data: { metric, years, data } }
+    expect(body.data.metric).toBe("kpi");
+    expect(body.data.years).toEqual([2024, 2025]);
+    expect(body.data.data).toHaveProperty("2024");
+    expect(body.data.data).toHaveProperty("2025");
   });
 
   it("returns workload trend data for specified metric", async () => {
@@ -353,8 +357,9 @@ describe("GET /api/reports/trends", () => {
     );
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.metric).toBe("workload");
-    expect(body.data[2024]).toHaveLength(12);
+    // Response is wrapped: { ok: true, data: { metric, years, data } }
+    expect(body.data.metric).toBe("workload");
+    expect(body.data.data[2024]).toHaveLength(12);
   });
 
   it("returns 400 for invalid years parameter", async () => {
@@ -377,13 +382,12 @@ describe("GET /api/reports/trends", () => {
     expect(res.status).toBe(400);
   });
 
-  it("throws UnauthorizedError when unauthenticated", async () => {
+  it("returns 401 when unauthenticated", async () => {
     mockGetServerSession.mockResolvedValue(null);
     const { GET } = await import("@/app/api/reports/trends/route");
-    // trends route does not use withAuth wrapper, so UnauthorizedError propagates
-    await expect(
-      GET(createMockRequest("/api/reports/trends")),
-    ).rejects.toThrow("未授權");
+    // trends route uses apiHandler which catches UnauthorizedError and returns 401
+    const res = await GET(createMockRequest("/api/reports/trends"));
+    expect(res.status).toBe(401);
   });
 });
 

--- a/__tests__/api/system-routes.test.ts
+++ b/__tests__/api/system-routes.test.ts
@@ -43,6 +43,21 @@ jest.mock("@/lib/logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
+// Mock @/auth for withAuth / requireAuth (Auth.js v5 uses auth() not getServerSession)
+const mockAuthSession = { user: { id: "sys-1", name: "System", email: "sys@e.com", role: "ADMIN" }, expires: "2099" };
+jest.mock("@/auth", () => ({ auth: jest.fn().mockResolvedValue(mockAuthSession) }));
+
+// Helper: create minimal NextRequest for metrics endpoint
+function createSystemRequest(url: string) {
+  return {
+    url: `http://localhost${url}`,
+    method: "GET",
+    json: jest.fn(() => Promise.resolve({})),
+    headers: { get: (_: string) => null },
+    nextUrl: new URL(`http://localhost${url}`),
+  } as unknown as import("next/server").NextRequest;
+}
+
 // ========================================================================
 // GET /api/health
 // ========================================================================
@@ -93,7 +108,7 @@ describe("GET /api/health", () => {
     const body = await res.json();
     expect(body.status).toBe("degraded");
     expect(body.checks.database.status).toBe("error");
-    expect(body.checks.database.error).toContain("Connection refused");
+    expect(body.checks.database.error).toContain("database connection failed");
   });
 
   it("returns 503 with status degraded when Redis connection fails", async () => {
@@ -104,7 +119,7 @@ describe("GET /api/health", () => {
     const body = await res.json();
     expect(body.status).toBe("degraded");
     expect(body.checks.redis.status).toBe("error");
-    expect(body.checks.redis.error).toContain("Redis timeout");
+    expect(body.checks.redis.error).toContain("redis connection failed");
   });
 
   it("returns 503 when Redis returns non-PONG response", async () => {
@@ -253,7 +268,7 @@ describe("GET /api/metrics", () => {
   it("returns Prometheus text format content type", async () => {
     mockSerializeMetrics.mockReturnValue("# HELP titan_uptime_seconds\n");
     const { GET } = await import("@/app/api/metrics/route");
-    const res = await GET();
+    const res = await GET(createSystemRequest("/api/metrics"));
     expect(res.headers.get("Content-Type")).toBe(
       "text/plain; version=0.0.4; charset=utf-8"
     );
@@ -272,7 +287,7 @@ describe("GET /api/metrics", () => {
 
     mockSerializeMetrics.mockReturnValue(metricsText);
     const { GET } = await import("@/app/api/metrics/route");
-    const res = await GET();
+    const res = await GET(createSystemRequest("/api/metrics"));
     const body = await res.text();
     expect(body).toBe(metricsText);
     expect(body).toContain("titan_http_requests_total");
@@ -282,14 +297,14 @@ describe("GET /api/metrics", () => {
   it("calls serializeMetrics exactly once", async () => {
     mockSerializeMetrics.mockReturnValue("");
     const { GET } = await import("@/app/api/metrics/route");
-    await GET();
+    await GET(createSystemRequest("/api/metrics"));
     expect(mockSerializeMetrics).toHaveBeenCalledTimes(1);
   });
 
   it("returns 200 status", async () => {
     mockSerializeMetrics.mockReturnValue("");
     const { GET } = await import("@/app/api/metrics/route");
-    const res = await GET();
+    const res = await GET(createSystemRequest("/api/metrics"));
     expect(res.status).toBe(200);
   });
 });

--- a/__tests__/api/tasks.test.ts
+++ b/__tests__/api/tasks.test.ts
@@ -37,6 +37,12 @@ jest.mock("@/lib/prisma", () => ({
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...args: unknown[]) => mockGetServerSession(...args) }));
 
+// Mock @/auth for requireAuth() / withAuth / withManager (Auth.js v5 uses auth() not getServerSession)
+// Delegate to mockGetServerSession so all beforeEach session setups work transparently.
+jest.mock("@/auth", () => ({
+  auth: (...args: unknown[]) => mockGetServerSession(...args),
+}));
+
 // ── Session helpers ───────────────────────────────────────────────────────
 const MEMBER_SESSION = {
   user: { id: "user-1", name: "Test", email: "t@e.com", role: "MEMBER" },
@@ -262,6 +268,10 @@ describe("DELETE /api/tasks/[id]", () => {
     mockTask.findUnique.mockResolvedValue(MOCK_TASK);
     mockTask.delete.mockResolvedValue(MOCK_TASK);
     mockAuditLog.create.mockResolvedValue({});
+    // taskService.deleteTask wraps delete+auditLog in $transaction; execute the callback with a tx proxy
+    mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ task: mockTask, auditLog: mockAuditLog })
+    );
   });
 
   it("deletes task and returns success", async () => {

--- a/__tests__/api/tdd3-kpi-milestones.test.ts
+++ b/__tests__/api/tdd3-kpi-milestones.test.ts
@@ -64,6 +64,9 @@ jest.mock("next-auth", () => ({
   getServerSession: (...a: unknown[]) => mockGetServerSession(...a),
 }));
 
+// Mock @/auth for requireAuth() (Auth.js v5 uses auth() not getServerSession)
+jest.mock("@/auth", () => ({ auth: (...args: unknown[]) => mockGetServerSession(...args) }));
+
 const MEMBER = {
   user: { id: "u1", name: "Member", email: "m@e.com", role: "MEMBER" },
   expires: "2099-01-01",
@@ -171,7 +174,7 @@ describe("POST /api/milestones", () => {
   };
 
   it("creates milestone as authenticated user", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(MANAGER); // POST /api/milestones requires MANAGER
     const created = { id: "ms-new", ...validBody };
     mockMilestone.create.mockResolvedValue(created);
 
@@ -198,7 +201,7 @@ describe("POST /api/milestones", () => {
   });
 
   it("returns 400 when title is missing (Zod validation)", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(MANAGER); // POST /api/milestones requires MANAGER
 
     const { POST } = await import("@/app/api/milestones/route");
     const res = await (POST as Function)(
@@ -212,7 +215,7 @@ describe("POST /api/milestones", () => {
   });
 
   it("returns 400 when annualPlanId is missing", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(MANAGER); // POST /api/milestones requires MANAGER
 
     const { POST } = await import("@/app/api/milestones/route");
     const res = await (POST as Function)(
@@ -226,7 +229,7 @@ describe("POST /api/milestones", () => {
   });
 
   it("returns 400 when plannedStart > plannedEnd", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(MANAGER); // POST /api/milestones requires MANAGER
 
     const { POST } = await import("@/app/api/milestones/route");
     const res = await (POST as Function)(
@@ -337,7 +340,7 @@ describe("DELETE /api/milestones/[id]", () => {
   });
 
   it("deletes a milestone when authenticated", async () => {
-    mockGetServerSession.mockResolvedValue(MEMBER);
+    mockGetServerSession.mockResolvedValue(MANAGER); // DELETE /api/milestones/[id] requires MANAGER
     mockMilestone.findUnique.mockResolvedValue({ id: "ms-1", title: "To Delete" });
     mockMilestone.delete.mockResolvedValue({ id: "ms-1" });
 

--- a/__tests__/components/notification-bell.test.tsx
+++ b/__tests__/components/notification-bell.test.tsx
@@ -47,7 +47,7 @@ describe("NotificationBell", () => {
     await act(async () => {
       render(<NotificationBell />);
     });
-    expect(screen.getByLabelText("通知")).toBeInTheDocument();
+    expect(screen.getByLabelText(/通知/)).toBeInTheDocument();
   });
 
   it("shows unread count badge when there are unread notifications", async () => {
@@ -77,7 +77,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />);
     });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("通知"));
+      fireEvent.click(screen.getByLabelText(/通知/));
     });
     expect(screen.getByText("通知")).toBeInTheDocument();
   });
@@ -87,7 +87,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />);
     });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("通知"));
+      fireEvent.click(screen.getByLabelText(/通知/));
     });
     await waitFor(() => {
       expect(screen.getByText("You have a new task")).toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />);
     });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("通知"));
+      fireEvent.click(screen.getByLabelText(/通知/));
     });
     await waitFor(() => {
       expect(screen.getByText("任務指派")).toBeInTheDocument();
@@ -115,7 +115,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />);
     });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("通知"));
+      fireEvent.click(screen.getByLabelText(/通知/));
     });
     await waitFor(() => {
       expect(screen.getByText("目前沒有通知")).toBeInTheDocument();
@@ -127,7 +127,7 @@ describe("NotificationBell", () => {
       render(<NotificationBell />);
     });
     await act(async () => {
-      fireEvent.click(screen.getByLabelText("通知"));
+      fireEvent.click(screen.getByLabelText(/通知/));
     });
     await waitFor(() => {
       expect(screen.getByText("通知")).toBeInTheDocument();

--- a/__tests__/components/task-detail-modal.test.tsx
+++ b/__tests__/components/task-detail-modal.test.tsx
@@ -91,13 +91,8 @@ describe("TaskDetailModal", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("Test Task")).toBeInTheDocument();
     });
-    // Click the X button — find it by looking for all buttons and picking the close one in the header
-    const buttons = screen.getAllByRole("button");
-    // The X button is after Save, tabs (詳情, 變更歷史, 評論), so find by iterating from end
-    const closeBtn = buttons.find((b) => {
-      // The X button is the one that is not Save, not a tab
-      return b.closest(".flex.items-center.gap-2") && !b.textContent?.includes("儲存");
-    }) ?? buttons[buttons.length - 1];
+    // Click the X button — identified by its aria-label="關閉任務詳情"
+    const closeBtn = screen.getByLabelText("關閉任務詳情");
     fireEvent.click(closeBtn);
     expect(onClose).toHaveBeenCalled();
   });

--- a/__tests__/integration/branch-coverage.test.ts
+++ b/__tests__/integration/branch-coverage.test.ts
@@ -648,6 +648,11 @@ describe("TaskService — deleteTask branch coverage", () => {
     service = new TaskService(prisma as never);
     (prisma.task.delete as jest.Mock).mockResolvedValue({});
     (prisma.auditLog.create as jest.Mock).mockResolvedValue({});
+    // deleteTask wraps delete + auditLog in $transaction; execute the callback with a tx proxy
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (fn: (tx: unknown) => Promise<unknown>) =>
+        fn({ task: prisma.task, auditLog: prisma.auditLog })
+    );
   });
 
   it("logs task title when task exists", async () => {

--- a/__tests__/pages/kanban-extended.test.tsx
+++ b/__tests__/pages/kanban-extended.test.tsx
@@ -21,6 +21,13 @@ jest.mock("next-auth/react", () => ({
   })),
 }));
 
+// Mock next/navigation — useSearchParams returns null if not mocked, crashing the page
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn() })),
+  usePathname: jest.fn(() => "/kanban"),
+}));
+
 jest.mock("@/app/components/task-card", () => ({
   TaskCard: ({ task }: { task: { title: string } }) => (
     <div data-testid="task-card">{task.title}</div>
@@ -30,6 +37,7 @@ jest.mock("@/app/components/task-filters", () => ({
   TaskFilters: () => <div data-testid="task-filters" />,
   emptyFilters: { assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" },
   hasActiveFilters: () => false,
+  parseFiltersFromUrl: () => ({ assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" }),
 }));
 jest.mock("@/app/components/task-detail-modal", () => ({
   TaskDetailModal: () => <div data-testid="task-detail-modal" />,

--- a/__tests__/pages/kanban.test.tsx
+++ b/__tests__/pages/kanban.test.tsx
@@ -12,6 +12,13 @@ jest.mock("next-auth/react", () => ({
   })),
 }));
 
+// Mock next/navigation — useSearchParams returns null if not mocked, crashing the page
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+  useRouter: jest.fn(() => ({ push: jest.fn(), replace: jest.fn() })),
+  usePathname: jest.fn(() => "/kanban"),
+}));
+
 // Mock child components
 jest.mock("@/app/components/task-card", () => ({
   TaskCard: ({ task }: { task: { title: string } }) => (
@@ -22,6 +29,7 @@ jest.mock("@/app/components/task-filters", () => ({
   TaskFilters: () => <div data-testid="task-filters" />,
   emptyFilters: { assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" },
   hasActiveFilters: () => false,
+  parseFiltersFromUrl: () => ({ assignee: "", priority: "", category: "", tags: [], dueDateFrom: "", dueDateTo: "" }),
 }));
 jest.mock("@/app/components/task-detail-modal", () => ({
   TaskDetailModal: () => <div data-testid="task-detail-modal" />,
@@ -81,9 +89,9 @@ describe("Kanban Page", () => {
       render(<KanbanPage />);
     });
     await waitFor(() => {
-      // 空資料時顯示 PageEmpty 引導訊息
-      expect(screen.getByText("尚無任務")).toBeInTheDocument();
-      expect(screen.getByText("目前沒有任何任務，請點擊「新增任務」開始")).toBeInTheDocument();
+      // 空資料時顯示 PageEmpty 引導訊息（文字隨 UI 更新）
+      expect(screen.getByText("建立第一個任務開始工作")).toBeInTheDocument();
+      expect(screen.getByText("把待辦事項加入看板，拖曳卡片即可更新進度")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes 13 test files that have been failing on `main` since RBAC strengthening (T1273-T1279) and other recent changes
- No production code modified — all changes are in test files only
- Full suite: 236 suites, 3100 tests passed, 0 failures after fix

## Root Cause Classification

| Root Cause | Files Affected | Description |
|------------|---------------|-------------|
| A) Missing `@/auth` mock | 8 API tests | RBAC now uses `auth()` not `getServerSession()`; tests only mocked `next-auth` |
| B) Missing `CRON_SECRET` env + header | 2 cron tests | Issue #1210 mandates CRON_SECRET; tests sent no env var or header |
| C) Missing `next/navigation` + `parseFiltersFromUrl` mock | 2 kanban tests | `useSearchParams()` returns `null` without mock, crashes on `.toString()` |
| D) aria-label changed for notification bell | 5 notification-bell tests | Label is now `"通知 (N 則未讀)"` when unread > 0; tests used exact string |
| E) Close button CSS selector unreliable | 1 task-detail-modal test | Button now has `aria-label="關閉任務詳情"`; use that instead |
| F) `plans/[id]` unexpectedly exports DELETE | 1 plans-archive test | DELETE endpoint was added after test wrote the opposite assertion |
| G) `$transaction` not executing callback | 2 branch-coverage tests | `deleteTask` wraps delete+audit in `$transaction`; mock must call the callback |
| H) Response shape mismatch / stale assertions | 3 reports-extended tests | `success()` wraps in `{ data: ... }`; test accessed top-level fields directly |

## Fix Strategy

- Root cause A: Added `jest.mock("@/auth", () => ({ auth: (...args) => mockGetServerSession(...args) }))` to delegate auth mock transparently
- Root cause B: Added `beforeAll`/`afterAll` env setup + `createCronRequest()` helper with `x-cron-secret` header
- Root cause C: Added `jest.mock("next/navigation", ...)` + `parseFiltersFromUrl` to task-filters mock
- Root cause D: Changed `getByLabelText("通知")` to `getByLabelText(/通知/)` regex
- Root cause E: Changed to `screen.getByLabelText("關閉任務詳情")`
- Root cause F: Updated assertion to expect DELETE exists (reflects actual product)
- Root cause G: Added `$transaction` mock implementation calling callback with tx proxy
- Root cause H: Updated accessors to `body.data.metric` etc.; updated stale error message strings

## Test Plan

- [x] All 13 originally-failing test files run green locally (248 tests)
- [x] Full suite run: 236 suites, 3100 tests passed, 0 failures, 4 skipped
- [x] No production files modified — only test files changed

Closes #1343