### PR TITLE
fix(T1475): generic fallback for quick-log toast errors (no raw message leak)

### DIFF
--- a/__tests__/components/dashboard/quick-log-actions.test.tsx
+++ b/__tests__/components/dashboard/quick-log-actions.test.tsx
@@ -114,11 +114,11 @@ describe("StartTimerButton", () => {
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
-  it("shows generic error toast on non-409 errors", async () => {
+  it("shows generic error toast on non-409 errors (no raw server message leak)", async () => {
     mockFetch.mockResolvedValue({
       ok: false,
       status: 500,
-      json: async () => ({ message: "內部伺服器錯誤" }),
+      json: async () => ({ message: "內部伺服器錯誤：Prisma ... stack ..." }),
     } as unknown as Response);
     const onSuccess = jest.fn();
 
@@ -135,7 +135,12 @@ describe("StartTimerButton", () => {
       expect(mockToastError).toHaveBeenCalled();
     });
 
-    // Should not show the 409-specific message
+    // Issue #1475: non-409 errors must use a generic fallback string,
+    // not the raw server-provided message (prevents Prisma/stack leaks).
+    expect(mockToastError).toHaveBeenCalledWith("無法啟動計時器，請稍後再試");
+    expect(mockToastError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Prisma"),
+    );
     expect(mockToastError).not.toHaveBeenCalledWith(
       "已有正在計時的項目，請先停止目前計時器"
     );
@@ -232,8 +237,8 @@ describe("ApplySuggestionButton", () => {
     expect(body.description).toContain(SUGGESTION.title);
   });
 
-  it("shows error toast on failure and stays enabled", async () => {
-    mockFetch.mockImplementation(makeFetchError(400, "時數不能為零"));
+  it("shows generic error toast on failure and stays enabled (no raw message leak)", async () => {
+    mockFetch.mockImplementation(makeFetchError(400, "Prisma constraint X violated"));
     const onSuccess = jest.fn();
 
     const { ApplySuggestionButton } = await import(
@@ -250,6 +255,12 @@ describe("ApplySuggestionButton", () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalled();
     });
+
+    // Issue #1475: use generic fallback, never forward raw server error to users.
+    expect(mockToastError).toHaveBeenCalledWith("套用建議失敗，請稍後再試");
+    expect(mockToastError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Prisma"),
+    );
 
     expect(onSuccess).not.toHaveBeenCalled();
 

--- a/app/components/dashboard/quick-log-actions.tsx
+++ b/app/components/dashboard/quick-log-actions.tsx
@@ -56,7 +56,9 @@ export function StartTimerButton({ taskId, compact, onSuccess }: StartTimerButto
       if (status === 409) {
         toast.error("已有正在計時的項目，請先停止目前計時器");
       } else {
-        toast.error(error);
+        // Don't forward the raw server error — can leak Prisma/stack detail.
+        toast.error("無法啟動計時器，請稍後再試");
+        console.error("[quick-log] start timer failed", { status, error });
       }
       return;
     }
@@ -124,7 +126,9 @@ export function ApplySuggestionButton({ suggestion, onSuccess }: ApplySuggestion
     setLoading(false);
 
     if (error) {
-      toast.error(error);
+      // Don't forward the raw server error — can leak Prisma/stack detail.
+      toast.error("套用建議失敗，請稍後再試");
+      console.error("[quick-log] apply suggestion failed", { error });
       return;
     }
 


### PR DESCRIPTION
## Summary

- Stop forwarding raw server error messages to \`toast.error\` in quick-log actions
- Prevents Prisma/stack/internal detail from leaking to end users

## Change

| Location | Before | After |
|---|---|---|
| \`quick-log-actions.tsx:59\` | \`toast.error(error)\` | Generic "無法啟動計時器，請稍後再試" + \`console.error\` |
| \`quick-log-actions.tsx:127\` | \`toast.error(error)\` | Generic "套用建議失敗，請稍後再試" + \`console.error\` |

409 conflict messages kept as-is (user-actionable state, not internal error).

## Test plan

- [x] \`npx jest __tests__/components/dashboard/quick-log-actions.test.tsx\` — 8/8 passed
- [x] Tests now assert both the generic string is used AND raw server message never leaks
- [ ] CI green

Closes #1475