### PR TITLE
feat(T1324): undo/redo via soft delete + 5-second undo toast

### DIFF
--- a/__tests__/api/deliverables.test.ts
+++ b/__tests__/api/deliverables.test.ts
@@ -7,8 +7,9 @@
 import { createMockRequest } from "../utils/test-utils";
 
 const mockDeliverable = { create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+const mockAuditLog = { create: jest.fn().mockResolvedValue({}) };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { deliverable: mockDeliverable } }));
+jest.mock("@/lib/prisma", () => ({ prisma: { deliverable: mockDeliverable, auditLog: mockAuditLog } }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));

--- a/__tests__/api/subtasks.test.ts
+++ b/__tests__/api/subtasks.test.ts
@@ -8,8 +8,9 @@ import { createMockRequest } from "../utils/test-utils";
 
 const mockSubTask = { create: jest.fn(), update: jest.fn(), delete: jest.fn(), findMany: jest.fn().mockResolvedValue([]), findUnique: jest.fn() };
 const mockTask = { update: jest.fn() };
+const mockAuditLog = { create: jest.fn().mockResolvedValue({}) };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { subTask: mockSubTask, task: mockTask } }));
+jest.mock("@/lib/prisma", () => ({ prisma: { subTask: mockSubTask, task: mockTask, auditLog: mockAuditLog } }));
 
 const mockGetServerSession = jest.fn();
 jest.mock("next-auth", () => ({ getServerSession: (...a: unknown[]) => mockGetServerSession(...a) }));

--- a/__tests__/api/tasks/stale.test.ts
+++ b/__tests__/api/tasks/stale.test.ts
@@ -31,6 +31,7 @@ jest.mock("@/lib/rbac", () => ({
   requireAuth: () => mockRequireAuth(),
   requireRole: jest.fn(),
   requireManagerOrAbove: jest.fn(),
+  enforcePasswordChange: jest.fn(),
 }));
 
 // Mock prisma (needed by imported dependencies)
@@ -115,7 +116,7 @@ describe("GET /api/tasks/stale", () => {
     expect(res.status).toBe(401);
     const body = await res.json();
     expect(body.ok).toBe(false);
-    expect(body.error).toBe("Unauthorized");
+    expect(body.error).toBe("UnauthorizedError");
   });
 
   it("returns 200 with tasks for ENGINEER (own tasks only)", async () => {

--- a/__tests__/integration/branch-coverage.test.ts
+++ b/__tests__/integration/branch-coverage.test.ts
@@ -646,9 +646,9 @@ describe("TaskService — deleteTask branch coverage", () => {
   beforeEach(() => {
     prisma = createMockPrisma();
     service = new TaskService(prisma as never);
-    (prisma.task.delete as jest.Mock).mockResolvedValue({});
+    (prisma.task.update as jest.Mock).mockResolvedValue({});
     (prisma.auditLog.create as jest.Mock).mockResolvedValue({});
-    // deleteTask wraps delete + auditLog in $transaction; execute the callback with a tx proxy
+    // deleteTask wraps update + auditLog in $transaction; execute the callback with a tx proxy
     (prisma.$transaction as jest.Mock).mockImplementation(
       async (fn: (tx: unknown) => Promise<unknown>) =>
         fn({ task: prisma.task, auditLog: prisma.auditLog })
@@ -656,12 +656,12 @@ describe("TaskService — deleteTask branch coverage", () => {
   });
 
   it("logs task title when task exists", async () => {
-    (prisma.task.findUnique as jest.Mock).mockResolvedValue({ id: "t1", title: "My Task" });
+    (prisma.task.findUnique as jest.Mock).mockResolvedValue({ id: "t1", title: "My Task", deletedAt: null });
     await service.deleteTask("t1", "u1", "127.0.0.1");
     expect(prisma.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          detail: "Deleted task: My Task",
+          detail: "Soft-deleted task: My Task",
         }),
       })
     );
@@ -673,7 +673,7 @@ describe("TaskService — deleteTask branch coverage", () => {
     expect(prisma.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
-          detail: "Deleted task: t1",
+          detail: "Soft-deleted task: t1",
         }),
       })
     );
@@ -709,8 +709,8 @@ describe("TaskService — listTasks filter branches", () => {
   it("applies no filters when none provided", async () => {
     await service.listTasks({});
     const call = (prisma.task.findMany as jest.Mock).mock.calls[0][0];
-    // T1340: listTasks now defaults to filtering out sample data
-    expect(call.where).toEqual({ isSample: false });
+    // T1324: listTasks now filters out soft-deleted tasks and sample data
+    expect(call.where).toEqual({ isSample: false, deletedAt: null });
   });
 });
 
@@ -821,9 +821,14 @@ describe("DocumentService — branch coverage", () => {
 
     it("deletes existing document", async () => {
       (prisma.document.findUnique as jest.Mock).mockResolvedValue({ id: "d1" });
-      (prisma.document.delete as jest.Mock).mockResolvedValue({ id: "d1" });
+      (prisma.document.update as jest.Mock).mockResolvedValue({ id: "d1", deletedAt: new Date() });
       await service.deleteDocument("d1");
-      expect(prisma.document.delete).toHaveBeenCalledWith({ where: { id: "d1" } });
+      expect(prisma.document.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "d1" },
+          data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+        })
+      );
     });
   });
 

