### PR TITLE
fix(T1441): Docker security hardening — non-root migrate + cron privilege drop

### DIFF
--- a/Dockerfile.cron
+++ b/Dockerfile.cron
@@ -8,13 +8,16 @@
 FROM alpine:3.19
 
 # Install required packages at build time (network access available here)
+# su-exec is used to drop privileges when running curl commands inside cron jobs
 RUN apk add --no-cache \
       curl \
       tzdata \
       dcron \
       tini \
+      su-exec \
     && cp /usr/share/zoneinfo/Asia/Taipei /etc/localtime \
-    && echo 'Asia/Taipei' > /etc/timezone
+    && echo 'Asia/Taipei' > /etc/timezone \
+    && addgroup -g 1001 -S croner && adduser -S -u 1001 croner -G croner
 
 # Copy the cron schedule script (entrypoint sets up crontab from env then runs crond)
 COPY scripts/cron-entrypoint.sh /usr/local/bin/cron-entrypoint.sh

--- a/Dockerfile.migrate
+++ b/Dockerfile.migrate
@@ -23,4 +23,8 @@ COPY prisma.config.ts ./
 RUN npm ci --ignore-scripts && \
     DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" npx prisma generate
 
+# Run as non-root user (least-privilege principle)
+RUN addgroup -g 1001 -S prisma && adduser -S -u 1001 prisma -G prisma
+USER prisma
+
 CMD ["npx", "prisma", "db", "push", "--accept-data-loss"]

--- a/scripts/cron-entrypoint.sh
+++ b/scripts/cron-entrypoint.sh
@@ -11,11 +11,24 @@ set -eu
 : "${CRON_SECRET:?CRON_SECRET is required}"
 TITAN_APP_URL="${TITAN_APP_URL:-http://titan-app:3100}"
 
+# Write CRON_SECRET to a header file readable only by croner user.
+# This avoids exposing the secret in the process list (ps aux would show
+# command-line args including -H headers, but not file contents).
+# Risk assessment: this container is single-purpose and isolated; the
+# /tmp/cron-headers file is only accessible within the container.
+CRON_HEADER_FILE="/tmp/cron-headers"
+printf 'x-cron-secret: %s\n' "${CRON_SECRET}" > "${CRON_HEADER_FILE}"
+chmod 640 "${CRON_HEADER_FILE}"
+# croner (uid 1001) needs to read the header file at job runtime
+chown root:croner "${CRON_HEADER_FILE}" 2>/dev/null || true
+
 # Common curl options:
 # -fsS  — fail on HTTP error, silent except on error, show error message
 # --max-time 60 — abort if takes longer than 60s
+# -H @FILE — read headers from file (secret never appears in process list)
+# su-exec croner — drop from root to unprivileged croner user before exec
 # || true — never let cron fail; we log success/failure to stdout via crond
-CURL="curl -fsS --max-time 60 -X POST -H 'x-cron-secret: ${CRON_SECRET}'"
+CURL="su-exec croner curl -fsS --max-time 60 -X POST -H @${CRON_HEADER_FILE}"
 
 cat > /etc/crontabs/root <<EOF
 # TITAN cron schedule (Asia/Taipei timezone)


### PR DESCRIPTION
## Summary

- **Dockerfile.migrate**: 新增 non-root user `prisma` (uid 1001)，在 CMD 前切換 `USER prisma`，避免以 root 執行 Prisma migration
- **Dockerfile.cron**: 安裝 `su-exec`，建立 non-root user `croner` (uid 1001)；dcron 本身需 root 啟動，但 cron job 透過 `su-exec croner` 降權執行
- **cron-entrypoint.sh**: 將 `CRON_SECRET` 寫入 header file（`/tmp/cron-headers`，chmod 640），避免 token 出現在 process list；curl 改用 `-H @FILE` 讀取 header
- **.env.recovered**: 已在 `.gitignore` 第 73 行涵蓋，未被 git track，無需額外處理

## Test plan

- [x] `docker build -f Dockerfile.migrate -t titan-migrate:test .` — build 成功
- [x] `docker run --rm titan-migrate:test whoami` — 回傳 `prisma`（非 root）
- [x] `docker build -f Dockerfile.cron -t titan-cron:test .` — build 成功
- [x] 確認 `.env.recovered` 未被 git track（`git ls-files .env.recovered` 無輸出）

Closes #1441