### PR TITLE
fix(T1474): quick-log suggestion date — use local YYYY-MM-DD

### DIFF
--- a/__tests__/components/dashboard/quick-log-actions.test.tsx
+++ b/__tests__/components/dashboard/quick-log-actions.test.tsx
@@ -230,6 +230,16 @@ describe("ApplySuggestionButton", () => {
     expect(body.hours).toBe(SUGGESTION.estimatedHours);
     expect(body.category).toBe("PLANNED_TASK");
     expect(body.description).toContain(SUGGESTION.title);
+
+    // Issue #1474: date must be local YYYY-MM-DD (not ISO timestamp),
+    // matching Zod pastOrTodayDate schema and avoiding UTC+8 evening drift.
+    expect(body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const now = new Date();
+    const expectedDate =
+      `${now.getFullYear()}-` +
+      `${String(now.getMonth() + 1).padStart(2, "0")}-` +
+      `${String(now.getDate()).padStart(2, "0")}`;
+    expect(body.date).toBe(expectedDate);
   });
 
   it("shows error toast on failure and stays enabled", async () => {

--- a/app/components/dashboard/quick-log-actions.tsx
+++ b/app/components/dashboard/quick-log-actions.tsx
@@ -15,6 +15,7 @@ import { useState, useCallback } from "react";
 import { Play, Check, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { apiFetch } from "@/lib/api-client";
+import { formatLocalDate } from "@/lib/utils/date";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -106,8 +107,10 @@ export function ApplySuggestionButton({ suggestion, onSuccess }: ApplySuggestion
   const handleApply = useCallback(async () => {
     setLoading(true);
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // Send YYYY-MM-DD in the user's local timezone.
+    // The server-side Zod schema (pastOrTodayDate) rejects full ISO timestamps,
+    // and toISOString() would shift evening entries in UTC+8 to the previous day.
+    const localDate = formatLocalDate(new Date());
 
     const { error } = await apiFetch("/api/time-entries", {
       method: "POST",
@@ -115,7 +118,7 @@ export function ApplySuggestionButton({ suggestion, onSuccess }: ApplySuggestion
       body: JSON.stringify({
         taskId: suggestion.taskId,
         hours: suggestion.estimatedHours ?? 1,
-        date: today.toISOString(),
+        date: localDate,
         category: "PLANNED_TASK",
         description: `自動套用建議：${suggestion.title}`,
       }),


### PR DESCRIPTION
## Summary

- 修正 `ApplySuggestionButton` 送出日期格式不對 + UTC 偏移雙重 bug
- 改用 `formatLocalDate()`（專案既有工具，正是為此設計）
- 補測試驗證 POST payload 是本地 `YYYY-MM-DD`

## Root cause

原實作 `today.toISOString()` 有兩個問題：

1. **格式錯誤**：server Zod schema `pastOrTodayDate = z.string().date()` 要求 `YYYY-MM-DD`，ISO timestamp 會被 400 拒絕
2. **跨日漂移**：`setHours(0,0,0,0)` 取本地午夜，`toISOString()` 轉 UTC，UTC+8 晚上 16:00 後會倒退一天

`lib/utils/date.ts:5-7` 的 jsdoc 甚至明確警告過這個情境，原 PR 未使用該工具。

## Changes

- `app/components/dashboard/quick-log-actions.tsx`
  - import `formatLocalDate` from `@/lib/utils/date`
  - `date: today.toISOString()` → `date: formatLocalDate(new Date())`
- `__tests__/components/dashboard/quick-log-actions.test.tsx`
  - 新增 assertion: payload `date` 符合 `^\d{4}-\d{2}-\d{2}$` 且等於本地日期

## Test plan

- [x] `npx jest __tests__/components/dashboard/quick-log-actions.test.tsx` — 8/8 passed
- [x] `npx tsc --noEmit` — clean for touched files
- [ ] CI green

Closes #1474