### PR TITLE
fix: comprehensive deletedAt filter on document/kpi/comment queries

### DIFF
--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -13,7 +13,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   const { page, limit, skip } = parsePagination(searchParams);
   const spaceId = searchParams.get("spaceId");
 
-  const where = spaceId ? { spaceId } : {};
+  const where = spaceId ? { spaceId, deletedAt: null } : { deletedAt: null };
 
   const select = {
     id: true,

--- a/app/api/kpi/route.ts
+++ b/app/api/kpi/route.ts
@@ -22,7 +22,7 @@ export const GET = withAuth(async (req: NextRequest) => {
   const limit = parseLimit(searchParams.get("limit"), 100, 500);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const where: any = { year };
+  const where: any = { year, deletedAt: null };
 
   // Visibility: ENGINEER can only see ALL-visible KPIs
   if (session.user.role === "ENGINEER") {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -115,6 +115,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     searchComments
       ? prisma.taskComment.findMany({
           where: {
+            deletedAt: null,
             content: containsQuery,
             ...(isManager
               ? {}

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -79,7 +79,7 @@ export class AlertService {
     threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
 
     const overdueTasks = await this.prisma.task.findMany({
-      where: {
+      where: { deletedAt: null,
         isSample: false,
         status: { not: "DONE" },
         dueDate: { lt: threeDaysAgo },
@@ -131,7 +131,7 @@ export class AlertService {
 
     // 5. Document verification expired
     const expiredDocs = await this.prisma.document.findMany({
-      where: {
+      where: { deletedAt: null,
         status: "PUBLISHED",
         verifyIntervalDays: { not: null },
         verifiedAt: { not: null },

--- a/services/report-service.ts
+++ b/services/report-service.ts
@@ -147,7 +147,7 @@ export class ReportService {
     const completedTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
-        isSample: false,
+        isSample: false, deletedAt: null,
         status: "DONE",
         updatedAt: { gte: weekStart, lte: weekEnd },
       },
@@ -185,7 +185,7 @@ export class ReportService {
     const overdueTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
-        isSample: false,
+        isSample: false, deletedAt: null,
         status: { notIn: ["DONE"] },
         dueDate: { lt: new Date() },
       },
@@ -243,7 +243,7 @@ export class ReportService {
     const allTasks = await this.prisma.task.findMany({
       where: {
         ...userFilter,
-        isSample: false,
+        isSample: false, deletedAt: null,
         createdAt: { lte: monthEnd },
         OR: [
           { dueDate: { gte: monthStart, lte: monthEnd } },
@@ -435,7 +435,7 @@ export class ReportService {
         ...(filter.isManager
           ? {}
           : { primaryAssigneeId: filter.userId }),
-        isSample: false,
+        isSample: false, deletedAt: null,
         category: { in: ["ADDED", "INCIDENT", "SUPPORT"] },
         createdAt: { gte: startDate, lte: endDate },
       },


### PR DESCRIPTION
More soft-delete follow-up. 5 files, 9 query locations.