### PR TITLE
chore(T1478): fail-loud CI seed guard + remove dead Prisma 6 config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,23 @@ jobs:
         env:
           DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
 
+      # Issue #1478: fail-loud if seed silently no-op'd (happened on
+      # Prisma 7 upgrade when migrations.seed moved from package.json).
+      # The seed CLI exits 0 even when no seed command is configured,
+      # so we verify fixture users actually exist before proceeding.
+      - name: Verify seed created fixtures
+        env:
+          PGPASSWORD: titan_test
+          FIXTURE_EMAIL: admin@titan.local
+        run: |
+          count=$(psql -h localhost -U titan -d titan_test -tAc "SELECT COUNT(*) FROM \"User\" WHERE email = '$FIXTURE_EMAIL'")
+          if [ "$count" -lt 1 ]; then
+            echo "::error::Seed step produced 0 admin users — seed did not run."
+            echo "Check that prisma.config.ts has migrations.seed configured (Prisma 7+)."
+            exit 1
+          fi
+          echo "Seed verified: $FIXTURE_EMAIL present (count=$count)"
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "db:studio": "prisma studio",
     "generate:mobile-types": "tsx scripts/generate-mobile-types.ts"
   },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
-  },
   "dependencies": {
     "@prisma/adapter-pg": "7.6.0",
     "@prisma/client": "7.6.0",


### PR DESCRIPTION
## Summary

- Add a CI step that fails loudly if seed silently no-op'd (e.g. after a Prisma major-version bump where \`migrations.seed\` location moved)
- Remove the dead \`prisma.seed\` block from \`package.json\` (Prisma 7 ignores it)

## Why

When the Prisma 7 upgrade landed, the seed step silently no-op'd for hours because Prisma 7 reads seed from \`prisma.config.ts\` not \`package.json\`. CI passed the seed step (exit 0); E2E failed 20 min later with opaque \`CredentialsSignin\`. The fail-loud guard would have produced an actionable error immediately after the seed step.

## Change

\`\`\`yaml
- name: Verify seed created fixtures
  env:
    PGPASSWORD: titan_test
    FIXTURE_EMAIL: admin@titan.local
  run: |
    count=\$(psql -h localhost -U titan -d titan_test -tAc "SELECT COUNT(*) FROM \\\"User\\\" WHERE email = '\$FIXTURE_EMAIL'")
    if [ "\$count" -lt 1 ]; then
      echo "::error::Seed step produced 0 admin users — seed did not run."
      exit 1
    fi
\`\`\`

## Test plan

- [x] No \`\${{ github.event.* }}\` injection surfaces (email is static env var)
- [ ] CI green when seed works
- [ ] CI fails fast with clear message when seed is misconfigured

Closes #1478
Related: #1472, #1487