### PR TITLE
feat(T1470): Engineer My Day quick-log actions

### DIFF
--- a/__tests__/components/dashboard/quick-log-actions.test.tsx
+++ b/__tests__/components/dashboard/quick-log-actions.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * Component tests: quick-log-actions — Issue #1470
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock sonner toast
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SUGGESTION = {
+  taskId: "task-001",
+  title: "設計新功能",
+  estimatedHours: 2,
+  suggestion: "建議投入 2 小時進行設計",
+};
+
+function makeFetchSuccess(data: unknown = { id: "entry-1" }) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true, data }),
+  } as Response);
+}
+
+function makeFetchError(status = 500, message = "伺服器錯誤") {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({ message }),
+  } as unknown as Response);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("StartTimerButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with start-timer-btn testid", async () => {
+    mockFetch.mockImplementation(makeFetchSuccess());
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton onSuccess={onSuccess} />);
+
+    expect(screen.getByTestId("start-timer-btn")).toBeInTheDocument();
+    expect(screen.getByText("開始計時")).toBeInTheDocument();
+  });
+
+  it("calls POST /api/time-entries/start, shows success toast, and calls onSuccess", async () => {
+    mockFetch.mockImplementation(makeFetchSuccess({ id: "timer-1" }));
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton taskId="task-001" onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("start-timer-btn"));
+    });
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith("計時器已啟動");
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[0]).toBe("/api/time-entries/start");
+    expect(callArgs[1]?.method).toBe("POST");
+    expect(JSON.parse(callArgs[1]?.body as string)).toEqual({ taskId: "task-001" });
+  });
+
+  it("shows 409 conflict error toast when timer already running", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ message: "已有計時器在執行中" }),
+    } as unknown as Response);
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("start-timer-btn"));
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "已有正在計時的項目，請先停止目前計時器"
+      );
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows generic error toast on non-409 errors", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ message: "內部伺服器錯誤" }),
+    } as unknown as Response);
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton onSuccess={onSuccess} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("start-timer-btn"));
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    // Should not show the 409-specific message
+    expect(mockToastError).not.toHaveBeenCalledWith(
+      "已有正在計時的項目，請先停止目前計時器"
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("disables button while loading", async () => {
+    // Delay resolution so we can observe the loading state
+    let resolvePromise!: (value: Response) => void;
+    const pendingFetch = new Promise<Response>((resolve) => {
+      resolvePromise = resolve;
+    });
+    mockFetch.mockReturnValue(pendingFetch);
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton onSuccess={onSuccess} />);
+
+    const btn = screen.getByTestId("start-timer-btn");
+    fireEvent.click(btn);
+
+    // Button should be disabled while the request is in flight
+    expect(btn).toBeDisabled();
+
+    // Cleanup: resolve the pending fetch
+    resolvePromise({
+      ok: true,
+      json: async () => ({ ok: true, data: {} }),
+    } as Response);
+
+    await waitFor(() => {
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  it("compact mode uses task-timer-btn testid", async () => {
+    mockFetch.mockImplementation(makeFetchSuccess());
+    const onSuccess = jest.fn();
+
+    const { StartTimerButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<StartTimerButton compact taskId="task-002" onSuccess={onSuccess} />);
+
+    expect(screen.getByTestId("task-timer-btn")).toBeInTheDocument();
+    expect(screen.queryByTestId("start-timer-btn")).not.toBeInTheDocument();
+  });
+});
+
+describe("ApplySuggestionButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("applies suggestion, shows success toast, and becomes disabled with 已套用 text", async () => {
+    mockFetch.mockImplementation(makeFetchSuccess({ id: "entry-99" }));
+    const onSuccess = jest.fn();
+
+    const { ApplySuggestionButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<ApplySuggestionButton suggestion={SUGGESTION} onSuccess={onSuccess} />);
+
+    const btn = screen.getByTestId("apply-suggestion-btn");
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("套用");
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        `已記錄 ${SUGGESTION.estimatedHours}h — ${SUGGESTION.title}`
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    // Button should now be disabled and show 已套用
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent("已套用");
+
+    // Verify the POST payload
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[0]).toBe("/api/time-entries");
+    expect(callArgs[1]?.method).toBe("POST");
+    const body = JSON.parse(callArgs[1]?.body as string);
+    expect(body.taskId).toBe(SUGGESTION.taskId);
+    expect(body.hours).toBe(SUGGESTION.estimatedHours);
+    expect(body.category).toBe("PLANNED_TASK");
+    expect(body.description).toContain(SUGGESTION.title);
+  });
+
+  it("shows error toast on failure and stays enabled", async () => {
+    mockFetch.mockImplementation(makeFetchError(400, "時數不能為零"));
+    const onSuccess = jest.fn();
+
+    const { ApplySuggestionButton } = await import(
+      "@/app/components/dashboard/quick-log-actions"
+    );
+    render(<ApplySuggestionButton suggestion={SUGGESTION} onSuccess={onSuccess} />);
+
+    const btn = screen.getByTestId("apply-suggestion-btn");
+
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    // Button should remain enabled (not applied) after error
+    expect(btn).not.toBeDisabled();
+    expect(btn).toHaveTextContent("套用");
+  });
+});

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -23,6 +23,7 @@ import Link from "next/link";
 import { StaleTaskWidget } from "@/app/components/stale-task-widget";
 import ManagerTodayCard from "@/app/components/dashboard/manager-today-card";
 import WidgetSettings, { DEFAULT_WIDGETS, type WidgetConfig } from "@/app/components/dashboard/widget-settings";
