### PR TITLE
fix(T1438): race conditions in timer/time-entry/approval/kpi

### DIFF
--- a/app/api/kpi/[id]/achievement/route.ts
+++ b/app/api/kpi/[id]/achievement/route.ts
@@ -94,35 +94,40 @@ export const POST = withAuth(async (
     );
   }
 
-  // Upsert: 同一 KPI + 同一週期只有一筆（重複填報為更新）
-  const achievement = await prisma.kPIAchievement.upsert({
-    where: { kpiId_period: { kpiId: id, period } },
-    create: {
-      kpiId: id,
-      period,
-      actualValue,
-      note: note || null,
-      reportedBy: session.user.id,
-    },
-    update: {
-      actualValue,
-      note: note || null,
-      reportedBy: session.user.id,
-    },
-  });
-
-  // 更新 KPI 的 actual 值（取所有填報的平均或最新值）
-  const allAchievements = await prisma.kPIAchievement.findMany({
-    where: { kpiId: id },
-    orderBy: { period: "desc" },
-  });
-  if (allAchievements.length > 0) {
-    const latestActual = Number(allAchievements[0].actualValue);
-    await prisma.kPI.update({
-      where: { id },
-      data: { actual: latestActual },
+  // Upsert + KPI actual update in one transaction to prevent the achievement
+  // being written without the parent KPI.actual being updated (or vice versa).
+  const achievement = await prisma.$transaction(async (tx) => {
+    const upserted = await tx.kPIAchievement.upsert({
+      where: { kpiId_period: { kpiId: id, period } },
+      create: {
+        kpiId: id,
+        period,
+        actualValue,
+        note: note || null,
+        reportedBy: session.user.id,
+      },
+      update: {
+        actualValue,
+        note: note || null,
+        reportedBy: session.user.id,
+      },
     });
-  }
+
+    // 更新 KPI 的 actual 值（取最新週期的填報值）
+    const allAchievements = await tx.kPIAchievement.findMany({
+      where: { kpiId: id },
+      orderBy: { period: "desc" },
+    });
+    if (allAchievements.length > 0) {
+      const latestActual = Number(allAchievements[0].actualValue);
+      await tx.kPI.update({
+        where: { id },
+        data: { actual: latestActual },
+      });
+    }
+
+    return upserted;
+  });
 
   // Banking compliance: audit trail for KPI achievement changes
   const auditService = new AuditService(prisma);

--- a/app/api/time-entries/approve/route.ts
+++ b/app/api/time-entries/approve/route.ts
@@ -12,7 +12,7 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
-import { ForbiddenError } from "@/services/errors";
+import { ForbiddenError, ConflictError } from "@/services/errors";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
@@ -56,14 +56,23 @@ export const POST = withManager(async (req: NextRequest) => {
 
   // Transaction: update entries + create approval records + audit log
   await prisma.$transaction(async (tx) => {
-    // Batch update entries
-    await tx.timeEntry.updateMany({
-      where: { id: { in: eligibleIds } },
+    // Double-approve fix: add approvalStatus condition so concurrent approve
+    // requests only update entries that are still PENDING/REJECTED.
+    const result = await tx.timeEntry.updateMany({
+      where: {
+        id: { in: eligibleIds },
+        approvalStatus: { in: ["PENDING", "REJECTED"] },
+      },
       data: {
         locked: true,
         approvalStatus: "APPROVED",
       },
     });
+
+    // If count mismatches, some entries were already approved by a concurrent request.
+    if (result.count !== eligibleIds.length) {
+      throw new ConflictError("部分工時記錄已被其他請求審核，請重新整理後再試");
+    }
 
     // Create approval records
     await tx.timesheetApproval.createMany({

--- a/app/api/time-entries/reject/route.ts
+++ b/app/api/time-entries/reject/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { ConflictError } from "@/services/errors";
 import { withManager } from "@/lib/auth-middleware";
 import { requireRole } from "@/lib/rbac";
 import { validateBody } from "@/lib/validate";
@@ -52,14 +53,23 @@ export const POST = withManager(async (req: NextRequest) => {
 
   // Transaction: update entries + create approval records + notifications + audit log
   await prisma.$transaction(async (tx) => {
-    // Batch update entries
-    await tx.timeEntry.updateMany({
-      where: { id: { in: eligibleIds } },
+    // Double-reject fix: add approvalStatus condition so concurrent reject
+    // requests only update entries that are still PENDING/APPROVED.
+    const result = await tx.timeEntry.updateMany({
+      where: {
+        id: { in: eligibleIds },
+        approvalStatus: { in: ["PENDING", "APPROVED"] },
+      },
       data: {
         locked: false,
         approvalStatus: "REJECTED",
       },
     });
+
+    // If count mismatches, some entries were already rejected by a concurrent request.
+    if (result.count !== eligibleIds.length) {
+      throw new ConflictError("部分工時記錄已被其他請求審核，請重新整理後再試");
+    }
 
     // Create approval records
     await tx.timesheetApproval.createMany({

--- a/app/api/time-entries/route.ts
+++ b/app/api/time-entries/route.ts
@@ -108,14 +108,13 @@ export const POST = withAuth(async (req: NextRequest) => {
   const cleanDescription = description ? sanitizeHtml(description) || null : null;
 
   const entry = await prisma.$transaction(async (tx) => {
-    const existingEntries = await tx.timeEntry.findMany({
-      where: {
-        userId: session.user.id,
-        date: targetDate,
-        isDeleted: false,
-      },
-      select: { hours: true },
-    });
+    // Row-level locking prevents concurrent requests from bypassing the 24hr limit.
+    // FOR UPDATE locks matching rows so parallel transactions must wait.
+    const existingEntries = await tx.$queryRaw<Array<{ hours: number }>>`
+      SELECT hours FROM time_entries
+      WHERE "userId" = ${session.user.id} AND date = ${targetDate}::date AND "isDeleted" = false
+      FOR UPDATE
+    `;
     const existingTotal = existingEntries.reduce((sum, e) => sum + Number(e.hours), 0);
     const limitError = validateDailyLimit(existingTotal, hours);
     if (limitError) {

--- a/app/api/time-entries/start/route.ts
+++ b/app/api/time-entries/start/route.ts
@@ -24,15 +24,6 @@ export const POST = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
   const userId = session.user.id;
 
-  // Check for an already-running timer
-  const existing = await prisma.timeEntry.findFirst({
-    where: { userId, isRunning: true },
-  });
-
-  if (existing) {
-    throw new ConflictError("已有正在計時的項目，請先停止目前計時器");
-  }
-
   // Parse optional fields from body
   let taskId: string | null = null;
   let category: TimeCategory = "PLANNED_TASK";
@@ -50,21 +41,33 @@ export const POST = withAuth(async (req: NextRequest) => {
 
   const now = new Date();
 
-  const entry = await prisma.timeEntry.create({
-    data: {
-      userId,
-      taskId,
-      date: now,
-      hours: 0,
-      startTime: now,
-      endTime: null,
-      isRunning: true,
-      category,
-      description,
-    },
-    include: {
-      task: { select: { id: true, title: true, category: true } },
-    },
+  // TOCTOU fix: wrap findFirst + create in a transaction so concurrent requests
+  // cannot both pass the running-timer check before either insert commits.
+  const entry = await prisma.$transaction(async (tx) => {
+    const existing = await tx.timeEntry.findFirst({
+      where: { userId, isRunning: true },
+    });
+
+    if (existing) {
+      throw new ConflictError("已有正在計時的項目，請先停止目前計時器");
+    }
+
+    return tx.timeEntry.create({
+      data: {
+        userId,
+        taskId,
+        date: now,
+        hours: 0,
+        startTime: now,
+        endTime: null,
+        isRunning: true,
+        category,
+        description,
+      },
+      include: {
+        task: { select: { id: true, title: true, category: true } },
+      },
+    });
   });
 
   return success(entry, 201);

--- a/app/api/time-entries/stop/route.ts
+++ b/app/api/time-entries/stop/route.ts
@@ -28,30 +28,34 @@ export const POST = withAuth(async (_req: NextRequest) => {
   const session = await requireAuth();
   const userId = session.user.id;
 
-  // Find the running timer for this user
-  const running = await prisma.timeEntry.findFirst({
-    where: { userId, isRunning: true },
-  });
-
-  if (!running) {
-    throw new NotFoundError("目前沒有正在計時的項目");
-  }
-
   const now = new Date();
-  const hours = running.startTime
-    ? calculateHours(running.startTime, now)
-    : 0.25; // Fallback if startTime is somehow null
 
-  const entry = await prisma.timeEntry.update({
-    where: { id: running.id },
-    data: {
-      endTime: now,
-      hours,
-      isRunning: false,
-    },
-    include: {
-      task: { select: { id: true, title: true, category: true } },
-    },
+  // Phantom-read fix: wrap findFirst + update in a transaction so concurrent
+  // stop requests cannot both see the same running timer before either update commits.
+  const entry = await prisma.$transaction(async (tx) => {
+    const running = await tx.timeEntry.findFirst({
+      where: { userId, isRunning: true },
+    });
+
+    if (!running) {
+      throw new NotFoundError("目前沒有正在計時的項目");
+    }
+
+    const hours = running.startTime
+      ? calculateHours(running.startTime, now)
+      : 0.25; // Fallback if startTime is somehow null
+
+    return tx.timeEntry.update({
+      where: { id: running.id },
+      data: {
+        endTime: now,
+        hours,
+        isRunning: false,
+      },
+      include: {
+        task: { select: { id: true, title: true, category: true } },
+      },
+    });
   });
 
   return success(entry);

--- a/prisma/migrations/20260411040000_timer_partial_unique_index/migration.sql
+++ b/prisma/migrations/20260411040000_timer_partial_unique_index/migration.sql
@@ -1,0 +1,6 @@
+-- Partial unique index: enforce at most one running timer per user at the DB level.
+-- This prevents TOCTOU race conditions where two concurrent requests both pass
+-- the application-level check and create duplicate running timers.
+-- Prisma does not support partial unique indexes natively, so this is a raw SQL migration.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "time_entries_userId_running_unique"
+ON time_entries ("userId") WHERE "isRunning" = true;


### PR DESCRIPTION
## Summary

- **CRITICAL**: Timer start TOCTOU → `$transaction` + partial unique index `WHERE isRunning=true`
- **CRITICAL**: 24hr limit bypass → `FOR UPDATE` row locking in existing transaction
- **HIGH**: Timer stop phantom read → `$transaction`
- **HIGH**: Approval double-approve → `approvalStatus` WHERE condition + count check (409)
- **HIGH**: KPI achievement upsert → single `$transaction` for upsert + actual update

## Test plan

- [ ] Open 2 browser tabs, click "Start Timer" simultaneously → only 1 should succeed
- [ ] Submit 2 time entries that would exceed 24hr total → second should fail
- [ ] 2 managers approve same batch simultaneously → one gets 409 ConflictError
- [ ] KPI achievement upsert → parent KPI.actual updates atomically

Closes #1438