### PR TITLE
feat(T1321): daily personal + weekly manager email digest

### DIFF
--- a/app/api/cron/email-digest/route.ts
+++ b/app/api/cron/email-digest/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/cron/email-digest — Daily personal digest email (Issue #1321)
+ *
+ * Sends each active user a personalized daily digest at 08:00 containing:
+ *   - Today's due tasks (if any)
+ *   - Yesterday's new task assignments
+ *   - Unread @mention/comment count
+ *   - Pending approval count (MANAGER/ADMIN only)
+ *
+ * Called daily at 08:00 by titan-cron (reuses the daily-digest schedule slot).
+ * Protected by CRON_SECRET header (timingSafeEqual via verifyCronSecret).
+ */
+
+import { NextRequest } from "next/server";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { prisma } from "@/lib/prisma";
+import { EmailNotificationService } from "@/services/email-notification-service";
+import { logger } from "@/lib/logger";
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const service = new EmailNotificationService(prisma);
+  const now = new Date();
+  const result = await service.generateDailyDigest(now);
+
+  logger.info(
+    { event: "cron_email_digest_complete", ...result },
+    "Daily email digest complete"
+  );
+
+  return success({ ...result, timestamp: now.toISOString() });
+});

--- a/app/api/cron/weekly-manager-digest/route.ts
+++ b/app/api/cron/weekly-manager-digest/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/cron/weekly-manager-digest — Weekly manager summary email (Issue #1321)
+ *
+ * Sends a weekly summary to MANAGER and ADMIN users containing:
+ *   - Team health snapshot (overdue count, flagged count)
+ *   - This week's velocity (completed tasks count)
+ *   - KPI items behind schedule
+ *   - Next week's due items
+ *
+ * Called every Friday at 16:00 by titan-cron.
+ * Protected by CRON_SECRET header (timingSafeEqual via verifyCronSecret).
+ */
+
+import { NextRequest } from "next/server";
+import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { prisma } from "@/lib/prisma";
+import { EmailNotificationService } from "@/services/email-notification-service";
+import { logger } from "@/lib/logger";
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const service = new EmailNotificationService(prisma);
+  const now = new Date();
+  const result = await service.generateWeeklyManagerSummary(now);
+
+  logger.info(
+    { event: "cron_weekly_manager_digest_complete", ...result },
+    "Weekly manager digest complete"
+  );
+
+  return success({ ...result, timestamp: now.toISOString() });
+});

