### PR TITLE
test(T1452): fix last failing test — 247/247 suites pass

### DIFF
--- a/__tests__/pages/dashboard-extended.test.tsx
+++ b/__tests__/pages/dashboard-extended.test.tsx
@@ -168,21 +168,18 @@ describe("Dashboard Extended — Error recovery interaction", () => {
 
   it("Manager: error state shows 發生錯誤 and retry triggers re-fetch", async () => {
     setSession("MANAGER");
-    let callCount = 0;
-    mockFetch.mockImplementation(() => {
-      callCount++;
-      if (callCount <= 1) {
-        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
-      }
-      return Promise.resolve({ ok: true, json: async () => MANAGER_DATA_HAPPY } as Response);
-    });
+    // All fetches fail until we explicitly switch to success after verifying error state.
+    const failResponse = { ok: false, status: 500, json: async () => ({}) } as Response;
+    mockFetch.mockResolvedValue(failResponse);
     await act(async () => { render(<DashboardPage />); });
     await waitFor(() => {
       expect(screen.getAllByText("發生錯誤").length).toBeGreaterThan(0);
-    });
+    }, { timeout: 3000 });
 
     const retryButtons = screen.getAllByText("重試");
     expect(retryButtons.length).toBeGreaterThan(0);
+    // Switch to success before clicking retry
+    mockFetch.mockResolvedValue({ ok: true, json: async () => MANAGER_DATA_HAPPY } as Response);
     await act(async () => { fireEvent.click(retryButtons[0]); });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary

Fixes the last remaining test failure (`dashboard-extended.test.tsx`).

**Root cause:** `fetchMyDay` useCallback re-fires during render when `isManager` state settles, consuming the first `mockResolvedValueOnce` (error) and immediately hitting the second mock (success), so error state never renders.

**Fix:** Mock all fetches as failure until error state verified, then switch to success before retry.

**Result:** 247/247 suites, 3164 passed, 0 failed.

Ref #1452