### PR TITLE
feat(T1328) + fix(T1390): Feature Flags DB + deletedAt coverage

### DIFF
--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -1,5 +1,5 @@
 /**
- * Feature Flags API — Issue #988
+ * Feature Flags API — Issue #1328
  *
  * GET  /api/admin/feature-flags — read all flags (any authenticated user)
  * PUT  /api/admin/feature-flags — update a flag (ADMIN only)
@@ -7,15 +7,17 @@
 import { NextRequest } from "next/server";
 import { success } from "@/lib/api-response";
 import { withAuth, withAdmin } from "@/lib/auth-middleware";
-import { getAllFeatureFlags, isValidFlagName } from "@/lib/feature-flags";
+import { getAllFeatureFlags, setFeatureFlag, isValidFlagName } from "@/lib/feature-flags";
+import { requireAuth } from "@/lib/rbac";
 import { ValidationError } from "@/services/errors";
 
 export const GET = withAuth(async (_req: NextRequest) => {
-  const flags = getAllFeatureFlags();
+  const flags = await getAllFeatureFlags();
   return success({ flags });
 });
 
 export const PUT = withAdmin(async (req: NextRequest) => {
+  const session = await requireAuth();
   const body = await req.json();
   const { name, enabled } = body;
 
@@ -27,10 +29,8 @@ export const PUT = withAdmin(async (req: NextRequest) => {
     throw new ValidationError(`未知的 feature flag: ${name}`);
   }
 
-  // Set the env var at runtime (in-memory only, persists until restart)
-  const envKey = `TITAN_FF_${name}`;
-  process.env[envKey] = enabled ? "true" : "false";
+  await setFeatureFlag(name, enabled, session.user.id);
 
-  const flags = getAllFeatureFlags();
+  const flags = await getAllFeatureFlags();
   return success({ flags });
 });

--- a/app/api/cron/verification-reminder/route.ts
+++ b/app/api/cron/verification-reminder/route.ts
@@ -24,7 +24,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
 
   // Get all documents with verification configured
   const docs = await prisma.document.findMany({
-    where: {
+    where: { deletedAt: null,
       verifyIntervalDays: { not: null },
       verifierId: { not: null },
     },

--- a/app/api/dashboard/manager-today/route.ts
+++ b/app/api/dashboard/manager-today/route.ts
@@ -72,7 +72,7 @@ export const GET = withManager(async () => {
     // Only flag when month is already >50% through
     monthProgress > 50
       ? prisma.kPI.findMany({
-          where: {
+          where: { deletedAt: null,
             year: now.getFullYear(),
             status: "ACTIVE",
             frequency: "MONTHLY",

--- a/app/api/documents/search/route.ts
+++ b/app/api/documents/search/route.ts
@@ -40,7 +40,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   // PostgreSQL full-text search with 'simple' config tokenizes by whitespace,
   // which doesn't work for CJK languages where words aren't space-separated.
   const likeResults = await prisma.document.findMany({
-    where: {
+    where: { deletedAt: null,
       OR: [
         { title: { contains: q, mode: "insensitive" } },
         { content: { contains: q, mode: "insensitive" } },

--- a/app/api/documents/tags/route.ts
+++ b/app/api/documents/tags/route.ts
@@ -9,7 +9,7 @@ import { withAuth } from "@/lib/auth-middleware";
  */
 export const GET = withAuth(async () => {
   const docs = await prisma.document.findMany({
-    where: { tags: { isEmpty: false } },
+    where: { deletedAt: null, tags: { isEmpty: false } },
     select: { tags: true },
   });
 

--- a/app/api/documents/verification-due/route.ts
+++ b/app/api/documents/verification-due/route.ts
@@ -21,7 +21,7 @@ export const GET = withAuth(async (req: NextRequest) => {
 
   // Get all documents with verification configured, using verifyByDate for query
   const docs = await prisma.document.findMany({
-    where: {
+    where: { deletedAt: null,
       verifyIntervalDays: { not: null },
       ...(userId && { verifierId: userId }),
     },

--- a/app/api/kpi/copy-year/route.ts
+++ b/app/api/kpi/copy-year/route.ts
@@ -40,7 +40,7 @@ export const POST = withManager(async (req: NextRequest) => {
 
   // Fetch all KPIs from source year
   const sourceKpis = await prisma.kPI.findMany({
-    where: { year: sourceYear },
+    where: { deletedAt: null, year: sourceYear },
     orderBy: { code: "asc" },
   });
 
@@ -51,7 +51,7 @@ export const POST = withManager(async (req: NextRequest) => {
   // Idempotency check: if target year already has KPIs, return existing data
   // instead of throwing an error (safe for re-calls)
   const existingKpis = await prisma.kPI.findMany({
-    where: { year: targetYear },
+    where: { deletedAt: null, year: targetYear },
     orderBy: { code: "asc" },
   });
   if (existingKpis.length > 0) {

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -113,7 +113,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     const year = parseYear(searchParams.get("year"));
 
     const kpis = await prisma.kPI.findMany({
-      where: { year },
+      where: { deletedAt: null, year },
       include: {
         taskLinks: {
           include: { task: { select: { id: true, status: true, progressPct: true } } },

--- a/app/api/reports/trends/route.ts
+++ b/app/api/reports/trends/route.ts
@@ -55,7 +55,7 @@ export const GET = apiHandler(async (req: NextRequest) => {
     if (metric === "kpi" || metric === "kpi-achievement") {
       // KPI achievement rate by month (average across all KPIs)
       const kpis = await prisma.kPI.findMany({
-        where: { year },
+        where: { deletedAt: null, year },
         select: { code: true, title: true, target: true, actual: true, status: true, weight: true },
       });
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -93,7 +93,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     // Documents: search by title + content
     searchDocuments
       ? prisma.document.findMany({
-          where: {
+          where: { deletedAt: null,
             OR: [
               { title: containsQuery },
               { content: containsQuery },
@@ -144,7 +144,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     // KPIs: search by code or title (scope=all only)
     scope === "all"
       ? prisma.kPI.findMany({
-          where: {
+          where: { deletedAt: null,
             OR: [
               { code: containsQuery },
               { title: containsQuery },

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,8 +1,8 @@
 /**
- * Feature Flags — Issue #988
+ * Feature Flags — Issue #1328 (DB化)
  *
- * Simple env-var based feature flag system.
- * Flags are read from process.env with prefix TITAN_FF_.
+ * Stores feature flags in PostgreSQL with 60s Redis cache TTL.
+ * Falls back to in-memory cache when both DB and Redis are down.
  *
  * Supported flags:
  * - V2_DASHBOARD: Toggle new dashboard vs old
@@ -10,43 +10,118 @@
  * - ALERT_BANNER: Toggle global alert banner
  */
 
-export type FeatureFlagName = "V2_DASHBOARD" | "V2_REPORTS" | "ALERT_BANNER";
+import { prisma } from "@/lib/prisma";
+import { getRedisClient } from "@/lib/redis";
+import { logger } from "@/lib/logger";
 
-/** Default values when env var is not set */
-const FLAG_DEFAULTS: Record<FeatureFlagName, boolean> = {
+const CACHE_KEY = "titan:feature-flags";
+const CACHE_TTL = 60; // seconds
+
+/** Default values when DB record does not exist yet */
+const FLAG_DEFAULTS: Record<string, boolean> = {
   V2_DASHBOARD: false,
   V2_REPORTS: false,
   ALERT_BANNER: true,
 };
 
+export type FeatureFlagName = "V2_DASHBOARD" | "V2_REPORTS" | "ALERT_BANNER";
+
 /** All known flag names */
-export const ALL_FLAGS: FeatureFlagName[] = ["V2_DASHBOARD", "V2_REPORTS", "ALERT_BANNER"];
+export const ALL_FLAGS: FeatureFlagName[] = [
+  "V2_DASHBOARD",
+  "V2_REPORTS",
+  "ALERT_BANNER",
+];
+
+/** In-memory fallback when both DB and Redis are down */
+let memoryCache: Record<string, boolean> = {};
+let memoryCacheAge = 0;
 
 /**
- * Get a feature flag value (server-side).
- * Reads from `process.env.TITAN_FF_<NAME>`.
- * Values: "true"/"1" = enabled, anything else = disabled.
+ * Get a single feature flag value (server-side).
+ * Lookup order: Redis → DB → in-memory fallback.
  */
-export function getFeatureFlag(name: FeatureFlagName): boolean {
-  const envKey = `TITAN_FF_${name}`;
-  const envVal = process.env[envKey];
+export async function getFeatureFlag(name: FeatureFlagName): Promise<boolean> {
+  const redis = getRedisClient();
 
-  if (envVal === undefined || envVal === "") {
-    return FLAG_DEFAULTS[name] ?? false;
+  // 1. Try Redis cache
+  if (redis) {
+    try {
+      const cached = await redis.hget(CACHE_KEY, name);
+      if (cached !== null) return cached === "true";
+    } catch {
+      // Redis unavailable — fall through to DB
+    }
   }
 
-  return envVal === "true" || envVal === "1";
+  // 2. DB lookup
+  try {
+    const flag = await prisma.featureFlag.findUnique({ where: { key: name } });
+    const value = flag?.enabled ?? (FLAG_DEFAULTS[name] ?? false);
+
+    // Update Redis cache
+    if (redis) {
+      try {
+        await redis.hset(CACHE_KEY, name, String(value));
+        await redis.expire(CACHE_KEY, CACHE_TTL);
+      } catch {
+        // Swallow Redis write errors
+      }
+    }
+
+    memoryCache[name] = value;
+    memoryCacheAge = Date.now();
+    return value;
+  } catch (err) {
+    logger.warn({ err, name }, "[feature-flags] DB lookup failed — using in-memory fallback");
+    // DB down — use memory cache if fresh enough
+    if (Date.now() - memoryCacheAge < CACHE_TTL * 1000) {
+      return memoryCache[name] ?? (FLAG_DEFAULTS[name] ?? false);
+    }
+    return FLAG_DEFAULTS[name] ?? false;
+  }
+}
+
+/**
+ * Set a feature flag value (ADMIN only — enforced at route layer).
+ * Writes to DB and invalidates Redis cache entry.
+ */
+export async function setFeatureFlag(
+  name: FeatureFlagName,
+  enabled: boolean,
+  updatedBy?: string,
+): Promise<void> {
+  await prisma.featureFlag.upsert({
+    where: { key: name },
+    create: { key: name, enabled, updatedBy },
+    update: { enabled, updatedBy },
+  });
+
+  // Invalidate this flag's Redis cache entry
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      await redis.hdel(CACHE_KEY, name);
+    } catch {
+      // Swallow Redis errors
+    }
+  }
+
+  memoryCache[name] = enabled;
+  memoryCacheAge = Date.now();
 }
 
 /**
  * Get all feature flags (server-side).
+ * Merges DB state with FLAG_DEFAULTS so every known flag is always returned.
  */
-export function getAllFeatureFlags(): Record<FeatureFlagName, boolean> {
-  const flags: Record<string, boolean> = {};
+export async function getAllFeatureFlags(): Promise<Record<FeatureFlagName, boolean>> {
+  const rows = await prisma.featureFlag.findMany();
+  const result: Record<string, boolean> = {};
   for (const name of ALL_FLAGS) {
-    flags[name] = getFeatureFlag(name);
+    result[name] = rows.find((f) => f.key === name)?.enabled ?? (FLAG_DEFAULTS[name] ?? false);
   }
-  return flags as Record<FeatureFlagName, boolean>;
+  return result as Record<FeatureFlagName, boolean>;
 }
 
 /**

--- a/prisma/migrations/20260410030000_add_feature_flags_table/migration.sql
+++ b/prisma/migrations/20260410030000_add_feature_flags_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "feature_flags" (
+    "key" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedBy" TEXT,
+
+    CONSTRAINT "feature_flags_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1749,3 +1749,16 @@ model SystemSetting {
 
   @@map("system_settings")
 }
+
+// ═══════════════════════════════════════
+// Feature Flags（T1328）
+// ═══════════════════════════════════════
+
+model FeatureFlag {
+  key       String   @id
+  enabled   Boolean  @default(false)
+  updatedAt DateTime @updatedAt
+  updatedBy String?
+
+  @@map("feature_flags")
+}

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -56,7 +56,7 @@ export class AlertService {
 
     // 2. KPI critical (< 60% achievement)
     const kpis = await this.prisma.kPI.findMany({
-      where: { year: now.getFullYear(), status: "ACTIVE" },
+      where: { deletedAt: null, year: now.getFullYear(), status: "ACTIVE" },
       select: { id: true, title: true, target: true, actual: true },
     });
 


### PR DESCRIPTION
Two changes in one branch:
1. #1328: Feature flags stored in DB+Redis instead of process.env mutation
2. #1390 follow-up: 12 more document/KPI queries filtered for soft delete