### PR TITLE
feat(T1506): @mention notifications on comments — Phase 1

### DIFF
--- a/__tests__/api/tasks/task-comments-mentions.test.ts
+++ b/__tests__/api/tasks/task-comments-mentions.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API: POST /api/tasks/[id]/comments — @mention notification wiring (Issue #1506).
+ *
+ * Verifies:
+ *  - Comment create still succeeds when no mentions supplied
+ *  - Mentioned active users receive Notification rows (type = MENTION)
+ *  - Self-mentions are dropped
+ *  - Duplicate userIds are deduplicated
+ *  - Deactivated users are silently dropped (no Notification row)
+ *  - Users who opted out of MENTION NotificationPreference are skipped
+ *  - Redis publish failure does not rollback the comment (SSE best-effort)
+ */
+import { createMockRequest } from "../../utils/test-utils";
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+const mockRequireAuth = jest.fn();
+jest.mock("@/lib/rbac", () => ({
+  requireAuth: () => mockRequireAuth(),
+  requireRole: jest.fn(),
+  requireManagerOrAbove: jest.fn(),
+  enforcePasswordChange: jest.fn(),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn().mockResolvedValue(null),
+}));
+
+// jest.mock() is hoisted above top-level `const` declarations. Build the
+// mocks lazily inside the factory so we can still reference them later
+// via a shared registry.
+jest.mock("@/lib/prisma", () => {
+  const mock = {
+    task: { findUnique: jest.fn() },
+    taskComment: { create: jest.fn() },
+    user: { findMany: jest.fn() },
+    notificationPreference: { findMany: jest.fn() },
+    notification: { create: jest.fn() },
+    $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(mock)),
+  };
+  return { prisma: mock };
+});
+
+jest.mock("@/lib/notification-publisher", () => ({
+  publishNotifications: jest.fn(),
+}));
+
+jest.mock("@/services/activity-logger", () => ({
+  logActivity: jest.fn(),
+  ActivityAction: { CREATE: "CREATE", UPDATE: "UPDATE", DELETE: "DELETE" },
+  ActivityModule: { KANBAN: "KANBAN" },
+}));
+
+jest.mock("@/lib/security/sanitize", () => ({
+  sanitizeMarkdown: (s: string) => s,
+}));
+
+jest.mock("@/lib/auth-middleware", () => ({
+  withAuth: (fn: unknown) => fn,
+}));
+
+// Import under test AFTER mocks are registered.
+import { POST } from "@/app/api/tasks/[id]/comments/route";
+import { prisma } from "@/lib/prisma";
+import { publishNotifications } from "@/lib/notification-publisher";
+
+// Typed handles onto the factory-created mocks.
+const prismaMock = prisma as unknown as {
+  task: { findUnique: jest.Mock };
+  taskComment: { create: jest.Mock };
+  user: { findMany: jest.Mock };
+  notificationPreference: { findMany: jest.Mock };
+  notification: { create: jest.Mock };
+  $transaction: jest.Mock;
+};
+const mockPublishNotifications = publishNotifications as unknown as jest.Mock;
+
+const AUTHOR_ID = "cku123456789abcdefghij01";
+const TASK_ID = "ckt123456789abcdefghij01";
+
+function callPost(body: Record<string, unknown>) {
+  const req = createMockRequest(`/api/tasks/${TASK_ID}/comments`, {
+    method: "POST",
+    body,
+  });
+  return POST(req, { params: Promise.resolve({ id: TASK_ID }) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset mockReturnValue explicitly (global memory: clearAllMocks does not).
+  mockRequireAuth.mockResolvedValue({ user: { id: AUTHOR_ID, name: "Author" } });
+  prismaMock.task.findUnique.mockResolvedValue({ id: TASK_ID, title: "Test Task" });
+  prismaMock.taskComment.create.mockResolvedValue({
+    id: "comment-1",
+    user: { id: AUTHOR_ID, name: "Author", avatar: null },
+  });
+  prismaMock.user.findMany.mockResolvedValue([]);
+  prismaMock.notificationPreference.findMany.mockResolvedValue([]);
+  prismaMock.notification.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+    Promise.resolve({
+      id: `notif-${data.userId as string}`,
+      isRead: false,
+      createdAt: new Date("2026-04-24T00:00:00Z"),
+      ...data,
+    })
+  );
+});
+
+describe("POST /api/tasks/[id]/comments — @mention wiring", () => {
+  it("creates comment with no notifications when mentionedUserIds is omitted", async () => {
+    const res = await callPost({ content: "hello world" });
+    expect(res.status).toBe(201);
+    expect(prismaMock.taskComment.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+    expect(mockPublishNotifications).not.toHaveBeenCalled();
+  });
+
+  it("emits Notification rows for each active mentioned user", async () => {
+    const alice = "cku111111111111111111111";
+    const bob = "cku222222222222222222222";
+    prismaMock.user.findMany.mockResolvedValue([{ id: alice }, { id: bob }]);
+
+    await callPost({
+      content: "hey @Alice @Bob check this",
+      mentionedUserIds: [alice, bob],
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(2);
+    const userIds = prismaMock.notification.create.mock.calls.map(
+      ([arg]: [{ data: { userId: string } }]) => arg.data.userId
+    );
+    expect(userIds).toEqual(expect.arrayContaining([alice, bob]));
+    expect(mockPublishNotifications).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops self-mentions before DB lookup", async () => {
+    await callPost({
+      content: "note to self",
+      mentionedUserIds: [AUTHOR_ID],
+    });
+    // user.findMany should not be called for empty candidate set.
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("dedupes duplicate userIds in the payload", async () => {
+    const alice = "cku111111111111111111111";
+    prismaMock.user.findMany.mockResolvedValue([{ id: alice }]);
+
+    await callPost({
+      content: "@Alice @Alice @Alice",
+      mentionedUserIds: [alice, alice, alice],
+    });
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: { in: [alice] } }),
+      })
+    );
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("silently drops deactivated users", async () => {
+    const alive = "cku111111111111111111111";
+    const dead = "cku333333333333333333333";
+    // findMany only returns active ones
+    prismaMock.user.findMany.mockResolvedValue([{ id: alive }]);
+
+    await callPost({
+      content: "@Alice @Ghost",
+      mentionedUserIds: [alive, dead],
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: alive }) })
+    );
+  });
+
+  it("respects NotificationPreference opt-out", async () => {
+    const alice = "cku111111111111111111111";
+    const bob = "cku222222222222222222222";
+    prismaMock.user.findMany.mockResolvedValue([{ id: alice }, { id: bob }]);
+    prismaMock.notificationPreference.findMany.mockResolvedValue([{ userId: bob }]);
+
+    await callPost({
+      content: "@Alice @Bob",
+      mentionedUserIds: [alice, bob],
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: alice }) })
+    );
+  });
+
+  it("does not rollback comment when Redis publish fails", async () => {
+    const alice = "cku111111111111111111111";
+    prismaMock.user.findMany.mockResolvedValue([{ id: alice }]);
+    mockPublishNotifications.mockImplementation(() => {
+      throw new Error("redis down");
+    });
+
+    const res = await callPost({
+      content: "@Alice",
+      mentionedUserIds: [alice],
+    });
+
+    // Comment still persists + response is 201.
+    expect(res.status).toBe(201);
+    expect(prismaMock.taskComment.create).toHaveBeenCalledTimes(1);
+    // Publish was attempted (fire-and-forget).
+    expect(mockPublishNotifications).toHaveBeenCalled();
+  });
+});

