### PR TITLE
fix(T1500): correct table name in CI seed guard (users not User)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
           PGPASSWORD: titan_test
           FIXTURE_EMAIL: admin@titan.local
         run: |
-          count=$(psql -h localhost -U titan -d titan_test -tAc "SELECT COUNT(*) FROM \"User\" WHERE email = '$FIXTURE_EMAIL'")
+          count=$(psql -h localhost -U titan -d titan_test -tAc "SELECT COUNT(*) FROM users WHERE email = '$FIXTURE_EMAIL'")
           if [ "$count" -lt 1 ]; then
             echo "::error::Seed step produced 0 admin users — seed did not run."
             echo "Check that prisma.config.ts has migrations.seed configured (Prisma 7+)."


### PR DESCRIPTION
## Summary

- The CI seed fail-loud guard introduced in PR #1488 used `"User"` (quoted, capitalized) in the SQL query
- Prisma's `User` model has `@@map("users")`, so the actual Postgres table is `users` (lowercase, unquoted)
- Every E2E CI run was failing at `Verify seed created fixtures` with `ERROR: relation "User" does not exist`

## Change

Single-line fix in `.github/workflows/ci.yml`: `"User"` → `users`

## Test plan

- [ ] CI E2E run passes the `Verify seed created fixtures` step
- [ ] Seed still creates 3 fixture users as before (no behavioral change)

Closes #1500