### PR TITLE
fix(T1411): add Zod validation to CRITICAL routes + harden RBAC

### DIFF
--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -6,12 +6,12 @@
  */
 import { NextRequest } from "next/server";
 import { success } from "@/lib/api-response";
-import { withAuth, withAdmin } from "@/lib/auth-middleware";
+import { withAdmin } from "@/lib/auth-middleware";
 import { getAllFeatureFlags, setFeatureFlag, isValidFlagName } from "@/lib/feature-flags";
 import { requireAuth } from "@/lib/rbac";
 import { ValidationError } from "@/services/errors";
 
-export const GET = withAuth(async (_req: NextRequest) => {
+export const GET = withAdmin(async (_req: NextRequest) => {
   const flags = await getAllFeatureFlags();
   return success({ flags });
 });

--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -1,7 +1,7 @@
 /**
  * Feature Flags API — Issue #1328
  *
- * GET  /api/admin/feature-flags — read all flags (any authenticated user)
+ * GET  /api/admin/feature-flags — read all flags (ADMIN only)
  * PUT  /api/admin/feature-flags — update a flag (ADMIN only)
  */
 import { NextRequest } from "next/server";

--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -6,6 +6,8 @@ import { AuditService } from "@/services/audit-service";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { getClientIp } from "@/lib/get-client-ip";
+import { validateBody } from "@/lib/validate";
+import { updateDeliverableSchema } from "@/validators/deliverable-validators";
 
 const auditService = new AuditService(prisma);
 
@@ -24,7 +26,8 @@ export const PATCH = withManager(async (
   context: { params: Promise<Record<string, string>> }
 ) => {
   const { id } = await context.params;
-  const body = await req.json();
+  const raw = await req.json();
+  const body = validateBody(updateDeliverableSchema, raw);
 
   const deliverable = await prisma.deliverable.update({
     where: { id },

--- a/app/api/deliverables/[id]/route.ts
+++ b/app/api/deliverables/[id]/route.ts
@@ -4,7 +4,7 @@ import { success } from "@/lib/api-response";
 import { DeliverableService } from "@/services/deliverable-service";
 import { AuditService } from "@/services/audit-service";
 import { withAuth, withManager } from "@/lib/auth-middleware";
-import { requireRole } from "@/lib/rbac";
+import { requireRole, requireMinRole } from "@/lib/rbac";
 import { getClientIp } from "@/lib/get-client-ip";
 import { validateBody } from "@/lib/validate";
 import { updateDeliverableSchema } from "@/validators/deliverable-validators";
@@ -25,19 +25,29 @@ export const PATCH = withManager(async (
   req: NextRequest,
   context: { params: Promise<Record<string, string>> }
 ) => {
+  const session = await requireMinRole("MANAGER");
   const { id } = await context.params;
   const raw = await req.json();
   const body = validateBody(updateDeliverableSchema, raw);
 
+  // Server-side enforcement: acceptedBy/acceptedAt come from session, not client
+  const data: Record<string, unknown> = {
+    ...(body.status !== undefined && { status: body.status }),
+    ...(body.title !== undefined && { title: body.title }),
+    ...(body.attachmentUrl !== undefined && { attachmentUrl: body.attachmentUrl }),
+  };
+  if (body.status === "ACCEPTED") {
+    data.acceptedBy = session.user.id;
+    data.acceptedAt = new Date();
+  } else if (body.status !== undefined) {
+    // Reset acceptance when status changes away from ACCEPTED
+    data.acceptedBy = null;
+    data.acceptedAt = null;
+  }
+
   const deliverable = await prisma.deliverable.update({
     where: { id },
-    data: {
-      ...(body.status !== undefined && { status: body.status }),
-      ...(body.title !== undefined && { title: body.title }),
-      ...(body.attachmentUrl !== undefined && { attachmentUrl: body.attachmentUrl }),
-      ...(body.acceptedBy !== undefined && { acceptedBy: body.acceptedBy }),
-      ...(body.acceptedAt !== undefined && { acceptedAt: body.acceptedAt ? new Date(body.acceptedAt) : null }),
-    },
+    data,
   });
 
   return success(deliverable);

--- a/app/api/kpi/[id]/link/route.ts
+++ b/app/api/kpi/[id]/link/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { ValidationError } from "@/services/errors";
 import { withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { sanitizeHtml } from "@/lib/security/sanitize";
 
 export const POST = withManager(async (
   req: NextRequest,
@@ -15,15 +16,22 @@ export const POST = withManager(async (
 
   if (!taskId) throw new ValidationError("taskId 為必填");
 
+  const safeTaskId = sanitizeHtml(String(taskId));
+
   if (remove) {
-    await prisma.kPITaskLink.deleteMany({ where: { kpiId: id, taskId } });
+    await prisma.kPITaskLink.deleteMany({ where: { kpiId: id, taskId: safeTaskId } });
     return success({ message: "已移除連結" });
   }
 
+  const parsedWeight = weight != null ? parseFloat(weight) : 1;
+  if (!Number.isFinite(parsedWeight) || parsedWeight < 0 || parsedWeight > 100) {
+    throw new ValidationError("weight 必須為 0-100 之間的數字");
+  }
+
   const link = await prisma.kPITaskLink.upsert({
-    where: { kpiId_taskId: { kpiId: id, taskId } },
-    update: { weight: weight != null ? parseFloat(weight) : 1 },
-    create: { kpiId: id, taskId, weight: weight != null ? parseFloat(weight) : 1 },
+    where: { kpiId_taskId: { kpiId: id, taskId: safeTaskId } },
+    update: { weight: parsedWeight },
+    create: { kpiId: id, taskId: safeTaskId, weight: parsedWeight },
   });
 
   return success(link, 201);

--- a/app/api/kpi/[id]/link/route.ts
+++ b/app/api/kpi/[id]/link/route.ts
@@ -1,9 +1,16 @@
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { ValidationError } from "@/services/errors";
 import { withManager } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
-import { sanitizeHtml } from "@/lib/security/sanitize";
+import { validateBody } from "@/lib/validate";
+
+const kpiLinkSchema = z.object({
+  taskId: z.string().min(1).max(30),
+  weight: z.union([z.number(), z.string()]).optional(),
+  remove: z.boolean().optional(),
+});
 
 export const POST = withManager(async (
   req: NextRequest,
@@ -11,27 +18,23 @@ export const POST = withManager(async (
 ) => {
 
   const { id } = await context.params;
-  const body = await req.json();
-  const { taskId, weight, remove } = body;
-
-  if (!taskId) throw new ValidationError("taskId 為必填");
-
-  const safeTaskId = sanitizeHtml(String(taskId));
+  const raw = await req.json();
+  const { taskId, weight, remove } = validateBody(kpiLinkSchema, raw);
 
   if (remove) {
-    await prisma.kPITaskLink.deleteMany({ where: { kpiId: id, taskId: safeTaskId } });
+    await prisma.kPITaskLink.deleteMany({ where: { kpiId: id, taskId: taskId } });
     return success({ message: "已移除連結" });
   }
 
-  const parsedWeight = weight != null ? parseFloat(weight) : 1;
+  const parsedWeight = weight != null ? parseFloat(String(weight)) : 1;
   if (!Number.isFinite(parsedWeight) || parsedWeight < 0 || parsedWeight > 100) {
     throw new ValidationError("weight 必須為 0-100 之間的數字");
   }
 
   const link = await prisma.kPITaskLink.upsert({
-    where: { kpiId_taskId: { kpiId: id, taskId: safeTaskId } },
+    where: { kpiId_taskId: { kpiId: id, taskId: taskId } },
     update: { weight: parsedWeight },
-    create: { kpiId: id, taskId: safeTaskId, weight: parsedWeight },
+    create: { kpiId: id, taskId: taskId, weight: parsedWeight },
   });
 
   return success(link, 201);

--- a/app/api/monitoring-alerts/[id]/route.ts
+++ b/app/api/monitoring-alerts/[id]/route.ts
@@ -10,6 +10,8 @@ import { MonitoringService } from "@/services/monitoring-service";
 import { success, error } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { acknowledgeAlertSchema, createTaskFromAlertSchema } from "@/validators/monitoring-validators";
 
 const service = new MonitoringService(prisma);
 
@@ -19,6 +21,7 @@ export const PATCH = withAuth(async (req: NextRequest, context: { params: Promis
   const raw = await req.json();
 
   if (raw.action === "acknowledge") {
+    validateBody(acknowledgeAlertSchema, raw);
     if (session.user.role !== "MANAGER" && session.user.role !== "ADMIN") {
       return error("FORBIDDEN", "僅限管理員可確認警報", 403);
     }
@@ -27,6 +30,7 @@ export const PATCH = withAuth(async (req: NextRequest, context: { params: Promis
   }
 
   if (raw.action === "create_task") {
+    validateBody(createTaskFromAlertSchema, raw);
     const task = await service.createTaskFromAlert(id, session.user.id);
     if (!task) {
       return error("NOT_FOUND", "Alert not found", 404);

--- a/app/api/time-entries/start/route.ts
+++ b/app/api/time-entries/start/route.ts
@@ -5,12 +5,20 @@
  * Returns 409 if the user already has a running timer.
  */
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { TimeCategory } from "@prisma/client";
 import { ConflictError } from "@/services/errors";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { validateBody } from "@/lib/validate";
+
+const startTimerSchema = z.object({
+  taskId: z.string().min(1).optional(),
+  category: z.enum(["PLANNED_TASK", "ADDED_TASK", "INCIDENT", "SUPPORT", "ADMIN", "LEARNING"]).optional(),
+  description: z.string().max(500).optional(),
+});
 
 export const POST = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
@@ -31,7 +39,8 @@ export const POST = withAuth(async (req: NextRequest) => {
   let description: string | null = null;
 
   try {
-    const body = await req.json();
+    const raw = await req.json();
+    const body = validateBody(startTimerSchema, raw);
     if (body.taskId) taskId = body.taskId;
     if (body.category) category = body.category as TimeCategory;
     if (body.description) description = body.description;


### PR DESCRIPTION
## Summary

- **CRITICAL**: Add Zod validation to 3 routes that had zero input validation
  - `PATCH /api/deliverables/:id` — wire up existing `updateDeliverableSchema`
  - `POST /api/time-entries/start` — new `startTimerSchema` with enum validation
  - `POST /api/kpi/:id/link` — weight NaN/Infinity/bounds check (0-100, finite)
- **MEDIUM**: `GET /api/admin/feature-flags` changed `withAuth` → `withAdmin` (ENGINEER could read all flags)
- **Code cleanup**: Wire up 2 unused Zod schemas in `monitoring-alerts/:id`

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `PATCH /api/deliverables/:id` rejects invalid body
- [ ] `POST /api/time-entries/start` rejects invalid category enum
- [ ] `POST /api/kpi/:id/link` rejects NaN/Infinity/out-of-range weight
- [ ] `GET /api/admin/feature-flags` returns 403 for ENGINEER role
- [ ] monitoring-alerts acknowledge/create_task validates action field

Closes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)