--- a/app/api/documents/[id]/comments/route.ts
+++ b/app/api/documents/[id]/comments/route.ts
@@ -6,6 +6,7 @@ import { validateBody } from "@/lib/validate";
 import { createDocCommentSchema } from "@/validators/knowledge-validators";
 import { success } from "@/lib/api-response";
 import { NotFoundError } from "@/services/errors";
+import { publishNotifications } from "@/lib/notification-publisher";
 
 export const GET = withAuth(async (
   _req: NextRequest,
@@ -42,7 +43,10 @@ export const POST = withAuth(async (
   const raw = await req.json();
   const body = validateBody(createDocCommentSchema, raw);
 
-  const doc = await prisma.document.findUnique({ where: { id } });
+  const doc = await prisma.document.findUnique({
+    where: { id },
+    select: { id: true, title: true },
+  });
   if (!doc) throw new NotFoundError("文件不存在");
 
   if (body.parentId) {
@@ -52,17 +56,88 @@ export const POST = withAuth(async (
     if (!parent) throw new NotFoundError("父評論不存在");
   }
 
-  const comment = await prisma.documentComment.create({
-    data: {
-      documentId: id,
-      authorId: session.user.id,
-      content: body.content,
-      parentId: body.parentId ?? null,
-    },
-    include: {
-      author: { select: { id: true, name: true, avatar: true } },
-    },
+  // Issue #1506: resolve + validate mentioned users before tx.
+  const candidateIds = Array.from(
+    new Set((body.mentionedUserIds ?? []).filter((uid) => uid !== session.user.id))
+  );
+  const activeMentioned =
+    candidateIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: candidateIds }, isActive: true },
+          select: { id: true },
+        })
+      : [];
+  const mentionedIds = activeMentioned.map((u) => u.id);
+
+  const { comment, notifications } = await prisma.$transaction(async (tx) => {
+    const created = await tx.documentComment.create({
+      data: {
+        documentId: id,
+        authorId: session.user.id,
+        content: body.content,
+        parentId: body.parentId ?? null,
+      },
+      include: {
+        author: { select: { id: true, name: true, avatar: true } },
+      },
+    });
+
+    if (mentionedIds.length === 0) {
+      return { comment: created, notifications: [] };
+    }
+
+    const optedOut = await tx.notificationPreference.findMany({
+      where: { userId: { in: mentionedIds }, type: "MENTION", enabled: false },
+      select: { userId: true },
+    });
+    const optedOutSet = new Set(optedOut.map((p) => p.userId));
+    const targets = mentionedIds.filter((uid) => !optedOutSet.has(uid));
+
+    if (targets.length === 0) {
+      return { comment: created, notifications: [] };
+    }
+
+    const preview = body.content.substring(0, 140);
+    const title = `${created.author.name} 在文件「${doc.title}」中提到你`;
+
+    const createdNotifications = await Promise.all(
+      targets.map((uid) =>
+        tx.notification.create({
+          data: {
+            userId: uid,
+            type: "MENTION",
+            title,
+            body: preview,
+            relatedId: id,
+            relatedType: "Document",
+          },
+        })
+      )
+    );
+
+    return { comment: created, notifications: createdNotifications };
   });
+
+  if (notifications.length > 0) {
+    try {
+      const publishPromise = publishNotifications(
+        notifications.map((n) => ({
+          id: n.id,
+          userId: n.userId,
+          type: n.type,
+          title: n.title,
+          body: n.body,
+          isRead: n.isRead,
+          createdAt: n.createdAt,
+          relatedId: n.relatedId,
+          relatedType: n.relatedType,
+        }))
+      );
+      void Promise.resolve(publishPromise).catch(() => undefined);
+    } catch {
+      // Sync throw from publisher — ignore, comment already persisted.
+    }
+  }
 
   return success(comment, 201);
 });

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -17,12 +17,20 @@ import { requireAuth } from "@/lib/rbac";
 import { logActivity, ActivityAction, ActivityModule } from "@/services/activity-logger";
 import { sanitizeMarkdown } from "@/lib/security/sanitize";
 import { ForbiddenError } from "@/services/errors";
+import { publishNotifications } from "@/lib/notification-publisher";
+
+/** Max mentions per comment — hard cap to prevent notification flooding (#1506). */
+const MAX_MENTIONS_PER_COMMENT = 20;
 
 const createCommentSchema = z.object({
   content: z
     .string()
     .min(1, "評論內容不可為空")
     .max(10000, "評論不得超過 10,000 字元"),
+  mentionedUserIds: z
+    .array(z.string().cuid())
+    .max(MAX_MENTIONS_PER_COMMENT, `單則評論最多 @${MAX_MENTIONS_PER_COMMENT} 人`)
+    .optional(),
 });
 
 const updateCommentSchema = z.object({
@@ -60,25 +68,104 @@ export const POST = withAuth(async (
   const session = await requireAuth();
   const { id: taskId } = await context.params;
 
-  const { content } = validateBody(createCommentSchema, await req.json());
+  const { content, mentionedUserIds } = validateBody(createCommentSchema, await req.json());
   const sanitized = sanitizeMarkdown(content);
 
   // Verify task exists
-  const task = await prisma.task.findUnique({ where: { id: taskId }, select: { id: true } });
+  const task = await prisma.task.findUnique({
+    where: { id: taskId },
+    select: { id: true, title: true },
+  });
   if (!task) {
     return error("NotFoundError", "任務不存在", 404);
   }
 
-  const comment = await prisma.taskComment.create({
-    data: {
-      taskId,
-      userId: session.user.id,
-      content: sanitized,
-    },
-    include: {
-      user: { select: { id: true, name: true, avatar: true } },
-    },
+  // Deduplicate + drop self-mentions before DB lookup
+  const candidateIds = Array.from(
+    new Set((mentionedUserIds ?? []).filter((id) => id !== session.user.id))
+  );
+
+  // Validate mentioned users exist + are active. Silently drop unknowns
+  // (user may have been deactivated between composer fetch and submit).
+  const activeMentioned =
+    candidateIds.length > 0
+      ? await prisma.user.findMany({
+          where: { id: { in: candidateIds }, isActive: true },
+          select: { id: true },
+        })
+      : [];
+  const mentionedIds = activeMentioned.map((u) => u.id);
+
+  // Atomic: create comment + mention notifications in single transaction.
+  const { comment, notifications } = await prisma.$transaction(async (tx) => {
+    const created = await tx.taskComment.create({
+      data: {
+        taskId,
+        userId: session.user.id,
+        content: sanitized,
+      },
+      include: {
+        user: { select: { id: true, name: true, avatar: true } },
+      },
+    });
+
+    if (mentionedIds.length === 0) {
+      return { comment: created, notifications: [] };
+    }
+
+    // Respect per-user NotificationPreference opt-out for MENTION type.
+    const optedOut = await tx.notificationPreference.findMany({
+      where: {
+        userId: { in: mentionedIds },
+        type: "MENTION",
+        enabled: false,
+      },
+      select: { userId: true },
+    });
+    const optedOutSet = new Set(optedOut.map((p) => p.userId));
+    const targets = mentionedIds.filter((id) => !optedOutSet.has(id));
+
+    if (targets.length === 0) {
+      return { comment: created, notifications: [] };
+    }
+
+    const preview = sanitized.substring(0, 140);
+    const title = `${created.user.name} 在任務「${task.title}」中提到你`;
+
+    const created_notifications = await Promise.all(
+      targets.map((userId) =>
+        tx.notification.create({
+          data: {
+            userId,
+            type: "MENTION",
+            title,
+            body: preview,
+            relatedId: taskId,
+            relatedType: "Task",
+          },
+        })
+      )
+    );
+
+    return { comment: created, notifications: created_notifications };
   });
+
+  // Fire-and-forget SSE publish (outside tx; Redis failure must not rollback comment).
+  if (notifications.length > 0) {
+    void publishNotifications(
+      notifications.map((n) => ({
+        id: n.id,
+        userId: n.userId,
+        type: n.type,
+        title: n.title,
+        body: n.body,
+        isRead: n.isRead,
+        createdAt: n.createdAt,
+        relatedId: n.relatedId,
+        relatedType: n.relatedType,
+      }))
+    );
+  }
 
   // Fire-and-forget activity log
   logActivity({
@@ -90,6 +177,7 @@ export const POST = withAuth(async (
     metadata: {
       taskId,
       contentPreview: sanitized.substring(0, 100),
+      mentionCount: notifications.length,
     },
   });
 

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -151,20 +151,28 @@ export const POST = withAuth(async (
   });
 
   // Fire-and-forget SSE publish (outside tx; Redis failure must not rollback comment).
+  // Wrap in try/catch so a sync-throwing publisher (or future variant) never
+  // surfaces past the comment response.
   if (notifications.length > 0) {
-    void publishNotifications(
-      notifications.map((n) => ({
-        id: n.id,
-        userId: n.userId,
-        type: n.type,
-        title: n.title,
-        body: n.body,
-        isRead: n.isRead,
-        createdAt: n.createdAt,
-        relatedId: n.relatedId,
-        relatedType: n.relatedType,
-      }))
-    );
+    try {
+      const publishPromise = publishNotifications(
+        notifications.map((n) => ({
+          id: n.id,
+          userId: n.userId,
+          type: n.type,
+          title: n.title,
+          body: n.body,
+          isRead: n.isRead,
+          createdAt: n.createdAt,
+          relatedId: n.relatedId,
+          relatedType: n.relatedType,
+        }))
+      );
+      // Swallow async rejection too.
+      void Promise.resolve(publishPromise).catch(() => undefined);
+    } catch {
+      // Sync throw from publisher — ignore, comment already persisted.
+    }
   }
 
   // Fire-and-forget activity log

--- a/app/components/comment-list.tsx
+++ b/app/components/comment-list.tsx
@@ -115,6 +115,9 @@ export function CommentList({ taskId, currentUserId }: CommentListProps) {
   const [users, setUsers] = useState<User[]>([]);
   const [showMention, setShowMention] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
+  // Track which users were inserted via @mention so the server can notify them (#1506).
+  // A user removed from the content string is pruned at submit time.
+  const [mentionedUserIds, setMentionedUserIds] = useState<string[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const editTextareaRef = useRef<HTMLTextAreaElement>(null);
   const { confirmDialog, ConfirmDialog } = useConfirmDialog();
@@ -167,7 +170,7 @@ export function CommentList({ taskId, currentUserId }: CommentListProps) {
     setShowMention(false);
   }
 
-  function insertMention(userName: string) {
+  function insertMention(user: User) {
     const textarea = editingId ? editTextareaRef.current : textareaRef.current;
     const currentValue = editingId ? editContent : newContent;
     const setter = editingId ? setEditContent : setNewContent;
@@ -179,9 +182,11 @@ export function CommentList({ taskId, currentUserId }: CommentListProps) {
     if (lastAtIdx >= 0) {
       const newValue =
         currentValue.substring(0, lastAtIdx) +
-        `@${userName} ` +
+        `@${user.name} ` +
         currentValue.substring(cursorPos);
       setter(newValue);
+      // Track the id so the server knows who to notify. Dedupe on insert.
+      setMentionedUserIds((prev) => (prev.includes(user.id) ? prev : [...prev, user.id]));
     }
     setShowMention(false);
     textarea?.focus();
@@ -197,14 +202,24 @@ export function CommentList({ taskId, currentUserId }: CommentListProps) {
     if (!newContent.trim() || sending) return;
     setSending(true);
     try {
+      // Prune mentions whose @<name> token was deleted from the content before submit.
+      const finalContent = newContent.trim();
+      const surviving = mentionedUserIds.filter((uid) => {
+        const u = users.find((x) => x.id === uid);
+        return u ? finalContent.includes(`@${u.name}`) : false;
+      });
       const res = await fetch(`/api/tasks/${taskId}/comments`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ content: newContent.trim() }),
+        body: JSON.stringify({
+          content: finalContent,
+          mentionedUserIds: surviving.length > 0 ? surviving : undefined,
+        }),
       });
       if (res.ok) {
         toast.success("評論已發送");
         setNewContent("");
+        setMentionedUserIds([]);
         await fetchComments();
       } else {
         const errBody = await res.json().catch(() => ({}));
@@ -269,7 +284,7 @@ export function CommentList({ taskId, currentUserId }: CommentListProps) {
             key={u.id}
             type="button"
             onMouseDown={(e) => e.preventDefault()}
-            onClick={() => insertMention(u.name)}
+            onClick={() => insertMention(u)}
             className="w-full flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent transition-colors text-left"
           >
             <CommentAvatar user={u} />

--- a/prisma/migrations/20260424180000_add_mention_notification_type/migration.sql
+++ b/prisma/migrations/20260424180000_add_mention_notification_type/migration.sql
@@ -1,0 +1,19 @@
+-- Add MENTION to NotificationType enum (Issue #1506)
+--
+-- Enables @mention-driven notifications on comments. Guarded with
+-- IF NOT EXISTS so this is idempotent across fresh `prisma migrate deploy`
+-- and existing prod databases already aligned via `prisma db push`
+-- (see memory project_titan_prod_db_push_baseline).
+--
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction block on
+-- PostgreSQL < 12; Prisma wraps migrations in BEGIN/COMMIT, so we use
+-- the DO block pattern with EXCEPTION to tolerate a concurrent add
+-- that may have landed via db push.
+
+DO $$
+BEGIN
+  ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'MENTION';
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -825,6 +825,7 @@ enum NotificationType {
   MANAGER_FLAG          // Issue #960: 主管標記任務
   DAILY_DIGEST          // Issue #1321: 每日個人摘要
   WEEKLY_DIGEST         // Issue #1321: 每週主管摘要
+  MENTION               // Issue #1506: 評論 @mention 通知
 }
 
 model Notification {

--- a/validators/knowledge-validators.ts
+++ b/validators/knowledge-validators.ts
@@ -37,6 +37,8 @@ export const createDocAttachmentSchema = z.object({
 export const createDocCommentSchema = z.object({
   content: z.string().min(1),
   parentId: z.string().nullish(),
+  /** Issue #1506: users to notify via @mention. Max 20 per comment. */
+  mentionedUserIds: z.array(z.string().cuid()).max(20).optional(),
 });
 
 // ── DocumentLink ──


### PR DESCRIPTION
Closes #1506
Refs #1505 (parent team-love initiative)

## Problem

The @mention UI in `comment-list.tsx` was shipped in #805 (Sprint 5) but is **cosmetic-only** — mentioning a teammate never notifies them. This blocks the most expected reaction a user has to typing `@Alice` ("Alice will see this").

## What this PR does

End-to-end @mention for **task comments** and **document comments**:

1. **Schema** — `MENTION` added to `NotificationType` enum. Migration uses `ALTER TYPE ... ADD VALUE IF NOT EXISTS` in a guarded `DO` block for prod compatibility (titan prod runs `prisma db push`, not `migrate deploy` — see memory `project_titan_prod_db_push_baseline`).
2. **Client** — `comment-list.tsx` tracks mentioned user IDs when inserting via @-autocomplete. Prunes IDs whose `@<name>` text was deleted before submit. Sends `mentionedUserIds: string[]` in the POST body.
3. **Task comments API** — accepts `mentionedUserIds[]` (cuid, max 20). Dedupes, drops self-mentions before DB lookup, validates active users only, respects per-user `NotificationPreference` opt-out, writes comment + notifications in one atomic transaction, fires SSE publish outside the tx so Redis failure never rolls back the comment.
4. **Document comments API** — same pattern.
5. **Defensive publish** — wraps `publishNotifications` in `try/catch` + `Promise.catch` so neither sync nor async throw can bubble past the comment response.

## Verification

- ✅ Migration applied cleanly on throwaway `postgres:16-alpine` (per CLAUDE.md rule)
- ✅ `npx tsc --noEmit` clean
- ✅ 7/7 new unit tests pass:
  - no mentions → no notifications
  - happy path → one Notification per active user
  - self-mention dropped before DB lookup
  - duplicate IDs deduped
  - deactivated users silently skipped
  - `NotificationPreference.enabled=false` for `MENTION` honored
  - Redis publish failure does not rollback comment

## Non-goals (deferred to follow-ups)

- Mentions in knowledge doc body (markdown, not just comments)
- Email digest of unread mentions
- `@everyone` / `@team`
- Rich mention chips with avatar preview

## Test plan

- [ ] Manual: comment `@Alice check this`, verify Alice's notification bell lights up
- [ ] Manual: deactivate a user, mention them, verify no notification created
- [ ] Manual: Alice opts out of MENTION in preferences, verify mention is silent
- [ ] Manual: mention yourself, verify no self-notification

## Rollout

No feature flag — behavior is strictly additive. If mentioned user list is empty, the code path is unchanged.

## Labels

P2-medium · ux · frontend