### PR TITLE
test(T1452): fix 12 broken test suites from security fixes

### DIFF
--- a/__tests__/api/deliverables.test.ts
+++ b/__tests__/api/deliverables.test.ts
@@ -65,14 +65,15 @@ describe("PATCH/DELETE /api/deliverables/[id]", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetServerSession.mockResolvedValue(MANAGER_SESSION);
-    mockDeliverable.update.mockResolvedValue({ ...MOCK_DEL, status: "DONE" });
+    // T1452: Zod schema only allows NOT_STARTED|IN_PROGRESS|DELIVERED|ACCEPTED
+    mockDeliverable.update.mockResolvedValue({ ...MOCK_DEL, status: "DELIVERED" });
     mockDeliverable.delete.mockResolvedValue(MOCK_DEL);
   });
 
   it("PATCH updates deliverable status", async () => {
     const { PATCH } = await import("@/app/api/deliverables/[id]/route");
     const res = await PATCH(
-      createMockRequest("/api/deliverables/del-1", { method: "PATCH", body: { status: "DONE" } }),
+      createMockRequest("/api/deliverables/del-1", { method: "PATCH", body: { status: "DELIVERED" } }),
       { params: Promise.resolve({ id: "del-1" }) }
     );
     expect(res.status).toBe(200);

--- a/__tests__/api/feature-flags.test.ts
+++ b/__tests__/api/feature-flags.test.ts
@@ -71,14 +71,22 @@ describe("GET /api/admin/feature-flags", () => {
     mockFeatureFlagFindMany.mockResolvedValue([]);
   });
 
-  it("returns flags for any authenticated user", async () => {
-    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+  // T1452: GET /api/admin/feature-flags requires ADMIN (withAdmin middleware).
+  it("returns flags for ADMIN user", async () => {
+    mockGetServerSession.mockResolvedValue(ADMIN_SESSION);
     const { GET } = await import("@/app/api/admin/feature-flags/route");
     const res = await GET(createMockRequest("/api/admin/feature-flags"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.flags).toBeDefined();
+  });
+
+  it("returns 403 for non-ADMIN user", async () => {
+    mockGetServerSession.mockResolvedValue(ENGINEER_SESSION);
+    const { GET } = await import("@/app/api/admin/feature-flags/route");
+    const res = await GET(createMockRequest("/api/admin/feature-flags"));
+    expect(res.status).toBe(403);
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/__tests__/api/goals.test.ts
+++ b/__tests__/api/goals.test.ts
@@ -6,7 +6,8 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockMonthlyGoal = { findMany: jest.fn(), create: jest.fn() };
+// T1452: GET route uses Promise.all([findMany, count]) — count must be mocked.
+const mockMonthlyGoal = { findMany: jest.fn(), create: jest.fn(), count: jest.fn().mockResolvedValue(0) };
 const mockAnnualPlan = { findUnique: jest.fn() };
 const mockUser = { findUnique: jest.fn() };
 
@@ -40,7 +41,8 @@ describe("GET /api/goals", () => {
     const res = await GET(createMockRequest("/api/goals"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("goal-1");
+    // T1452: GET returns paginated { items, total, page, limit } shape
+    expect(body.data.items[0].id).toBe("goal-1");
   });
 
   it("returns 401 when no session", async () => {

--- a/__tests__/api/kpi-achievement.test.ts
+++ b/__tests__/api/kpi-achievement.test.ts
@@ -13,8 +13,20 @@ const mockKPIAchievement = {
   upsert: jest.fn(),
 };
 
+// T1452: POST route wraps upsert + kpi.update in $transaction to prevent
+// partial writes. Mock invokes the callback with the same prisma mock.
+const mockPrismaKpi = {
+  kPI: mockKPI,
+  kPIAchievement: mockKPIAchievement,
+  auditLog: { create: jest.fn() },
+  $transaction: jest.fn().mockImplementation((arg: unknown) => {
+    if (typeof arg === "function") return (arg as (tx: unknown) => unknown)(mockPrismaKpi);
+    return Promise.all(arg as unknown[]);
+  }),
+};
+
 jest.mock("@/lib/prisma", () => ({
-  prisma: { kPI: mockKPI, kPIAchievement: mockKPIAchievement },
+  prisma: mockPrismaKpi,
 }));
 
 const mockGetServerSession = jest.fn();

--- a/__tests__/api/ldap-stub.test.ts
+++ b/__tests__/api/ldap-stub.test.ts
@@ -35,10 +35,13 @@ describe("lib/auth/ldap-config", () => {
     const origUrl = process.env.LDAP_URL;
     const origBindDn = process.env.LDAP_BIND_DN;
     const origBaseDn = process.env.LDAP_BASE_DN;
+    // T1452: getLdapConfig now requires LDAP_BIND_PASSWORD when LDAP_URL is set
+    const origBindPassword = process.env.LDAP_BIND_PASSWORD;
 
     process.env.LDAP_URL = "ldap://test.local:389";
     process.env.LDAP_BIND_DN = "cn=admin,dc=test,dc=local";
     process.env.LDAP_BASE_DN = "dc=test,dc=local";
+    process.env.LDAP_BIND_PASSWORD = "test-password";
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { getLdapConfig } = require("@/lib/auth/ldap-config");
@@ -52,6 +55,7 @@ describe("lib/auth/ldap-config", () => {
     process.env.LDAP_URL = origUrl;
     process.env.LDAP_BIND_DN = origBindDn;
     process.env.LDAP_BASE_DN = origBaseDn;
+    process.env.LDAP_BIND_PASSWORD = origBindPassword;
   });
 });
 

--- a/__tests__/api/password-routes.test.ts
+++ b/__tests__/api/password-routes.test.ts
@@ -393,11 +393,14 @@ describe("POST /api/auth/reset-password", () => {
 // ========================================================================
 
 describe("POST /api/admin/generate-reset-token", () => {
+  // T1452: generate-reset-token now checks caller vs target role hierarchy.
+  // MANAGER can only generate tokens for ENGINEER targets.
   const TARGET_USER = {
     id: "target-1",
     name: "Bob",
     email: "bob@example.com",
     isActive: true,
+    role: "ENGINEER",
   };
 
   beforeEach(() => {

--- a/__tests__/api/remaining-routes.test.ts
+++ b/__tests__/api/remaining-routes.test.ts
@@ -20,7 +20,8 @@ const mockDocument = { findMany: jest.fn() };
 const mockTaskComment = { findMany: jest.fn() };
 const mockKPI = { findMany: jest.fn() };
 const mockUser = { findMany: jest.fn(), findUnique: jest.fn() };
-const mockTimeEntry = { findMany: jest.fn() };
+// T1452: GET /api/time-entries uses Promise.all([count, findMany]) — count must be mocked.
+const mockTimeEntry = { findMany: jest.fn(), count: jest.fn().mockResolvedValue(0) };
 const mockApprovalRequest = {
   findMany: jest.fn(),
   findUnique: jest.fn(),

--- a/__tests__/api/system-routes.test.ts
+++ b/__tests__/api/system-routes.test.ts
@@ -181,7 +181,9 @@ describe("POST /api/error-report", () => {
     const res = await POST(makeRequest({ digest: "abc123" }));
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toBe("message required");
+    // T1452: error() returns { error: <errorName>, message: <msg> }
+    expect(body.error).toBe("ValidationError");
+    expect(body.message).toBe("message required");
   });
 
   it("returns 200 and persists error to auditLog on valid report", async () => {
@@ -242,7 +244,8 @@ describe("POST /api/error-report", () => {
     const res = await POST(makeRequest({ message: "some error" }));
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error).toBe("internal");
+    // T1452: error() returns { error: <errorName>, message: <msg> }
+    expect(body.error).toBe("InternalError");
   });
 
   it("returns 500 when request JSON parsing fails", async () => {

--- a/__tests__/api/time-entries-timer.test.ts
+++ b/__tests__/api/time-entries-timer.test.ts
@@ -20,7 +20,17 @@ const mockTimeEntry = {
   delete: jest.fn(),
 };
 
-jest.mock("@/lib/prisma", () => ({ prisma: { timeEntry: mockTimeEntry } }));
+// T1452: start/stop routes wrap logic in $transaction. Mock invokes the
+// callback with the same prisma mock so tx.timeEntry.* calls work correctly.
+const mockPrismaTimer = {
+  timeEntry: mockTimeEntry,
+  $transaction: jest.fn().mockImplementation((arg: unknown) => {
+    if (typeof arg === "function") return (arg as (tx: unknown) => unknown)(mockPrismaTimer);
+    return Promise.all(arg as unknown[]);
+  }),
+};
+
+jest.mock("@/lib/prisma", () => ({ prisma: mockPrismaTimer }));
 
 // ── Auth mock ────────────────────────────────────────────────────────────────
 const mockGetServerSession = jest.fn();

--- a/__tests__/api/time-entries.test.ts
+++ b/__tests__/api/time-entries.test.ts
@@ -6,14 +6,17 @@
  */
 import { createMockRequest } from "../utils/test-utils";
 
-const mockTimeEntry = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn() };
+// T1452: GET route uses Promise.all([count, findMany]) — count must be mocked.
+const mockTimeEntry = { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn(), update: jest.fn(), delete: jest.fn(), count: jest.fn().mockResolvedValue(0) };
 const mockAuditLog = { create: jest.fn() };
 
-// T1353: time-entries POST now wraps daily-limit check + create in $transaction.
-// Mock invokes the callback with the same prisma mock, so tx.timeEntry.findMany etc. work.
+// T1353/T1452: time-entries POST wraps daily-limit check ($queryRaw FOR UPDATE) +
+// create in $transaction. Mock invokes callback with prisma mock and provides
+// $queryRaw returning [{hours: 0}] so the daily limit check passes.
 const mockPrisma = {
   timeEntry: mockTimeEntry,
   auditLog: mockAuditLog,
+  $queryRaw: jest.fn().mockResolvedValue([{ hours: 0 }]),
   $transaction: jest.fn().mockImplementation((arg: unknown) => {
     if (typeof arg === "function") return (arg as (tx: unknown) => unknown)(mockPrisma);
     return Promise.all(arg as unknown[]);
@@ -49,7 +52,8 @@ describe("GET /api/time-entries", () => {
     const res = await GET(createMockRequest("/api/time-entries"));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.data[0].id).toBe("entry-1");
+    // T1452: GET returns paginated { items, pagination } shape
+    expect(body.data.items[0].id).toBe("entry-1");
   });
 
   it("returns 401 when no session", async () => {

--- a/__tests__/integration/api-security-middleware.test.ts
+++ b/__tests__/integration/api-security-middleware.test.ts
@@ -39,6 +39,8 @@ const mockTimeEntry = {
   create: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
+  // T1452: GET /api/time-entries uses Promise.all([count, findMany])
+  count: jest.fn().mockResolvedValue(0),
 };
 const mockTaskActivity = { create: jest.fn() };
 const mockTaskChange = { create: jest.fn() };
@@ -61,6 +63,8 @@ const mockTransaction = jest.fn().mockImplementation((arg: unknown) => {
   return Promise.all(arg as unknown[]);
 });
 mockPrisma.$transaction = mockTransaction;
+// T1452: POST /api/time-entries uses tx.$queryRaw FOR UPDATE inside transaction
+mockPrisma.$queryRaw = jest.fn().mockResolvedValue([{ hours: 0 }]);
 
 jest.mock("@/lib/prisma", () => ({ prisma: mockPrisma }));
 

--- a/lib/__tests__/api-handler.test.ts
+++ b/lib/__tests__/api-handler.test.ts
@@ -15,17 +15,34 @@ import {
 } from "@/services/errors";
 
 // ── Mock next/server ──────────────────────────────────────────────────────
+// T1452: success() now uses `new NextResponse(body, {status, headers})`.
+// Mock NextResponse as a constructor that also exposes the .json() static method.
 jest.mock("next/server", () => {
   const actual = jest.requireActual("next/server");
+
+  function MockNextResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+    const status = init?.status ?? 200;
+    // Parse body if it is a JSON string (as success() passes JSON.stringify output)
+    let parsed: unknown = body;
+    if (typeof body === "string") {
+      try { parsed = JSON.parse(body); } catch { /* leave as-is */ }
+    }
+    return {
+      status,
+      _body: parsed,
+      json: async () => parsed,
+      headers: { set: jest.fn(), get: jest.fn() },
+    };
+  }
+  MockNextResponse.json = jest.fn((body: unknown, init?: { status?: number }) => ({
+    status: init?.status ?? 200,
+    _body: body,
+    json: async () => body,
+  }));
+
   return {
     ...actual,
-    NextResponse: {
-      json: jest.fn((body: unknown, init?: { status?: number }) => ({
-        status: init?.status ?? 200,
-        _body: body,
-        json: async () => body,
-      })),
-    },
+    NextResponse: MockNextResponse,
   };
 });
 

--- a/lib/__tests__/rbac-coverage.test.ts
+++ b/lib/__tests__/rbac-coverage.test.ts
@@ -19,17 +19,33 @@ jest.mock("next-auth", () => ({
 }));
 
 // ── Mock next/server ────────────────────────────────────────────────────────
+// T1452: success() uses `new NextResponse(body, {status, headers})` constructor.
+// Mock both constructor and static .json() method.
 jest.mock("next/server", () => {
   const actual = jest.requireActual("next/server");
+
+  function MockNextResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }) {
+    const status = init?.status ?? 200;
+    let parsed: unknown = body;
+    if (typeof body === "string") {
+      try { parsed = JSON.parse(body); } catch { /* leave as-is */ }
+    }
+    return {
+      status,
+      _body: parsed,
+      json: async () => parsed,
+      headers: { set: jest.fn(), get: jest.fn() },
+    };
+  }
+  MockNextResponse.json = jest.fn((body: unknown, init?: { status?: number }) => ({
+    status: init?.status ?? 200,
+    _body: body,
+    json: async () => body,
+  }));
+
   return {
     ...actual,
-    NextResponse: {
-      json: jest.fn((body: unknown, init?: { status?: number }) => ({
-        status: init?.status ?? 200,
-        _body: body,
-        json: async () => body,
-      })),
-    },
+    NextResponse: MockNextResponse,
   };
 });
 


### PR DESCRIPTION
## Summary

- Fixed 12 of 14 test suites broken by the security hardening in #1430 (R2–R8 changes)
- Net result: **52 → 15 failed tests**, **14 → 2 failed suites** — the 2 remaining failures are pre-existing (verified at baseline before this branch)
- No production code changed; all fixes are in test mock setup

## Root causes fixed

| Change in security PR | Test fix applied |
|---|---|
| `$transaction` callback wrapping in time-entries, kpi-achievement | Added `$transaction` mock that invokes callback with prisma mock |
| `tx.$queryRaw FOR UPDATE` inside POST time-entries | Added `$queryRaw` mock returning `[{hours: 0}]` |
| Pagination `Promise.all([count, findMany])` | Added `count: jest.fn().mockResolvedValue(0)` to all affected mocks |
| `success()` uses `new NextResponse()` constructor (not `.json()`) | Rewrote NextResponse mock as constructor class with static `.json` |
| `feature-flags` route switched to `withAdmin` | Changed test session to ADMIN_SESSION; added 403 test for engineer |
| `error()` response shape is `{error: name, message: text}` | Fixed assertions to check both `error` and `message` fields |
| Privilege escalation guard checks target user `role` | Added `role: "ENGINEER"` to `TARGET_USER` fixture |
| `getLdapConfig()` requires `LDAP_BIND_PASSWORD` when URL is set | Added env var save/set/restore in ldap-stub test |
| Paginated GET routes return `{items, pagination}` shape | Fixed assertions to use `body.data.items[0]` |
| Deliverable Zod enum excludes `"DONE"` | Changed test fixture to `"DELIVERED"` |

## Pre-existing failures (out of scope, unchanged count)

- `__tests__/api/remaining-routes.test.ts` — 14 failures (search, stats, approvals, notification-preferences, backup-status returning 500) — same count at baseline before any changes
- `__tests__/pages/dashboard-extended.test.tsx` — 1 failure ("發生錯誤" not found) — same count at baseline

## Test plan

- [x] `time-entries-timer.test.ts` — 10/10 pass
- [x] `time-entries.test.ts` — 14/14 pass
- [x] `kpi-achievement.test.ts` — 11/11 pass
- [x] `feature-flags.test.ts` — 7/7 pass
- [x] `lib/__tests__/api-handler.test.ts` — 13/13 pass
- [x] `lib/__tests__/rbac-coverage.test.ts` — 17/17 pass
- [x] `system-routes.test.ts` — 19/19 pass
- [x] `password-routes.test.ts` — 28/28 pass
- [x] `ldap-stub.test.ts` — 15/15 pass
- [x] `goals.test.ts` — 10/10 pass
- [x] `deliverables.test.ts` — 9/9 pass
- [x] `integration/api-security-middleware.test.ts` — 21/21 pass (bonus: also fixed 3 extra failures from baseline)

Closes #1452