### PR TITLE
feat(T1512): ReactionBar on activity timeline items (Phase 2 final)

### DIFF
--- a/app/components/activity-item.tsx
+++ b/app/components/activity-item.tsx
@@ -3,6 +3,8 @@
 import { cn } from "@/lib/utils";
 import { formatRelative, formatDateTime } from "@/lib/format";
 import { formatActivityDescription } from "@/lib/utils/activity-formatter";
+import { useFeatureFlag } from "@/lib/hooks/use-feature-flag";
+import { ReactionBar } from "@/app/components/reaction-bar";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -72,6 +74,11 @@ export function ActivityItem({ item }: ActivityItemProps) {
   });
 
   const userName = item.userName ?? "系統";
+  // Issue #1512: reactions gated behind FEATURE_REACTIONS + restricted to
+  // task_activity sources (audit_log items live in a different table that
+  // the reactions API does not target — the 404 would just create noise).
+  const { enabled: reactionsEnabled } = useFeatureFlag("FEATURE_REACTIONS");
+  const canReact = reactionsEnabled && item.source === "task_activity";
 
   return (
     <div className="flex items-start gap-3 px-4 py-3 hover:bg-accent/30 transition-colors rounded-lg">
@@ -111,6 +118,10 @@ export function ActivityItem({ item }: ActivityItemProps) {
             </span>
           )}
         </div>
+
+        {canReact && (
+          <ReactionBar targetType="ACTIVITY" targetId={item.id} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Refs #1512 · Parent #1505 · Follows #1514 (task comments)

## Scope

Third and final integration site for reactions: activity timeline items.

## What's in

- `activity-item.tsx`: renders `<ReactionBar targetType="ACTIVITY">` under each item when source is `task_activity` and `FEATURE_REACTIONS` is enabled.
- Skips `audit_log` items: they live in a different table and the reactions API intentionally only targets `TaskActivity` rows. System events (login, config changes) are not things peers typically react to.

## Non-goals

Document comments are **not** integrated. Surveyed the app: doc comments have no TITAN-native UI consumer (Outline wiki integration owns that surface). Leaving the doc-comment code path in the API + DB layer so when a future TITAN-native viewer lands it plugs in directly.

## Phase 2 state after this PR

- Reactions backend: ✅ #1513
- Task comments UI: ✅ #1514
- Activity timeline UI: ✅ this PR
- Document comments UI: intentionally skipped (no consumer)
- Phase 2.1 (daily-digest batched notifications): separate future PR

## Feature flag

`FEATURE_REACTIONS` still default OFF. Next deploy lands all three integration sites at once; flipping the flag on turns everything on together.

## Verification

- `npx tsc --noEmit` clean

## Expected CI state

Same pre-existing a11y cascade pattern. Admin-merge under `feedback_autonomous_feature_loops.md` criteria.