### PR TITLE
fix(security): MANAGER → ADMIN privilege escalation (CRITICAL)

### DIFF
--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -30,6 +30,13 @@ export const PUT = withManager(async (
   const { id } = await context.params;
   const raw = await req.json();
   const body = validateBody(updateUserSchema, raw);
+
+  // Privilege escalation guard: only ADMIN can assign the ADMIN role.
+  // Without this, any MANAGER could promote themselves or others to ADMIN.
+  if (body.role === "ADMIN" && session.user.role !== "ADMIN") {
+    return error("ForbiddenError", "只有管理員可以指派管理員角色", 403);
+  }
+
   const user = await userService.updateUser(id, body);
 
   // Exclude sensitive fields from audit detail

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -4,7 +4,7 @@ import { UserService } from "@/services/user-service";
 import { AuditService } from "@/services/audit-service";
 import { validateBody } from "@/lib/validate";
 import { createUserSchema } from "@/validators/user-validators";
-import { success } from "@/lib/api-response";
+import { success, error } from "@/lib/api-response";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { getClientIp } from "@/lib/get-client-ip";
@@ -34,6 +34,12 @@ export const POST = withManager(async (req: NextRequest) => {
   const session = await requireRole("MANAGER");
   const raw = await req.json();
   const body = validateBody(createUserSchema, raw);
+
+  // Privilege escalation guard: only ADMIN can create ADMIN users
+  if (body.role === "ADMIN" && session.user.role !== "ADMIN") {
+    return error("ForbiddenError", "只有管理員可以建立管理員帳號", 403);
+  }
+
   const user = await userService.createUser(body);
 
   await auditService.log({

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -173,6 +173,8 @@ export class UserService {
     const updates: Record<string, unknown> = {};
     if (input.name !== undefined) updates.name = input.name;
     if (normalizedNewEmail !== undefined) updates.email = normalizedNewEmail;
+    // IMPORTANT: role escalation guard is in the API route, NOT here.
+    // The route checks session.user.role before allowing role=ADMIN.
     if (input.role !== undefined) updates.role = input.role;
     if (input.avatar !== undefined) updates.avatar = input.avatar;
     if (input.isActive !== undefined) updates.isActive = input.isActive;


### PR DESCRIPTION
CRITICAL: any MANAGER could set role=ADMIN on any user, including themselves. Now only ADMIN can assign ADMIN.