### PR TITLE
fix(T1492): baseline migration — 11 tables + tasks.projectId missing from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    # Issue #1480: cap total job time so a hung test cannot burn 6h of runner budget.
+    timeout-minutes: 20
     needs: test
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,10 +220,13 @@ jobs:
           AUTH_SECRET: test-secret-for-ci
 
       - name: Start server and run E2E tests
+        # Issue #1484: dropped `--workers=1` override so playwright.config.ts
+        # `workers: 3` takes effect. Saved auth state bypasses the login
+        # rate limiter, so concurrent workers are safe.
         run: |
           npm run start &
           npx wait-on http://localhost:3100/api/health --timeout 60000
-          npx playwright test --project=chromium --workers=1
+          npx playwright test --project=chromium
         env:
           DATABASE_URL: postgresql://titan:titan_test@localhost:5432/titan_test
           REDIS_URL: redis://localhost:6379/0

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -16,9 +16,10 @@ async function loginAndSave(
   const page = await browser.newPage();
 
   await page.goto(`${BASE_URL}/login`);
-  await page.waitForLoadState('networkidle');
-
-  // 等待 React 水合完成
+  // Issue #1480: dropped `waitForLoadState('networkidle')`. networkidle
+  // hangs when long-polls / beacons keep connections open — was the root
+  // of the 2h+ E2E hangs. Waiting for the hydrated submit button is a
+  // reliable interactive-readiness signal.
   await page.waitForSelector('button[type="submit"]', { state: 'visible', timeout: 10000 });
 
   await page.locator('#username').click();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,10 +4,11 @@ import { defineConfig, devices } from '@playwright/test';
  * Playwright E2E configuration — unified for Docker and local environments.
  *
  * Environment variables:
- *   BASE_URL     — app base URL (default: http://localhost:3100)
- *   CI           — set in CI environments; adjusts retries/workers
- *   E2E_TIMEOUT  — per-test timeout in ms (default: 30000)
- *   E2E_WORKERS  — parallel worker count (default: 3, CI: 1)
+ *   BASE_URL                — app base URL (default: http://localhost:3100)
+ *   CI                      — set in CI environments; adjusts retries/workers
+ *   E2E_TIMEOUT             — per-test timeout in ms (default: 30000)
+ *   E2E_WORKERS             — parallel worker count (default: 3)
+ *   E2E_GLOBAL_TIMEOUT_MS   — full-run cap in ms (default: 15 min)
  */
 
 const isCI = !!process.env.CI;
@@ -15,9 +16,16 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testDir: './e2e',
   timeout: parseInt(process.env.E2E_TIMEOUT ?? '30000', 10),
+  // Issue #1480: cap total run time so one hung test cannot eat 6h runner
+  // budget. 15 min covers the 920-test suite at 3 workers with margin.
+  globalTimeout: parseInt(process.env.E2E_GLOBAL_TIMEOUT_MS ?? String(15 * 60_000), 10),
   retries: isCI ? 2 : 1,
-  // Limit workers to avoid rate limiter triggering on concurrent logins
-  workers: parseInt(process.env.E2E_WORKERS ?? (isCI ? '1' : '3'), 10),
+  // Issue #1484: bumped CI workers from 1 to 3. Saved auth state files
+  // (manager.json / engineer.json, populated in global-setup) mean most
+  // tests do not re-login, so the per-IP login rate limiter is not a
+  // concern at this concurrency. Tests that do explicit login should use
+  // test.describe.configure({ mode: 'serial' }) in their own file.
+  workers: parseInt(process.env.E2E_WORKERS ?? '3', 10),
   globalSetup: './e2e/global-setup.ts',
   expect: { timeout: 10000 },
   use: {

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -3,6 +3,11 @@ import { defineConfig, env } from 'prisma/config'
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',
+  migrations: {
+    path: 'prisma/migrations',
+    // Prisma 7+ reads seed from here, not package.json "prisma.seed"
+    seed: 'npx tsx prisma/seed.ts',
+  },
   datasource: {
     url: env('DATABASE_URL'),
   },

--- a/prisma/migrations/20260418020000_fix_document_status_column_type/migration.sql
+++ b/prisma/migrations/20260418020000_fix_document_status_column_type/migration.sql
@@ -1,0 +1,36 @@
+-- Fix documents.status column type (Issue #1481)
+--
+-- The 20260327000000_add_missing_columns migration created the column
+-- as TEXT, but the Prisma schema declares it as DocumentStatus. Under
+-- Prisma 6 the mismatch was tolerated (driver let string = text compare
+-- work); Prisma 7 + @prisma/adapter-pg surfaces the mismatch as:
+--     DriverAdapterError: operator does not exist: text = "DocumentStatus"
+-- which cascades into the alerts polling storm described in #1481.
+--
+-- The DocumentStatus enum type already exists in the database (created
+-- alongside the TEXT column in the same migration). We only need to
+-- retype the column; existing data already uses the enum value names.
+--
+-- Safe on both fresh and existing databases:
+--   - prisma db push prod: already has DocumentStatus enum, column is TEXT
+--   - migrate deploy CI:   same state
+--   - fresh migrate deploy: same state
+--
+-- USING clause handles the cast explicitly for existing rows.
+
+DO $$
+DECLARE
+  current_type text;
+BEGIN
+  SELECT data_type INTO current_type
+  FROM information_schema.columns
+  WHERE table_name = 'documents' AND column_name = 'status';
+
+  IF current_type = 'text' THEN
+    ALTER TABLE "documents"
+      ALTER COLUMN "status" DROP DEFAULT,
+      ALTER COLUMN "status" TYPE "DocumentStatus"
+        USING "status"::"DocumentStatus",
+      ALTER COLUMN "status" SET DEFAULT 'DRAFT'::"DocumentStatus";
+  END IF;
+END $$;

--- a/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
+++ b/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
@@ -516,3 +516,39 @@ DO $$ BEGIN
   ALTER TABLE "project_gates" ADD CONSTRAINT "project_gates_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
+
+-- ==========================================================
+-- Column-level schema drift fix (28 columns across 8 tables)
+-- Detected by parsing `prisma migrate diff --from-empty --to-schema`
+-- against cumulative migration state.
+-- ==========================================================
+-- Auto-generated missing column ALTERs
+
+ALTER TABLE "notification_preferences" ADD COLUMN IF NOT EXISTS "emailEnabled" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "slug" TEXT;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "icon" TEXT;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "color" TEXT;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "visibility" TEXT NOT NULL DEFAULT 'TEAM';
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "sortOrder" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "updatedBy" TEXT;
+ALTER TABLE "knowledge_spaces" ADD COLUMN IF NOT EXISTS "createdBy" TEXT NOT NULL;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "tags" TEXT[];
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "verifyByDate" TIMESTAMP(3);
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "categoryId" TEXT;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "summary" TEXT;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "pinned" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "coverImage" TEXT;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "publishedVersion" INTEGER;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "publishedAt" TIMESTAMP(3);
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "publishedBy" TEXT;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "archivedAt" TIMESTAMP(3);
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "archivedBy" TEXT;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "wordCount" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "readTimeMin" INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "visibility" TEXT NOT NULL DEFAULT 'TEAM';
+ALTER TABLE "documents" ADD COLUMN IF NOT EXISTS "replacedById" TEXT;
+ALTER TABLE "document_versions" ADD COLUMN IF NOT EXISTS "title" TEXT;
+ALTER TABLE "reading_list_items" ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "reading_list_assignments" ADD COLUMN IF NOT EXISTS "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "knowledge_categories" ADD COLUMN IF NOT EXISTS "updatedAt" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "document_attachments" ADD COLUMN IF NOT EXISTS "uploaderId" TEXT NOT NULL;

--- a/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
+++ b/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
@@ -2,6 +2,42 @@
 -- All statements are idempotent so this is safe on both fresh CI DBs and existing prod DBs.
 -- Tables: change_records, notification_logs, project_gates, project_issues, project_risks, project_stakeholders, projects, push_tokens, reading_list_item_reads, task_attachments, task_documents
 
+-- CreateEnum (idempotent): CMChangeType
+DO $$ BEGIN
+  CREATE TYPE "CMChangeType" AS ENUM ('NORMAL', 'STANDARD', 'EMERGENCY');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): RiskLevel
+DO $$ BEGIN
+  CREATE TYPE "RiskLevel" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): ChangeStatus
+DO $$ BEGIN
+  CREATE TYPE "ChangeStatus" AS ENUM ('DRAFT', 'PENDING_APPROVAL', 'APPROVED', 'IN_PROGRESS', 'VERIFYING', 'COMPLETED', 'ROLLED_BACK', 'CANCELLED');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): SpaceRole
+DO $$ BEGIN
+  CREATE TYPE "SpaceRole" AS ENUM ('OWNER', 'EDITOR', 'VIEWER');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): LinkType
+DO $$ BEGIN
+  CREATE TYPE "LinkType" AS ENUM ('REFERENCE', 'RELATED');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): PushPlatform
+DO $$ BEGIN
+  CREATE TYPE "PushPlatform" AS ENUM ('IOS', 'ANDROID');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+-- CreateEnum (idempotent): ProjectStatus
+DO $$ BEGIN
+  CREATE TYPE "ProjectStatus" AS ENUM ('PROPOSED', 'EVALUATING', 'APPROVED', 'SCHEDULED', 'REQUIREMENTS', 'DESIGN', 'DEVELOPMENT', 'TESTING', 'DEPLOYMENT', 'WARRANTY', 'COMPLETED', 'POST_REVIEW', 'CLOSED', 'ON_HOLD', 'CANCELLED');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
 -- AddColumn: tasks.projectId (retroactive FK column, never migrated)
 ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "projectId" TEXT;
 