--- a/app/api/cron/cleanup-deleted/route.ts
+++ b/app/api/cron/cleanup-deleted/route.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /api/cron/cleanup-deleted — Hard-delete soft-deleted records (Issue #1324)
+ *
+ * Permanently removes:
+ * - Task, TaskComment, Document, KPI where deletedAt < now - 24h
+ * - TimeEntry where isDeleted = true AND updatedAt < now - 24h
+ *
+ * Protected by CRON_SECRET header.
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success, error } from "@/lib/api-response";
+import { apiHandler } from "@/lib/api-handler";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+
+const HARD_DELETE_AFTER_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const cutoff = new Date(Date.now() - HARD_DELETE_AFTER_MS);
+
+  try {
+    // Hard-delete soft-deleted Tasks (cascade deletes subTasks, comments, attachments via DB)
+    const deletedTasks = await prisma.task.deleteMany({
+      where: { deletedAt: { lt: cutoff } },
+    });
+
+    // Hard-delete soft-deleted TaskComments
+    const deletedComments = await prisma.taskComment.deleteMany({
+      where: { deletedAt: { lt: cutoff } },
+    });
+
+    // Hard-delete soft-deleted Documents
+    const deletedDocuments = await prisma.document.deleteMany({
+      where: { deletedAt: { lt: cutoff } },
+    });
+
+    // Hard-delete soft-deleted KPIs (also clean up task links)
+    const expiredKpis = await prisma.kPI.findMany({
+      where: { deletedAt: { lt: cutoff } },
+      select: { id: true },
+    });
+    const expiredKpiIds = expiredKpis.map((k) => k.id);
+    let deletedKpis = { count: 0 };
+    if (expiredKpiIds.length > 0) {
+      await prisma.kPITaskLink.deleteMany({ where: { kpiId: { in: expiredKpiIds } } });
+      deletedKpis = await prisma.kPI.deleteMany({
+        where: { id: { in: expiredKpiIds } },
+      });
+    }
+
+    // Hard-delete isDeleted TimeEntries older than 24h
+    const deletedTimeEntries = await prisma.timeEntry.deleteMany({
+      where: {
+        isDeleted: true,
+        updatedAt: { lt: cutoff },
+      },
+    });
+
+    const result = {
+      tasks: deletedTasks.count,
+      comments: deletedComments.count,
+      documents: deletedDocuments.count,
+      kpis: deletedKpis.count,
+      timeEntries: deletedTimeEntries.count,
+      cleanedAt: new Date().toISOString(),
+      cutoff: cutoff.toISOString(),
+    };
+
+    logger.info(result, "[cleanup-deleted] hard-delete sweep completed");
+    return success(result);
+  } catch (err) {
+    logger.error({ err }, "[cleanup-deleted] sweep failed");
+    return error("ServerError", "Cleanup sweep failed", 500);
+  }
+});

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -42,7 +42,7 @@ export const GET = withAuth(async (
   const { id } = await context.params;
 
   const comments = await prisma.taskComment.findMany({
-    where: { taskId: id },
+    where: { taskId: id, deletedAt: null },
     include: {
       user: { select: { id: true, name: true, avatar: true } },
     },
@@ -175,10 +175,10 @@ export const DELETE = withAuth(async (
 
   const comment = await prisma.taskComment.findUnique({
     where: { id: commentId },
-    select: { id: true, userId: true, taskId: true },
+    select: { id: true, userId: true, taskId: true, deletedAt: true },
   });
 
-  if (!comment || comment.taskId !== taskId) {
+  if (!comment || comment.taskId !== taskId || comment.deletedAt) {
     return error("NotFoundError", "評論不存在", 404);
   }
 
@@ -187,7 +187,8 @@ export const DELETE = withAuth(async (
     throw new ForbiddenError("只能刪除自己的評論");
   }
 
-  await prisma.taskComment.delete({ where: { id: commentId } });
+  // Issue #1324: soft delete — set deletedAt instead of hard delete
+  await prisma.taskComment.update({ where: { id: commentId }, data: { deletedAt: new Date() } });
 
   // Fire-and-forget activity log
   logActivity({

--- a/app/api/undo/route.ts
+++ b/app/api/undo/route.ts
@@ -1,0 +1,147 @@
+/**
+ * POST /api/undo — Undo soft delete (Issue #1324)
+ *
+ * Restores a soft-deleted Task, TaskComment, Document, or KPI
+ * by clearing its deletedAt field.
+ *
+ * Rules:
+ * - Only works within 24 hours of deletion.
+ * - ENGINEER: can only undo their own records (by creatorId / userId).
+ * - MANAGER or above: can undo any record.
+ */
+
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { validateBody } from "@/lib/validate";
+import { success, error } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { hasMinimumRole } from "@/lib/auth/permissions";
+import { logActivity, ActivityAction, ActivityModule } from "@/services/activity-logger";
+
+const UNDO_WINDOW_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const undoSchema = z.object({
+  resourceType: z.enum(["Task", "TaskComment", "Document", "KPI"]),
+  resourceId: z.string().min(1),
+});
+
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const { resourceType, resourceId } = validateBody(undoSchema, await req.json());
+  const isManager = hasMinimumRole(session.user.role, "MANAGER");
+
+  switch (resourceType) {
+    case "Task": {
+      const task = await prisma.task.findUnique({
+        where: { id: resourceId },
+        select: { id: true, title: true, deletedAt: true, creatorId: true, primaryAssigneeId: true },
+      });
+      if (!task || !task.deletedAt) {
+        return error("NotFoundError", "任務不存在或未被刪除", 404);
+      }
+      if (!isManager && task.creatorId !== session.user.id && task.primaryAssigneeId !== session.user.id) {
+        return error("ForbiddenError", "無權限復原此任務", 403);
+      }
+      const elapsed = Date.now() - task.deletedAt.getTime();
+      if (elapsed > UNDO_WINDOW_MS) {
+        return error("ForbiddenError", "刪除超過 24 小時，無法復原", 403);
+      }
+      await prisma.task.update({ where: { id: resourceId }, data: { deletedAt: null } });
+      logActivity({
+        userId: session.user.id,
+        action: ActivityAction.UPDATE,
+        module: ActivityModule.KANBAN,
+        targetType: "Task",
+        targetId: resourceId,
+        metadata: { action: "undo_delete", title: task.title },
+      });
+      return success({ restored: true, resourceType, resourceId });
+    }
+
+    case "TaskComment": {
+      const comment = await prisma.taskComment.findUnique({
+        where: { id: resourceId },
+        select: { id: true, userId: true, deletedAt: true },
+      });
+      if (!comment || !comment.deletedAt) {
+        return error("NotFoundError", "評論不存在或未被刪除", 404);
+      }
+      if (!isManager && comment.userId !== session.user.id) {
+        return error("ForbiddenError", "無權限復原此評論", 403);
+      }
+      const elapsed = Date.now() - comment.deletedAt.getTime();
+      if (elapsed > UNDO_WINDOW_MS) {
+        return error("ForbiddenError", "刪除超過 24 小時，無法復原", 403);
+      }
+      await prisma.taskComment.update({ where: { id: resourceId }, data: { deletedAt: null } });
+      logActivity({
+        userId: session.user.id,
+        action: ActivityAction.UPDATE,
+        module: ActivityModule.KANBAN,
+        targetType: "TaskComment",
+        targetId: resourceId,
+        metadata: { action: "undo_delete" },
+      });
+      return success({ restored: true, resourceType, resourceId });
+    }
+
+    case "Document": {
+      const doc = await prisma.document.findUnique({
+        where: { id: resourceId },
+        select: { id: true, title: true, createdBy: true, deletedAt: true },
+      });
+      if (!doc || !doc.deletedAt) {
+        return error("NotFoundError", "文件不存在或未被刪除", 404);
+      }
+      if (!isManager && doc.createdBy !== session.user.id) {
+        return error("ForbiddenError", "無權限復原此文件", 403);
+      }
+      const elapsed = Date.now() - doc.deletedAt.getTime();
+      if (elapsed > UNDO_WINDOW_MS) {
+        return error("ForbiddenError", "刪除超過 24 小時，無法復原", 403);
+      }
+      await prisma.document.update({ where: { id: resourceId }, data: { deletedAt: null } });
+      logActivity({
+        userId: session.user.id,
+        action: ActivityAction.UPDATE,
+        module: ActivityModule.KANBAN,
+        targetType: "Document",
+        targetId: resourceId,
+        metadata: { action: "undo_delete", title: doc.title },
+      });
+      return success({ restored: true, resourceType, resourceId });
+    }
+
+    case "KPI": {
+      const kpi = await prisma.kPI.findUnique({
+        where: { id: resourceId },
+        select: { id: true, title: true, createdBy: true, deletedAt: true },
+      });
+      if (!kpi || !kpi.deletedAt) {
+        return error("NotFoundError", "KPI 不存在或未被刪除", 404);
+      }
+      if (!isManager && kpi.createdBy !== session.user.id) {
+        return error("ForbiddenError", "無權限復原此 KPI", 403);
+      }
+      const elapsed = Date.now() - kpi.deletedAt.getTime();
+      if (elapsed > UNDO_WINDOW_MS) {
+        return error("ForbiddenError", "刪除超過 24 小時，無法復原", 403);
+      }
+      await prisma.kPI.update({ where: { id: resourceId }, data: { deletedAt: null } });
+      logActivity({
+        userId: session.user.id,
+        action: ActivityAction.UPDATE,
+        module: ActivityModule.KANBAN,
+        targetType: "KPI",
+        targetId: resourceId,
+        metadata: { action: "undo_delete", title: kpi.title },
+      });
+      return success({ restored: true, resourceType, resourceId });
+    }
+
+    default:
+      return error("ValidationError", "不支援的資源類型", 400);
+  }
+});

--- a/app/components/task-detail-modal.tsx
+++ b/app/components/task-detail-modal.tsx
@@ -185,13 +185,35 @@ export function TaskDetailModal({ taskId, onClose, onUpdated }: TaskDetailModalP
   }
 
   async function deleteTask() {
-    if (!window.confirm("確定要刪除此任務嗎？此操作無法復原。")) return;
+    if (!window.confirm("確定要刪除此任務嗎？可在 5 秒內復原。")) return;
     setDeleting(true);
     try {
       const res = await fetch(`/api/tasks/${taskId}`, { method: "DELETE" });
       if (res.ok) {
-        toast.success("任務已刪除");
         onUpdated?.();
+        // Issue #1324: show undo toast with 5-second window
+        toast("任務已刪除", {
+          action: {
+            label: "復原",
+            onClick: () => {
+              fetch("/api/undo", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ resourceType: "Task", resourceId: taskId }),
+              })
+                .then((r) => {
+                  if (r.ok) {
+                    toast.success("任務已復原");
+                    onUpdated?.();
+                  } else {
+                    toast.error("復原失敗，請聯繫管理員");
+                  }
+                })
+                .catch(() => toast.error("復原失敗，請聯繫管理員"));
+            },
+          },
+          duration: 5000,
+        });
       } else {
         const errBody = await res.json().catch(() => ({}));
         toast.error(errBody?.message ?? errBody?.error ?? "刪除失敗");

--- a/prisma/migrations/20260410020000_add_soft_delete_fields/migration.sql
+++ b/prisma/migrations/20260410020000_add_soft_delete_fields/migration.sql
@@ -1,0 +1,19 @@
+-- Migration: add_soft_delete_fields (Issue #1324)
+-- Adds deletedAt DateTime? to Task, TaskComment, Document, KPI
+-- Uses ADD COLUMN IF NOT EXISTS for idempotent deployment
+
+-- tasks
+ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "tasks_deletedAt_idx" ON "tasks"("deletedAt");
+
+-- task_comments
+ALTER TABLE "task_comments" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "task_comments_deletedAt_idx" ON "task_comments"("deletedAt");
+
+-- kpis
+ALTER TABLE "kpis" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "kpis_deletedAt_idx" ON "kpis"("deletedAt");
+
+-- documents
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "deletedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "documents_deletedAt_idx" ON "documents"("deletedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,7 @@ model KPI {
   visibility     KPIVisibility @default(ALL)       // 可視權限
   status         KPIStatus     @default(DRAFT)     // 預設草稿
   autoCalc       Boolean       @default(false)
+  deletedAt      DateTime?     // Issue #1324: 軟刪除時間戳
   createdBy      String
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
@@ -171,6 +172,7 @@ model KPI {
   @@index([createdBy])
   @@index([status])
   @@index([frequency])
+  @@index([deletedAt])
   @@map("kpis")
 }
 
@@ -367,6 +369,7 @@ model Task {
   flaggedAt         DateTime?    // Issue #960: 標記時間
   flaggedBy         String?      // Issue #960: 標記者 userId
   projectId         String?      // Issue #1168: FK to Project (PMO)
+  deletedAt         DateTime?    // Issue #1324: 軟刪除時間戳
   createdAt         DateTime     @default(now())
   updatedAt         DateTime     @updatedAt
 
@@ -398,6 +401,7 @@ model Task {
   @@index([status, dueDate])
   @@index([primaryAssigneeId, status])
   @@index([managerFlagged, status])
+  @@index([deletedAt])
   @@map("tasks")
 }
 
@@ -545,18 +549,20 @@ model SubTask {
 }
 
 model TaskComment {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   taskId    String
   userId    String
-  content   String   // Markdown
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  content   String    // Markdown
+  deletedAt DateTime? // Issue #1324: 軟刪除時間戳
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   task Task @relation(fields: [taskId], references: [id], onDelete: Cascade)
   user User @relation(fields: [userId], references: [id], onDelete: Restrict)
 
   @@index([taskId])
   @@index([userId])
+  @@index([deletedAt])
   @@map("task_comments")
 }
 
@@ -951,6 +957,7 @@ model Document {
   visibility         String         @default("TEAM")
   // Retirement fields (Issue #987)
   replacedById       String?        // 替代文件 ID（RETIRED 時使用）
+  deletedAt          DateTime?      // Issue #1324: 軟刪除時間戳
   createdAt          DateTime       @default(now())
   updatedAt          DateTime       @updatedAt
 
@@ -978,6 +985,7 @@ model Document {
   @@index([verifierId])
   @@index([verifyByDate])
   @@index([status, createdAt])
+  @@index([deletedAt])
   @@map("documents")
 }
 

--- a/scripts/cron-entrypoint.sh
+++ b/scripts/cron-entrypoint.sh
@@ -47,6 +47,9 @@ cat > /etc/crontabs/root <<EOF
 
 # 08:30 Mondays — weekly verification reminder
 30 8 * * 1 ${CURL} ${TITAN_APP_URL}/api/cron/verification-reminder || true
+
+# 03:00 daily — hard-delete soft-deleted records older than 24h (Issue #1324)
+0 3 * * * ${CURL} ${TITAN_APP_URL}/api/cron/cleanup-deleted || true
 EOF
 
 echo "[titan-cron] Crontab installed:"

--- a/services/__tests__/delete-operations.test.ts
+++ b/services/__tests__/delete-operations.test.ts
@@ -21,27 +21,26 @@ describe("KPIService.deleteKPI", () => {
 
   test("deletes KPI and its task links", async () => {
     const mockKPI = { id: "kpi-1", year: 2026, title: "KPI 1" };
+    const softDeletedKPI = { ...mockKPI, deletedAt: new Date() };
     (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(mockKPI);
-    (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
-    (prisma.kPI.delete as jest.Mock).mockResolvedValue(mockKPI);
+    (prisma.kPI.update as jest.Mock).mockResolvedValue(softDeletedKPI);
 
     const result = await service.deleteKPI("kpi-1");
 
-    expect(prisma.kPITaskLink.deleteMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { kpiId: "kpi-1" } })
+    expect(prisma.kPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "kpi-1" },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      })
     );
-    expect(prisma.kPI.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "kpi-1" } })
-    );
-    expect(result).toEqual(mockKPI);
+    expect(result).toEqual(softDeletedKPI);
   });
 
   test("throws NotFoundError for invalid id", async () => {
     (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
 
     await expect(service.deleteKPI("nonexistent")).rejects.toThrow(NotFoundError);
-    expect(prisma.kPITaskLink.deleteMany).not.toHaveBeenCalled();
-    expect(prisma.kPI.delete).not.toHaveBeenCalled();
+    expect(prisma.kPI.update).not.toHaveBeenCalled();
   });
 });
 

--- a/services/__tests__/document-service.test.ts
+++ b/services/__tests__/document-service.test.ts
@@ -84,12 +84,15 @@ describe("DocumentService", () => {
 
   test("deleteDocument removes document", async () => {
     (prisma.document.findUnique as jest.Mock).mockResolvedValue({ id: "doc-1" });
-    (prisma.document.delete as jest.Mock).mockResolvedValue({ id: "doc-1" });
+    (prisma.document.update as jest.Mock).mockResolvedValue({ id: "doc-1", deletedAt: new Date() });
 
     await service.deleteDocument("doc-1");
 
-    expect(prisma.document.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "doc-1" } })
+    expect(prisma.document.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "doc-1" },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      })
     );
   });
 });

--- a/services/__tests__/kpi-service.test.ts
+++ b/services/__tests__/kpi-service.test.ts
@@ -239,16 +239,15 @@ describe("KPIService", () => {
     test("deletes kpi and its task links in transaction", async () => {
       const existingKPI = { id: "kpi-1", title: "KPI 1" };
       (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(existingKPI);
-      (prisma.kPI.delete as jest.Mock).mockResolvedValue(existingKPI);
-      (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+      (prisma.kPI.update as jest.Mock).mockResolvedValue({ ...existingKPI, deletedAt: new Date() });
 
       await service.deleteKPI("kpi-1");
 
-      expect(prisma.kPITaskLink.deleteMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { kpiId: "kpi-1" } })
-      );
-      expect(prisma.kPI.delete).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: "kpi-1" } })
+      expect(prisma.kPI.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "kpi-1" },
+          data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+        })
       );
     });
   });

