### PR TITLE
test(T1486): real-Postgres integration test skeleton + DocumentStatus contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,52 @@ jobs:
           NEXTAUTH_SECRET: test-secret-for-ci
           NEXTAUTH_URL: http://localhost:3000
 
+  db-integration:
+    runs-on: ubuntu-latest
+    # Issue #1486: catches Prisma driver/adapter-level bugs that mocked
+    # unit tests miss (e.g. enum column type drift). Fast (<3 min) so it
+    # surfaces in the PR feedback loop well before E2E.
+    timeout-minutes: 5
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: titan
+          POSTGRES_PASSWORD: titan_test
+          POSTGRES_DB: titan_test
+        ports:
+          - '5432:5432'
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx prisma generate
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Run database migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
+      - name: Run DB integration tests
+        run: npm run test:db
+        env:
+          DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
+
   docker-build:
     runs-on: ubuntu-latest
     needs: test

--- a/__tests__/db-integration/README.md
+++ b/__tests__/db-integration/README.md
@@ -1,0 +1,34 @@
+# DB-integration tests
+
+Tests in this directory **connect to a real Postgres database**. They catch
+driver/adapter-level bugs that unit tests with mocked Prisma cannot see —
+for example, the `DocumentStatus` enum cast failure (#1481) that cascaded
+into 2h+ E2E hangs despite `alert-service` having 6 passing unit tests.
+
+## Running locally
+
+```bash
+export DATABASE_URL=postgresql://titan:titan_test@localhost:5432/titan_test
+npm run db:migrate:deploy
+npm run test:db
+```
+
+If `DATABASE_URL` is not set the suite skips with a warning — never fails.
+
+## Running in CI
+
+The `db-integration` job in `.github/workflows/ci.yml` provisions a
+Postgres service container, runs migrations, and calls `npm run test:db`.
+
+## What belongs here
+
+- **One smoke test per enum-bearing column** — exercises the Prisma query
+  that would fail if the column type drifted from the schema declaration.
+- **Query contracts that depend on the driver adapter** — e.g. array
+  inclusion, JSONB filters, timezone-aware date columns.
+
+## What does NOT belong here
+
+- Business logic (use unit tests with mocked Prisma)
+- UI rendering (use React Testing Library)
+- End-to-end user flows (use Playwright in `e2e/`)

--- a/__tests__/db-integration/document-status-enum.test.ts
+++ b/__tests__/db-integration/document-status-enum.test.ts
@@ -1,0 +1,70 @@
+/**
+ * DB-integration test: Document.status enum contract (Issue #1481, #1486)
+ *
+ * Exercises the exact findMany shape that failed in production after the
+ * Prisma 7 + @prisma/adapter-pg upgrade:
+ *
+ *     DriverAdapterError: operator does not exist: text = "DocumentStatus"
+ *
+ * If the documents.status column type drifts from DocumentStatus back to
+ * TEXT (or any future enum field suffers the same retrofit-as-TEXT bug),
+ * this test fails immediately with a clear error — not 2h into E2E.
+ */
+
+import { PrismaClient, DocumentStatus } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+
+const dbUrl = process.env.DATABASE_URL;
+
+// Skip (not fail) when no DB is available — e.g. contributor's first
+// clone. CI always sets DATABASE_URL via the postgres service container.
+const describeIfDb = dbUrl ? describe : describe.skip;
+
+describeIfDb("Document.status enum contract", () => {
+  let prisma: PrismaClient;
+  let pool: Pool;
+
+  beforeAll(() => {
+    pool = new Pool({ connectionString: dbUrl, max: 2 });
+    const adapter = new PrismaPg(pool);
+    prisma = new PrismaClient({ adapter });
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await pool.end();
+  });
+
+  test("findMany with status literal does not explode on the driver adapter", async () => {
+    await expect(
+      prisma.document.findMany({
+        where: { status: "PUBLISHED" },
+        select: { id: true },
+        take: 1,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("findMany with typed enum import does not explode", async () => {
+    await expect(
+      prisma.document.findMany({
+        where: { status: DocumentStatus.PUBLISHED },
+        select: { id: true },
+        take: 1,
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("documents.status column type matches DocumentStatus (not TEXT)", async () => {
+    const rows = await prisma.$queryRaw<Array<{ data_type: string; udt_name: string }>>`
+      SELECT data_type, udt_name
+      FROM information_schema.columns
+      WHERE table_name = 'documents' AND column_name = 'status'
+    `;
+    expect(rows).toHaveLength(1);
+    // Postgres reports enum columns as data_type='USER-DEFINED', udt_name='DocumentStatus'
+    expect(rows[0].data_type).toBe("USER-DEFINED");
+    expect(rows[0].udt_name).toBe("DocumentStatus");
+  });
+});

--- a/jest.config.db-integration.js
+++ b/jest.config.db-integration.js
@@ -1,0 +1,26 @@
+/**
+ * Jest config for real-Postgres integration tests (Issue #1486).
+ *
+ * Run via: `npm run test:db`
+ *
+ * These tests require DATABASE_URL and are skipped automatically if unset.
+ * Kept separate from the main Jest config because:
+ *   - testEnvironment must be `node`, not `jsdom`
+ *   - testPathIgnorePatterns are narrower (only db-integration suites)
+ *   - slower to run, should not block the main watch loop
+ */
+
+module.exports = {
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/__tests__/db-integration/**/*.test.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
+  transform: {
+    "^.+\\.(ts|tsx)$": ["ts-jest", { tsconfig: "tsconfig.json" }],
+  },
+  setupFilesAfterEnv: [],
+  forceExit: true,
+  // No coverage on these — they're contract tests, not unit tests.
+  collectCoverage: false,
+};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,10 @@ const config: Config = {
     "^@/(.*)$": "<rootDir>/$1",
   },
   testMatch: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
+  // Issue #1486: db-integration suites need a real Postgres and run via
+  // `npm run test:db` with a dedicated config. Exclude them here so the
+  // default Jest run (mocked Prisma) doesn't pick them up.
+  testPathIgnorePatterns: ["/node_modules/", "/__tests__/db-integration/"],
   collectCoverageFrom: [
     "services/**/*.ts",
     "!services/**/__tests__/**",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:push": "prisma db push",
     "db:seed": "tsx prisma/seed.ts",
     "db:studio": "prisma studio",
+    "test:db": "jest --config jest.config.db-integration.js --forceExit",
     "generate:mobile-types": "tsx scripts/generate-mobile-types.ts"
   },
   "prisma": {


### PR DESCRIPTION
## Summary

Introduces a fast (<5 min) **db-integration** CI job that catches Prisma driver/adapter bugs that mocked unit tests miss. First test reproduces the #1481 DocumentStatus cascade at the contract level.

## Why this exists

\`alert-service\` had 6 passing unit tests. Production still broke for hours because:

- Unit tests mock \`prisma.*.findMany\` — real SQL is never emitted
- Prisma 7 + \`@prisma/adapter-pg\` strictness (strict enum ↔ column type check) never runs
- Driver bugs surface only in E2E — 2-3 h after the regression landed

This PR adds a thin seam that exercises the real driver against a real Postgres service container, without duplicating business logic into E2E.

## What's in the skeleton

| File | Purpose |
|---|---|
| \`__tests__/db-integration/README.md\` | Usage + scope rules |
| \`__tests__/db-integration/document-status-enum.test.ts\` | 3 tests: string literal findMany, typed enum findMany, \`information_schema\` assertion (the column type MUST be \`DocumentStatus\`, never TEXT) |
| \`jest.config.db-integration.js\` | Separate config, \`testEnvironment: node\` |
| \`package.json\` | \`npm run test:db\` script |
| \`.github/workflows/ci.yml\` | New \`db-integration\` job (5 min timeout, parallel to \`test\`) |

## Why skip when DATABASE_URL is unset

Contributors' first clone shouldn't fail. CI always has the Postgres service container, so DATABASE_URL is always set there.

## Expected impact

- **Future schema drift** (any enum column retrofitted as TEXT) is flagged in 3 min, not 2-3 h
- **Future Prisma major-version bumps** get a fast signal on which query shapes broke

## Test plan

- [x] \`npx jest --config jest.config.db-integration.js\` without \`DATABASE_URL\` — 3 skipped (not failed)
- [ ] CI green in the new \`db-integration\` job

Closes #1486
Related: #1481, #1487 (real-cause column migration)