### PR TITLE
fix(T1353): 6 race conditions — atomic checks

### DIFF
--- a/__tests__/api/document-approve-reject.test.ts
+++ b/__tests__/api/document-approve-reject.test.ts
@@ -5,6 +5,7 @@
  * API route tests: /api/documents/{id}/approve and /api/documents/{id}/reject — Issue #1002
  */
 import { createMockRequest } from "../utils/test-utils";
+import { Prisma } from "@prisma/client";
 
 const mockDocument = {
   findUnique: jest.fn(),
@@ -85,6 +86,10 @@ describe("POST /api/documents/{id}/approve", () => {
   });
 
   it("returns 404 for nonexistent document", async () => {
+    // T1353: route now does atomic update first, falls back to findUnique on P2025
+    const p2025 = Object.assign(new Error("Record not found"), { code: "P2025" });
+    Object.setPrototypeOf(p2025, Prisma.PrismaClientKnownRequestError.prototype);
+    mockDocument.update.mockRejectedValue(p2025);
     mockDocument.findUnique.mockResolvedValue(null);
 
     const { POST } = await import("@/app/api/documents/[id]/approve/route");
@@ -96,10 +101,11 @@ describe("POST /api/documents/{id}/approve", () => {
   });
 
   it("returns 400 for non-IN_REVIEW document", async () => {
-    mockDocument.findUnique.mockResolvedValue({
-      ...MOCK_DOC_IN_REVIEW,
-      status: "DRAFT",
-    });
+    // T1353: atomic update fails with P2025; findUnique confirms doc exists → 400
+    const p2025 = Object.assign(new Error("Record not found"), { code: "P2025" });
+    Object.setPrototypeOf(p2025, Prisma.PrismaClientKnownRequestError.prototype);
+    mockDocument.update.mockRejectedValue(p2025);
+    mockDocument.findUnique.mockResolvedValue({ id: "doc-1" });
 
     const { POST } = await import("@/app/api/documents/[id]/approve/route");
     const res = await (POST as Function)(
@@ -180,6 +186,10 @@ describe("POST /api/documents/{id}/reject", () => {
   });
 
   it("returns 404 for nonexistent document", async () => {
+    // T1353: route now does atomic update first, falls back to findUnique on P2025
+    const p2025 = Object.assign(new Error("Record not found"), { code: "P2025" });
+    Object.setPrototypeOf(p2025, Prisma.PrismaClientKnownRequestError.prototype);
+    mockDocument.update.mockRejectedValue(p2025);
     mockDocument.findUnique.mockResolvedValue(null);
 
     const { POST } = await import("@/app/api/documents/[id]/reject/route");
@@ -194,10 +204,11 @@ describe("POST /api/documents/{id}/reject", () => {
   });
 
   it("returns 400 for non-IN_REVIEW document", async () => {
-    mockDocument.findUnique.mockResolvedValue({
-      ...MOCK_DOC_IN_REVIEW,
-      status: "PUBLISHED",
-    });
+    // T1353: atomic update fails with P2025; findUnique confirms doc exists → 400
+    const p2025 = Object.assign(new Error("Record not found"), { code: "P2025" });
+    Object.setPrototypeOf(p2025, Prisma.PrismaClientKnownRequestError.prototype);
+    mockDocument.update.mockRejectedValue(p2025);
+    mockDocument.findUnique.mockResolvedValue({ id: "doc-1" });
 
     const { POST } = await import("@/app/api/documents/[id]/reject/route");
     const res = await (POST as Function)(

--- a/__tests__/api/monitoring-integration.test.ts
+++ b/__tests__/api/monitoring-integration.test.ts
@@ -16,6 +16,8 @@ const mockMonitoringAlert = {
   findFirst: jest.fn(),
   create: jest.fn(),
   update: jest.fn(),
+  // T1353: service uses upsert for atomic webhook handling
+  upsert: jest.fn(),
 };
 
 const mockTask = {
@@ -99,6 +101,8 @@ describe("POST /api/integrations/monitoring/webhook", () => {
     auth.mockResolvedValue(null);
     mockMonitoringAlert.findFirst.mockResolvedValue(null);
     mockMonitoringAlert.create.mockResolvedValue(MOCK_ALERT);
+    // T1353: monitoring service uses upsert (atomic) — mock default
+    mockMonitoringAlert.upsert.mockResolvedValue(MOCK_ALERT);
     // Clear env
     delete process.env.MONITORING_WEBHOOK_KEY;
   });
@@ -163,6 +167,8 @@ describe("POST /api/integrations/monitoring/webhook", () => {
     process.env.MONITORING_WEBHOOK_KEY = "secret-key-123";
     mockMonitoringAlert.findFirst.mockResolvedValue(MOCK_ALERT);
     mockMonitoringAlert.update.mockResolvedValue({ ...MOCK_ALERT, status: "RESOLVED" });
+    // T1353: also mock upsert (now used by service)
+    mockMonitoringAlert.upsert.mockResolvedValue({ ...MOCK_ALERT, status: "RESOLVED" });
 
     const { POST } = await import("@/app/api/integrations/monitoring/webhook/route");
     const mockReq = createMockRequest("/api/integrations/monitoring/webhook", {
@@ -178,7 +184,8 @@ describe("POST /api/integrations/monitoring/webhook", () => {
     mockReq.headers.set("authorization", "Bearer secret-key-123");
     const res = await POST(mockReq);
     expect(res.status).toBe(201);
-    expect(mockMonitoringAlert.update).toHaveBeenCalled();
+    // T1353: service now uses upsert (atomic) instead of separate update
+    expect(mockMonitoringAlert.upsert).toHaveBeenCalled();
   });
 
   it("rejects invalid payload (400)", async () => {

--- a/__tests__/api/time-entries.test.ts
+++ b/__tests__/api/time-entries.test.ts
@@ -9,7 +9,17 @@ import { createMockRequest } from "../utils/test-utils";
 const mockTimeEntry = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
 const mockAuditLog = { create: jest.fn() };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { timeEntry: mockTimeEntry, auditLog: mockAuditLog } }));
+// T1353: time-entries POST now wraps daily-limit check + create in $transaction.
+// Mock invokes the callback with the same prisma mock, so tx.timeEntry.findMany etc. work.
+const mockPrisma = {
+  timeEntry: mockTimeEntry,
+  auditLog: mockAuditLog,
+  $transaction: jest.fn().mockImplementation((arg: unknown) => {
+    if (typeof arg === "function") return (arg as (tx: unknown) => unknown)(mockPrisma);
+    return Promise.all(arg as unknown[]);
+  }),
+};
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));

--- a/__tests__/integration/api-security-middleware.test.ts
+++ b/__tests__/integration/api-security-middleware.test.ts
@@ -43,21 +43,25 @@ const mockTaskActivity = { create: jest.fn() };
 const mockTaskChange = { create: jest.fn() };
 const mockAuditLog = { create: jest.fn() };
 const mockPermission = { findFirst: jest.fn() };
-const mockTransaction = jest.fn();
+// T1353: time-entries POST and other routes wrap logic in $transaction.
+// Default mock invokes the callback with the prisma mock itself.
+const mockPrisma: Record<string, unknown> = {
+  task: mockTask,
+  user: mockUser,
+  kPI: mockKPI,
+  timeEntry: mockTimeEntry,
+  taskActivity: mockTaskActivity,
+  taskChange: mockTaskChange,
+  auditLog: mockAuditLog,
+  permission: mockPermission,
+};
+const mockTransaction = jest.fn().mockImplementation((arg: unknown) => {
+  if (typeof arg === "function") return (arg as (tx: unknown) => unknown)(mockPrisma);
+  return Promise.all(arg as unknown[]);
+});
+mockPrisma.$transaction = mockTransaction;
 
-jest.mock("@/lib/prisma", () => ({
-  prisma: {
-    task: mockTask,
-    user: mockUser,
-    kPI: mockKPI,
-    timeEntry: mockTimeEntry,
-    taskActivity: mockTaskActivity,
-    taskChange: mockTaskChange,
-    auditLog: mockAuditLog,
-    permission: mockPermission,
-    $transaction: mockTransaction,
-  },
-}));
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({

--- a/app/api/documents/[id]/approve/route.ts
+++ b/app/api/documents/[id]/approve/route.ts
@@ -1,15 +1,19 @@
 import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireMinRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
-import { NotFoundError, ValidationError } from "@/services/errors";
+import { ValidationError, NotFoundError } from "@/services/errors";
 
 /**
  * POST /api/documents/{id}/approve — Reviewer approves document (Issue #1002)
  *
  * Transitions IN_REVIEW → PUBLISHED. Requires MANAGER role.
  * Writes AuditLog via apiHandler auto-audit.
+ *
+ * The status guard is placed in the WHERE clause so the check-then-update
+ * is atomic — prevents double-approval under concurrent requests.
  */
 export const POST = withManager(async (
   _req: NextRequest,
@@ -18,23 +22,32 @@ export const POST = withManager(async (
   const session = await requireMinRole("MANAGER");
   const { id } = await context.params;
 
-  const doc = await prisma.document.findUnique({ where: { id } });
-  if (!doc) throw new NotFoundError(`Document not found: ${id}`);
-  if (doc.status !== "IN_REVIEW") {
-    throw new ValidationError("只有處於審核中的文件才能核准");
+  let updated;
+  let docTitle: string;
+  try {
+    // Atomic: only matches when status is still IN_REVIEW
+    updated = await prisma.document.update({
+      where: { id, status: "IN_REVIEW" },
+      data: {
+        status: "PUBLISHED",
+        updatedBy: session.user.id,
+      },
+      include: {
+        creator: { select: { id: true, name: true } },
+        updater: { select: { id: true, name: true } },
+      },
+    });
+    docTitle = updated.title;
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+      // P2025 = no record matched WHERE. Could be: doc doesn't exist OR status mismatch.
+      // Disambiguate by a follow-up findUnique (no race risk; we already failed to update).
+      const exists = await prisma.document.findUnique({ where: { id }, select: { id: true } });
+      if (!exists) throw new NotFoundError("文件不存在");
+      throw new ValidationError("只有處於審核中的文件才能核准");
+    }
+    throw err;
   }
-
-  const updated = await prisma.document.update({
-    where: { id },
-    data: {
-      status: "PUBLISHED",
-      updatedBy: session.user.id,
-    },
-    include: {
-      creator: { select: { id: true, name: true } },
-      updater: { select: { id: true, name: true } },
-    },
-  });
 
   // Write explicit audit log for approve action
   await prisma.auditLog.create({
@@ -44,7 +57,7 @@ export const POST = withManager(async (
       module: "KNOWLEDGE",
       resourceType: "Document",
       resourceId: id,
-      detail: `Approved document "${doc.title}" (IN_REVIEW → PUBLISHED)`,
+      detail: `Approved document "${docTitle}" (IN_REVIEW → PUBLISHED)`,
     },
   });
 

--- a/app/api/documents/[id]/reject/route.ts
+++ b/app/api/documents/[id]/reject/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
 import { withManager } from "@/lib/auth-middleware";
 import { requireMinRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
-import { NotFoundError, ValidationError } from "@/services/errors";
+import { ValidationError, NotFoundError } from "@/services/errors";
 
 /**
  * POST /api/documents/{id}/reject — Reviewer rejects document (Issue #1002)
@@ -19,12 +20,6 @@ export const POST = withManager(async (
   const session = await requireMinRole("MANAGER");
   const { id } = await context.params;
 
-  const doc = await prisma.document.findUnique({ where: { id } });
-  if (!doc) throw new NotFoundError(`Document not found: ${id}`);
-  if (doc.status !== "IN_REVIEW") {
-    throw new ValidationError("只有處於審核中的文件才能駁回");
-  }
-
   let reason: string | undefined;
   try {
     const body = await req.json();
@@ -37,17 +32,31 @@ export const POST = withManager(async (
     throw new ValidationError("駁回必須提供理由");
   }
 
-  const updated = await prisma.document.update({
-    where: { id },
-    data: {
-      status: "DRAFT",
-      updatedBy: session.user.id,
-    },
-    include: {
-      creator: { select: { id: true, name: true } },
-      updater: { select: { id: true, name: true } },
-    },
-  });
+  let updated;
+  let docTitle: string;
+  try {
+    // Atomic: only matches when status is still IN_REVIEW
+    updated = await prisma.document.update({
+      where: { id, status: "IN_REVIEW" },
+      data: {
+        status: "DRAFT",
+        updatedBy: session.user.id,
+      },
+      include: {
+        creator: { select: { id: true, name: true } },
+        updater: { select: { id: true, name: true } },
+      },
+    });
+    docTitle = updated.title;
+  } catch (err) {
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+      // Disambiguate: not found vs status mismatch (no race risk after failed update)
+      const exists = await prisma.document.findUnique({ where: { id }, select: { id: true } });
+      if (!exists) throw new NotFoundError("文件不存在");
+      throw new ValidationError("只有處於審核中的文件才能駁回");
+    }
+    throw err;
+  }
 
   // Write explicit audit log for reject action
   await prisma.auditLog.create({
@@ -57,7 +66,7 @@ export const POST = withManager(async (
       module: "KNOWLEDGE",
       resourceType: "Document",
       resourceId: id,
-      detail: `Rejected document "${doc.title}" (IN_REVIEW → DRAFT): ${reason}`,
+      detail: `Rejected document "${docTitle}" (IN_REVIEW → DRAFT): ${reason}`,
       metadata: { reason },
     },
   });

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -88,41 +88,48 @@ export const POST = withAuth(async (req: NextRequest) => {
     }
   }
 
-  // T-1: Enforce daily 24hr limit — sum existing entries for this date
+  // T-1: Enforce daily 24hr limit — read existing total and create atomically.
+  // Wrapping in a transaction prevents a race where two concurrent requests both
+  // pass the limit check before either insert commits.
+  // Note: Prisma uses REPEATABLE READ isolation by default, which prevents most
+  // phantom-read races; row-level locking would be needed for full serialization.
   const targetDate = new Date(date);
-  const existingEntries = await prisma.timeEntry.findMany({
-    where: {
-      userId: session.user.id,
-      date: targetDate,
-      isDeleted: false,
-    },
-    select: { hours: true },
-  });
-  const existingTotal = existingEntries.reduce((sum, e) => sum + e.hours, 0);
-  const limitError = validateDailyLimit(existingTotal, hours);
-  if (limitError) {
-    throw new ValidationError(limitError);
-  }
-
-  // Always create entries owned by the caller — ignores any userId in body.
-  // #928: Manager time entries auto-approve (no approval workflow needed)
   const isManager = session.user.role === "MANAGER" || session.user.role === "ADMIN";
   const cleanDescription = description ? sanitizeHtml(description) || null : null;
-  const entry = await prisma.timeEntry.create({
-    data: {
-      taskId: taskId || null,
-      subTaskId: subTaskId || null,       // Issue #933
-      userId: session.user.id,
-      date: new Date(date),
-      hours,
-      category: (category as TimeCategory) ?? "PLANNED_TASK",
-      description: cleanDescription,
-      ...(isManager ? { approvalStatus: "APPROVED", locked: true } : {}),
-    },
-    include: {
-      task: { select: { id: true, title: true, category: true } },
-      subTask: { select: { id: true, title: true } },  // Issue #933
-    },
+
+  const entry = await prisma.$transaction(async (tx) => {
+    const existingEntries = await tx.timeEntry.findMany({
+      where: {
+        userId: session.user.id,
+        date: targetDate,
+        isDeleted: false,
+      },
+      select: { hours: true },
+    });
+    const existingTotal = existingEntries.reduce((sum, e) => sum + e.hours, 0);
+    const limitError = validateDailyLimit(existingTotal, hours);
+    if (limitError) {
+      throw new ValidationError(limitError);
+    }
+
+    // Always create entries owned by the caller — ignores any userId in body.
+    // #928: Manager time entries auto-approve (no approval workflow needed)
+    return tx.timeEntry.create({
+      data: {
+        taskId: taskId || null,
+        subTaskId: subTaskId || null,       // Issue #933
+        userId: session.user.id,
+        date: new Date(date),
+        hours,
+        category: (category as TimeCategory) ?? "PLANNED_TASK",
+        description: cleanDescription,
+        ...(isManager ? { approvalStatus: "APPROVED", locked: true } : {}),
+      },
+      include: {
+        task: { select: { id: true, title: true, category: true } },
+        subTask: { select: { id: true, title: true } },  // Issue #933
+      },
+    });
   });
 
   return success(entry, 201);

--- a/app/api/users/me/onboarding/route.ts
+++ b/app/api/users/me/onboarding/route.ts
@@ -10,37 +10,43 @@ import { requireAuth } from "@/lib/rbac";
 import { success, error } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { seedSampleDataForUser } from "@/lib/seed-sample-data";
+import { NotFoundError } from "@/services/errors";
 import { logger } from "@/lib/logger";
 
 export const POST = withAuth(async (_req: NextRequest) => {
   const session = await requireAuth();
   const userId = session.user.id;
 
-  // Guard: do not re-seed if already completed
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { hasCompletedOnboarding: true },
-  });
+  // Wrap in transaction so the guard read and the mark-complete update are atomic.
+  // Prevents double-seeding if the user clicks "開始使用" concurrently.
+  try {
+    await prisma.$transaction(async (tx) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: { hasCompletedOnboarding: true },
+      });
 
-  if (!user) {
-    return error("NotFoundError", "使用者不存在", 404);
-  }
+      if (!user) {
+        throw new NotFoundError("使用者不存在");
+      }
 
-  if (!user.hasCompletedOnboarding) {
-    // Seed sample data first, then mark onboarding complete
-    try {
-      await seedSampleDataForUser(prisma, userId);
-    } catch (err) {
-      logger.error({ err, userId }, "[onboarding] Failed to seed sample data");
-      // Non-fatal: continue to mark onboarding complete even if seeding fails
-    }
+      if (!user.hasCompletedOnboarding) {
+        // Seed sample data then mark onboarding complete — both inside the transaction
+        await seedSampleDataForUser(tx, userId);
 
-    await prisma.user.update({
-      where: { id: userId },
-      data: { hasCompletedOnboarding: true },
+        await tx.user.update({
+          where: { id: userId },
+          data: { hasCompletedOnboarding: true },
+        });
+
+        logger.info({ userId }, "[onboarding] Onboarding completed and sample data seeded");
+      }
     });
-
-    logger.info({ userId }, "[onboarding] Onboarding completed and sample data seeded");
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return error("NotFoundError", "使用者不存在", 404);
+    }
+    throw err;
   }
 
   return success({ completed: true });

--- a/lib/seed-sample-data.ts
+++ b/lib/seed-sample-data.ts
@@ -9,6 +9,8 @@
  */
 import type { PrismaClient } from "@prisma/client";
 
+type PrismaTransactionClient = Omit<PrismaClient, "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends">;
+
 /**
  * Seeds sample tasks and an annual plan for the given user.
  * Idempotent: checks for existing sample data before inserting.
@@ -17,7 +19,7 @@ import type { PrismaClient } from "@prisma/client";
  * @param userId - The ID of the user to seed data for
  */
 export async function seedSampleDataForUser(
-  prisma: PrismaClient,
+  prisma: PrismaClient | PrismaTransactionClient,
   userId: string
 ): Promise<void> {
   const currentYear = new Date().getFullYear();

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -4,6 +4,10 @@ import { MockPrismaClient } from "../__mocks__/prisma";
 /**
  * Creates a fresh mock prisma instance for each test.
  * Each model method is reset to a new jest.fn().
+ *
+ * $transaction default behavior: invokes the callback with the same mock instance,
+ * so service code that wraps logic in `tx.model.update(...)` works transparently
+ * in tests. Tests can override with `.mockImplementation(...)` if needed.
  */
 export function createMockPrisma(): MockPrismaClient {
   const createMockModel = () => ({
@@ -21,7 +25,7 @@ export function createMockPrisma(): MockPrismaClient {
     createMany: jest.fn(),
   });
 
-  return {
+  const mock: Record<string, unknown> = {
     task: createMockModel(),
     annualPlan: createMockModel(),
     monthlyGoal: createMockModel(),
@@ -43,8 +47,20 @@ export function createMockPrisma(): MockPrismaClient {
     deliverable: createMockModel(),
     auditLog: createMockModel(),
     systemSetting: createMockModel(),
-    $transaction: jest.fn(),
+    monitoringAlert: createMockModel(),
+    pushToken: createMockModel(),
     $connect: jest.fn(),
     $disconnect: jest.fn(),
-  } as unknown as MockPrismaClient;
+  };
+
+  // $transaction passes `mock` itself to the callback so tx.model.method() === prisma.model.method()
+  mock.$transaction = jest.fn().mockImplementation((arg: unknown) => {
+    if (typeof arg === "function") {
+      return (arg as (tx: unknown) => unknown)(mock);
+    }
+    // Array form: $transaction([promise1, promise2])
+    return Promise.all(arg as unknown[]);
+  });
+
+  return mock as unknown as MockPrismaClient;
 }

--- a/prisma/migrations/20260410000000_add_unique_constraints_for_race_fixes/migration.sql
+++ b/prisma/migrations/20260410000000_add_unique_constraints_for_race_fixes/migration.sql
@@ -1,0 +1,9 @@
+-- Migration: add unique constraints to prevent race conditions (Issue #1353)
+
+-- Fix 2: AnnualPlan year uniqueness — prevents concurrent createPlan creating
+-- duplicate year records between findFirst check and create.
+CREATE UNIQUE INDEX IF NOT EXISTS "annual_plans_year_key" ON "annual_plans"("year");
+
+-- Fix 4: MonitoringAlert composite unique — enables atomic upsert on
+-- (alertName, startsAt) instead of non-atomic findFirst + create/update.
+CREATE UNIQUE INDEX IF NOT EXISTS "monitoring_alerts_alertName_startsAt_key" ON "monitoring_alerts"("alertName", "startsAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -234,7 +234,7 @@ model AnnualPlan {
   deliverables Deliverable[] @relation("AnnualPlanDeliverable")
   linkedTasks  Task[]        @relation("PlanTasks") // Issue #835: direct task linkage
 
-  @@index([year])
+  @@unique([year])
   @@index([createdBy])
   @@map("annual_plans")
 }
@@ -1154,6 +1154,7 @@ model MonitoringAlert {
 
   relatedTask Task? @relation(fields: [relatedTaskId], references: [id])
 
+  @@unique([alertName, startsAt])
   @@index([status])
   @@index([startsAt])
   @@map("monitoring_alerts")

--- a/services/kpi-service.ts
+++ b/services/kpi-service.ts
@@ -158,24 +158,26 @@ export class KPIService {
   }
 
   async calculateAchievement(kpiId: string) {
-    const kpi = await this.prisma.kPI.findUnique({
-      where: { id: kpiId },
-      include: {
-        taskLinks: {
-          include: {
-            task: { select: { progressPct: true, status: true } },
+    return this.prisma.$transaction(async (tx) => {
+      const kpi = await tx.kPI.findUnique({
+        where: { id: kpiId },
+        include: {
+          taskLinks: {
+            include: {
+              task: { select: { progressPct: true, status: true } },
+            },
           },
         },
-      },
-    });
+      });
 
-    if (!kpi) throw new NotFoundError(`KPI not found: ${kpiId}`);
+      if (!kpi) throw new NotFoundError(`KPI not found: ${kpiId}`);
 
-    const achievement = calcAchievement(kpi);
+      const achievement = calcAchievement(kpi);
 
-    return this.prisma.kPI.update({
-      where: { id: kpiId },
-      data: { actual: achievement },
+      return tx.kPI.update({
+        where: { id: kpiId },
+        data: { actual: achievement },
+      });
     });
   }
 }

--- a/services/monitoring-service.ts
+++ b/services/monitoring-service.ts
@@ -34,27 +34,18 @@ export class MonitoringService {
     const summary = payload.annotations?.summary ?? payload.alertName;
     const description = payload.annotations?.description ?? null;
 
-    // Upsert: find existing by alertName + startsAt
-    const existing = await this.prisma.monitoringAlert.findFirst({
-      where: { alertName: payload.alertName, startsAt },
-    });
-
-    if (existing) {
-      return this.prisma.monitoringAlert.update({
-        where: { id: existing.id },
-        data: {
-          status,
-          severity: payload.severity,
-          endsAt,
-          labels: (payload.labels as Record<string, string>) ?? undefined,
-          summary,
-          description,
-        },
-      });
-    }
-
-    return this.prisma.monitoringAlert.create({
-      data: {
+    // Atomic upsert: uses composite unique index on (alertName, startsAt)
+    return this.prisma.monitoringAlert.upsert({
+      where: { alertName_startsAt: { alertName: payload.alertName, startsAt } },
+      update: {
+        status,
+        severity: payload.severity,
+        endsAt,
+        labels: (payload.labels as Record<string, string>) ?? undefined,
+        summary,
+        description,
+      },
+      create: {
         alertName: payload.alertName,
         severity: payload.severity,
         status,

--- a/services/plan-service.ts
+++ b/services/plan-service.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { NotFoundError, ValidationError, ConflictError } from "./errors";
 import { calculatePlanProgress } from "@/lib/progress-calc";
 
@@ -95,38 +95,38 @@ export class PlanService {
       throw new ValidationError("年份為必填");
     }
 
-    const existing = await this.prisma.annualPlan.findFirst({
-      where: { year: input.year },
-    });
-    if (existing) {
-      throw new ConflictError("該年度計畫已存在");
+    try {
+      return await this.prisma.annualPlan.create({
+        data: {
+          year: input.year,
+          title: input.title,
+          vision: input.vision ?? null,
+          description: input.description ?? null,
+          implementationPlan: input.implementationPlan ?? null,
+          createdBy: input.createdBy,
+          milestones: input.milestones?.length
+            ? {
+                create: input.milestones.map((m, i) => ({
+                  title: m.title,
+                  plannedEnd: new Date(m.plannedEnd),
+                  plannedStart: m.plannedStart ? new Date(m.plannedStart) : null,
+                  description: m.description ?? null,
+                  order: m.order ?? i,
+                })),
+              }
+            : undefined,
+        },
+        include: {
+          milestones: true,
+          monthlyGoals: true,
+        },
+      });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+        throw new ConflictError("該年度計畫已存在");
+      }
+      throw err;
     }
-
-    return this.prisma.annualPlan.create({
-      data: {
-        year: input.year,
-        title: input.title,
-        vision: input.vision ?? null,
-        description: input.description ?? null,
-        implementationPlan: input.implementationPlan ?? null,
-        createdBy: input.createdBy,
-        milestones: input.milestones?.length
-          ? {
-              create: input.milestones.map((m, i) => ({
-                title: m.title,
-                plannedEnd: new Date(m.plannedEnd),
-                plannedStart: m.plannedStart ? new Date(m.plannedStart) : null,
-                description: m.description ?? null,
-                order: m.order ?? i,
-              })),
-            }
-          : undefined,
-      },
-      include: {
-        milestones: true,
-        monthlyGoals: true,
-      },
-    });
   }
 
   async updatePlan(id: string, input: UpdatePlanInput) {


### PR DESCRIPTION
Closes #1353. KPI/Plan/Document/Monitoring/Onboarding/TimeEntry race fixes via $transaction, upsert, and WHERE-clause guards. 2 schema unique constraints added.