--- a/services/__tests__/task-service.test.ts
+++ b/services/__tests__/task-service.test.ts
@@ -26,7 +26,7 @@ describe("TaskService", () => {
       const result = await service.listTasks({});
 
       expect(prisma.task.findMany).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { isSample: false } })
+        expect.objectContaining({ where: expect.objectContaining({ isSample: false, deletedAt: null }) })
       );
       expect(result).toEqual({ tasks: mockTasks, total: 2 });
     });
@@ -196,12 +196,21 @@ describe("TaskService", () => {
 
   describe("deleteTask", () => {
     test("deleteTask soft deletes", async () => {
-      (prisma.task.delete as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.task.findUnique as jest.Mock).mockResolvedValue({ id: "task-1", title: "Task 1", deletedAt: null });
+      (prisma.task.update as jest.Mock).mockResolvedValue({ id: "task-1" });
+      (prisma.auditLog.create as jest.Mock).mockResolvedValue({});
+      (prisma.$transaction as jest.Mock).mockImplementation(
+        async (fn: (tx: unknown) => Promise<unknown>) =>
+          fn({ task: prisma.task, auditLog: prisma.auditLog })
+      );
 
       await service.deleteTask("task-1");
 
-      expect(prisma.task.delete).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: "task-1" } })
+      expect(prisma.task.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "task-1" },
+          data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+        })
       );
     });
   });

