### PR TITLE
fix(T1479): replace toISOString for user-facing date filters (Phase 1)

### DIFF
--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -28,15 +28,19 @@ import {
   ProjectBudgetReport,
 } from "@/app/components/reports/report-table-audit";
 import { ReportsExtended } from "@/app/components/reports-extended";
+import { formatLocalDate } from "@/lib/utils/date";
 
 // ─── Date helpers ─────────────────────────────────────────────────────────────
 
 function defaultDateRange(): { from: string; to: string } {
   const now = new Date();
   const from = new Date(now.getFullYear(), now.getMonth() - 2, 1);
+  // Issue #1479: use local-timezone YYYY-MM-DD so evening UTC+8 users
+  // see today's data, not yesterday's. toISOString() converts to UTC
+  // and silently drifts by up to a day for non-UTC timezones.
   return {
-    from: from.toISOString().split("T")[0],
-    to: now.toISOString().split("T")[0],
+    from: formatLocalDate(from),
+    to: formatLocalDate(now),
   };
 }
 

--- a/app/components/task-filters.tsx
+++ b/app/components/task-filters.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { extractItems, extractData } from "@/lib/api-client";
 import { useRouter, usePathname } from "next/navigation";
+import { formatLocalDate } from "@/lib/utils/date";
 
 export type TaskFilters = {
   assignee: string;
@@ -465,12 +466,14 @@ export function TaskFilters({ filters, onChange, totalCount, filteredCount, sync
             <button
               key={days}
               onClick={() => {
+                // Issue #1479: local-timezone YYYY-MM-DD so filter matches
+                // the user's calendar day, not a UTC-shifted one.
                 const to = new Date();
                 const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000);
                 onChange({
                   ...filters,
-                  createdAtFrom: from.toISOString().split("T")[0],
-                  createdAtTo: to.toISOString().split("T")[0],
+                  createdAtFrom: formatLocalDate(from),
+                  createdAtTo: formatLocalDate(to),
                 });
               }}
               className="text-[10px] px-2 py-1 rounded border border-border hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
## Summary

Phase 1 of the \`toISOString().split/slice\` UTC-drift audit. Fixes two high-risk user-facing date sources that silently shifted by a day for UTC+8 evening users.

## Changes

| File | Why it matters |
|---|---|
| \`app/(app)/reports/page.tsx:34-41\` | Report default date range — UTC+8 after 16:00 saw prior-day range |
| \`app/components/task-filters.tsx:468-473\` | Task quick-range filters (7d/14d/30d) — missed today's tasks |

Both now use \`formatLocalDate()\` from \`lib/utils/date.ts\`, which already exists with an explicit JSDoc warning against the anti-pattern.

## What is intentionally not changed

| Usage | Why keep toISOString() |
|---|---|
| Export filenames (\`projects-2026-04-18.csv\`) | UTC stability is desirable for consistent sorting across users |
| Idempotency alert IDs (\`overdue-2026-04-18\`) | UTC day boundary gives deterministic daily dedupe |
| Log timestamps | ISO 8601 with Z is the logging standard |

## Remaining phases (tracked in #1479)

- Phase 2: ESLint rule forbidding \`toISOString().slice(0, 10)\` / \`toISOString().split("T")[0]\` outside whitelisted surfaces
- Phase 3: Audit the 20+ other occurrences; case-by-case classification

## Test plan

- [x] \`npx jest --testPathPatterns="reports|task-filters"\` — 106/106 passed
- [ ] CI green

Refs #1479