### PR TITLE
perf(T1440): add composite indexes + bound unbounded queries

### DIFF
--- a/app/api/tasks/gantt/route.ts
+++ b/app/api/tasks/gantt/route.ts
@@ -37,6 +37,7 @@ export const GET = withAuth(async (req: NextRequest) => {
               backupAssignee: { select: { id: true, name: true } },
             },
             orderBy: [{ priority: "asc" }, { startDate: "asc" }, { dueDate: "asc" }],
+            take: 500,
           },
         },
       },

--- a/prisma/migrations/20260411060000_add_perf_indexes/migration.sql
+++ b/prisma/migrations/20260411060000_add_perf_indexes/migration.sql
@@ -1,0 +1,9 @@
+-- Issue #1440: Add composite indexes for performance
+-- Using CONCURRENTLY to avoid locking in production; IF NOT EXISTS for idempotency
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "annual_plans_archivedAt_year_idx" ON "annual_plans" ("archivedAt", "year");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "kpis_year_status_idx" ON "kpis" ("year", "status");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "notifications_userId_type_isRead_idx" ON "notifications" ("userId", "type", "isRead");
+
+-- Note: "time_entries_date_isDeleted_idx" already exists (@@index([date, isDeleted]) in schema)
+-- No new index needed for TimeEntry.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -176,6 +176,7 @@ model KPI {
   @@unique([year, title])
   @@index([createdBy])
   @@index([status])
+  @@index([year, status])
   @@index([frequency])
   @@index([deletedAt])
   @@map("kpis")
@@ -244,6 +245,7 @@ model AnnualPlan {
 
   @@unique([year])
   @@index([createdBy])
+  @@index([archivedAt, year])
   @@map("annual_plans")
 }
 
@@ -839,6 +841,7 @@ model Notification {
   user User @relation(fields: [userId], references: [id])
 
   @@index([userId])
+  @@index([userId, type, isRead])
   @@map("notifications")
 }
 

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -38,6 +38,7 @@ export class AlertService {
     const plans = await this.prisma.annualPlan.findMany({
       where: { archivedAt: null, year: now.getFullYear() },
       select: { id: true, title: true, progressPct: true, createdAt: true },
+      take: 1000,
     });
 
     const monthProgress = ((now.getMonth() + 1) / 12) * 100;
@@ -58,6 +59,7 @@ export class AlertService {
     const kpis = await this.prisma.kPI.findMany({
       where: { deletedAt: null, year: now.getFullYear(), status: "ACTIVE" },
       select: { id: true, title: true, target: true, actual: true },
+      take: 1000,
     });
 
     for (const kpi of kpis) {
@@ -85,6 +87,7 @@ export class AlertService {
         dueDate: { lt: threeDaysAgo },
       },
       select: { id: true },
+      take: 1000,
     });
 
     if (overdueTasks.length > 0) {
@@ -107,11 +110,13 @@ export class AlertService {
     const activeUsers = await this.prisma.user.findMany({
       where: { isActive: true },
       select: { id: true, name: true },
+      take: 1000,
     });
 
     const weekEntries = await this.prisma.timeEntry.findMany({
       where: { date: { gte: weekStart, lte: now }, isDeleted: false },
       select: { userId: true },
+      take: 1000,
     });
 
     const usersWithEntries = new Set(weekEntries.map((e) => e.userId));
@@ -137,6 +142,7 @@ export class AlertService {
         verifiedAt: { not: null },
       },
       select: { id: true, title: true, verifiedAt: true, verifyIntervalDays: true },
+      take: 1000,
     });
 
     for (const doc of expiredDocs) {

--- a/services/email-notification-service.ts
+++ b/services/email-notification-service.ts
@@ -122,6 +122,7 @@ export class EmailNotificationService {
         primaryAssigneeId: true,
         primaryAssignee: { select: { email: true } },
       },
+      take: 500,
     });
 
     for (const task of dueSoonTasks) {
@@ -172,6 +173,7 @@ export class EmailNotificationService {
         primaryAssigneeId: true,
         primaryAssignee: { select: { email: true } },
       },
+      take: 500,
     });
 
     for (const task of overdueTasks) {
@@ -354,12 +356,14 @@ export class EmailNotificationService {
         isRead: false,
       },
       select: { userId: true },
+      take: 500,
     });
 
     // Pending approvals (for MANAGER/ADMIN) — any PENDING ApprovalRequest
     const pendingApprovals = await this.prisma.approvalRequest.findMany({
       where: { status: "PENDING" },
       select: { approverId: true },
+      take: 500,
     });
 
     // Group by userId

--- a/services/report-v2-service.ts
+++ b/services/report-v2-service.ts
@@ -246,6 +246,7 @@ export class ReportV2Service {
       where: { id: planId },
       include: {
         linkedTasks: {
+          take: 500,
           select: {
             id: true,
             status: true,


### PR DESCRIPTION
## Summary

- Add 3 composite indexes to `prisma/schema.prisma`: `AnnualPlan([archivedAt, year])`, `KPI([year, status])`, `Notification([userId, type, isRead])`
- `TimeEntry([date, isDeleted])` already existed — skipped
- Migration SQL uses `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for zero-downtime, idempotent execution
- Bound all unbounded `findMany` calls in `alert-service.ts` (5 queries, `take: 1000`), `email-notification-service.ts` (4 queries, `take: 500`), `report-v2-service.ts` (`linkedTasks`, `take: 500`), and `gantt/route.ts` (inner tasks include, `take: 500`)

## Test plan

- [x] `npx prisma validate` passes
- [x] `npm run build` passes with no errors
- [ ] Verify new indexes appear in DB after `prisma migrate deploy`

Closes #1440