--- a/services/__tests__/transaction.test.ts
+++ b/services/__tests__/transaction.test.ts
@@ -92,8 +92,10 @@ describe("GoalService.deleteGoal — transaction", () => {
 });
 
 // ─── KPIService.deleteKPI ─────────────────────────────────────────────────────
+// Issue #1324: deleteKPI now uses soft delete (prisma.kPI.update with deletedAt)
+// instead of a transaction with kPITaskLink.deleteMany + kPI.delete.
 
-describe("KPIService.deleteKPI — transaction", () => {
+describe("KPIService.deleteKPI — soft delete", () => {
   let service: KPIService;
   let prisma: ReturnType<typeof createMockPrisma>;
 
@@ -103,49 +105,34 @@ describe("KPIService.deleteKPI — transaction", () => {
     setupTransaction(prisma);
   });
 
-  test("calls $transaction when deleting a KPI", async () => {
+  test("soft-deletes the KPI by setting deletedAt", async () => {
     (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({ id: "kpi-1" });
-    (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
-    (prisma.kPI.delete as jest.Mock).mockResolvedValue({ id: "kpi-1" });
+    (prisma.kPI.update as jest.Mock).mockResolvedValue({ id: "kpi-1", deletedAt: new Date() });
 
     await service.deleteKPI("kpi-1");
 
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.kPI.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "kpi-1" },
+        data: expect.objectContaining({ deletedAt: expect.any(Date) }),
+      })
+    );
   });
 
-  test("deletes task links before the KPI inside the transaction", async () => {
+  test("does not use $transaction when deleting a KPI", async () => {
     (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({ id: "kpi-1" });
-    (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 3 });
-    (prisma.kPI.delete as jest.Mock).mockResolvedValue({ id: "kpi-1" });
+    (prisma.kPI.update as jest.Mock).mockResolvedValue({ id: "kpi-1", deletedAt: new Date() });
 
     await service.deleteKPI("kpi-1");
 
-    expect(prisma.kPITaskLink.deleteMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { kpiId: "kpi-1" } })
-    );
-    expect(prisma.kPI.delete).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "kpi-1" } })
-    );
-  });
-
-  test("throws NotFoundError without starting a transaction when KPI missing", async () => {
-    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
-
-    await expect(service.deleteKPI("nonexistent")).rejects.toThrow(NotFoundError);
     expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
-  test("passes timeout option to $transaction", async () => {
-    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue({ id: "kpi-1" });
-    (prisma.kPITaskLink.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
-    (prisma.kPI.delete as jest.Mock).mockResolvedValue({ id: "kpi-1" });
+  test("throws NotFoundError without updating when KPI missing", async () => {
+    (prisma.kPI.findUnique as jest.Mock).mockResolvedValue(null);
 
-    await service.deleteKPI("kpi-1");
-
-    expect(prisma.$transaction).toHaveBeenCalledWith(
-      expect.any(Function),
-      expect.objectContaining({ timeout: 10000 })
-    );
+    await expect(service.deleteKPI("nonexistent")).rejects.toThrow(NotFoundError);
+    expect(prisma.kPI.update).not.toHaveBeenCalled();
   });
 });
 

--- a/services/document-service.ts
+++ b/services/document-service.ts
@@ -30,6 +30,7 @@ export class DocumentService {
   async listDocuments(filter: ListDocumentsFilter) {
     return this.prisma.document.findMany({
       where: {
+        deletedAt: null,
         ...(filter.parentId !== undefined && { parentId: filter.parentId }),
         ...(filter.search && {
           OR: [
@@ -144,6 +145,22 @@ export class DocumentService {
     const doc = await this.prisma.document.findUnique({ where: { id } });
     if (!doc) throw new NotFoundError(`Document not found: ${id}`);
 
-    return this.prisma.document.delete({ where: { id } });
+    // Issue #1324: soft delete — set deletedAt instead of hard delete
+    return this.prisma.document.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  /** Issue #1324: restore a soft-deleted document */
+  async restoreDocument(id: string) {
+    const doc = await this.prisma.document.findUnique({ where: { id } });
+    if (!doc) throw new NotFoundError(`Document not found: ${id}`);
+    if (!doc.deletedAt) throw new ValidationError("文件未被刪除，無需復原");
+
+    return this.prisma.document.update({
+      where: { id },
+      data: { deletedAt: null },
+    });
   }
 }

--- a/services/kpi-service.ts
+++ b/services/kpi-service.ts
@@ -33,7 +33,7 @@ export class KPIService {
   async listKPIs(filter: ListKPIsFilter) {
     const year = filter.year ?? new Date().getFullYear();
     return this.prisma.kPI.findMany({
-      where: { year },
+      where: { year, deletedAt: null },
       include: {
         taskLinks: {
           include: {
@@ -148,13 +148,23 @@ export class KPIService {
     const existing = await this.prisma.kPI.findUnique({ where: { id } });
     if (!existing) throw new NotFoundError(`KPI not found: ${id}`);
 
-    return this.prisma.$transaction(
-      async (tx) => {
-        await tx.kPITaskLink.deleteMany({ where: { kpiId: id } });
-        return tx.kPI.delete({ where: { id } });
-      },
-      { timeout: 10000 }
-    );
+    // Issue #1324: soft delete — set deletedAt instead of hard delete
+    return this.prisma.kPI.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  /** Issue #1324: restore a soft-deleted KPI */
+  async restoreKPI(id: string) {
+    const existing = await this.prisma.kPI.findUnique({ where: { id } });
+    if (!existing) throw new NotFoundError(`KPI not found: ${id}`);
+    if (!existing.deletedAt) throw new ValidationError("KPI 未被刪除，無需復原");
+
+    return this.prisma.kPI.update({
+      where: { id },
+      data: { deletedAt: null },
+    });
   }
 
   async calculateAchievement(kpiId: string) {

--- a/services/task-service.ts
+++ b/services/task-service.ts
@@ -71,7 +71,7 @@ export class TaskService {
   }
 
   async listTasks(filter: ListTasksFilter) {
-    const where: Record<string, unknown> = { isSample: false };
+    const where: Record<string, unknown> = { isSample: false, deletedAt: null };
 
     if (filter.assignee) {
       where.OR = [
@@ -451,11 +451,17 @@ export class TaskService {
   }
 
   async deleteTask(id: string, deletedBy?: string, ipAddress?: string) {
-    const task = await this.prisma.task.findUnique({ where: { id }, select: { id: true, title: true } });
+    const task = await this.prisma.task.findUnique({
+      where: { id },
+      select: { id: true, title: true, deletedAt: true },
+    });
 
-    // Issue #1213: wrap delete + audit in transaction for atomicity
+    // Issue #1324: soft delete — set deletedAt instead of hard delete
     return this.prisma.$transaction(async (tx) => {
-      const result = await tx.task.delete({ where: { id } });
+      const result = await tx.task.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
 
       await tx.auditLog.create({
         data: {
@@ -463,12 +469,27 @@ export class TaskService {
           action: "DELETE_TASK",
           resourceType: "Task",
           resourceId: id,
-          detail: task ? `Deleted task: ${task.title}` : `Deleted task: ${id}`,
+          detail: task ? `Soft-deleted task: ${task.title}` : `Soft-deleted task: ${id}`,
           ipAddress: ipAddress ?? null,
         },
       });
 
       return result;
+    });
+  }
+
+  /** Issue #1324: restore a soft-deleted task */
+  async restoreTask(id: string) {
+    const task = await this.prisma.task.findUnique({
+      where: { id },
+      select: { id: true, deletedAt: true },
+    });
+    if (!task) throw new NotFoundError(`Task not found: ${id}`);
+    if (!task.deletedAt) throw new ValidationError("任務未被刪除，無需復原");
+
+    return this.prisma.task.update({
+      where: { id },
+      data: { deletedAt: null },
     });
   }
 }


### PR DESCRIPTION
Closes #1324. Phase 2 final item. Soft delete on Task/TaskComment/Document/KPI + undo API + cleanup cron + frontend toast.