### PR TITLE
fix(T1450): Zod validation for 3 routes + type cast cleanup

### DIFF
--- a/app/api/admin/feature-flags/route.ts
+++ b/app/api/admin/feature-flags/route.ts
@@ -5,11 +5,18 @@
  * PUT  /api/admin/feature-flags — update a flag (ADMIN only)
  */
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { success } from "@/lib/api-response";
 import { withAdmin } from "@/lib/auth-middleware";
 import { getAllFeatureFlags, setFeatureFlag, isValidFlagName } from "@/lib/feature-flags";
 import { requireAuth } from "@/lib/rbac";
 import { ValidationError } from "@/services/errors";
+import { validateBody } from "@/lib/validate";
+
+const updateFeatureFlagSchema = z.object({
+  name: z.string().min(1).max(100),
+  enabled: z.boolean(),
+});
 
 export const GET = withAdmin(async (_req: NextRequest) => {
   const flags = await getAllFeatureFlags();
@@ -18,12 +25,8 @@ export const GET = withAdmin(async (_req: NextRequest) => {
 
 export const PUT = withAdmin(async (req: NextRequest) => {
   const session = await requireAuth();
-  const body = await req.json();
-  const { name, enabled } = body;
-
-  if (!name || typeof enabled !== "boolean") {
-    throw new ValidationError("需提供 name (string) 和 enabled (boolean)");
-  }
+  const rawBody = await req.json();
+  const { name, enabled } = validateBody(updateFeatureFlagSchema, rawBody);
 
   if (!isValidFlagName(name)) {
     throw new ValidationError(`未知的 feature flag: ${name}`);

--- a/app/api/approvals/route.ts
+++ b/app/api/approvals/route.ts
@@ -3,12 +3,22 @@
 // See Issue #382 for the full approval workflow design.
 
 import { NextRequest } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { withAuth, withManager } from "@/lib/auth-middleware";
 import { requireAuth } from "@/lib/rbac";
 import { success, error } from "@/lib/api-response";
+import { validateBody } from "@/lib/validate";
 import { parsePagination, buildPaginationMeta } from "@/lib/pagination";
 import { sanitizeHtml } from "@/lib/security/sanitize";
+
+const createApprovalSchema = z.object({
+  type: z.enum(["TASK_STATUS_CHANGE", "DELIVERABLE_ACCEPTANCE", "PLAN_MODIFICATION"]),
+  resourceId: z.string().min(1),
+  resourceType: z.string().min(1),
+  reason: z.string().max(1000).optional(),
+  approverId: z.string().optional(),
+});
 
 /**
  * GET /api/approvals?status=PENDING&type=TASK_STATUS_CHANGE
@@ -75,41 +85,14 @@ export const GET = withAuth(async (req: NextRequest) => {
 export const POST = withAuth(async (req: NextRequest) => {
   const session = await requireAuth();
 
-  let body: {
-    type?: string;
-    resourceId?: string;
-    resourceType?: string;
-    reason?: string;
-    approverId?: string;
-  };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return error("ParseError", "Invalid JSON body", 400);
   }
 
-  const { type, resourceId, resourceType, reason, approverId } = body;
-
-  if (!type || !resourceId || !resourceType) {
-    return error(
-      "ValidationError",
-      "type, resourceId, and resourceType are required",
-      400
-    );
-  }
-
-  const validTypes = [
-    "TASK_STATUS_CHANGE",
-    "DELIVERABLE_ACCEPTANCE",
-    "PLAN_MODIFICATION",
-  ];
-  if (!validTypes.includes(type)) {
-    return error(
-      "ValidationError",
-      `type must be one of: ${validTypes.join(", ")}`,
-      400
-    );
-  }
+  const { type, resourceId, resourceType, reason, approverId } = validateBody(createApprovalSchema, rawBody);
 
   // If approverId specified, verify it's a valid MANAGER
   if (approverId) {
@@ -130,7 +113,7 @@ export const POST = withAuth(async (req: NextRequest) => {
     data: {
       requesterId: session.user.id,
       approverId: approverId ?? null,
-      type: type as "TASK_STATUS_CHANGE" | "DELIVERABLE_ACCEPTANCE" | "PLAN_MODIFICATION",
+      type,
       resourceId,
       resourceType,
       reason: sanitizedReason,

--- a/app/api/permissions/route.ts
+++ b/app/api/permissions/route.ts
@@ -1,13 +1,22 @@
 import { NextRequest } from "next/server";
-import { ValidationError } from "@/services/errors";
+import { z } from "zod";
 import { withManager } from "@/lib/auth-middleware";
 import { requireAuth, requireRole } from "@/lib/rbac";
 import { success } from "@/lib/api-response";
+import { validateBody } from "@/lib/validate";
+import { ValidationError } from "@/services/errors";
 import { PermissionService } from "@/services/permission-service";
 import { AuditService } from "@/services/audit-service";
 import { prisma } from "@/lib/prisma";
 import { getClientIp } from "@/lib/get-client-ip";
 import { parsePagination } from "@/lib/pagination";
+
+const createPermissionSchema = z.object({
+  granteeId: z.string().min(1),
+  permType: z.string().min(1),
+  targetId: z.string().optional(),
+  expiresAt: z.string().datetime().optional(),
+});
 
 const permissionService = new PermissionService(prisma);
 const auditService = new AuditService(prisma);
@@ -36,12 +45,8 @@ export const GET = withManager(async (req: NextRequest) => {
 export const POST = withManager(async (req: NextRequest) => {
   const session = await requireAuth();
 
-  const body = await req.json();
-  const { granteeId, permType, targetId, expiresAt } = body;
-
-  if (!granteeId || !permType) {
-    throw new ValidationError("缺少必填欄位：granteeId, permType");
-  }
+  const rawBody = await req.json();
+  const { granteeId, permType, targetId, expiresAt } = validateBody(createPermissionSchema, rawBody);
 
   const permission = await permissionService.grantPermission({
     granteeId,

--- a/app/api/reports/department-timesheet/route.ts
+++ b/app/api/reports/department-timesheet/route.ts
@@ -59,7 +59,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
   for (const entry of entries) {
     const userId = entry.userId;
-    const userName = (entry as unknown as { user: { name: string } }).user?.name ?? "Unknown";
+    const userName = entry.user?.name ?? "Unknown";
     const dateStr = formatLocalDate(new Date(entry.date));
 
     if (!byUserMap.has(userId)) {

--- a/app/api/reports/timesheet-compliance/route.ts
+++ b/app/api/reports/timesheet-compliance/route.ts
@@ -63,7 +63,7 @@ export const GET = withManager(async (req: NextRequest) => {
 
   for (const entry of entries) {
     const userId = entry.userId;
-    const userName = (entry as unknown as { user: { name: string } }).user?.name ?? "Unknown";
+    const userName = entry.user?.name ?? "Unknown";
     if (!byUser.has(userId)) {
       byUser.set(userId, { userName, entries: [] });
     }
@@ -77,8 +77,8 @@ export const GET = withManager(async (req: NextRequest) => {
     const dailyEntries: DailyEntry[] = userEntries.map((e) => ({
       date: formatLocalDate(new Date(e.date)),
       hours: Number(e.hours),
-      overtime: Boolean((e as Record<string, unknown>).overtime),
-      locked: Boolean((e as Record<string, unknown>).locked),
+      overtime: Boolean(e.overtime),
+      locked: Boolean(e.locked),
       category: e.category,
     }));
 


### PR DESCRIPTION
## Summary

- **MEDIUM**: Added Zod schemas for permissions (POST), feature-flags (PUT), approvals (POST)
- **LOW**: Removed 4 `as unknown as` type casts in reports routes (Prisma include already provides correct types)

## Test plan
- [ ] POST /api/permissions with missing fields → 400 Zod error
- [ ] PUT /api/admin/feature-flags with invalid type → 400 Zod error
- [ ] POST /api/approvals with invalid type enum → 400 Zod error
- [ ] Reports still render correctly (no type errors)

Closes #1450