### PR TITLE
fix(T1446): Redis NX lock for 3 email crons + Zod validation for auth routes

### DIFF
--- a/app/api/auth/change-password/route.ts
+++ b/app/api/auth/change-password/route.ts
@@ -6,6 +6,7 @@
  * Updates passwordChangedAt and clears mustChangePassword.
  */
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { compare, hash } from "bcryptjs";
 import { prisma } from "@/lib/prisma";
 import { getCachedSession } from "@/lib/session-cache";
@@ -16,6 +17,12 @@ import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/get-client-ip";
 import { apiHandler } from "@/lib/api-handler";
 import { createLoginRateLimiter, checkRateLimit } from "@/lib/rate-limiter";
+import { validateBody } from "@/lib/validate";
+
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string().min(8).max(128),
+});
 
 const auditService = new AuditService(prisma);
 
@@ -44,18 +51,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
     }
   }
 
-  let body: { currentPassword?: string; newPassword?: string };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return error("ValidationError", "無效的請求格式", 400);
   }
 
-  const { currentPassword, newPassword } = body;
-
-  if (!currentPassword || !newPassword) {
-    return error("ValidationError", "請填寫目前密碼與新密碼", 400);
-  }
+  const { currentPassword, newPassword } = validateBody(changePasswordSchema, rawBody);
 
   if (currentPassword === newPassword) {
     return error("ValidationError", "新密碼不得與目前密碼相同", 400);

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -11,6 +11,7 @@
  *   4. Password updated, OTP marked as used, mustChangePassword cleared
  */
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { hash } from "bcryptjs";
 import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
@@ -21,6 +22,13 @@ import { logger } from "@/lib/logger";
 import { getClientIp } from "@/lib/get-client-ip";
 import { createLoginRateLimiter, checkRateLimit } from "@/lib/rate-limiter";
 import { apiHandler } from "@/lib/api-handler";
+import { validateBody } from "@/lib/validate";
+
+const resetPasswordSchema = z.object({
+  email: z.string().min(1),
+  token: z.string().min(1),
+  newPassword: z.string().min(8).max(128),
+});
 
 const auditService = new AuditService(prisma);
 
@@ -46,18 +54,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
     }
   }
 
-  let body: { email?: string; token?: string; newPassword?: string };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return error("ValidationError", "無效的請求格式", 400);
   }
 
-  const { email: rawEmail, token, newPassword } = body;
-
-  if (!rawEmail || !token || !newPassword) {
-    return error("ValidationError", "請填寫 email、重設碼與新密碼", 400);
-  }
+  const { email: rawEmail, token, newPassword } = validateBody(resetPasswordSchema, rawBody);
 
   // Normalize email to lowercase (consistent with login — see auth.ts)
   const email = rawEmail.toLowerCase().trim();

--- a/app/api/cron/email-digest/route.ts
+++ b/app/api/cron/email-digest/route.ts
@@ -18,19 +18,38 @@ import { verifyCronSecret } from "@/lib/cron-auth";
 import { prisma } from "@/lib/prisma";
 import { EmailNotificationService } from "@/services/email-notification-service";
 import { logger } from "@/lib/logger";
+import { getRedisClient } from "@/lib/redis";
+
+const LOCK_KEY = "cron:email-digest:lock";
+const LOCK_TTL = 300; // 5 minutes
 
 export const POST = apiHandler(async (req: NextRequest) => {
   const authError = verifyCronSecret(req);
   if (authError) return authError;
 
-  const service = new EmailNotificationService(prisma);
-  const now = new Date();
-  const result = await service.generateDailyDigest(now);
+  const redis = getRedisClient();
+  if (redis) {
+    const acquired = await redis.set(LOCK_KEY, "1", "EX", LOCK_TTL, "NX");
+    if (!acquired) {
+      logger.warn({ event: "cron_email_digest_skipped" }, "Skipped: previous run still active");
+      return success({ skipped: true, reason: "lock_held" });
+    }
+  }
 
-  logger.info(
-    { event: "cron_email_digest_complete", ...result },
-    "Daily email digest complete"
-  );
+  try {
+    const service = new EmailNotificationService(prisma);
+    const now = new Date();
+    const result = await service.generateDailyDigest(now);
 
-  return success({ ...result, timestamp: now.toISOString() });
+    logger.info(
+      { event: "cron_email_digest_complete", ...result },
+      "Daily email digest complete"
+    );
+
+    return success({ ...result, timestamp: now.toISOString() });
+  } finally {
+    if (redis) {
+      await redis.del(LOCK_KEY).catch(() => {});
+    }
+  }
 });

