### PR TITLE
fix(T1362): pagination on 8 unbounded list endpoints

### DIFF
--- a/__tests__/api/permissions.test.ts
+++ b/__tests__/api/permissions.test.ts
@@ -6,7 +6,7 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockPermission = { findMany: jest.fn(), create: jest.fn(), updateMany: jest.fn() };
+const mockPermission = { findMany: jest.fn(), count: jest.fn().mockResolvedValue(1), create: jest.fn(), updateMany: jest.fn() };
 const mockAuditLog = { create: jest.fn() };
 
 jest.mock("@/lib/prisma", () => ({
@@ -50,7 +50,8 @@ describe("GET /api/permissions", () => {
     const res = await GET(createMockRequest("/api/permissions"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("perm-1");
+    // T1362: response now wrapped in { items, total, page, limit }
+    expect(body.data.items[0].id).toBe("perm-1");
   });
 
   it("returns 403 for non-manager", async () => {

--- a/__tests__/api/plans.test.ts
+++ b/__tests__/api/plans.test.ts
@@ -6,7 +6,7 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockAnnualPlan = { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockAnnualPlan = { findMany: jest.fn(), findFirst: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), count: jest.fn().mockResolvedValue(1) };
 
 jest.mock("@/lib/prisma", () => ({ prisma: { annualPlan: mockAnnualPlan } }));
 
@@ -40,7 +40,7 @@ describe("GET /api/plans", () => {
     const res = await GET(createMockRequest("/api/plans"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("plan-1");
+    expect(body.data.items[0].id).toBe("plan-1");
   });
 
   it("returns 401 when no session", async () => {

--- a/__tests__/api/tdd3-kpi-milestones.test.ts
+++ b/__tests__/api/tdd3-kpi-milestones.test.ts
@@ -23,7 +23,7 @@ const mockMilestone = {
   create: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
-  count: jest.fn(),
+  count: jest.fn().mockResolvedValue(1), // T1362: pagination calls count by default
 };
 
 const mockKPI = {
@@ -128,8 +128,9 @@ describe("GET /api/milestones", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
-    expect(body.data).toHaveLength(1);
-    expect(body.data[0].id).toBe("ms-1");
+    // T1362: response wrapped in { items, total, page, limit }
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].id).toBe("ms-1");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/__tests__/integration/api-security-middleware.test.ts
+++ b/__tests__/integration/api-security-middleware.test.ts
@@ -23,6 +23,7 @@ const mockUser = {
   findUnique: jest.fn(),
   create: jest.fn(),
   update: jest.fn(),
+  count: jest.fn().mockResolvedValue(1), // T1362: pagination
 };
 const mockKPI = {
   findMany: jest.fn(),
@@ -226,7 +227,7 @@ describe("A3: GET /api/users — withAuth middleware", () => {
     const res = await GET(createMockRequest("/api/users"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("user-1");
+    expect(body.data.items[0].id).toBe("user-1");
   });
 
   it("unauthenticated user receives 401", async () => {

--- a/app/api/deliverables/route.ts
+++ b/app/api/deliverables/route.ts
@@ -5,6 +5,7 @@ import { success } from "@/lib/api-response";
 import { DeliverableService } from "@/services/deliverable-service";
 import { listDeliverablesSchema, createDeliverableSchema } from "@/validators/deliverable-validators";
 import { withAuth, withManager } from "@/lib/auth-middleware";
+import { parsePagination } from "@/lib/pagination";
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
@@ -24,9 +25,15 @@ export const GET = withAuth(async (req: NextRequest) => {
     );
   }
 
+  const { page, limit, skip } = parsePagination(searchParams);
   const service = new DeliverableService(prisma);
-  const deliverables = await service.listDeliverables(query.data);
-  return success(deliverables);
+
+  const [deliverables, total] = await Promise.all([
+    service.listDeliverables(query.data, { skip, take: limit }),
+    service.countDeliverables(query.data),
+  ]);
+
+  return success({ items: deliverables, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -6,27 +6,36 @@ import { withAuth, withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
 import { ValidationError } from "@/services/errors";
 import { parseMonth } from "@/lib/query-params";
+import { parsePagination } from "@/lib/pagination";
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const planId = searchParams.get("planId");
   const month = searchParams.get("month");
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  const goals = await prisma.monthlyGoal.findMany({
-    where: {
-      ...(planId && { annualPlanId: planId }),
-      ...(month !== null && { month: parseMonth(month) }),
-    },
-    include: {
-      annualPlan: { select: { id: true, title: true, year: true, archivedAt: true } },
-      assignee: { select: { id: true, name: true, avatar: true } },
-      _count: { select: { tasks: true } },
-      deliverables: true,
-    },
-    orderBy: [{ annualPlanId: "asc" }, { month: "asc" }],
-  });
+  const where = {
+    ...(planId && { annualPlanId: planId }),
+    ...(month !== null && { month: parseMonth(month) }),
+  };
 
-  return success(goals);
+  const [goals, total] = await Promise.all([
+    prisma.monthlyGoal.findMany({
+      where,
+      include: {
+        annualPlan: { select: { id: true, title: true, year: true, archivedAt: true } },
+        assignee: { select: { id: true, name: true, avatar: true } },
+        _count: { select: { tasks: true } },
+        deliverables: true,
+      },
+      orderBy: [{ annualPlanId: "asc" }, { month: "asc" }],
+      skip,
+      take: limit,
+    }),
+    prisma.monthlyGoal.count({ where }),
+  ]);
+
+  return success({ items: goals, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/milestones/route.ts
+++ b/app/api/milestones/route.ts
@@ -5,16 +5,24 @@ import { createMilestoneSchema } from "@/validators/milestone-validators";
 import { MilestoneService } from "@/services/milestone-service";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { parsePagination } from "@/lib/pagination";
 
 const getService = () => new MilestoneService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const planId = searchParams.get("planId") ?? undefined;
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  const milestones = await getService().listMilestones({ planId });
+  const filter = { planId };
+  const svc = getService();
 
-  return success(milestones);
+  const [milestones, total] = await Promise.all([
+    svc.listMilestones(filter, { skip, take: limit }),
+    svc.countMilestones(filter),
+  ]);
+
+  return success({ items: milestones, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -7,6 +7,7 @@ import { PermissionService } from "@/services/permission-service";
 import { AuditService } from "@/services/audit-service";
 import { prisma } from "@/lib/prisma";
 import { getClientIp } from "@/lib/get-client-ip";
+import { parsePagination } from "@/lib/pagination";
 
 const permissionService = new PermissionService(prisma);
 const auditService = new AuditService(prisma);
@@ -19,14 +20,16 @@ export const GET = withManager(async (req: NextRequest) => {
   const isActiveParam = url.searchParams.get("isActive");
   const isActive =
     isActiveParam === "true" ? true : isActiveParam === "false" ? false : undefined;
+  const { page, limit, skip } = parsePagination(url.searchParams);
 
-  const permissions = await permissionService.listPermissions({
-    granteeId,
-    permType,
-    isActive,
-  });
+  const filter = { granteeId, permType, isActive };
 
-  return success(permissions);
+  const [permissions, total] = await Promise.all([
+    permissionService.listPermissions(filter, { skip, take: limit }),
+    permissionService.countPermissions(filter),
+  ]);
+
+  return success({ items: permissions, total, page, limit });
 });
 
 /** POST /api/permissions — grant a permission (MANAGER only) */

--- a/app/api/plans/route.ts
+++ b/app/api/plans/route.ts
@@ -7,18 +7,23 @@ import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { parseYearOptional } from "@/lib/query-params";
+import { parsePagination } from "@/lib/pagination";
 
 const planService = new PlanService(prisma);
 
 export const GET = withAuth(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const year = searchParams.get("year");
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  const plans = await planService.listPlans({
-    year: parseYearOptional(year),
-  });
+  const filter = { year: parseYearOptional(year) };
 
-  return success(plans);
+  const [plans, total] = await Promise.all([
+    planService.listPlans(filter, { skip, take: limit }),
+    planService.countPlans(filter),
+  ]);
+
+  return success({ items: plans, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/reading-lists/route.ts
+++ b/app/api/reading-lists/route.ts
@@ -5,17 +5,29 @@ import { requireAuth } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
 import { createReadingListSchema } from "@/validators/reading-list-validators";
 import { success } from "@/lib/api-response";
+import { parsePagination } from "@/lib/pagination";
 
-export const GET = withAuth(async () => {
-  const lists = await prisma.readingList.findMany({
-    include: {
-      creator: { select: { id: true, name: true } },
-      _count: { select: { items: true, assignments: true } },
-    },
-    orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
-  });
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  return success(lists);
+  const where = {};
+
+  const [lists, total] = await Promise.all([
+    prisma.readingList.findMany({
+      where,
+      include: {
+        creator: { select: { id: true, name: true } },
+        _count: { select: { items: true, assignments: true } },
+      },
+      orderBy: [{ isDefault: "desc" }, { createdAt: "desc" }],
+      skip,
+      take: limit,
+    }),
+    prisma.readingList.count({ where }),
+  ]);
+
+  return success({ items: lists, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/app/api/spaces/route.ts
+++ b/app/api/spaces/route.ts
@@ -5,17 +5,29 @@ import { createSpaceSchema } from "@/validators/space-validators";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { parsePagination } from "@/lib/pagination";
 
-export const GET = withAuth(async (_req: NextRequest) => {
-  const spaces = await prisma.knowledgeSpace.findMany({
-    include: {
-      creator: { select: { id: true, name: true } },
-      _count: { select: { documents: true } },
-    },
-    orderBy: { name: "asc" },
-  });
+export const GET = withAuth(async (req: NextRequest) => {
+  const { searchParams } = new URL(req.url);
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  return success({ items: spaces });
+  const where = {};
+
+  const [spaces, total] = await Promise.all([
+    prisma.knowledgeSpace.findMany({
+      where,
+      include: {
+        creator: { select: { id: true, name: true } },
+        _count: { select: { documents: true } },
+      },
+      orderBy: { name: "asc" },
+      skip,
+      take: limit,
+    }),
+    prisma.knowledgeSpace.count({ where }),
+  ]);
+
+  return success({ items: spaces, total, page, limit });
 });
 
 export const POST = withAuth(async (req: NextRequest) => {

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -8,6 +8,7 @@ import { success } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { getClientIp } from "@/lib/get-client-ip";
+import { parsePagination } from "@/lib/pagination";
 
 const userService = new UserService(prisma);
 const auditService = new AuditService(prisma);
@@ -17,9 +18,16 @@ export const GET = withAuth(async (req: NextRequest) => {
   const includeSuspended = searchParams.get("includeSuspended") === "true";
   const search = searchParams.get("search") ?? undefined;
   const role = searchParams.get("role") ?? undefined;
+  const { page, limit, skip } = parsePagination(searchParams);
 
-  const users = await userService.listUsers({ includeSuspended, search, role });
-  return success(users);
+  const filter = { includeSuspended, search, role };
+
+  const [users, total] = await Promise.all([
+    userService.listUsers(filter, { skip, take: limit }),
+    userService.countUsers(filter),
+  ]);
+
+  return success({ items: users, total, page, limit });
 });
 
 export const POST = withManager(async (req: NextRequest) => {

--- a/lib/__tests__/rbac-coverage.test.ts
+++ b/lib/__tests__/rbac-coverage.test.ts
@@ -67,6 +67,7 @@ jest.mock("@/lib/prisma", () => ({
 jest.mock("@/services/deliverable-service", () => ({
   DeliverableService: jest.fn().mockImplementation(() => ({
     listDeliverables: jest.fn().mockResolvedValue([]),
+    countDeliverables: jest.fn().mockResolvedValue(0), // T1362: pagination support
     createDeliverable: jest.fn().mockResolvedValue({ id: "d1" }),
     getDeliverable: jest.fn().mockResolvedValue({ id: "d1" }),
   })),

--- a/services/deliverable-service.ts
+++ b/services/deliverable-service.ts
@@ -31,7 +31,10 @@ export interface UpdateDeliverableInput {
 export class DeliverableService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async listDeliverables(filter: ListDeliverablesFilter) {
+  async listDeliverables(
+    filter: ListDeliverablesFilter,
+    pagination?: { skip: number; take: number }
+  ) {
     const where: Record<string, unknown> = {};
 
     if (filter.taskId) where.taskId = filter.taskId;
@@ -51,7 +54,21 @@ export class DeliverableService {
         acceptor: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: "desc" },
+      ...(pagination ?? {}),
     });
+  }
+
+  async countDeliverables(filter: ListDeliverablesFilter) {
+    const where: Record<string, unknown> = {};
+
+    if (filter.taskId) where.taskId = filter.taskId;
+    if (filter.kpiId) where.kpiId = filter.kpiId;
+    if (filter.annualPlanId) where.annualPlanId = filter.annualPlanId;
+    if (filter.monthlyGoalId) where.monthlyGoalId = filter.monthlyGoalId;
+    if (filter.status) where.status = filter.status;
+    if (filter.type) where.type = filter.type;
+
+    return this.prisma.deliverable.count({ where });
   }
 
   async getDeliverable(id: string) {

--- a/services/milestone-service.ts
+++ b/services/milestone-service.ts
@@ -31,15 +31,29 @@ export interface UpdateMilestoneInput {
 export class MilestoneService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async listMilestones(filter: ListMilestonesFilter) {
+  async listMilestones(
+    filter: ListMilestonesFilter,
+    pagination?: { skip: number; take: number }
+  ) {
+    const where = {
+      ...(filter.planId && { annualPlanId: filter.planId }),
+    };
+
     return this.prisma.milestone.findMany({
-      where: {
-        ...(filter.planId && { annualPlanId: filter.planId }),
-      },
+      where,
       include: {
         annualPlan: { select: { id: true, title: true, year: true } },
       },
       orderBy: [{ order: "asc" }, { plannedEnd: "asc" }],
+      ...(pagination ?? {}),
+    });
+  }
+
+  async countMilestones(filter: ListMilestonesFilter) {
+    return this.prisma.milestone.count({
+      where: {
+        ...(filter.planId && { annualPlanId: filter.planId }),
+      },
     });
   }
 

--- a/services/permission-service.ts
+++ b/services/permission-service.ts
@@ -69,7 +69,10 @@ export class PermissionService {
   /**
    * List all permission records matching the given filter.
    */
-  async listPermissions(filter: ListPermissionsFilter) {
+  async listPermissions(
+    filter: ListPermissionsFilter,
+    pagination?: { skip: number; take: number }
+  ) {
     const where: Record<string, unknown> = {};
     if (filter.granteeId !== undefined) where.granteeId = filter.granteeId;
     if (filter.granterId !== undefined) where.granterId = filter.granterId;
@@ -83,7 +86,18 @@ export class PermissionService {
         granter: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: "desc" },
+      ...(pagination ?? {}),
     });
+  }
+
+  async countPermissions(filter: ListPermissionsFilter) {
+    const where: Record<string, unknown> = {};
+    if (filter.granteeId !== undefined) where.granteeId = filter.granteeId;
+    if (filter.granterId !== undefined) where.granterId = filter.granterId;
+    if (filter.permType !== undefined) where.permType = filter.permType;
+    if (filter.isActive !== undefined) where.isActive = filter.isActive;
+
+    return this.prisma.permission.count({ where });
   }
 
   /**

--- a/services/plan-service.ts
+++ b/services/plan-service.ts
@@ -44,9 +44,14 @@ export interface UpdatePlanInput {
 export class PlanService {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async listPlans(filter: ListPlansFilter) {
+  async listPlans(
+    filter: ListPlansFilter,
+    pagination?: { skip: number; take: number }
+  ) {
+    const where = filter.year ? { year: filter.year } : undefined;
+
     const plans = await this.prisma.annualPlan.findMany({
-      where: filter.year ? { year: filter.year } : undefined,
+      where,
       include: {
         creator: { select: { id: true, name: true } },
         milestones: { orderBy: { order: "asc" } },
@@ -57,6 +62,7 @@ export class PlanService {
         _count: { select: { monthlyGoals: true } },
       },
       orderBy: [{ year: "desc" }, { createdAt: "desc" }],
+      ...(pagination ?? {}),
     });
 
     // Auto-compute progressPct from goal statuses
@@ -64,6 +70,12 @@ export class PlanService {
       ...plan,
       progressPct: calculatePlanProgress(plan.monthlyGoals),
     }));
+  }
+
+  async countPlans(filter: ListPlansFilter) {
+    return this.prisma.annualPlan.count({
+      where: filter.year ? { year: filter.year } : undefined,
+    });
   }
 
   async getPlan(id: string) {

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -37,7 +37,10 @@ export class UserService {
     this.auditor = new AuditService(prisma);
   }
 
-  async listUsers(filter: ListUsersFilter) {
+  async listUsers(
+    filter: ListUsersFilter,
+    pagination?: { skip: number; take: number }
+  ) {
     const where: Record<string, unknown> = {};
     if (filter.role) where.role = filter.role;
     // By default exclude suspended (isActive = false)
@@ -66,7 +69,23 @@ export class UserService {
         createdAt: true,
       },
       orderBy: { name: "asc" },
+      ...(pagination ?? {}),
     });
+  }
+
+  async countUsers(filter: ListUsersFilter) {
+    const where: Record<string, unknown> = {};
+    if (filter.role) where.role = filter.role;
+    if (!filter.includeSuspended) {
+      where.isActive = true;
+    }
+    if (filter.search) {
+      where.OR = [
+        { name: { contains: filter.search, mode: "insensitive" } },
+        { email: { contains: filter.search, mode: "insensitive" } },
+      ];
+    }
+    return this.prisma.user.count({ where });
   }
 
   async getUser(id: string) {


### PR DESCRIPTION
Closes #1362. Adds parsePagination + count to 8 routes. Frontend transparent via existing extractItems helper.