--- a/lib/email-templates/index.ts
+++ b/lib/email-templates/index.ts
@@ -131,3 +131,214 @@ export function timesheetReminderEmail(currentHours: number, targetHours: number
     ${WRAPPER_END}`,
   };
 }
+
+// ─── Issue #1321: Daily Personal Digest ───────────────────────────────────────
+
+export interface DigestTaskItem {
+  taskId: string;
+  taskTitle: string;
+  dueDate?: string; // formatted date string
+}
+
+export interface DigestItems {
+  dueTodayTasks: DigestTaskItem[];
+  newAssignments: DigestTaskItem[];
+  unreadMentionCount: number;
+  pendingApprovalCount: number; // MANAGER only; 0 for ENGINEER
+}
+
+export function dailyDigestEmail(
+  userName: string,
+  items: DigestItems,
+  date: string
+): { subject: string; html: string } {
+  const safeName = escapeHtml(userName);
+  const safeDate = escapeHtml(date);
+
+  const dueTodayRows = items.dueTodayTasks
+    .map(t => {
+      const safeTitle = escapeHtml(t.taskTitle);
+      const safeId = urlPart(t.taskId);
+      return `<tr>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0;">
+          <a href="${BASE_URL}/kanban?taskId=${safeId}" style="color: #4f46e5; text-decoration: none;">${safeTitle}</a>
+        </td>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0; color: #666; font-size: 13px; text-align: right;">${escapeHtml(t.dueDate ?? "")}</td>
+      </tr>`;
+    })
+    .join("");
+
+  const newAssignRows = items.newAssignments
+    .map(t => {
+      const safeTitle = escapeHtml(t.taskTitle);
+      const safeId = urlPart(t.taskId);
+      return `<tr>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0;">
+          <a href="${BASE_URL}/kanban?taskId=${safeId}" style="color: #4f46e5; text-decoration: none;">${safeTitle}</a>
+        </td>
+      </tr>`;
+    })
+    .join("");
+
+  const dueTodaySection =
+    items.dueTodayTasks.length > 0
+      ? `<h3 style="color: #f59e0b; margin: 24px 0 8px; font-size: 15px;">今日到期任務（${items.dueTodayTasks.length} 筆）</h3>
+         <table style="width: 100%; border-collapse: collapse;">${dueTodayRows}</table>`
+      : "";
+
+  const newAssignSection =
+    items.newAssignments.length > 0
+      ? `<h3 style="color: #4f46e5; margin: 24px 0 8px; font-size: 15px;">昨日新指派任務（${items.newAssignments.length} 筆）</h3>
+         <table style="width: 100%; border-collapse: collapse;">${newAssignRows}</table>`
+      : "";
+
+  const mentionSection =
+    items.unreadMentionCount > 0
+      ? `<div style="background: #f0f4ff; border-left: 4px solid #6366f1; padding: 10px 14px; margin: 16px 0; border-radius: 4px;">
+           <strong>${items.unreadMentionCount}</strong> 則未讀 @提及或留言，
+           <a href="${BASE_URL}/activity" style="color: #4f46e5;">前往查看</a>
+         </div>`
+      : "";
+
+  const approvalSection =
+    items.pendingApprovalCount > 0
+      ? `<div style="background: #fff7ed; border-left: 4px solid #f97316; padding: 10px 14px; margin: 16px 0; border-radius: 4px;">
+           <strong>${items.pendingApprovalCount}</strong> 筆申請待您審核，
+           <a href="${BASE_URL}/kanban" style="color: #f97316;">前往審核</a>
+         </div>`
+      : "";
+
+  return {
+    subject: safeSubject(`[TITAN] ${safeDate} 每日摘要`),
+    html: `${WRAPPER_START}
+      <h2 style="color: #333; margin: 0 0 4px;">每日工作摘要</h2>
+      <p style="color: #666; margin: 0 0 16px;">${safeName}，${safeDate}</p>
+      ${dueTodaySection}
+      ${newAssignSection}
+      ${mentionSection}
+      ${approvalSection}
+      <div style="margin-top: 20px;">
+        <a href="${BASE_URL}/dashboard" style="display: inline-block; background: #4f46e5; color: #fff; padding: 10px 20px; border-radius: 6px; text-decoration: none;">前往儀表板</a>
+      </div>
+    ${WRAPPER_END}`,
+  };
+}
+
+// ─── Issue #1321: Weekly Manager Summary ─────────────────────────────────────
+
+export interface KpiBehindItem {
+  kpiCode: string;
+  kpiTitle: string;
+  actual: number;
+  target: number;
+  unit: string;
+}
+
+export interface NextWeekDueItem {
+  taskId: string;
+  taskTitle: string;
+  dueDate: string;
+  assigneeName: string;
+}
+
+export interface ManagerSummary {
+  overdueCount: number;
+  flaggedCount: number;
+  weeklyCompletedCount: number;
+  kpiBehindItems: KpiBehindItem[];
+  nextWeekDueItems: NextWeekDueItem[];
+  weekLabel: string; // e.g. "2026/04/07 ~ 04/11"
+}
+
+export function weeklyManagerEmail(
+  userName: string,
+  summary: ManagerSummary
+): { subject: string; html: string } {
+  const safeName = escapeHtml(userName);
+  const safeWeek = escapeHtml(summary.weekLabel);
+
+  const kpiBehindRows = summary.kpiBehindItems
+    .map(k => {
+      const pct = k.target > 0 ? Math.round((k.actual / k.target) * 100) : 0;
+      return `<tr>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0; font-size: 13px;">${escapeHtml(k.kpiCode)}</td>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0;">${escapeHtml(k.kpiTitle)}</td>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0; color: #dc2626; text-align: right;">${k.actual} / ${k.target} ${escapeHtml(k.unit ?? "")} (${pct}%)</td>
+      </tr>`;
+    })
+    .join("");
+
+  const nextWeekRows = summary.nextWeekDueItems
+    .map(t => {
+      const safeId = urlPart(t.taskId);
+      return `<tr>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0;">
+          <a href="${BASE_URL}/kanban?taskId=${safeId}" style="color: #4f46e5; text-decoration: none;">${escapeHtml(t.taskTitle)}</a>
+        </td>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0; color: #666; font-size: 13px;">${escapeHtml(t.assigneeName)}</td>
+        <td style="padding: 8px 0; border-bottom: 1px solid #f0f0f0; color: #666; font-size: 13px; text-align: right;">${escapeHtml(t.dueDate)}</td>
+      </tr>`;
+    })
+    .join("");
+
+  const healthBlock = `
+    <div style="display: flex; gap: 16px; margin: 16px 0;">
+      <div style="flex: 1; background: #fef2f2; border-radius: 8px; padding: 14px 16px; text-align: center;">
+        <div style="font-size: 28px; font-weight: bold; color: #dc2626;">${summary.overdueCount}</div>
+        <div style="color: #666; font-size: 13px; margin-top: 4px;">逾期任務</div>
+      </div>
+      <div style="flex: 1; background: #fff7ed; border-radius: 8px; padding: 14px 16px; text-align: center;">
+        <div style="font-size: 28px; font-weight: bold; color: #f97316;">${summary.flaggedCount}</div>
+        <div style="color: #666; font-size: 13px; margin-top: 4px;">主管標記</div>
+      </div>
+      <div style="flex: 1; background: #f0fdf4; border-radius: 8px; padding: 14px 16px; text-align: center;">
+        <div style="font-size: 28px; font-weight: bold; color: #16a34a;">${summary.weeklyCompletedCount}</div>
+        <div style="color: #666; font-size: 13px; margin-top: 4px;">本週完成</div>
+      </div>
+    </div>`;
+
+  const kpiBehindSection =
+    summary.kpiBehindItems.length > 0
+      ? `<h3 style="color: #dc2626; margin: 24px 0 8px; font-size: 15px;">落後 KPI 項目（${summary.kpiBehindItems.length} 項）</h3>
+         <table style="width: 100%; border-collapse: collapse;">
+           <thead>
+             <tr style="color: #999; font-size: 12px; text-align: left;">
+               <th style="padding: 4px 0; font-weight: normal;">代碼</th>
+               <th style="padding: 4px 0; font-weight: normal;">名稱</th>
+               <th style="padding: 4px 0; font-weight: normal; text-align: right;">實績 / 目標</th>
+             </tr>
+           </thead>
+           <tbody>${kpiBehindRows}</tbody>
+         </table>`
+      : `<p style="color: #16a34a; margin: 16px 0;">✓ 本週無落後 KPI 項目</p>`;
+
+  const nextWeekSection =
+    summary.nextWeekDueItems.length > 0
+      ? `<h3 style="color: #4f46e5; margin: 24px 0 8px; font-size: 15px;">下週到期任務（${summary.nextWeekDueItems.length} 筆）</h3>
+         <table style="width: 100%; border-collapse: collapse;">
+           <thead>
+             <tr style="color: #999; font-size: 12px; text-align: left;">
+               <th style="padding: 4px 0; font-weight: normal;">任務</th>
+               <th style="padding: 4px 0; font-weight: normal;">負責人</th>
+               <th style="padding: 4px 0; font-weight: normal; text-align: right;">到期日</th>
+             </tr>
+           </thead>
+           <tbody>${nextWeekRows}</tbody>
+         </table>`
+      : "";
+
+  return {
+    subject: safeSubject(`[TITAN] ${safeWeek} 週報摘要`),
+    html: `${WRAPPER_START}
+      <h2 style="color: #333; margin: 0 0 4px;">每週主管摘要</h2>
+      <p style="color: #666; margin: 0 0 16px;">${safeName}，${safeWeek}</p>
+      <h3 style="color: #333; margin: 16px 0 8px; font-size: 15px;">團隊健康狀況</h3>
+      ${healthBlock}
+      ${kpiBehindSection}
+      ${nextWeekSection}
+      <div style="margin-top: 20px;">
+        <a href="${BASE_URL}/dashboard" style="display: inline-block; background: #4f46e5; color: #fff; padding: 10px 20px; border-radius: 6px; text-decoration: none;">前往儀表板</a>
+      </div>
+    ${WRAPPER_END}`,
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -805,6 +805,8 @@ enum NotificationType {
   SLA_EXPIRING          // Issue #860: SLA 即將到期
   VERIFICATION_DUE      // Issue #968: 文件驗證到期
   MANAGER_FLAG          // Issue #960: 主管標記任務
+  DAILY_DIGEST          // Issue #1321: 每日個人摘要
+  WEEKLY_DIGEST         // Issue #1321: 每週主管摘要
 }
 
 model Notification {

--- a/scripts/cron-entrypoint.sh
+++ b/scripts/cron-entrypoint.sh
@@ -30,8 +30,14 @@ cat > /etc/crontabs/root <<EOF
 # Every 15 minutes — trigger email notifications
 */15 * * * * ${CURL} ${TITAN_APP_URL}/api/cron/email-notifications || true
 
-# 08:00 daily — daily digest
+# 08:00 daily — daily digest (push notifications)
 0 8 * * * ${CURL} ${TITAN_APP_URL}/api/cron/daily-digest || true
+
+# 08:00 daily — daily personal digest email (Issue #1321)
+0 8 * * * ${CURL} ${TITAN_APP_URL}/api/cron/email-digest || true
+
+# 16:00 Fridays — weekly manager summary email (Issue #1321)
+0 16 * * 5 ${CURL} ${TITAN_APP_URL}/api/cron/weekly-manager-digest || true
 
 # 17:00 weekdays — daily reminder
 0 17 * * 1-5 ${CURL} ${TITAN_APP_URL}/api/cron/daily-reminder || true

--- a/services/email-notification-service.ts
+++ b/services/email-notification-service.ts
@@ -4,11 +4,25 @@
  * Scans for due/overdue tasks and sends email notifications.
  * Respects user NotificationPreference.emailEnabled.
  * Idempotent: uses NotificationLog to prevent duplicate sends within the same hour.
+ *
+ * Issue #1321: Also provides generateDailyDigest() and generateWeeklyManagerSummary().
  */
 
 import { PrismaClient } from "@prisma/client";
 import { sendEmail } from "@/lib/email";
-import { dueSoonEmail, overdueEmail, timesheetReminderEmail } from "@/lib/email-templates";
+import { logger } from "@/lib/logger";
+import {
+  dueSoonEmail,
+  overdueEmail,
+  timesheetReminderEmail,
+  dailyDigestEmail,
+  weeklyManagerEmail,
+  type DigestItems,
+  type DigestTaskItem,
+  type ManagerSummary,
+  type KpiBehindItem,
+  type NextWeekDueItem,
+} from "@/lib/email-templates";
 
 export interface TriggerResult {
   triggered: number;
@@ -257,6 +271,361 @@ export class EmailNotificationService {
         else failed++;
       }
     }
+
+    return { triggered, sent, failed, skipped };
+  }
+
+  // ─── Issue #1321: Daily Personal Digest ────────────────────────────────────
+
+  /**
+   * Generate and send daily personal digest emails (08:00 daily).
+   *
+   * Each user receives a single email with:
+   *   - Today's due tasks (≥1 triggers send)
+   *   - Yesterday's new task assignments
+   *   - Unread @mention/comment count (via Notification records)
+   *   - Pending approval count (MANAGER/ADMIN only)
+   *
+   * Skips users who have disabled DAILY_DIGEST notifications.
+   * Idempotent within the same hour via NotificationLog.
+   */
+  async generateDailyDigest(now: Date = new Date()): Promise<TriggerResult> {
+    const prefMap = await this.loadEmailPreferences();
+    const hourKey = new Date(now);
+    hourKey.setMinutes(0, 0, 0);
+    const hourKeyStr = hourKey.toISOString();
+
+    let triggered = 0;
+    let sent = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    // Date boundaries
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const todayEnd = new Date(todayStart);
+    todayEnd.setDate(todayEnd.getDate() + 1);
+
+    const yesterdayStart = new Date(todayStart);
+    yesterdayStart.setDate(yesterdayStart.getDate() - 1);
+
+    // Fetch all active users
+    const users = await this.prisma.user.findMany({
+      where: { isActive: true },
+      select: { id: true, email: true, name: true, role: true },
+    });
+
+    // Batch queries (not per-user, to avoid N+1)
+
+    // Tasks due today (not DONE, not sample)
+    const dueTodayTasks = await this.prisma.task.findMany({
+      where: {
+        status: { notIn: ["DONE"] },
+        isSample: false,
+        dueDate: { gte: todayStart, lt: todayEnd },
+        primaryAssigneeId: { not: null },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        primaryAssigneeId: true,
+      },
+    });
+
+    // Tasks assigned yesterday (not sample)
+    const newAssignedTasks = await this.prisma.task.findMany({
+      where: {
+        isSample: false,
+        createdAt: { gte: yesterdayStart, lt: todayStart },
+        primaryAssigneeId: { not: null },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        primaryAssigneeId: true,
+      },
+    });
+
+    // Unread notifications of type TASK_COMMENTED (as a proxy for @mentions/comments)
+    const unreadNotifs = await this.prisma.notification.findMany({
+      where: {
+        type: "TASK_COMMENTED",
+        isRead: false,
+      },
+      select: { userId: true },
+    });
+
+    // Pending approvals (for MANAGER/ADMIN) — any PENDING ApprovalRequest
+    const pendingApprovals = await this.prisma.approvalRequest.findMany({
+      where: { status: "PENDING" },
+      select: { approverId: true },
+    });
+
+    // Group by userId
+    const dueTodayByUser = new Map<string, DigestTaskItem[]>();
+    for (const t of dueTodayTasks) {
+      if (!t.primaryAssigneeId) continue;
+      const existing = dueTodayByUser.get(t.primaryAssigneeId) ?? [];
+      existing.push({
+        taskId: t.id,
+        taskTitle: t.title,
+        dueDate: t.dueDate ? new Date(t.dueDate).toLocaleDateString("zh-TW") : undefined,
+      });
+      dueTodayByUser.set(t.primaryAssigneeId, existing);
+    }
+
+    const newAssignByUser = new Map<string, DigestTaskItem[]>();
+    for (const t of newAssignedTasks) {
+      if (!t.primaryAssigneeId) continue;
+      const existing = newAssignByUser.get(t.primaryAssigneeId) ?? [];
+      existing.push({ taskId: t.id, taskTitle: t.title });
+      newAssignByUser.set(t.primaryAssigneeId, existing);
+    }
+
+    const unreadCountByUser = new Map<string, number>();
+    for (const n of unreadNotifs) {
+      unreadCountByUser.set(n.userId, (unreadCountByUser.get(n.userId) ?? 0) + 1);
+    }
+
+    // Pending approvals: count per approverId (null approverId = any manager gets notified)
+    const pendingCountByApprover = new Map<string, number>();
+    let pendingForAnyManager = 0;
+    for (const a of pendingApprovals) {
+      if (a.approverId) {
+        pendingCountByApprover.set(a.approverId, (pendingCountByApprover.get(a.approverId) ?? 0) + 1);
+      } else {
+        pendingForAnyManager++;
+      }
+    }
+
+    const dateLabel = todayStart.toLocaleDateString("zh-TW");
+
+    for (const user of users) {
+      const prefKey = `${user.id}:DAILY_DIGEST`;
+      if (prefMap.get(prefKey) === false) {
+        skipped++;
+        continue;
+      }
+
+      const dueTasks = dueTodayByUser.get(user.id) ?? [];
+      const newTasks = newAssignByUser.get(user.id) ?? [];
+      const mentionCount = unreadCountByUser.get(user.id) ?? 0;
+      const isManager = user.role === "MANAGER" || user.role === "ADMIN";
+
+      let pendingApprovalCount = 0;
+      if (isManager) {
+        pendingApprovalCount =
+          (pendingCountByApprover.get(user.id) ?? 0) + pendingForAnyManager;
+      }
+
+      // Skip if nothing to report
+      if (dueTasks.length === 0 && newTasks.length === 0 && mentionCount === 0 && pendingApprovalCount === 0) {
+        skipped++;
+        continue;
+      }
+
+      const items: DigestItems = {
+        dueTodayTasks: dueTasks,
+        newAssignments: newTasks,
+        unreadMentionCount: mentionCount,
+        pendingApprovalCount,
+      };
+
+      const email = dailyDigestEmail(user.name, items, dateLabel);
+      triggered++;
+
+      if (await this.alreadySent(user.email, email.subject, hourKeyStr)) {
+        skipped++;
+        continue;
+      }
+
+      const result = await sendEmail({ to: user.email, subject: email.subject, html: email.html });
+
+      await this.logSend({
+        recipient: user.email,
+        subject: email.subject,
+        status: result.success ? "sent" : "failed",
+        errorMessage: result.error,
+      });
+
+      if (result.success) sent++;
+      else failed++;
+    }
+
+    logger.info(
+      { event: "daily_digest_complete", triggered, sent, failed, skipped },
+      "Daily digest emails complete"
+    );
+
+    return { triggered, sent, failed, skipped };
+  }
+
+  // ─── Issue #1321: Weekly Manager Summary ───────────────────────────────────
+
+  /**
+   * Generate and send weekly manager summary emails (Friday 16:00).
+   *
+   * Sent to MANAGER and ADMIN users. Contains:
+   *   - Team health snapshot (overdue count, flagged count)
+   *   - This week's velocity (completed tasks)
+   *   - KPI items behind schedule (actual < target, ACTIVE status)
+   *   - Next week's due items
+   *
+   * Respects WEEKLY_DIGEST notification preference.
+   * Idempotent within the same hour via NotificationLog.
+   */
+  async generateWeeklyManagerSummary(now: Date = new Date()): Promise<TriggerResult> {
+    const prefMap = await this.loadEmailPreferences();
+    const hourKey = new Date(now);
+    hourKey.setMinutes(0, 0, 0);
+    const hourKeyStr = hourKey.toISOString();
+
+    let triggered = 0;
+    let sent = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    // Week boundaries
+    // Current week: Monday 00:00 → Sunday 23:59
+    const thisMonday = new Date(now);
+    const dayOfWeek = thisMonday.getDay() === 0 ? 6 : thisMonday.getDay() - 1; // Mon=0..Sun=6
+    thisMonday.setDate(thisMonday.getDate() - dayOfWeek);
+    thisMonday.setHours(0, 0, 0, 0);
+
+    const thisSunday = new Date(thisMonday);
+    thisSunday.setDate(thisSunday.getDate() + 7);
+
+    // Next week: Sun+1 (Mon) → Sun+8
+    const nextMonday = new Date(thisSunday);
+    const nextSunday = new Date(nextMonday);
+    nextSunday.setDate(nextSunday.getDate() + 7);
+
+    const weekLabel = `${thisMonday.toLocaleDateString("zh-TW")} ~ ${new Date(thisSunday.getTime() - 1).toLocaleDateString("zh-TW")}`;
+
+    // --- Batch queries ---
+
+    // Overdue count (not DONE, not sample, dueDate < now)
+    const overdueCount = await this.prisma.task.count({
+      where: {
+        status: { notIn: ["DONE"] },
+        isSample: false,
+        dueDate: { lt: now },
+      },
+    });
+
+    // Flagged count (managerFlagged, not DONE, not sample)
+    const flaggedCount = await this.prisma.task.count({
+      where: {
+        status: { notIn: ["DONE"] },
+        isSample: false,
+        managerFlagged: true,
+      },
+    });
+
+    // This week's completed tasks (status DONE, updatedAt in this week)
+    const weeklyCompletedCount = await this.prisma.task.count({
+      where: {
+        status: "DONE",
+        isSample: false,
+        updatedAt: { gte: thisMonday, lt: thisSunday },
+      },
+    });
+
+    // KPI items behind schedule: ACTIVE status, then filter actual < target in code
+    // (Prisma does not support column-to-column comparisons in where clauses without raw SQL)
+    const activeKpis = await this.prisma.kPI.findMany({
+      where: { status: "ACTIVE" },
+      select: {
+        id: true,
+        code: true,
+        title: true,
+        actual: true,
+        target: true,
+        unit: true,
+      },
+    });
+    const kpisBehind = activeKpis.filter(k => k.actual < k.target);
+
+    // Next week's due tasks (not DONE, not sample)
+    const nextWeekTasks = await this.prisma.task.findMany({
+      where: {
+        status: { notIn: ["DONE"] },
+        isSample: false,
+        dueDate: { gte: nextMonday, lt: nextSunday },
+      },
+      select: {
+        id: true,
+        title: true,
+        dueDate: true,
+        primaryAssignee: { select: { name: true } },
+      },
+      orderBy: { dueDate: "asc" },
+      take: 20, // cap to keep email readable
+    });
+
+    const kpiBehindItems: KpiBehindItem[] = kpisBehind.map(k => ({
+      kpiCode: k.code,
+      kpiTitle: k.title,
+      actual: k.actual,
+      target: k.target,
+      unit: k.unit ?? "",
+    }));
+
+    const nextWeekDueItems: NextWeekDueItem[] = nextWeekTasks.map(t => ({
+      taskId: t.id,
+      taskTitle: t.title,
+      dueDate: t.dueDate ? new Date(t.dueDate).toLocaleDateString("zh-TW") : "",
+      assigneeName: t.primaryAssignee?.name ?? "未指派",
+    }));
+
+    const summary: ManagerSummary = {
+      overdueCount,
+      flaggedCount,
+      weeklyCompletedCount,
+      kpiBehindItems,
+      nextWeekDueItems,
+      weekLabel,
+    };
+
+    // --- Send to MANAGER + ADMIN users ---
+    const managers = await this.prisma.user.findMany({
+      where: { isActive: true, role: { in: ["MANAGER", "ADMIN"] } },
+      select: { id: true, email: true, name: true },
+    });
+
+    for (const user of managers) {
+      const prefKey = `${user.id}:WEEKLY_DIGEST`;
+      if (prefMap.get(prefKey) === false) {
+        skipped++;
+        continue;
+      }
+
+      const email = weeklyManagerEmail(user.name, summary);
+      triggered++;
+
+      if (await this.alreadySent(user.email, email.subject, hourKeyStr)) {
+        skipped++;
+        continue;
+      }
+
+      const result = await sendEmail({ to: user.email, subject: email.subject, html: email.html });
+
+      await this.logSend({
+        recipient: user.email,
+        subject: email.subject,
+        status: result.success ? "sent" : "failed",
+        errorMessage: result.error,
+      });
+
+      if (result.success) sent++;
+      else failed++;
+    }
+
+    logger.info(
+      { event: "weekly_manager_digest_complete", triggered, sent, failed, skipped },
+      "Weekly manager digest complete"
+    );
 
     return { triggered, sent, failed, skipped };
   }


### PR DESCRIPTION
Closes #1321. Two email digests: daily personal (08:00) with tasks/assignments/mentions/approvals, weekly manager (Fri 16:00) with team health/KPI/velocity. All templates escape user input. Respects notification preferences.