--- a/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
+++ b/prisma/migrations/20260418030000_baseline_missing_tables/migration.sql
@@ -1,0 +1,482 @@
+-- Baseline migration for tables created via `prisma db push` but never migrated (#1492).
+-- All statements are idempotent so this is safe on both fresh CI DBs and existing prod DBs.
+-- Tables: change_records, notification_logs, project_gates, project_issues, project_risks, project_stakeholders, projects, push_tokens, reading_list_item_reads, task_attachments, task_documents
+
+-- AddColumn: tasks.projectId (retroactive FK column, never migrated)
+ALTER TABLE "tasks" ADD COLUMN IF NOT EXISTS "projectId" TEXT;
+
+-- Add FK from tasks.projectId to projects.id (once projects exists below)
+-- This FK is guarded and will only succeed after the CREATE TABLE "projects" below.
+-- The guard uses DO block so re-runs are safe.
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "change_records" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "changeNumber" TEXT NOT NULL,
+    "type" "CMChangeType" NOT NULL,
+    "riskLevel" "RiskLevel" NOT NULL,
+    "impactedSystems" TEXT[],
+    "scheduledStart" TIMESTAMP(3),
+    "scheduledEnd" TIMESTAMP(3),
+    "actualStart" TIMESTAMP(3),
+    "actualEnd" TIMESTAMP(3),
+    "rollbackPlan" TEXT,
+    "verificationPlan" TEXT,
+    "status" "ChangeStatus" NOT NULL DEFAULT 'DRAFT',
+    "cabApprovedBy" TEXT,
+    "cabApprovedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "change_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "task_documents" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "outlineDocumentId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "addedBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "task_documents_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "task_attachments" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "fileName" TEXT NOT NULL,
+    "fileSize" INTEGER NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "storagePath" TEXT NOT NULL,
+    "uploaderId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "task_attachments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "notification_logs" (
+    "id" TEXT NOT NULL,
+    "notificationId" TEXT,
+    "channel" TEXT NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "errorMessage" TEXT,
+    "sentAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "notification_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "reading_list_item_reads" (
+    "id" TEXT NOT NULL,
+    "readingListId" TEXT NOT NULL,
+    "documentId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "reading_list_item_reads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "push_tokens" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "platform" "PushPlatform" NOT NULL,
+    "deviceId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "push_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "projects" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "category" TEXT,
+    "subCategory" TEXT,
+    "tags" TEXT[],
+    "requestDept" TEXT NOT NULL,
+    "requestContact" TEXT,
+    "requestPhone" TEXT,
+    "requestDate" TIMESTAMP(3),
+    "businessGoal" TEXT,
+    "coDepts" TEXT[],
+    "coContacts" TEXT[],
+    "devDept" TEXT,
+    "ownerId" TEXT NOT NULL,
+    "leadDevId" TEXT,
+    "teamMembers" TEXT[],
+    "benefitRevenue" INTEGER,
+    "benefitCompliance" INTEGER,
+    "benefitEfficiency" INTEGER,
+    "benefitRisk" INTEGER,
+    "benefitScore" INTEGER,
+    "benefitNote" TEXT,
+    "benefitEvaluator" TEXT,
+    "benefitDate" TIMESTAMP(3),
+    "priority" TEXT NOT NULL DEFAULT 'P2',
+    "urgency" TEXT DEFAULT 'MEDIUM',
+    "strategicAlign" INTEGER,
+    "priorityScore" INTEGER,
+    "priorityNote" TEXT,
+    "feasibility" TEXT DEFAULT 'PENDING',
+    "feasibilityNote" TEXT,
+    "techComplexity" TEXT,
+    "techStack" TEXT,
+    "dependencies" TEXT,
+    "constraints" TEXT,
+    "assumptions" TEXT,
+    "riskLevel" TEXT DEFAULT 'MEDIUM',
+    "riskNote" TEXT,
+    "feasibilityBy" TEXT,
+    "feasibilityDate" TIMESTAMP(3),
+    "mdProjectMgmt" DOUBLE PRECISION DEFAULT 0,
+    "mdRequirements" DOUBLE PRECISION DEFAULT 0,
+    "mdDesign" DOUBLE PRECISION DEFAULT 0,
+    "mdDevelopment" DOUBLE PRECISION DEFAULT 0,
+    "mdTesting" DOUBLE PRECISION DEFAULT 0,
+    "mdDeployment" DOUBLE PRECISION DEFAULT 0,
+    "mdDocumentation" DOUBLE PRECISION DEFAULT 0,
+    "mdTraining" DOUBLE PRECISION DEFAULT 0,
+    "mdMaintenance" DOUBLE PRECISION DEFAULT 0,
+    "mdOther" DOUBLE PRECISION DEFAULT 0,
+    "mdTotalEstimated" DOUBLE PRECISION,
+    "mdActualTotal" DOUBLE PRECISION,
+    "budgetInternal" DOUBLE PRECISION DEFAULT 0,
+    "budgetExternal" DOUBLE PRECISION DEFAULT 0,
+    "budgetHardware" DOUBLE PRECISION DEFAULT 0,
+    "budgetLicense" DOUBLE PRECISION DEFAULT 0,
+    "budgetOther" DOUBLE PRECISION DEFAULT 0,
+    "budgetTotal" DOUBLE PRECISION,
+    "budgetActual" DOUBLE PRECISION,
+    "budgetApproved" BOOLEAN NOT NULL DEFAULT false,
+    "budgetApprovalNo" TEXT,
+    "costPerManDay" DOUBLE PRECISION DEFAULT 5000,
+    "vendor" TEXT,
+    "vendorContact" TEXT,
+    "vendorContract" TEXT,
+    "vendorAmount" DOUBLE PRECISION,
+    "vendorStartDate" TIMESTAMP(3),
+    "vendorEndDate" TIMESTAMP(3),
+    "subVendors" TEXT[],
+    "plannedStart" TIMESTAMP(3),
+    "plannedEnd" TIMESTAMP(3),
+    "actualStart" TIMESTAMP(3),
+    "actualEnd" TIMESTAMP(3),
+    "goLiveDate" TIMESTAMP(3),
+    "warrantyEndDate" TIMESTAMP(3),
+    "status" "ProjectStatus" NOT NULL DEFAULT 'PROPOSED',
+    "phase" TEXT,
+    "progressPct" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "progressNote" TEXT,
+    "blockers" TEXT,
+    "nextSteps" TEXT,
+    "progressUpdatedAt" TIMESTAMP(3),
+    "currentGate" TEXT,
+    "gateStatus" TEXT DEFAULT 'PENDING',
+    "postReviewSchedule" INTEGER,
+    "postReviewQuality" INTEGER,
+    "postReviewBudget" INTEGER,
+    "postReviewSatisfy" INTEGER,
+    "postReviewScore" INTEGER,
+    "postReviewNote" TEXT,
+    "lessonsLearned" TEXT,
+    "improvements" TEXT,
+    "postReviewBy" TEXT,
+    "postReviewDate" TIMESTAMP(3),
+    "approvalStatus" TEXT DEFAULT 'PENDING',
+    "approvedBy" TEXT,
+    "approvedDate" TIMESTAMP(3),
+    "approvalNo" TEXT,
+    "relatedRegulation" TEXT,
+    "internalNote" TEXT,
+    "createdBy" TEXT NOT NULL,
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "project_risks" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "category" TEXT,
+    "probability" TEXT NOT NULL,
+    "impact" TEXT NOT NULL,
+    "riskScore" INTEGER,
+    "mitigation" TEXT,
+    "contingency" TEXT,
+    "ownerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "dueDate" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_risks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "project_issues" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "category" TEXT,
+    "severity" TEXT NOT NULL,
+    "assigneeId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "resolution" TEXT,
+    "dueDate" TIMESTAMP(3),
+    "source" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_issues_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "project_stakeholders" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "department" TEXT,
+    "role" TEXT,
+    "influence" TEXT,
+    "interest" TEXT,
+    "engagement" TEXT,
+    "commStrategy" TEXT,
+    "contactInfo" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_stakeholders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "project_gates" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "phase" TEXT NOT NULL,
+    "order" INTEGER NOT NULL,
+    "checklist" JSONB,
+    "checklistPassed" BOOLEAN NOT NULL DEFAULT false,
+    "status" TEXT NOT NULL DEFAULT 'PENDING',
+    "reviewerId" TEXT,
+    "reviewedAt" TIMESTAMP(3),
+    "reviewNote" TEXT,
+    "blockerNote" TEXT,
+    "waiverReason" TEXT,
+    "attachments" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "project_gates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "change_records_taskId_key" ON "change_records"("taskId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "change_records_changeNumber_key" ON "change_records"("changeNumber");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "change_records_status_idx" ON "change_records"("status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "task_documents_taskId_idx" ON "task_documents"("taskId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "task_documents_taskId_outlineDocumentId_key" ON "task_documents"("taskId", "outlineDocumentId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "task_attachments_taskId_idx" ON "task_attachments"("taskId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "task_attachments_uploaderId_idx" ON "task_attachments"("uploaderId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "notification_logs_notificationId_idx" ON "notification_logs"("notificationId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "notification_logs_recipient_idx" ON "notification_logs"("recipient");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "reading_list_item_reads_readingListId_userId_idx" ON "reading_list_item_reads"("readingListId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "reading_list_item_reads_readingListId_documentId_userId_key" ON "reading_list_item_reads"("readingListId", "documentId", "userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "push_tokens_userId_idx" ON "push_tokens"("userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "push_tokens_isActive_idx" ON "push_tokens"("isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "push_tokens_deviceId_key" ON "push_tokens"("deviceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "projects_code_key" ON "projects"("code");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "projects_ownerId_idx" ON "projects"("ownerId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "projects_year_idx" ON "projects"("year");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "projects_status_idx" ON "projects"("status");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "projects_requestDept_idx" ON "projects"("requestDept");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "projects_priority_idx" ON "projects"("priority");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_risks_projectId_idx" ON "project_risks"("projectId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_risks_ownerId_idx" ON "project_risks"("ownerId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_issues_projectId_idx" ON "project_issues"("projectId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_issues_assigneeId_idx" ON "project_issues"("assigneeId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_stakeholders_projectId_idx" ON "project_stakeholders"("projectId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_gates_projectId_idx" ON "project_gates"("projectId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "project_gates_reviewerId_idx" ON "project_gates"("reviewerId");
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "tasks" ADD CONSTRAINT "tasks_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "change_records" ADD CONSTRAINT "change_records_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "task_documents" ADD CONSTRAINT "task_documents_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "task_attachments" ADD CONSTRAINT "task_attachments_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "tasks"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "task_attachments" ADD CONSTRAINT "task_attachments_uploaderId_fkey" FOREIGN KEY ("uploaderId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "reading_list_item_reads" ADD CONSTRAINT "reading_list_item_reads_readingListId_fkey" FOREIGN KEY ("readingListId") REFERENCES "reading_lists"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "reading_list_item_reads" ADD CONSTRAINT "reading_list_item_reads_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "documents"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "reading_list_item_reads" ADD CONSTRAINT "reading_list_item_reads_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "push_tokens" ADD CONSTRAINT "push_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "projects" ADD CONSTRAINT "projects_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "projects" ADD CONSTRAINT "projects_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_risks" ADD CONSTRAINT "project_risks_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_risks" ADD CONSTRAINT "project_risks_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_issues" ADD CONSTRAINT "project_issues_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_issues" ADD CONSTRAINT "project_issues_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_stakeholders" ADD CONSTRAINT "project_stakeholders_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_gates" ADD CONSTRAINT "project_gates_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AddForeignKey (idempotent)
+DO $$ BEGIN
+  ALTER TABLE "project_gates" ADD CONSTRAINT "project_gates_reviewerId_fkey" FOREIGN KEY ("reviewerId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/services/__tests__/alert-service.test.ts
+++ b/services/__tests__/alert-service.test.ts
@@ -112,5 +112,24 @@ describe("AlertService", () => {
         })
       );
     });
+
+    // Issue #1481: document query used to cascade into dashboard polling storms
+    test("文件查詢失敗時，其他告警仍正常產生（不連鎖崩潰）", async () => {
+      // Simulate the Prisma 7 DocumentStatus driver adapter failure
+      (prisma.document.findMany as jest.Mock).mockRejectedValue(
+        new Error('operator does not exist: text = "DocumentStatus"'),
+      );
+      (prisma.kPI.findMany as jest.Mock).mockResolvedValue([
+        { id: "kpi-1", title: "可用率", target: 100, actual: 30 },
+      ]);
+
+      const alerts = await service.getActiveAlerts();
+
+      // KPI alert should still fire even though document query threw
+      const kpiAlert = alerts.find((a) => a.category === "kpi_critical");
+      expect(kpiAlert).toBeDefined();
+      // No verification-expired alerts (query failed silently — degraded)
+      expect(alerts.some((a) => a.category === "verification_expired")).toBe(false);
+    });
   });
 });

--- a/services/alert-service.ts
+++ b/services/alert-service.ts
@@ -8,7 +8,7 @@
  * - Timesheet not submitted this week
  * - Document verification expired
  */
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, DocumentStatus } from "@prisma/client";
 
 export type AlertLevel = "CRITICAL" | "WARNING";
 export type AlertCategory =
@@ -134,32 +134,43 @@ export class AlertService {
       });
     }
 
-    // 5. Document verification expired
-    const expiredDocs = await this.prisma.document.findMany({
-      where: { deletedAt: null,
-        status: "PUBLISHED",
-        verifyIntervalDays: { not: null },
-        verifiedAt: { not: null },
-      },
-      select: { id: true, title: true, verifiedAt: true, verifyIntervalDays: true },
-      take: 1000,
-    });
+    // 5. Document verification expired.
+    // Issue #1481: wrapped in try/catch because a DocumentStatus enum
+    // cast failure here used to cascade into dashboard polling storms
+    // (/api/alerts/active would 500 every ~30s, hanging E2E). The
+    // verification-expired alert is non-critical, so we degrade to zero
+    // alerts here rather than fail the whole endpoint.
+    try {
+      const expiredDocs = await this.prisma.document.findMany({
+        where: {
+          deletedAt: null,
+          status: DocumentStatus.PUBLISHED,
+          verifyIntervalDays: { not: null },
+          verifiedAt: { not: null },
+        },
+        select: { id: true, title: true, verifiedAt: true, verifyIntervalDays: true },
+        take: 1000,
+      });
 
-    for (const doc of expiredDocs) {
-      if (doc.verifiedAt && doc.verifyIntervalDays) {
-        const expiryDate = new Date(doc.verifiedAt);
-        expiryDate.setDate(expiryDate.getDate() + doc.verifyIntervalDays);
-        if (expiryDate < now) {
-          alerts.push({
-            id: `verification-expired-${doc.id}`,
-            level: "WARNING",
-            category: "verification_expired",
-            message: `文件「${doc.title}」驗證已過期`,
-            link: `/knowledge`,
-            createdAt: now,
-          });
+      for (const doc of expiredDocs) {
+        if (doc.verifiedAt && doc.verifyIntervalDays) {
+          const expiryDate = new Date(doc.verifiedAt);
+          expiryDate.setDate(expiryDate.getDate() + doc.verifyIntervalDays);
+          if (expiryDate < now) {
+            alerts.push({
+              id: `verification-expired-${doc.id}`,
+              level: "WARNING",
+              category: "verification_expired",
+              message: `文件「${doc.title}」驗證已過期`,
+              link: `/knowledge`,
+              createdAt: now,
+            });
+          }
         }
       }
+    } catch {
+      // Non-critical branch: skip verification-expired alerts on query failure
+      // so the rest of the alert payload still ships to the dashboard.
     }
 
     // Sort: CRITICAL first, then by createdAt


### PR DESCRIPTION
## Summary

Adds a baseline migration for 11 tables + 1 column that exist in prod (via \`prisma db push\`) but were never captured as migration files. Without this, every CI E2E failed every alerts / tasks / projects request with:

\`\`\`
relation "public.projects" does not exist
column tasks.projectId does not exist
\`\`\`

Discovered during investigation of #1492 (CI schema drift).

## Missing tables (11)

Detected by \`prisma migrate diff --from-empty --to-schema\` + diff against \`grep CREATE TABLE prisma/migrations/\`:

- \`change_records\`
- \`notification_logs\`
- \`project_gates\`
- \`project_issues\`
- \`project_risks\`
- \`project_stakeholders\`
- \`projects\`
- \`push_tokens\`
- \`reading_list_item_reads\`
- \`task_attachments\`
- \`task_documents\`

## Missing column (1)

- \`tasks.projectId TEXT\` (seen in CI log, generator didn't surface)

## Idempotency

All statements are safe to replay on both fresh CI DBs and existing prod DBs:

- \`CREATE TABLE IF NOT EXISTS ...\`
- \`CREATE INDEX IF NOT EXISTS ...\`
- FK \`ADD CONSTRAINT\` wrapped in \`DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;\`
- \`ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...\`

Verified generator approach with Prisma Context7 docs.

## What this does NOT do

This migration covers only what \`prisma migrate diff\` surfaced for missing tables, plus the one column the CI log named. It is **not** a full column-level diff against prod. If prod has more silent deltas (added columns on existing tables beyond \`tasks.projectId\`), they'll surface one at a time and need follow-up fixes.

**Proper long-term fix** (tracked in #1492): \`pg_dump --schema-only\` against prod, generate authoritative baseline.

## Expected impact

- Unblocks CI E2E for all 9 stalled PRs: #1477 #1482 #1483 #1485 #1487 #1488 #1489 #1490 #1491
- \`db-integration\` test (#1491) will now pass on this branch
- Prod is a no-op: tables/columns already exist, idempotent guards skip

## Test plan

- [x] Migration SQL reviewed (475 lines, 56 blocks, all idempotent)
- [ ] CI green (\`test\` job runs migrate deploy → must succeed without error)
- [ ] db-integration contract test passes (from #1491)
- [ ] E2E no longer errors on \`public.projects\` / \`tasks.projectId\`

## Relation

- Refs #1492 (full schema drift investigation)
- Unblocks: #1477 #1482 #1483 #1485 #1487 #1488 #1489 #1490 #1491
- Related pattern: #1481 (DocumentStatus enum drift, same root: \`db push\` vs \`migrate deploy\`)