### PR TITLE
fix: don't fetch password + cap error-report fields

### DIFF
--- a/app/api/error-report/route.ts
+++ b/app/api/error-report/route.ts
@@ -41,11 +41,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "message required" }, { status: 400 });
     }
 
+    // Cap each field to prevent log-flood DoS via giant payloads.
     const detail = JSON.stringify({
       message: String(message).slice(0, 2000),
-      digest: digest ?? null,
-      source: source ?? "unknown",
-      url: url ?? null,
+      digest: digest ? String(digest).slice(0, 200) : null,
+      source: source ? String(source).slice(0, 100) : "unknown",
+      url: url ? String(url).slice(0, 500) : null,
       userAgent: req.headers.get("user-agent")?.slice(0, 500) ?? null,
     });
 

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -118,6 +118,7 @@ export class UserService {
     // Check for duplicate email
     const existing = await this.prisma.user.findUnique({
       where: { email: input.email },
+      select: { id: true },
     });
     if (existing) {
       throw new ValidationError(`Email already in use: ${input.email}`);
@@ -146,13 +147,18 @@ export class UserService {
   }
 
   async updateUser(id: string, input: UpdateUserInput) {
-    const existing = await this.prisma.user.findUnique({ where: { id } });
+    // Don't fetch password — only diffable fields needed below
+    const existing = await this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, name: true, email: true, role: true, avatar: true, isActive: true },
+    });
     if (!existing) throw new NotFoundError(`User not found: ${id}`);
 
     // Validate email uniqueness
     if (input.email && input.email !== existing.email) {
       const conflict = await this.prisma.user.findUnique({
         where: { email: input.email },
+        select: { id: true },
       });
       if (conflict) {
         throw new ValidationError(`Email already in use: ${input.email}`);


### PR DESCRIPTION
Two small hardenings: avoid pulling password hash when only checking existence; cap unauthenticated error-report payload sizes.