### PR TITLE
fix(security): enforce JWT blacklist on web requireAuth path

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -221,6 +221,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         session.user.mustChangePassword = token.mustChangePassword as boolean;
         session.user.passwordChangedAt = (token.passwordChangedAt as string) ?? null;
         session.user.hasCompletedOnboarding = (token.hasCompletedOnboarding as boolean) ?? false; // Issue #1315
+        // Propagate sessionId so requireAuth() can enforce JWT blacklist on web path
+        (session as { sessionId?: string }).sessionId = (token as { sessionId?: string }).sessionId;
       }
       return session;
     },

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -51,6 +51,15 @@ export async function requireAuth(): Promise<AuthSession> {
   if (!session || !session.user) {
     throw new UnauthorizedError("未授權");
   }
+
+  // [SA C-4 web path] Check if the session has been revoked via blacklist.
+  // Without this, a web cookie stays valid for up to 15 min after logout,
+  // defeating the revocation flow in /api/auth/logout.
+  const sessionId = (session as { sessionId?: string }).sessionId;
+  if (sessionId && await JwtBlacklist.has(`session:${sessionId}`)) {
+    throw new UnauthorizedError("Session 已撤銷");
+  }
+
   return session as AuthSession;
 }
 

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -17,6 +17,10 @@ declare module "next-auth" {
       passwordChangedAt?: string | null; // Issue #834: password expiry tracking
       hasCompletedOnboarding?: boolean;  // Issue #1315: onboarding flow
     } & DefaultSession["user"];
+    // Issue #184: propagated from JWT so requireAuth() can check the
+    // web-session blacklist (T1352 follow-up — web path had no revocation
+    // enforcement until the JWT expired naturally).
+    sessionId?: string;
   }
 
   interface User {


### PR DESCRIPTION
HIGH: web path of requireAuth() never checked the blacklist, so logged-out users could keep using cookies for 15 min (until JWT expiry). The mobile path had this check; web did not. This closes the revocation gap.