### PR TITLE
fix(security): wrap logout + reset-password in apiHandler

### DIFF
--- a/__tests__/api/jwt-auth-flow.test.ts
+++ b/__tests__/api/jwt-auth-flow.test.ts
@@ -207,7 +207,7 @@ describe("POST /api/auth/logout", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("should revoke refresh token on logout", async () => {
-    mockAuthFn.mockResolvedValueOnce({ user: { id: "user-1" } });
+    mockAuthFn.mockResolvedValue({ user: { id: "user-1" } });
     const req = new NextRequest("http://localhost/api/auth/logout", {
       method: "POST", body: JSON.stringify({ refreshToken: "some-token" }),
     });
@@ -219,7 +219,7 @@ describe("POST /api/auth/logout", () => {
   });
 
   it("should revoke all tokens when no specific token given", async () => {
-    mockAuthFn.mockResolvedValueOnce({ user: { id: "user-1" } });
+    mockAuthFn.mockResolvedValue({ user: { id: "user-1" } });
     const req = new NextRequest("http://localhost/api/auth/logout", {
       method: "POST", body: "{}",
     });

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -6,15 +6,18 @@
  */
 
 import { NextRequest } from "next/server";
-import { success, error } from "@/lib/api-response";
+import { success } from "@/lib/api-response";
 import { revokeRefreshToken, revokeAllRefreshTokens } from "@/lib/auth/jwt";
 import { auth } from "@/auth";
 import { logger } from "@/lib/logger";
 import { prisma } from "@/lib/prisma";
 import { AuditService } from "@/services/audit-service";
 import { JwtBlacklist } from "@/lib/jwt-blacklist";
+import { apiHandler } from "@/lib/api-handler";
 
-export async function POST(req: NextRequest) {
+// Wrapped in apiHandler so the CSRF validator runs (Round 7: custom
+// /api/auth/* routes are no longer blanket-exempted from CSRF).
+export const POST = apiHandler(async (req: NextRequest) => {
   let body: { refreshToken?: string } = {};
   try {
     body = await req.json();
@@ -60,4 +63,4 @@ export async function POST(req: NextRequest) {
   }
 
   return success({ message: "已登出" });
-}
+});

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -20,6 +20,7 @@ import { AuditService } from "@/services/audit-service";
 import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/get-client-ip";
 import { createLoginRateLimiter, checkRateLimit } from "@/lib/rate-limiter";
+import { apiHandler } from "@/lib/api-handler";
 
 const auditService = new AuditService(prisma);
 
@@ -30,7 +31,9 @@ const resetRateLimiter = createLoginRateLimiter({
   duration: 300,
 });
 
-export async function POST(req: NextRequest) {
+// Wrapped in apiHandler so CSRF validator runs (Round 7: custom
+// /api/auth/* routes are no longer blanket-exempted from CSRF).
+export const POST = apiHandler(async (req: NextRequest) => {
   const ip = getClientIp(req);
 
   // Rate limit by IP before any DB work. Same skip rule as mobile login (#1214).
@@ -142,4 +145,4 @@ export async function POST(req: NextRequest) {
   });
 
   return success({ message: "密碼已成功重設，請使用新密碼登入" });
-}
+});


### PR DESCRIPTION
Follow-up to #1368. Two custom auth routes were CSRF-bypassed because they didn't use apiHandler at all.