### PR TITLE
fix(security): sanitizer iterative pass + drop backslash corruption

### DIFF
--- a/lib/security/__tests__/sanitize.test.ts
+++ b/lib/security/__tests__/sanitize.test.ts
@@ -57,6 +57,32 @@ describe("sanitizeHtml", () => {
     expect(result).not.toContain("<object");
     expect(result).not.toContain("<embed");
   });
+
+  // Regression: single-pass removal left a <script> behind when nested.
+  // Iterative pass now cleans these up.
+  test("defeats nested-tag script bypass", () => {
+    const html = "<scr<script>ipt>alert(1)</script><p>ok</p>";
+    const result = sanitizeHtml(html);
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("alert(1)");
+    expect(result).toContain("<p>ok</p>");
+  });
+
+  test("removes orphan opening script tag without close", () => {
+    const html = "<p>before</p><script>alert(1)<p>after</p>";
+    const result = sanitizeHtml(html);
+    expect(result).not.toContain("<script");
+    expect(result).toContain("<p>before</p>");
+  });
+
+  // Regression: old Pass 8 doubled all backslashes, corrupting legitimate
+  // content like file paths and code-block escape sequences.
+  test("preserves backslashes in legitimate content", () => {
+    const html = "<pre><code>path: C:\\Users\\name\\file.txt</code></pre>";
+    const result = sanitizeHtml(html);
+    expect(result).toContain("C:\\Users\\name\\file.txt");
+    expect(result).not.toContain("\\\\\\\\");
+  });
 });
 
 describe("sanitizeMarkdown", () => {

--- a/lib/security/sanitize.ts
+++ b/lib/security/sanitize.ts
@@ -82,14 +82,25 @@ export function sanitizeHtml(html: string): string {
 
   let result = html;
 
-  // Pass 1: Remove dangerous tags entirely (including their content)
-  for (const tag of DISALLOWED_TAGS) {
-    // Match opening tag with any attributes
-    const openTag = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
-    result = result.replace(openTag, "");
-    // Match self-closing/void tags
-    const voidTag = new RegExp(`<${tag}\\b[^>]*(?:\\/\\s*)?>`, "gi");
-    result = result.replace(voidTag, "");
+  // Pass 1: Remove dangerous tags entirely (including their content).
+  // Iterate until stable to defeat nested-tag bypasses like
+  //   <scr<script>ipt>alert(1)</script>
+  // where a single-pass removal leaves a valid <script> behind.
+  // Cap at 10 iterations to prevent pathological input from DoS'ing the loop.
+  for (let iter = 0; iter < 10; iter++) {
+    const before = result;
+    for (const tag of DISALLOWED_TAGS) {
+      // Match opening tag with any attributes
+      const openTag = new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi");
+      result = result.replace(openTag, "");
+      // Match self-closing/void tags
+      const voidTag = new RegExp(`<${tag}\\b[^>]*(?:\\/\\s*)?>`, "gi");
+      result = result.replace(voidTag, "");
+      // Match orphan opening tag without close (prevents <script> with no </script> surviving)
+      const orphanTag = new RegExp(`<${tag}\\b[^>]*>`, "gi");
+      result = result.replace(orphanTag, "");
+    }
+    if (result === before) break;
   }
 
   // Pass 2: Remove SVG-based XSS vectors (animate, set, animation, keyframe)
@@ -131,16 +142,17 @@ export function sanitizeHtml(html: string): string {
     'style=""'
   );
 
-  // Pass 8: Remove CSS escape sequences that could bypass filters
-  result = result.replace(/\\/g, "\\\\");
-
-  // Pass 9: Normalize whitespace in URLs to prevent bypass via special chars
+  // Pass 8: normalize whitespace in URLs to prevent bypass via special chars
+  // (Previous "double all backslashes" pass was removed — it corrupted
+  // legitimate content like Windows paths and code-block escape sequences
+  // without providing meaningful XSS protection. CSS expression() is
+  // already neutralized by Pass 7 on the style attribute itself.)
   result = result.replace(
     /(href|src)\s*=\s*["']\s*[\s\n\r\t]+/gi,
     '$1="'
   );
 
-  // Pass 10: Final sweep for any remaining XSS patterns
+  // Pass 9: Final sweep for any remaining XSS patterns
   for (const pattern of XSS_ATTR_PATTERNS) {
     result = result.replace(pattern, "");
   }


### PR DESCRIPTION
Two concrete sanitizer bugs found during manual review: nested-tag bypass and legitimate-content corruption via backslash doubling. 3 regression tests added. DOMPurify migration (#1326) still pending separately.