### PR TITLE
fix(T1435): add missing FK constraints + indexes + Float→Decimal補漏

### DIFF
--- a/app/api/dashboard/manager-today/route.ts
+++ b/app/api/dashboard/manager-today/route.ts
@@ -94,7 +94,7 @@ export const GET = withManager(async () => {
     ? behindKpis.filter((kpi) => {
         const ach = kpi.achievements[0];
         if (!ach) return true; // No entry yet = behind
-        const pct = kpi.target > 0 ? (ach.actualValue / kpi.target) * 100 : 0;
+        const pct = kpi.target > 0 ? (Number(ach.actualValue) / kpi.target) * 100 : 0;
         return pct < 80;
       }).length
     : 0;

--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -117,7 +117,7 @@ export const POST = withAuth(async (
     orderBy: { period: "desc" },
   });
   if (allAchievements.length > 0) {
-    const latestActual = allAchievements[0].actualValue;
+    const latestActual = Number(allAchievements[0].actualValue);
     await prisma.kPI.update({
       where: { id },
       data: { actual: latestActual },

--- a/app/api/reports/time-distribution/route.ts
+++ b/app/api/reports/time-distribution/route.ts
@@ -44,7 +44,14 @@ export const GET = withAuth(async (req: NextRequest) => {
     },
   });
 
-  const result = aggregateTimeDistribution(entries);
+  const result = aggregateTimeDistribution(
+    entries.map((e) => ({
+      userId: e.userId,
+      hours: Number(e.hours),
+      category: e.category,
+      user: e.user ? { name: e.user.name } : null,
+    }))
+  );
 
   return success({
     from: startDate.toISOString(),

--- a/app/api/reports/timesheet-compliance/route.ts
+++ b/app/api/reports/timesheet-compliance/route.ts
@@ -76,7 +76,7 @@ export const GET = withManager(async (req: NextRequest) => {
   for (const [userId, { userName, entries: userEntries }] of byUser) {
     const dailyEntries: DailyEntry[] = userEntries.map((e) => ({
       date: formatLocalDate(new Date(e.date)),
-      hours: e.hours,
+      hours: Number(e.hours),
       overtime: Boolean((e as Record<string, unknown>).overtime),
       locked: Boolean((e as Record<string, unknown>).locked),
       category: e.category,

--- a/app/api/time-entries/suggestions/route.ts
+++ b/app/api/time-entries/suggestions/route.ts
@@ -77,7 +77,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     if (entry.taskId) {
       loggedHoursByTask.set(
         entry.taskId,
-        (loggedHoursByTask.get(entry.taskId) ?? 0) + entry.hours
+        (loggedHoursByTask.get(entry.taskId) ?? 0) + Number(entry.hours)
       );
     }
   }

--- a/prisma/migrations/20260411020000_add_missing_fk_and_indexes/migration.sql
+++ b/prisma/migrations/20260411020000_add_missing_fk_and_indexes/migration.sql
@@ -1,0 +1,67 @@
+-- Migration: add_missing_fk_and_indexes
+-- Adds missing FK constraints, composite indexes, and Float→Decimal conversions
+-- Issue #1435
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 1. Float→Decimal: kpi_achievements.actual_value
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "kpi_achievements" ALTER COLUMN "actualValue" TYPE DECIMAL(10,4) USING "actualValue"::DECIMAL(10,4);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 2. Float→Decimal: task_templates.estimated_hours
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "task_templates" ALTER COLUMN "estimatedHours" TYPE DECIMAL(5,2) USING "estimatedHours"::DECIMAL(5,2);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 3. Float→Decimal: recurring_rules.estimated_hours
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "recurring_rules" ALTER COLUMN "estimatedHours" TYPE DECIMAL(5,2) USING "estimatedHours"::DECIMAL(5,2);
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 4. FK: kpi_achievements.reportedBy → users.id
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "kpi_achievements" ADD CONSTRAINT "kpi_achievements_reportedBy_fkey"
+  FOREIGN KEY ("reportedBy") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 5. FK: sub_tasks.assigneeId → users.id (SET NULL on delete)
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "sub_tasks" ADD CONSTRAINT "sub_tasks_assigneeId_fkey"
+  FOREIGN KEY ("assigneeId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 6. FK: recurring_rules.assigneeId → users.id (SET NULL on delete)
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "recurring_rules" ADD CONSTRAINT "recurring_rules_assigneeId_fkey"
+  FOREIGN KEY ("assigneeId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 7. FK: monitoring_alerts.acknowledgedBy → users.id (SET NULL on delete)
+-- ──────────────────────────────────────────────────────────────────────────────
+ALTER TABLE "monitoring_alerts" ADD CONSTRAINT "monitoring_alerts_acknowledgedBy_fkey"
+  FOREIGN KEY ("acknowledgedBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 8. Index: sub_tasks.assigneeId
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS "sub_tasks_assigneeId_idx" ON "sub_tasks"("assigneeId");
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 9. Index: recurring_rules.assigneeId
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS "recurring_rules_assigneeId_idx" ON "recurring_rules"("assigneeId");
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 10. Index: monitoring_alerts.acknowledgedBy
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS "monitoring_alerts_acknowledgedBy_idx" ON "monitoring_alerts"("acknowledgedBy");
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 11. Composite index: tasks(deletedAt, status)
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS "tasks_deletedAt_status_idx" ON "tasks"("deletedAt", "status");
+
+-- ──────────────────────────────────────────────────────────────────────────────
+-- 12. Composite index: tasks(monthlyGoalId, status)
+-- ──────────────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS "tasks_monthlyGoalId_status_idx" ON "tasks"("monthlyGoalId", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,10 @@ model User {
   projectRisks             ProjectRisk[]        @relation("RiskOwner")
   projectIssues            ProjectIssue[]       @relation("IssueAssignee")
   gateReviews              ProjectGate[]        @relation("GateReviewer")
+  reportedKPIAchievements  KPIAchievement[]     @relation("KPIAchievementReporter")
+  assignedSubTasks         SubTask[]            @relation("SubTaskAssignee")
+  assignedRecurringRules   RecurringRule[]      @relation("RecurringRuleAssignee")
+  acknowledgedAlerts       MonitoringAlert[]    @relation("MonitoringAlertAcknowledger")
 
   @@map("users")
 }
@@ -182,13 +186,14 @@ model KPIAchievement {
   id          String   @id @default(cuid())
   kpiId       String
   period      String   // e.g., "2026-01", "2026-Q1", "2026"
-  actualValue Float
+  actualValue Decimal  @db.Decimal(10, 4)
   note        String?
   reportedBy  String
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
   kpi      KPI  @relation(fields: [kpiId], references: [id], onDelete: Cascade)
+  reporter User @relation("KPIAchievementReporter", fields: [reportedBy], references: [id])
 
   @@unique([kpiId, period])
   @@index([kpiId])
@@ -403,6 +408,8 @@ model Task {
   @@index([primaryAssigneeId, status])
   @@index([managerFlagged, status])
   @@index([deletedAt])
+  @@index([deletedAt, status])
+  @@index([monthlyGoalId, status])
   @@map("tasks")
 }
 
@@ -543,9 +550,11 @@ model SubTask {
   createdAt   DateTime  @default(now())
 
   task        Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  assignee    User?       @relation("SubTaskAssignee", fields: [assigneeId], references: [id], onDelete: SetNull)
   timeEntries TimeEntry[]
 
   @@index([taskId])
+  @@index([assigneeId])
   @@map("sub_tasks")
 }
 
@@ -1016,7 +1025,7 @@ model TaskTemplate {
   description    String?
   priority       Priority     @default(P2)
   category       TaskCategory @default(PLANNED)
-  estimatedHours Float?
+  estimatedHours Decimal?  @db.Decimal(5, 2)
   creatorId      String
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
@@ -1054,7 +1063,7 @@ model RecurringRule {
   dayOfMonth      Int?                // MONTHLY: 1-31
   monthOfYear     Int?                // YEARLY/QUARTERLY: 1-12
   timeOfDay       String?             // "HH:MM"
-  estimatedHours  Float?
+  estimatedHours  Decimal?            @db.Decimal(5, 2)
   isActive        Boolean             @default(true)
   lastGeneratedAt DateTime?
   nextDueAt       DateTime?
@@ -1063,9 +1072,11 @@ model RecurringRule {
   updatedAt       DateTime            @updatedAt
 
   creator  User          @relation("RecurringRuleCreator", fields: [creatorId], references: [id])
+  assignee User?         @relation("RecurringRuleAssignee", fields: [assigneeId], references: [id], onDelete: SetNull)
   template TaskTemplate? @relation(fields: [templateId], references: [id])
 
   @@index([isActive, nextDueAt])
+  @@index([assigneeId])
   @@map("recurring_rules")
 }
 
@@ -1164,10 +1175,12 @@ model MonitoringAlert {
   updatedAt      DateTime    @updatedAt
 
   relatedTask Task? @relation(fields: [relatedTaskId], references: [id])
+  acknowledger User? @relation("MonitoringAlertAcknowledger", fields: [acknowledgedBy], references: [id], onDelete: SetNull)
 
   @@unique([alertName, startsAt])
   @@index([status])
   @@index([startsAt])
+  @@index([acknowledgedBy])
   @@map("monitoring_alerts")
 }
 


### PR DESCRIPTION
## Summary

- 新增 4 個缺失的 FK 約束：`KPIAchievement.reportedBy`、`SubTask.assigneeId`、`RecurringRule.assigneeId`、`MonitoringAlert.acknowledgedBy` → User
- Task model 新增複合索引：`[deletedAt, status]`、`[monthlyGoalId, status]`
- Float→Decimal 補漏：`KPIAchievement.actualValue` (10,4)、`TaskTemplate.estimatedHours` (5,2)、`RecurringRule.estimatedHours` (5,2)
- 修復因 Decimal 型別轉換帶來的 TypeScript 型別錯誤（5 個 route 檔案）
- 手動建立 migration SQL（DB 無法連線，使用 `--create-only` 等效方案）

## Test plan

- [x] `npx prisma validate` — schema 驗證通過
- [x] `npm run build` — 型別檢查通過，零 Type error
- [ ] DB 連線後執行 `npm run db:migrate:deploy` 驗證 migration

Closes #1435