### PR TITLE
fix(T1496): include isomorphic-dompurify jsdom default-stylesheet.css in standalone build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,15 @@ const nextConfig: NextConfig = {
   output: "standalone",
   poweredByHeader: false,
 
+  // Issue #1496: isomorphic-dompurify bundles jsdom which reads this CSS file at
+  // runtime via readFileSync. Next.js standalone build does not auto-trace static
+  // assets referenced by readFileSync, so we must include it explicitly.
+  outputFileTracingIncludes: {
+    "**": [
+      "./node_modules/isomorphic-dompurify/node_modules/jsdom/lib/jsdom/browser/default-stylesheet.css",
+    ],
+  },
+
   // Feature flag: TITAN_V2_ENABLED — toggle new vs old UI (Issue #970)
   env: {
     NEXT_PUBLIC_TITAN_V2_ENABLED: process.env.TITAN_V2_ENABLED ?? "true",


### PR DESCRIPTION
## Summary

- `isomorphic-dompurify` bundles `jsdom`, which calls `readFileSync` at module load time to read `browser/default-stylesheet.css` using a `__dirname`-relative path
- Next.js standalone build tracing does not detect `readFileSync` asset references, so the file is omitted from `.next/standalone`, causing `ENOENT` → HTTP 500 in CI E2E
- Fix: add the exact file path to `outputFileTracingIncludes` so Next.js copies it alongside the server bundle

## Root cause

```
node_modules/isomorphic-dompurify/node_modules/jsdom/lib/jsdom/living/css/helpers/computed-style.js:17
  path.resolve(__dirname, "../../../browser/default-stylesheet.css")
```

## Test plan

- [ ] Verify `npm run build` completes without errors
- [ ] Confirm `.next/standalone/node_modules/isomorphic-dompurify/node_modules/jsdom/lib/jsdom/browser/default-stylesheet.css` exists after build
- [ ] CI E2E should no longer produce `ENOENT … default-stylesheet.css` 500 errors

Closes #1496