### PR TITLE
fix(T1361): TimeEntry soft delete coverage (21 queries)

### DIFF
--- a/app/api/cron/daily-digest/route.ts
+++ b/app/api/cron/daily-digest/route.ts
@@ -25,6 +25,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
     where: {
       date: { gte: today },
       approvalStatus: "PENDING",
+      isDeleted: false,
     },
     select: {
       userId: true,

--- a/services/__tests__/idor-protection.test.ts
+++ b/services/__tests__/idor-protection.test.ts
@@ -43,7 +43,7 @@ describe("TimeEntryService IDOR protection", () => {
   // ──────────────────────────────────────────────
 
   test("ENGINEER can only update own time entries", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(engineerEntry);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(engineerEntry);
     (prisma.timeEntry.update as jest.Mock).mockResolvedValue({ ...engineerEntry, hours: 4 });
 
     const result = await service.updateTimeEntry("te-1", { hours: 4 }, "user-engineer", "ENGINEER");
@@ -53,7 +53,7 @@ describe("TimeEntryService IDOR protection", () => {
   });
 
   test("ENGINEER cannot update other users time entries", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(otherEntry);
 
     await expect(
       service.updateTimeEntry("te-2", { hours: 4 }, "user-engineer", "ENGINEER")
@@ -67,7 +67,7 @@ describe("TimeEntryService IDOR protection", () => {
   // ──────────────────────────────────────────────
 
   test("ENGINEER cannot delete other users entries", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(otherEntry);
 
     await expect(
       service.deleteTimeEntry("te-2", "user-engineer", "ENGINEER")
@@ -94,7 +94,7 @@ describe("TimeEntryService IDOR protection", () => {
   // ──────────────────────────────────────────────
 
   test("MANAGER can only WRITE own entries by default", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(otherEntry);
 
     await expect(
       service.updateTimeEntry("te-2", { hours: 5 }, "user-manager", "MANAGER")
@@ -108,7 +108,7 @@ describe("TimeEntryService IDOR protection", () => {
   // ──────────────────────────────────────────────
 
   test("return 403 not 404 for unauthorized access", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(otherEntry);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(otherEntry);
 
     let caughtError: Error | undefined;
     try {

--- a/services/__tests__/time-entry-service.test.ts
+++ b/services/__tests__/time-entry-service.test.ts
@@ -36,7 +36,7 @@ describe("TimeEntryService", () => {
   });
 
   test("updateTimeEntry throws NotFoundError", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue(null);
 
     await expect(
       service.updateTimeEntry("nonexistent", { hours: 3 }, "user-1", "ENGINEER")
@@ -44,7 +44,7 @@ describe("TimeEntryService", () => {
   });
 
   test("deleteTimeEntry removes entry", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({ id: "te-1", userId: "user-1" });
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({ id: "te-1", userId: "user-1" });
     (prisma.timeEntry.delete as jest.Mock).mockResolvedValue({ id: "te-1" });
 
     await service.deleteTimeEntry("te-1", "user-1", "ENGINEER");

--- a/services/__tests__/time-entry-timer.test.ts
+++ b/services/__tests__/time-entry-timer.test.ts
@@ -105,7 +105,7 @@ describe("Timer — start/stop (TS-05)", () => {
     expect(result).toEqual(mockEntry);
     expect(prisma.timeEntry.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { userId: "user-1", isRunning: true },
+        where: { userId: "user-1", isRunning: true, isDeleted: false },
       })
     );
   });
@@ -121,7 +121,7 @@ describe("Locked entries (TS-04)", () => {
   });
 
   test("updateTimeEntry throws ForbiddenError when entry is locked", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({
       id: "te-locked",
       userId: "user-1",
       locked: true,
@@ -133,7 +133,7 @@ describe("Locked entries (TS-04)", () => {
   });
 
   test("deleteTimeEntry throws ForbiddenError when entry is locked", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({
       id: "te-locked",
       userId: "user-1",
       locked: true,
@@ -145,7 +145,7 @@ describe("Locked entries (TS-04)", () => {
   });
 
   test("updateTimeEntry succeeds when entry is not locked", async () => {
-    (prisma.timeEntry.findUnique as jest.Mock).mockResolvedValue({
+    (prisma.timeEntry.findFirst as jest.Mock).mockResolvedValue({
       id: "te-unlocked",
       userId: "user-1",
       locked: false,

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -110,7 +110,7 @@ export class AlertService {
     });
 
     const weekEntries = await this.prisma.timeEntry.findMany({
-      where: { date: { gte: weekStart, lte: now } },
+      where: { date: { gte: weekStart, lte: now }, isDeleted: false },
       select: { userId: true },
     });
 

--- a/services/notification-service.ts
+++ b/services/notification-service.ts
@@ -259,6 +259,7 @@ export class NotificationService {
       where: {
         userId: { in: engineers.map((e) => e.id) },
         date: { gte: weekStart, lte: weekEnd },
+        isDeleted: false,
       },
       select: { userId: true, hours: true },
     });
@@ -325,6 +326,7 @@ export class NotificationService {
       where: {
         userId: { in: activeUsers.map((u) => u.id) },
         date: { gte: todayStart, lte: todayEnd },
+        isDeleted: false,
       },
       select: { userId: true },
     });
@@ -406,6 +408,7 @@ export class NotificationService {
       where: {
         userId: { in: engineers.map((e: { id: string }) => e.id) },
         date: { gte: rangeStart, lte: rangeEnd },
+        isDeleted: false,
       },
       select: { userId: true, date: true, hours: true },
     });

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -165,8 +165,8 @@ export class ReportService {
     });
 
     const timeEntryFilter = filter.isManager
-      ? { date: { gte: weekStart, lte: weekEnd } }
-      : { userId: filter.userId, date: { gte: weekStart, lte: weekEnd } };
+      ? { date: { gte: weekStart, lte: weekEnd }, isDeleted: false }
+      : { userId: filter.userId, date: { gte: weekStart, lte: weekEnd }, isDeleted: false };
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
@@ -273,8 +273,8 @@ export class ReportService {
         : 0;
 
     const timeEntryFilter = filter.isManager
-      ? { date: { gte: monthStart, lte: monthEnd } }
-      : { userId: filter.userId, date: { gte: monthStart, lte: monthEnd } };
+      ? { date: { gte: monthStart, lte: monthEnd }, isDeleted: false }
+      : { userId: filter.userId, date: { gte: monthStart, lte: monthEnd }, isDeleted: false };
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
@@ -373,8 +373,8 @@ export class ReportService {
       new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
 
     const timeEntryFilter = filter.isManager
-      ? { date: { gte: startDate, lte: endDate } }
-      : { userId: filter.userId, date: { gte: startDate, lte: endDate } };
+      ? { date: { gte: startDate, lte: endDate }, isDeleted: false }
+      : { userId: filter.userId, date: { gte: startDate, lte: endDate }, isDeleted: false };
 
     const timeEntries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,
@@ -519,8 +519,8 @@ export class ReportService {
     isManager: boolean; userId?: string;
   }): Promise<TimesheetPivotData> {
     const timeEntryFilter = opts.isManager
-      ? { date: { gte: opts.start, lte: opts.end } }
-      : { userId: opts.userId, date: { gte: opts.start, lte: opts.end } };
+      ? { date: { gte: opts.start, lte: opts.end }, isDeleted: false }
+      : { userId: opts.userId, date: { gte: opts.start, lte: opts.end }, isDeleted: false };
 
     const entries = await this.prisma.timeEntry.findMany({
       where: timeEntryFilter,

--- a/services/report-v2-service.ts
+++ b/services/report-v2-service.ts
@@ -48,7 +48,7 @@ export class ReportV2Service {
     });
 
     const timeEntries = await this.prisma.timeEntry.findMany({
-      where: { date: { gte: start, lte: end } },
+      where: { date: { gte: start, lte: end }, isDeleted: false },
       select: { userId: true, hours: true },
     });
 
@@ -82,7 +82,7 @@ export class ReportV2Service {
     const { start, end } = defaultDateRange(startDate, endDate);
 
     const timeEntries = await this.prisma.timeEntry.findMany({
-      where: { date: { gte: start, lte: end } },
+      where: { date: { gte: start, lte: end }, isDeleted: false },
       select: { date: true, hours: true, category: true },
     });
 
@@ -120,7 +120,7 @@ export class ReportV2Service {
     const { start, end } = defaultDateRange(startDate, endDate);
 
     const timeEntries = await this.prisma.timeEntry.findMany({
-      where: { date: { gte: start, lte: end } },
+      where: { date: { gte: start, lte: end }, isDeleted: false },
       select: {
         userId: true,
         hours: true,
@@ -198,7 +198,7 @@ export class ReportV2Service {
     const { start, end } = defaultDateRange(startDate, endDate);
 
     const timeEntries = await this.prisma.timeEntry.findMany({
-      where: { date: { gte: start, lte: end } },
+      where: { date: { gte: start, lte: end }, isDeleted: false },
       select: { userId: true, hours: true, user: { select: { id: true, name: true } } },
     });
 
@@ -438,7 +438,7 @@ export class ReportV2Service {
 
     const taskIds = kpis.flatMap((k) => k.taskLinks.map((tl) => tl.taskId));
     const timeEntries = await this.prisma.timeEntry.findMany({
-      where: { taskId: { in: taskIds } },
+      where: { taskId: { in: taskIds }, isDeleted: false },
       select: { taskId: true, hours: true },
     });
 
@@ -502,6 +502,7 @@ export class ReportV2Service {
       where: {
         date: { gte: start, lte: end },
         overtimeType: { not: "NONE" },
+        isDeleted: false,
       },
       select: {
         userId: true,

--- a/services/time-entry-service.ts
+++ b/services/time-entry-service.ts
@@ -105,6 +105,8 @@ export class TimeEntryService {
       };
     }
 
+    where.isDeleted = false;
+
     return this.prisma.timeEntry.findMany({
       where,
       include: {
@@ -160,7 +162,7 @@ export class TimeEntryService {
     callerId: string,
     callerRole: CallerRole
   ) {
-    const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
+    const existing = await this.prisma.timeEntry.findFirst({ where: { id, isDeleted: false } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
 
     // TS-04: Locked entries cannot be modified
@@ -198,7 +200,7 @@ export class TimeEntryService {
    * TS-04: Locked entries cannot be deleted.
    */
   async deleteTimeEntry(id: string, callerId: string, callerRole: CallerRole) {
-    const existing = await this.prisma.timeEntry.findUnique({ where: { id } });
+    const existing = await this.prisma.timeEntry.findFirst({ where: { id, isDeleted: false } });
     if (!existing) throw new NotFoundError(`TimeEntry not found: ${id}`);
 
     // TS-04: Locked entries cannot be deleted
@@ -221,7 +223,7 @@ export class TimeEntryService {
   async startTimer(input: StartTimerInput) {
     // Check for existing running timer
     const running = await this.prisma.timeEntry.findFirst({
-      where: { userId: input.userId, isRunning: true },
+      where: { userId: input.userId, isRunning: true, isDeleted: false },
     });
     if (running) {
       throw new ValidationError("已有計時器正在運行，請先停止後再啟動新的");
@@ -252,7 +254,7 @@ export class TimeEntryService {
    */
   async stopTimer(userId: string) {
     const running = await this.prisma.timeEntry.findFirst({
-      where: { userId, isRunning: true },
+      where: { userId, isRunning: true, isDeleted: false },
     });
     if (!running) {
       throw new NotFoundError("沒有正在運行的計時器");
@@ -280,7 +282,7 @@ export class TimeEntryService {
    */
   async getRunningTimer(userId: string) {
     return this.prisma.timeEntry.findFirst({
-      where: { userId, isRunning: true },
+      where: { userId, isRunning: true, isDeleted: false },
       include: {
         task: { select: { id: true, title: true } },
         user: { select: { id: true, name: true } },


### PR DESCRIPTION
Closes #1361. 6 service methods + 15 cross-service queries adding isDeleted: false filter. Fixes T1340 regression where service layer didn't filter deleted entries.