### PR TITLE
fix(T1434): XSS in search/documents-search extractSnippet + frontend memory leak cleanup

### DIFF
--- a/app/api/documents/search/route.ts
+++ b/app/api/documents/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { withAuth } from "@/lib/auth-middleware";
 import { success } from "@/lib/api-response";
+import { escapeHtml } from "@/lib/security/sanitize";
 
 type SearchResult = {
   id: string;
@@ -31,9 +32,13 @@ export const GET = withAuth(async (req: NextRequest) => {
     LIMIT 20
   `;
 
-  // If FTS returned results, use them
+  // If FTS returned results, escape snippets before returning
   if (ftsResults.length > 0) {
-    return success(ftsResults);
+    const escaped = ftsResults.map((r) => ({
+      ...r,
+      snippet: escapeHtml(r.snippet),
+    }));
+    return success(escaped);
   }
 
   // Fallback: ILIKE search for CJK text (Chinese/Japanese/Korean)
@@ -61,7 +66,7 @@ export const GET = withAuth(async (req: NextRequest) => {
     title: doc.title,
     slug: doc.slug,
     parentId: doc.parentId,
-    snippet: doc.content.substring(0, 200),
+    snippet: escapeHtml(doc.content.substring(0, 200)),
   }));
 
   return success(mapped);

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { success, error } from "@/lib/api-response";
 import { withAuth } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
+import { escapeHtml } from "@/lib/security/sanitize";
 
 /**
  * Extract a snippet around the matched keyword.
@@ -18,9 +19,9 @@ function extractSnippet(text: string, keyword: string, contextLen = 50): string 
   const end = Math.min(text.length, idx + keyword.length + contextLen);
   let snippet = "";
   if (start > 0) snippet += "...";
-  snippet += text.substring(start, idx);
-  snippet += `<mark>${text.substring(idx, idx + keyword.length)}</mark>`;
-  snippet += text.substring(idx + keyword.length, end);
+  snippet += escapeHtml(text.substring(start, idx));
+  snippet += `<mark>${escapeHtml(text.substring(idx, idx + keyword.length))}</mark>`;
+  snippet += escapeHtml(text.substring(idx + keyword.length, end));
   if (end < text.length) snippet += "...";
   return snippet;
 }

--- a/app/components/activity-timeline.tsx
+++ b/app/components/activity-timeline.tsx
@@ -46,6 +46,18 @@ export function ActivityTimeline() {
   const [fetchError, setFetchError] = useState<string | null>(null);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  // Keep latest scroll-guard state in refs so the observer callback always
+  // reads fresh values without being recreated on every render.
+  const hasMoreRef = useRef(hasMore);
+  const loadingMoreRef = useRef(loadingMore);
+  const loadingRef = useRef(loading);
+  const pageRef = useRef(page);
+
+  // Sync refs on every render
+  hasMoreRef.current = hasMore;
+  loadingMoreRef.current = loadingMore;
+  loadingRef.current = loading;
+  pageRef.current = page;
 
   const fetchPage = useCallback(
     async (pageNum: number, append: boolean) => {
@@ -98,17 +110,18 @@ export function ActivityTimeline() {
     fetchPage(1, false);
   }, [fetchPage]);
 
-  // Infinite scroll: observe sentinel
+  // Infinite scroll: build observer once; read latest state through refs.
   useEffect(() => {
-    if (observerRef.current) {
-      observerRef.current.disconnect();
-    }
-
     observerRef.current = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        if (entry?.isIntersecting && hasMore && !loadingMore && !loading) {
-          const nextPage = page + 1;
+        if (
+          entry?.isIntersecting &&
+          hasMoreRef.current &&
+          !loadingMoreRef.current &&
+          !loadingRef.current
+        ) {
+          const nextPage = pageRef.current + 1;
           setPage(nextPage);
           fetchPage(nextPage, true);
         }
@@ -123,7 +136,8 @@ export function ActivityTimeline() {
     return () => {
       observerRef.current?.disconnect();
     };
-  }, [hasMore, loadingMore, loading, page, fetchPage]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchPage]); // fetchPage is stable (useCallback with empty deps)
 
   // ── Render ─────────────────────────────────────────────────────────────
 

--- a/app/components/document-search.tsx
+++ b/app/components/document-search.tsx
@@ -83,6 +83,13 @@ export function DocumentSearch({ onSelect }: DocumentSearchProps) {
     setHistory(loadHistory());
   }, []);
 
+  // Clear debounce timer on unmount to prevent state updates after unmount
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
   // Close dropdown on outside click
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {

--- a/app/components/notification-bell.tsx
+++ b/app/components/notification-bell.tsx
@@ -129,11 +129,11 @@ export function NotificationBell() {
     return filtered;
   })();
 
-  async function fetchNotifications() {
+  async function fetchNotifications(signal?: AbortSignal) {
     setLoading(true);
     try {
       // Fetch regular notifications
-      const res = await fetch("/api/notifications?limit=15");
+      const res = await fetch("/api/notifications?limit=15", { signal });
       let items: Notification[] = [];
       let unread = 0;
       if (res.ok) {
@@ -145,7 +145,7 @@ export function NotificationBell() {
 
       // Fetch system alerts and prepend as notifications
       try {
-        const alertRes = await fetch("/api/alerts/active");
+        const alertRes = await fetch("/api/alerts/active", { signal });
         if (alertRes.ok) {
           const alertBody = await alertRes.json();
           const alerts = extractData<{ alerts?: Array<{ type: string; message: string }> }>(alertBody)?.alerts ?? [];
@@ -164,7 +164,9 @@ export function NotificationBell() {
 
       setNotifications(items);
       setUnreadCount(unread);
-    } catch {
+    } catch (err) {
+      // Ignore abort errors — component was unmounted or signal was cancelled
+      if (err instanceof Error && err.name === "AbortError") return;
       toast.error("通知載入失敗");
     } finally {
       setLoading(false);
@@ -204,7 +206,8 @@ export function NotificationBell() {
 
   useEffect(() => {
     // 初始載入目前通知（SSE 只推送新通知，不補歷史）
-    fetchNotifications();
+    const initController = new AbortController();
+    fetchNotifications(initController.signal);
 
     // ── SSE 連線 ────────────────────────────────────────────────────────────
     let eventSource: EventSource | null = null;
@@ -213,9 +216,15 @@ export function NotificationBell() {
     let firstFailureAt = 0;
     let useFallbackPolling = false;
 
+    let pollController: AbortController | null = null;
+
     function startFallbackPolling() {
       if (fallbackInterval) return; // 已啟動
-      fallbackInterval = setInterval(fetchNotifications, FALLBACK_POLL_INTERVAL_MS);
+      fallbackInterval = setInterval(() => {
+        pollController?.abort();
+        pollController = new AbortController();
+        fetchNotifications(pollController.signal);
+      }, FALLBACK_POLL_INTERVAL_MS);
     }
 
     function connectSSE() {
@@ -276,6 +285,8 @@ export function NotificationBell() {
     }
 
     return () => {
+      initController.abort();
+      pollController?.abort();
       eventSource?.close();
       if (fallbackInterval) clearInterval(fallbackInterval);
     };

--- a/lib/security/sanitize.ts
+++ b/lib/security/sanitize.ts
@@ -1,4 +1,18 @@
 /**
+ * Escape HTML special characters to prevent XSS when inserting text into HTML context.
+ * Use this when you need to embed plain text inside an HTML string (e.g. search snippets).
+ */
+export function escapeHtml(text: string): string {
+  if (!text) return "";
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
  * XSS Sanitizer — Issue #805 (K-3a), enhanced Issue #1124, DOMPurify migration Issue #1326
  *
  * Sanitizes Markdown/HTML content to prevent XSS attacks.


### PR DESCRIPTION
## Summary

- **CRITICAL XSS fix**: `extractSnippet()` in `/api/search/route.ts` inserted DB content into `<mark>` HTML tags without escaping. Added `escapeHtml()` to sanitize all 3 text segments.
- **Same fix for `/api/documents/search/route.ts`**: FTS + ILIKE paths both returned raw `LEFT(content, 200)` / `substring(0, 200)` as snippet without HTML escaping.
- **Memory leak fixes**:
  - `notification-bell.tsx`: AbortController for initial fetch + per-poll AbortController for fallback polling
  - `document-search.tsx`: clearTimeout on unmount
  - `activity-timeline.tsx`: IntersectionObserver built once via ref-sync pattern (was rebuilt on every state change)

## Files Changed

| File | Change |
|------|--------|
| `lib/security/sanitize.ts` | Added `escapeHtml()` helper |
| `app/api/search/route.ts` | Apply escapeHtml in extractSnippet |
| `app/api/documents/search/route.ts` | Apply escapeHtml to FTS + ILIKE snippet |
| `app/components/notification-bell.tsx` | AbortController for fetch + polling |
| `app/components/document-search.tsx` | clearTimeout cleanup on unmount |
| `app/components/activity-timeline.tsx` | Stable IntersectionObserver via refs |

## Test plan

- [ ] Search for `<script>alert(1)</script>` — verify snippet shows escaped text, not executed script
- [ ] Document search returns escaped snippet
- [ ] Notification bell: mount/unmount quickly — no console warnings about setState on unmounted
- [ ] Activity timeline: scroll down to trigger infinite scroll — verify no duplicate observers

Closes #1434