### PR TITLE
fix(security): server-side password expiry enforcement

### DIFF
--- a/lib/auth-middleware.ts
+++ b/lib/auth-middleware.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { requireAuth, requireMinRole } from "@/lib/rbac";
+import { requireAuth, requireMinRole, enforcePasswordChange } from "@/lib/rbac";
 import { apiHandler, RouteContext } from "@/lib/api-handler";
 import type { ApiResponse } from "@/lib/api-response";
 
@@ -13,21 +13,27 @@ type RouteHandler = (req: NextRequest, context?: any) => Promise<NextResponse<Ap
 
 export function withAuth<T extends RouteHandler>(fn: T): T {
   return apiHandler(async (req: NextRequest, context?: RouteContext) => {
-    await requireAuth();
+    const session = await requireAuth();
+    // Server-side enforcement of password change policy.
+    // If mustChangePassword is true (first login or expired), block
+    // non-exempt routes to prevent access with stale credentials.
+    enforcePasswordChange(session, new URL(req.url).pathname);
     return fn(req, context);
   }) as unknown as T;
 }
 
 export function withManager<T extends RouteHandler>(fn: T): T {
   return apiHandler(async (req: NextRequest, context?: RouteContext) => {
-    await requireMinRole("MANAGER");
+    const session = await requireMinRole("MANAGER");
+    enforcePasswordChange(session, new URL(req.url).pathname);
     return fn(req, context);
   }) as unknown as T;
 }
 
 export function withAdmin<T extends RouteHandler>(fn: T): T {
   return apiHandler(async (req: NextRequest, context?: RouteContext) => {
-    await requireMinRole("ADMIN");
+    const session = await requireMinRole("ADMIN");
+    enforcePasswordChange(session, new URL(req.url).pathname);
     return fn(req, context);
   }) as unknown as T;
 }

--- a/lib/rbac.ts
+++ b/lib/rbac.ts
@@ -20,6 +20,7 @@ export interface SessionUser {
   email?: string | null;
   image?: string | null;
   role: string;
+  mustChangePassword?: boolean;
 }
 
 export interface AuthSession {
@@ -61,6 +62,40 @@ export async function requireAuth(): Promise<AuthSession> {
   }
 
   return session as AuthSession;
+}
+
+/**
+ * Routes that are allowed even when mustChangePassword / password expired.
+ * Without this allowlist, the user would be locked out entirely with
+ * no way to change their password.
+ */
+const PASSWORD_CHANGE_ALLOWED_PATHS = new Set([
+  "/api/auth/change-password",
+  "/api/auth/logout",
+  "/api/auth/mobile/logout",
+  "/api/health",
+  "/api/error-report",
+]);
+
+/**
+ * Enforce server-side password change requirement.
+ *
+ * If the session has mustChangePassword=true (first login or password
+ * expired), block ALL API access except the password-change and
+ * logout endpoints. This prevents attackers from using an account
+ * with an expired/must-change password to access business data.
+ *
+ * Banking compliance: password expiry must be server-enforced, not
+ * just a client-side redirect hint.
+ */
+export function enforcePasswordChange(session: AuthSession, pathname: string): void {
+  const mustChange = session.user.mustChangePassword;
+  if (!mustChange) return;
+  if (PASSWORD_CHANGE_ALLOWED_PATHS.has(pathname)) return;
+  // Allow all /api/auth/* routes for login/logout flows
+  if (pathname.startsWith("/api/auth/")) return;
+
+  throw new ForbiddenError("密碼已過期或為初次登入，請先變更密碼");
 }
 
 /**


### PR DESCRIPTION
HIGH: mustChangePassword was client-side only. Attackers could bypass by calling API directly. Now enforced in withAuth/withManager/withAdmin.