### PR TITLE
fix(CRITICAL T1352): cron scheduler — wire dead cron routes to actually run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,8 @@ MIN_MOBILE_VERSION=1.0.0
 # ── Cron Jobs ───────────────────────────────────────────────
 # 必填：Cron 路由驗證密鑰（使用 openssl rand -hex 32 產生）
 # 用於保護 /api/cron/* 端點，防止未授權觸發
+# Issue #1352: 由 titan-cron 容器（alpine crond）自動觸發，無需外部排程器
+# 所有 /api/cron/* 路由使用 timingSafeEqual 比對此密鑰，防止 timing attack
 CRON_SECRET=changeme_cron_secret_here
 
 # ── Monitoring Webhook ──────────────────────────────────────

--- a/__tests__/api/stale-task-scan.test.ts
+++ b/__tests__/api/stale-task-scan.test.ts
@@ -58,13 +58,15 @@ describe("POST /api/cron/stale-task-scan", () => {
 
   // ── Test 1: Missing CRON_SECRET env → 500 ───────────────────────────────
 
-  it("returns 500 when CRON_SECRET env var is not configured", async () => {
+  it("returns 503 when CRON_SECRET env var is not configured", async () => {
     delete process.env.CRON_SECRET;
 
     const { POST } = await import("@/app/api/cron/stale-task-scan/route");
     const res = await (POST as Function)(createCronRequest());
 
-    expect(res.status).toBe(500);
+    // T1352: shared cron-auth helper returns 503 (service unavailable)
+    // when secret env is missing — was 500 in original inline check
+    expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.ok).toBe(false);
     expect(body.error).toBe("ServerError");

--- a/app/api/cron/audit-queue-drain/route.ts
+++ b/app/api/cron/audit-queue-drain/route.ts
@@ -1,0 +1,31 @@
+/**
+ * POST /api/cron/audit-queue-drain — Drain Redis audit failure queue (Issue #1352)
+ *
+ * Retries up to 100 failed audit log entries from the Redis fallback queue
+ * into PostgreSQL. Called every 5 minutes by titan-cron to prevent OOM growth.
+ *
+ * Protected by CRON_SECRET header (timingSafeEqual via verifyCronSecret).
+ */
+
+import { NextRequest } from "next/server";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { prisma } from "@/lib/prisma";
+import { AuditService } from "@/services/audit-service";
+import { logger } from "@/lib/logger";
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const service = new AuditService(prisma);
+  const processed = await service.processAuditQueue();
+
+  logger.info(
+    { event: "cron_audit_drain_complete", processed },
+    "Audit queue drain complete"
+  );
+
+  return success({ processed, timestamp: new Date().toISOString() });
+});

--- a/app/api/cron/daily-digest/route.ts
+++ b/app/api/cron/daily-digest/route.ts
@@ -10,19 +10,13 @@
 
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { success, error } from "@/lib/api-response";
+import { success } from "@/lib/api-response";
 import { apiHandler } from "@/lib/api-handler";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  // Issue #1210: always enforce CRON_SECRET — reject if not configured
-  const expectedSecret = process.env.CRON_SECRET;
-  if (!expectedSecret) {
-    return error("ServerError", "CRON_SECRET not configured", 500);
-  }
-  const provided = req.headers.get("x-cron-secret");
-  if (provided !== expectedSecret) {
-    return error("UnauthorizedError", "Invalid cron secret", 401);
-  }
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
   const now = new Date();
   const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 

--- a/app/api/cron/daily-reminder/route.ts
+++ b/app/api/cron/daily-reminder/route.ts
@@ -10,20 +10,14 @@
 
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { success, error } from "@/lib/api-response";
+import { success } from "@/lib/api-response";
 import { NotificationService } from "@/services/notification-service";
 import { apiHandler } from "@/lib/api-handler";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  // Issue #1210: always enforce CRON_SECRET — reject if not configured
-  const expectedSecret = process.env.CRON_SECRET;
-  if (!expectedSecret) {
-    return error("ServerError", "CRON_SECRET not configured", 500);
-  }
-  const provided = req.headers.get("x-cron-secret");
-  if (provided !== expectedSecret) {
-    return error("UnauthorizedError", "Invalid cron secret", 401);
-  }
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
   const service = new NotificationService(prisma);
   const now = new Date();
 

--- a/app/api/cron/email-notifications/route.ts
+++ b/app/api/cron/email-notifications/route.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /api/cron/email-notifications — Trigger scheduled email notifications (Issue #1352)
+ *
+ * Scans for due/overdue tasks and timesheet reminders, then sends emails
+ * to relevant users. Idempotent within the same hour (uses NotificationLog).
+ * Called every 15 minutes by titan-cron.
+ *
+ * Protected by CRON_SECRET header (timingSafeEqual via verifyCronSecret).
+ */
+
+import { NextRequest } from "next/server";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { prisma } from "@/lib/prisma";
+import { EmailNotificationService } from "@/services/email-notification-service";
+import { logger } from "@/lib/logger";
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const service = new EmailNotificationService(prisma);
+  const now = new Date();
+  const result = await service.trigger(now);
+
+  logger.info(
+    { event: "cron_email_trigger_complete", ...result },
+    "Email notification trigger complete"
+  );
+
+  return success({ ...result, timestamp: now.toISOString() });
+});

--- a/app/api/cron/stale-task-scan/route.ts
+++ b/app/api/cron/stale-task-scan/route.ts
@@ -13,17 +13,11 @@ import { success, error } from "@/lib/api-response";
 import { apiHandler } from "@/lib/api-handler";
 import { scanStaleTasks } from "@/services/stale-task-service";
 import { logger } from "@/lib/logger";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  // Enforce CRON_SECRET — reject if not configured
-  const expectedSecret = process.env.CRON_SECRET;
-  if (!expectedSecret) {
-    return error("ServerError", "CRON_SECRET not configured", 500);
-  }
-  const provided = req.headers.get("x-cron-secret");
-  if (provided !== expectedSecret) {
-    return error("UnauthorizedError", "Invalid cron secret", 401);
-  }
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
 
   try {
     const result = await scanStaleTasks();

--- a/app/api/cron/verification-reminder/route.ts
+++ b/app/api/cron/verification-reminder/route.ts
@@ -12,19 +12,13 @@
 
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { success, error } from "@/lib/api-response";
+import { success } from "@/lib/api-response";
 import { apiHandler } from "@/lib/api-handler";
+import { verifyCronSecret } from "@/lib/cron-auth";
 
 export const POST = apiHandler(async (req: NextRequest) => {
-  // Issue #1210: always enforce CRON_SECRET — reject if not configured
-  const expectedSecret = process.env.CRON_SECRET;
-  if (!expectedSecret) {
-    return error("ServerError", "CRON_SECRET not configured", 500);
-  }
-  const provided = req.headers.get("x-cron-secret");
-  if (provided !== expectedSecret) {
-    return error("UnauthorizedError", "Invalid cron secret", 401);
-  }
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
   const now = new Date();
   const today = now.toISOString().slice(0, 10);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,6 +297,51 @@ services:
       retries: 3
       start_period: 30s
 
+  # ── Cron Scheduler（Issue #1352）─────────────────────────────
+  # Lightweight Alpine container that triggers all cron API routes via HTTP.
+  # No external scheduler required — works in air-gapped Docker Compose deployments.
+  #
+  # Schedule (Asia/Taipei timezone):
+  #   */5  * * * *   audit-queue-drain    — every 5 min (keep Redis lean)
+  #   */15 * * * *   email-notifications  — every 15 min
+  #   0    8 * * *   daily-digest         — 08:00 daily
+  #   0   17 * * 1-5 daily-reminder       — 17:00 weekdays
+  #   0    2 * * *   stale-task-scan      — 02:00 daily (low load)
+  #   30   8 * * 1   verification-reminder — 08:30 Monday
+  titan-cron:
+    image: alpine:3.19
+    container_name: titan-cron
+    restart: unless-stopped
+    depends_on:
+      titan-app:
+        condition: service_healthy
+    environment:
+      CRON_SECRET: ${CRON_SECRET:?CRON_SECRET is required}
+      TITAN_APP_URL: http://titan-app:3100
+    networks:
+      - titan-internal
+    command: >-
+      /bin/sh -c "
+      apk add --no-cache curl tzdata >/dev/null &&
+      cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime &&
+      echo 'Asia/Taipei' > /etc/timezone &&
+      echo '*/5 * * * * curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/audit-queue-drain || true' > /etc/crontabs/root &&
+      echo '*/15 * * * * curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/email-notifications || true' >> /etc/crontabs/root &&
+      echo '0 8 * * * curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/daily-digest || true' >> /etc/crontabs/root &&
+      echo '0 17 * * 1-5 curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/daily-reminder || true' >> /etc/crontabs/root &&
+      echo '0 2 * * * curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/stale-task-scan || true' >> /etc/crontabs/root &&
+      echo '30 8 * * 1 curl -fsS -X POST -H \"x-cron-secret: $CRON_SECRET\" $TITAN_APP_URL/api/cron/verification-reminder || true' >> /etc/crontabs/root &&
+      crond -f -L /dev/stdout
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 64M
+        reservations:
+          cpus: '0.05'
+          memory: 16M
+
   # ══════════════════════════════════════════════════════════
   # MONITORING PROFILE — docker compose --profile monitoring up -d
   # ══════════════════════════════════════════════════════════

--- a/lib/cron-auth.ts
+++ b/lib/cron-auth.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared cron authentication helper (Issue #1352)
+ *
+ * Replaces inline `!==` secret comparison in all cron routes with
+ * crypto.timingSafeEqual to prevent timing-based secret leakage.
+ */
+
+import { timingSafeEqual } from "node:crypto";
+import { NextRequest } from "next/server";
+import { error, type ApiResponse } from "@/lib/api-response";
+import { NextResponse } from "next/server";
+
+/**
+ * Verify the x-cron-secret header against CRON_SECRET env var.
+ *
+ * Returns null if auth passes (caller may proceed).
+ * Returns a NextResponse error if auth fails (caller must return it immediately).
+ */
+export function verifyCronSecret(
+  req: NextRequest
+): NextResponse<ApiResponse> | null {
+  const expectedSecret = process.env.CRON_SECRET;
+  if (!expectedSecret) {
+    return error("ServerError", "CRON_SECRET not configured", 503);
+  }
+
+  const provided = req.headers.get("x-cron-secret");
+  if (!provided) {
+    return error("UnauthorizedError", "Missing cron secret header", 401);
+  }
+
+  // timingSafeEqual requires equal-length buffers; length mismatch is itself rejected
+  const expectedBuf = Buffer.from(expectedSecret, "utf8");
+  const providedBuf = Buffer.from(provided, "utf8");
+
+  if (expectedBuf.length !== providedBuf.length) {
+    return error("UnauthorizedError", "Invalid cron secret", 401);
+  }
+
+  if (!timingSafeEqual(expectedBuf, providedBuf)) {
+    return error("UnauthorizedError", "Invalid cron secret", 401);
+  }
+
+  return null; // auth passed
+}

--- a/services/recurring-service.ts
+++ b/services/recurring-service.ts
@@ -5,6 +5,7 @@
  */
 
 import { PrismaClient, Prisma } from "@prisma/client";
+import { logger } from "@/lib/logger";
 
 type TransactionClient = Omit<PrismaClient, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends">;
 import {
@@ -139,18 +140,53 @@ export class RecurringService {
   /**
    * Generate tasks for all active recurring rules whose nextDueAt <= now.
    * Idempotent: uses lastGeneratedAt + nextDueAt to prevent duplicates.
+   *
+   * @param now         Reference time (defaults to current time)
+   * @param maxBackfillDays  Skip rules whose nextDueAt is older than this many days
+   *                        to prevent generating thousands of tasks after a long outage.
+   *                        Defaults to 7.
+   *
    * Returns count of tasks created.
    */
-  async generateTasks(now: Date = new Date()): Promise<{
+  async generateTasks(
+    now: Date = new Date(),
+    maxBackfillDays = 7
+  ): Promise<{
     generated: number;
     rules: Array<{ ruleId: string; taskId: string; title: string }>;
   }> {
+    const backfillCutoff = new Date(
+      now.getTime() - maxBackfillDays * 24 * 60 * 60 * 1000
+    );
+
     const dueRules = await this.prisma.recurringRule.findMany({
       where: {
         isActive: true,
-        nextDueAt: { lte: now },
+        nextDueAt: {
+          lte: now,
+          gte: backfillCutoff, // skip rules overdue by more than maxBackfillDays
+        },
       },
     });
+
+    // Count and warn about rules skipped due to age
+    const skipped = await this.prisma.recurringRule.count({
+      where: {
+        isActive: true,
+        nextDueAt: { lt: backfillCutoff },
+      },
+    });
+
+    if (skipped > 0) {
+      logger.warn(
+        {
+          skipped,
+          backfillCutoff: backfillCutoff.toISOString(),
+          event: "recurring_skip_old",
+        },
+        `Skipping ${skipped} very old recurring rules (nextDueAt < ${backfillCutoff.toISOString()})`
+      );
+    }
 
     const results: Array<{ ruleId: string; taskId: string; title: string }> = [];
 


### PR DESCRIPTION
Closes #1352

Round 5 audit found all 4 cron routes were dead code (no external scheduler).

## Highlights
- New `titan-cron` container in docker-compose.yml (Alpine + dcron + curl)
- 6 cron schedules in Asia/Taipei timezone
- New `lib/cron-auth.ts` with timingSafeEqual
- 2 new cron endpoints (audit-queue-drain, email-notifications)
- recurring-service maxBackfillDays=7 cutoff

## Test plan
- [x] tsc 0 errors
- [x] jest 0 regressions (3100 passed)
- [ ] Mac Mini deploy verifies cron container starts