### PR TITLE
fix(security): CSV/Excel formula injection in exports

### DIFF
--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -253,8 +253,14 @@ interface CsvColumn {
  * Handles quoting for values containing commas, quotes, or newlines.
  */
 function generateCsv(rows: Record<string, unknown>[], columns: CsvColumn[]): string {
+  // CSV-injection defense: neutralize cells starting with formula triggers.
+  // Excel/LibreOffice auto-evaluate =cmd|'/c calc'!A1 → RCE.
+  const FORMULA_PREFIXES = new Set(["=", "+", "-", "@", "\t", "\r"]);
   const escapeCsvField = (value: unknown): string => {
-    const str = value == null ? "" : String(value);
+    let str = value == null ? "" : String(value);
+    if (str.length > 0 && FORMULA_PREFIXES.has(str[0])) {
+      str = "\t" + str;
+    }
     // Quote fields that contain comma, double-quote, or newline
     if (str.includes(",") || str.includes('"') || str.includes("\n")) {
       return `"${str.replace(/"/g, '""')}"`;

--- a/app/components/timesheet/use-monthly-timesheet.ts
+++ b/app/components/timesheet/use-monthly-timesheet.ts
@@ -340,8 +340,14 @@ export function useMonthlyTimesheet() {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function escapeCSV(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-    return `"${value.replace(/"/g, '""')}"`;
+  // CSV-injection defense: neutralize formula prefix at start of cell.
+  // Excel/LibreOffice auto-evaluate =, +, -, @ → can lead to RCE / data exfil.
+  let str = value;
+  if (str.length > 0 && (str[0] === "=" || str[0] === "+" || str[0] === "-" || str[0] === "@" || str[0] === "\t" || str[0] === "\r")) {
+    str = "\t" + str;
   }
-  return value;
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
 }

--- a/lib/utils/csv-builder.ts
+++ b/lib/utils/csv-builder.ts
@@ -14,11 +14,30 @@ export interface CsvColumn {
 }
 
 /**
- * Escape a CSV field value according to RFC 4180.
- * Quotes fields containing commas, double-quotes, or newlines.
+ * Characters that Excel/LibreOffice/Numbers interpret as formula prefix
+ * when found at the start of a cell. An attacker who controls a CSV cell
+ * can inject formulas like =cmd|'/c calc'!A1 or =HYPERLINK("evil.com").
+ *
+ * Mitigation: prefix the cell with a single tab, which Excel renders as
+ * empty and a sane importer ignores. Per OWASP CSV-Injection prevention.
+ */
+const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * Escape a CSV field value according to RFC 4180 plus CSV-injection
+ * prevention (OWASP).
+ *
+ * - Prefixes formula triggers (= + - @) with a tab to neutralize.
+ * - Quotes fields containing commas, double-quotes, or newlines.
  */
 export function escapeCsvField(value: unknown): string {
-  const str = value == null ? "" : String(value);
+  let str = value == null ? "" : String(value);
+
+  // CSV-injection defense: neutralize formula prefix at start of cell.
+  if (str.length > 0 && FORMULA_PREFIXES.includes(str[0])) {
+    str = "\t" + str;
+  }
+
   if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/services/export-service.ts
+++ b/services/export-service.ts
@@ -1,6 +1,23 @@
 import ExcelJS from "exceljs";
 import { formatLocalDate } from "@/lib/utils/date";
 
+/**
+ * Neutralize a value before writing to a spreadsheet cell so that Excel
+ * does not auto-evaluate it as a formula. Cells starting with =, +, -, @,
+ * tab, or CR are formula triggers per OWASP CSV-Injection prevention.
+ *
+ * Number/Date values are passed through unchanged so Excel can format
+ * them natively. Only string-typed cells need defense.
+ */
+function neutralizeFormula(value: unknown): unknown {
+  if (typeof value !== "string" || value.length === 0) return value;
+  const first = value[0];
+  if (first === "=" || first === "+" || first === "-" || first === "@" || first === "\t" || first === "\r") {
+    return "\t" + value;
+  }
+  return value;
+}
+
 export interface ExportColumn {
   header: string;
   key: string;
@@ -25,7 +42,8 @@ export class ExportService {
     for (const row of data) {
       const rowData: Record<string, unknown> = {};
       for (const col of columns) {
-        rowData[col.key] = row[col.key] ?? "";
+        // Neutralize formula triggers to prevent CSV/Excel injection
+        rowData[col.key] = neutralizeFormula(row[col.key] ?? "");
       }
       worksheet.addRow(rowData);
     }


### PR DESCRIPTION
HIGH: 4 export paths allowed CSV formula injection. Banking IT exports to Excel daily — attacker-controlled task titles starting with = could RCE on the recipient's machine. Per OWASP defense applied.