### PR TITLE
fix: cleanup expired tokens in daily cron

### DIFF
--- a/app/api/cron/cleanup-deleted/route.ts
+++ b/app/api/cron/cleanup-deleted/route.ts
@@ -61,12 +61,29 @@ export const POST = apiHandler(async (req: NextRequest) => {
       },
     });
 
+    // Clean up expired refresh tokens (7-day expiry in schema)
+    const expiredRefreshTokens = await prisma.refreshToken.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+
+    // Clean up expired/used password reset tokens
+    const expiredResetTokens = await prisma.passwordResetToken.deleteMany({
+      where: {
+        OR: [
+          { expiresAt: { lt: new Date() } },
+          { usedAt: { not: null } },  // used tokens no longer needed
+        ],
+      },
+    });
+
     const result = {
       tasks: deletedTasks.count,
       comments: deletedComments.count,
       documents: deletedDocuments.count,
       kpis: deletedKpis.count,
       timeEntries: deletedTimeEntries.count,
+      expiredRefreshTokens: expiredRefreshTokens.count,
+      expiredResetTokens: expiredResetTokens.count,
       cleanedAt: new Date().toISOString(),
       cutoff: cutoff.toISOString(),
     };


### PR DESCRIPTION
Extend cleanup-deleted cron to also remove expired refresh/reset tokens. Prevents indefinite table growth.