### PR TITLE
fix: 4 report routes wrong auth import → withManager

### DIFF
--- a/app/api/reports/audit-summary/route.ts
+++ b/app/api/reports/audit-summary/route.ts
@@ -10,19 +10,12 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireManagerOrAbove as requireManager } from "@/lib/auth";
-import { success, error } from "@/lib/api-response";
-import { apiHandler } from "@/lib/api-handler";
+
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
 import { parseLimit, parseOffset } from "@/lib/query-params";
 
-// Issue #1212: wrap with apiHandler for rate limiting and error handling
-export const GET = apiHandler(async (req: NextRequest) => {
-  try {
-    await requireManager();
-  } catch {
-    return error("ForbiddenError", "僅限管理員", 403);
-  }
-
+export const GET = withManager(async (req: NextRequest) => {
   const { searchParams } = new URL(req.url);
   const mode = searchParams.get("mode") ?? "detail";
   const from = searchParams.get("from");

--- a/app/api/reports/login-activity/route.ts
+++ b/app/api/reports/login-activity/route.ts
@@ -10,9 +10,9 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireManagerOrAbove as requireManager } from "@/lib/auth";
+
 import { success, error } from "@/lib/api-response";
-import { apiHandler } from "@/lib/api-handler";
+import { withManager } from "@/lib/auth-middleware";
 import { parseLimit, parseOffset } from "@/lib/query-params";
 
 const LOGIN_ACTIONS = [
@@ -22,8 +22,7 @@ const LOGIN_ACTIONS = [
 ];
 
 // Issue #1212: wrap with apiHandler for rate limiting and error handling
-export const GET = apiHandler(async (req: NextRequest) => {
-  try { await requireManager(); } catch { return error("ForbiddenError", "僅限管理員", 403); }
+export const GET = withManager(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const mode = searchParams.get("mode") ?? "detail";

--- a/app/api/reports/overtime/route.ts
+++ b/app/api/reports/overtime/route.ts
@@ -6,14 +6,13 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireManagerOrAbove as requireManager } from "@/lib/auth";
+
 import { success, error } from "@/lib/api-response";
-import { apiHandler } from "@/lib/api-handler";
+import { withManager } from "@/lib/auth-middleware";
 
 const MONTHLY_OT_LIMIT = 46; // Taiwan Labor Standards Act
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  try { await requireManager(); } catch { return error("ForbiddenError", "權限不足", 403); }
+export const GET = withManager(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const from = searchParams.get("from");

--- a/app/api/reports/time-summary/route.ts
+++ b/app/api/reports/time-summary/route.ts
@@ -6,9 +6,8 @@
  */
 import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireManagerOrAbove as requireManager } from "@/lib/auth";
-import { success, error } from "@/lib/api-response";
-import { apiHandler } from "@/lib/api-handler";
+import { success } from "@/lib/api-response";
+import { withManager } from "@/lib/auth-middleware";
 
 const HOURS_PER_DAY = 8;
 
@@ -23,8 +22,7 @@ function countWorkdays(from: Date, to: Date): number {
   return count;
 }
 
-export const GET = apiHandler(async (req: NextRequest) => {
-  try { await requireManager(); } catch { return error("ForbiddenError", "權限不足", 403); }
+export const GET = withManager(async (req: NextRequest) => {
 
   const { searchParams } = new URL(req.url);
   const from = searchParams.get("from");


### PR DESCRIPTION
Red team sweep: 4 report routes used @/lib/auth (wrong path, no password-expiry enforcement). Now using withManager.