### PR TITLE
chore(T1476): quick-log-actions cleanup (icon, lambda, a11y, types)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -113,12 +113,7 @@ interface MonthlyGoalItem {
   status: string;
 }
 
-interface TimeSuggestion {
-  taskId: string;
-  title: string;
-  estimatedHours: number | null;
-  suggestion: string;
-}
+import type { TimeSuggestion } from "@/app/components/dashboard/types";
 
 interface EngineerData {
   role: "ENGINEER";
@@ -721,13 +716,13 @@ export default function DashboardPage() {
             </div>
           </div>
         ) : error ? (
-          <PageError message={error} onRetry={() => fetchMyDay()} />
+          <PageError message={error} onRetry={fetchMyDay} />
         ) : !data ? (
           <PageEmpty title="尚無資料" description="無法載入 My Day 資料" />
         ) : data.role === "MANAGER" ? (
           <ManagerMyDay data={data} isVisible={isVisible} />
         ) : (
-          <EngineerMyDay data={data} isVisible={isVisible} onRefresh={() => fetchMyDay()} />
+          <EngineerMyDay data={data} isVisible={isVisible} onRefresh={fetchMyDay} />
         )}
       </div>
     </div>

--- a/app/components/dashboard/quick-log-actions.tsx
+++ b/app/components/dashboard/quick-log-actions.tsx
@@ -16,15 +16,7 @@ import { Play, Check, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { apiFetch } from "@/lib/api-client";
 import { formatLocalDate } from "@/lib/utils/date";
-
-// ── Types ───────────────────────────────────────────────────────────────
-
-interface TimeSuggestion {
-  taskId: string;
-  title: string;
-  estimatedHours: number | null;
-  suggestion: string;
-}
+import type { TimeSuggestion } from "./types";
 
 // ── Start Timer Button ──────────────────────────────────────────────────
 
@@ -75,6 +67,7 @@ export function StartTimerButton({ taskId, compact, onSuccess }: StartTimerButto
         disabled={loading}
         className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-primary/10 text-primary disabled:opacity-50 flex-shrink-0"
         title="開始計時"
+        aria-label="開始計時"
         data-testid="task-timer-btn"
       >
         {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
@@ -149,8 +142,6 @@ export function ApplySuggestionButton({ suggestion, onSuccess }: ApplySuggestion
     >
       {loading ? (
         <Loader2 className="h-3 w-3 animate-spin" />
-      ) : applied ? (
-        <Check className="h-3 w-3" />
       ) : (
         <Check className="h-3 w-3" />
       )}

--- a/app/components/dashboard/types.ts
+++ b/app/components/dashboard/types.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared types for dashboard components.
+ *
+ * Keep shapes here when two or more dashboard surfaces need the same shape,
+ * so they can't drift independently.
+ */
+
+export interface TimeSuggestion {
+  taskId: string;
+  title: string;
+  estimatedHours: number | null;
+  suggestion: string;
+}


### PR DESCRIPTION
## Summary

Four small cleanups surfaced in R6 code review of PR #1471:

1. **Remove dead icon branch** — \`applied\` and default both rendered \`Check\`; collapsed to one branch
2. **Drop \`() => fetchMyDay()\` lambda wrappers** — pass \`fetchMyDay\` directly; avoids new function identity per render
3. **Add \`aria-label\`** to icon-only compact timer button (a11y)
4. **Extract \`TimeSuggestion\` interface** to \`app/components/dashboard/types.ts\` (DRY, drift-proof)

## Test plan

- [x] \`npx jest __tests__/components/dashboard/quick-log-actions.test.tsx\` — 8/8 passed
- [x] \`npx tsc --noEmit\` — clean
- [ ] CI green

Closes #1476