--- a/app/api/cron/email-notifications/route.ts
+++ b/app/api/cron/email-notifications/route.ts
@@ -15,19 +15,38 @@ import { verifyCronSecret } from "@/lib/cron-auth";
 import { prisma } from "@/lib/prisma";
 import { EmailNotificationService } from "@/services/email-notification-service";
 import { logger } from "@/lib/logger";
+import { getRedisClient } from "@/lib/redis";
+
+const LOCK_KEY = "cron:email-notifications:lock";
+const LOCK_TTL = 300; // 5 minutes
 
 export const POST = apiHandler(async (req: NextRequest) => {
   const authError = verifyCronSecret(req);
   if (authError) return authError;
 
-  const service = new EmailNotificationService(prisma);
-  const now = new Date();
-  const result = await service.trigger(now);
+  const redis = getRedisClient();
+  if (redis) {
+    const acquired = await redis.set(LOCK_KEY, "1", "EX", LOCK_TTL, "NX");
+    if (!acquired) {
+      logger.warn({ event: "cron_email_notifications_skipped" }, "Skipped: previous run still active");
+      return success({ skipped: true, reason: "lock_held" });
+    }
+  }
 
-  logger.info(
-    { event: "cron_email_trigger_complete", ...result },
-    "Email notification trigger complete"
-  );
+  try {
+    const service = new EmailNotificationService(prisma);
+    const now = new Date();
+    const result = await service.trigger(now);
 
-  return success({ ...result, timestamp: now.toISOString() });
+    logger.info(
+      { event: "cron_email_trigger_complete", ...result },
+      "Email notification trigger complete"
+    );
+
+    return success({ ...result, timestamp: now.toISOString() });
+  } finally {
+    if (redis) {
+      await redis.del(LOCK_KEY).catch(() => {});
+    }
+  }
 });

--- a/app/api/cron/weekly-manager-digest/route.ts
+++ b/app/api/cron/weekly-manager-digest/route.ts
@@ -18,19 +18,38 @@ import { verifyCronSecret } from "@/lib/cron-auth";
 import { prisma } from "@/lib/prisma";
 import { EmailNotificationService } from "@/services/email-notification-service";
 import { logger } from "@/lib/logger";
+import { getRedisClient } from "@/lib/redis";
+
+const LOCK_KEY = "cron:weekly-manager-digest:lock";
+const LOCK_TTL = 300; // 5 minutes
 
 export const POST = apiHandler(async (req: NextRequest) => {
   const authError = verifyCronSecret(req);
   if (authError) return authError;
 
-  const service = new EmailNotificationService(prisma);
-  const now = new Date();
-  const result = await service.generateWeeklyManagerSummary(now);
+  const redis = getRedisClient();
+  if (redis) {
+    const acquired = await redis.set(LOCK_KEY, "1", "EX", LOCK_TTL, "NX");
+    if (!acquired) {
+      logger.warn({ event: "cron_weekly_manager_digest_skipped" }, "Skipped: previous run still active");
+      return success({ skipped: true, reason: "lock_held" });
+    }
+  }
 
-  logger.info(
-    { event: "cron_weekly_manager_digest_complete", ...result },
-    "Weekly manager digest complete"
-  );
+  try {
+    const service = new EmailNotificationService(prisma);
+    const now = new Date();
+    const result = await service.generateWeeklyManagerSummary(now);
 
-  return success({ ...result, timestamp: now.toISOString() });
+    logger.info(
+      { event: "cron_weekly_manager_digest_complete", ...result },
+      "Weekly manager digest complete"
+    );
+
+    return success({ ...result, timestamp: now.toISOString() });
+  } finally {
+    if (redis) {
+      await redis.del(LOCK_KEY).catch(() => {});
+    }
+  }
 });


### PR DESCRIPTION
## Summary

- **HIGH**: 3 cron jobs (email-digest, email-notifications, weekly-manager-digest) had no concurrency protection → added Redis SET NX locks (300s TTL) with try/finally cleanup
- **MEDIUM**: reset-password and change-password POST routes used manual validation → replaced with Zod schema + validateBody()

## Test plan

- [ ] Trigger email-digest cron twice concurrently → second returns `{skipped: true}`
- [ ] Submit reset-password with empty token → Zod returns 400 validation error
- [ ] Submit change-password with short password → Zod returns 400

Closes #1446