+import { StartTimerButton, ApplySuggestionButton } from "@/app/components/dashboard/quick-log-actions";
 
 // ── Skeleton loader ─────────────────────────────────────────────────────
 
@@ -151,11 +152,11 @@ const PRIORITY_DOT: Record<string, string> = {
   P3: "bg-gray-400",
 };
 
-function TaskRow({ task }: { task: TaskItem }) {
+function TaskRow({ task, actions }: { task: TaskItem; actions?: React.ReactNode }) {
   const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && task.status !== "DONE";
 
   return (
-    <Link href={`/kanban?task=${task.id}`} className="flex items-center gap-2 p-2.5 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors cursor-pointer">
+    <Link href={`/kanban?task=${task.id}`} className="group flex items-center gap-2 p-2.5 bg-accent/40 rounded-md hover:bg-accent/60 transition-colors cursor-pointer">
       {task.managerFlagged && (
         <Flame className="h-3.5 w-3.5 text-red-500 fill-red-500 flex-shrink-0" />
       )}
@@ -170,6 +171,7 @@ function TaskRow({ task }: { task: TaskItem }) {
           {formatDate(task.dueDate)}
         </span>
       )}
+      {actions}
     </Link>
   );
 }
@@ -240,7 +242,7 @@ function MyProjectsCard() {
 
 // ── Engineer My Day ─────────────────────────────────────────────────────
 
-function EngineerMyDay({ data, isVisible }: { data: EngineerData; isVisible: (id: string) => boolean }) {
+function EngineerMyDay({ data, isVisible, onRefresh }: { data: EngineerData; isVisible: (id: string) => boolean; onRefresh: () => void }) {
   const hoursPct = Math.min((data.todayHours / data.dailyTarget) * 100, 100);
 
   return (
@@ -296,7 +298,7 @@ function EngineerMyDay({ data, isVisible }: { data: EngineerData; isVisible: (id
             ) : (
               <div className="space-y-2">
                 {data.inProgressTasks.map((t) => (
-                  <TaskRow key={t.id} task={t} />
+                  <TaskRow key={t.id} task={t} actions={<StartTimerButton compact taskId={t.id} onSuccess={onRefresh} />} />
                 ))}
               </div>
             )}
@@ -314,7 +316,8 @@ function EngineerMyDay({ data, isVisible }: { data: EngineerData; isVisible: (id
               {data.timeSuggestions.map((s) => (
                 <div key={s.taskId} className="flex items-center gap-2 p-2 bg-purple-50 dark:bg-purple-950/30 rounded text-sm text-purple-700 dark:text-purple-300">
                   <ArrowRight className="h-3 w-3 flex-shrink-0" />
-                  <span>{s.suggestion}</span>
+                  <span className="flex-1">{s.suggestion}</span>
+                  <ApplySuggestionButton suggestion={s} onSuccess={onRefresh} />
                 </div>
               ))}
             </div>
@@ -340,10 +343,13 @@ function EngineerMyDay({ data, isVisible }: { data: EngineerData; isVisible: (id
             />
           </div>
           {data.todayHours === 0 && (
-            <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-2 flex items-center gap-1">
-              <AlertTriangle className="h-3 w-3" />
-              尚未記錄任何工時
-            </p>
+            <div className="mt-2 flex items-center justify-between">
+              <p className="text-xs text-yellow-600 dark:text-yellow-400 flex items-center gap-1">
+                <AlertTriangle className="h-3 w-3" />
+                尚未記錄任何工時
+              </p>
+              <StartTimerButton onSuccess={onRefresh} />
+            </div>
           )}
         </div>}
 
@@ -721,7 +727,7 @@ export default function DashboardPage() {
         ) : data.role === "MANAGER" ? (
           <ManagerMyDay data={data} isVisible={isVisible} />
         ) : (
-          <EngineerMyDay data={data} isVisible={isVisible} />
+          <EngineerMyDay data={data} isVisible={isVisible} onRefresh={() => fetchMyDay()} />
         )}
       </div>
     </div>

--- a/app/components/dashboard/quick-log-actions.tsx
+++ b/app/components/dashboard/quick-log-actions.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * Quick-Log Actions — Issue #1470
+ *
+ * Adds actionable buttons to Engineer My Day cards so engineers can
+ * start timers and apply time suggestions without leaving the dashboard.
+ *
+ * Three injection points:
+ * 1. StartTimerButton — shown when todayHours === 0 (or standalone)
+ * 2. ApplySuggestionButton — per timeSuggestion row
+ * 3. TaskTimerButton — per in-progress task row (hover reveal)
+ */
+import { useState, useCallback } from "react";
+import { Play, Check, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { apiFetch } from "@/lib/api-client";
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+interface TimeSuggestion {
+  taskId: string;
+  title: string;
+  estimatedHours: number | null;
+  suggestion: string;
+}
+
+// ── Start Timer Button ──────────────────────────────────────────────────
+
+interface StartTimerButtonProps {
+  /** Optional task ID to bind the timer to */
+  taskId?: string;
+  /** Compact mode for inline task row usage */
+  compact?: boolean;
+  /** Called after successful start so parent can refetch data */
+  onSuccess: () => void;
+}
+
+export function StartTimerButton({ taskId, compact, onSuccess }: StartTimerButtonProps) {
+  const [loading, setLoading] = useState(false);
+
+  const handleStart = useCallback(async () => {
+    setLoading(true);
+    const body: Record<string, string> = {};
+    if (taskId) body.taskId = taskId;
+
+    const { error, status } = await apiFetch("/api/time-entries/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    setLoading(false);
+
+    if (error) {
+      if (status === 409) {
+        toast.error("已有正在計時的項目，請先停止目前計時器");
+      } else {
+        toast.error(error);
+      }
+      return;
+    }
+
+    toast.success("計時器已啟動");
+    onSuccess();
+  }, [taskId, onSuccess]);
+
+  if (compact) {
+    return (
+      <button
+        onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleStart(); }}
+        disabled={loading}
+        className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-primary/10 text-primary disabled:opacity-50 flex-shrink-0"
+        title="開始計時"
+        data-testid="task-timer-btn"
+      >
+        {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleStart}
+      disabled={loading}
+      className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+      data-testid="start-timer-btn"
+    >
+      {loading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Play className="h-3 w-3" />}
+      開始計時
+    </button>
+  );
+}
+
+// ── Apply Suggestion Button ─────────────────────────────────────────────
+
+interface ApplySuggestionButtonProps {
+  suggestion: TimeSuggestion;
+  onSuccess: () => void;
+}
+
+export function ApplySuggestionButton({ suggestion, onSuccess }: ApplySuggestionButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [applied, setApplied] = useState(false);
+
+  const handleApply = useCallback(async () => {
+    setLoading(true);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const { error } = await apiFetch("/api/time-entries", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        taskId: suggestion.taskId,
+        hours: suggestion.estimatedHours ?? 1,
+        date: today.toISOString(),
+        category: "PLANNED_TASK",
+        description: `自動套用建議：${suggestion.title}`,
+      }),
+    });
+
+    setLoading(false);
+
+    if (error) {
+      toast.error(error);
+      return;
+    }
+
+    setApplied(true);
+    toast.success(`已記錄 ${suggestion.estimatedHours ?? 1}h — ${suggestion.title}`);
+    onSuccess();
+  }, [suggestion, onSuccess]);
+
+  return (
+    <button
+      onClick={handleApply}
+      disabled={loading || applied}
+      className="flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors disabled:opacity-50 bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/40 dark:text-purple-300 dark:hover:bg-purple-900/60"
+      data-testid="apply-suggestion-btn"
+    >
+      {loading ? (
+        <Loader2 className="h-3 w-3 animate-spin" />
+      ) : applied ? (
+        <Check className="h-3 w-3" />
+      ) : (
+        <Check className="h-3 w-3" />
+      )}
+      {applied ? "已套用" : "套用"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #1470

Engineer My Day dashboard 的三個被動展示區塊加入可操作按鈕，讓工程師不用離開儀表板就能記錄工時：

- **今日工時卡片**（0h 狀態）→「▶ 開始計時」按鈕，呼叫 `POST /api/time-entries/start`
- **時間建議列表**（每列）→「套用」按鈕，直接建立 TimeEntry
- **進行中任務列表**（每列 hover）→ ▶ 迷你按鈕，啟動任務計時器

### 技術細節
- 新元件 `app/components/dashboard/quick-log-actions.tsx`（~140 LOC）
- 全部重用既有 API，**無 schema/migration 變更**
- Pessimistic UI + toast 反饋（409 Conflict 專門處理）
- `TaskRow` 加入 `actions` slot + `group` class 支援 hover 顯示

### 測試
- 8 個新增單元測試（成功、409 衝突、錯誤、loading 狀態、compact 模式）
- 25 個既有 dashboard 測試全部通過（無 regression）
- TypeScript noEmit 通過

## Test Plan
- [x] `npx jest __tests__/components/dashboard/quick-log-actions.test.tsx` — 8/8 passed
- [x] `npx jest __tests__/pages/dashboard` — 25/25 passed (no regression)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: 登入 Engineer 帳號 → 儀表板 → 點「開始計時」→ 確認 toast + 工時卡更新
- [ ] Manual: 登入 Engineer 帳號 → 時間建議 → 點「套用」→ 確認 entry 建立
- [ ] Manual: 進行中任務 → hover → 點 ▶ → 確認計時器啟動
- [ ] Manual: 已有 running timer → 再次點 ▶ → 確認顯示 409 提示