### PR TITLE
fix(T1498): set WEB_MAX_SESSIONS=10 in CI e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
           CRON_SECRET: ci-cron-secret
           NODE_ENV: test
           E2E_TESTING: "true"
+          WEB_MAX_SESSIONS: "10"
 
       - name: Upload test results (screenshots + traces)
         if: always()


### PR DESCRIPTION
## Summary

- Add `WEB_MAX_SESSIONS: "10"` to the `Start server and run E2E tests` step env block in `.github/workflows/ci.yml`
- Root cause: 3 Playwright workers all login as `admin@titan.local`; default `WEB_MAX_SESSIONS=2` causes the 3rd login to evict the 1st session → `UnauthorizedError: Session 已撤銷` → 112× 401 cascade

## Test plan

- [ ] CI e2e job passes with 3 concurrent workers without session eviction errors
- [ ] No changes to production defaults (`WEB_MAX_SESSIONS=2` unchanged in code)

Closes #1498