### PR TITLE
fix(T1516): public feature-flags endpoint for non-admin reads

### DIFF
--- a/app/api/feature-flags/public/route.ts
+++ b/app/api/feature-flags/public/route.ts
@@ -1,0 +1,18 @@
+/**
+ * Public Feature Flags — Issue #1516
+ *
+ * GET /api/feature-flags/public — read PUBLIC_FLAGS for any authenticated user.
+ *
+ * The admin endpoint at /api/admin/feature-flags returns every flag and is
+ * locked to ADMIN role; this endpoint complements it for client-side
+ * useFeatureFlag() which runs in pages rendered to all roles.
+ */
+import { NextRequest } from "next/server";
+import { success } from "@/lib/api-response";
+import { withAuth } from "@/lib/auth-middleware";
+import { getPublicFeatureFlags } from "@/lib/feature-flags";
+
+export const GET = withAuth(async (_req: NextRequest) => {
+  const flags = await getPublicFeatureFlags();
+  return success({ flags });
+});

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,5 +1,5 @@
 /**
- * Feature Flags — Issue #1328 (DB化)
+ * Feature Flags — Issue #1328 (DB化), extended in #1516 (public read)
  *
  * Stores feature flags in PostgreSQL with 60s Redis cache TTL.
  * Falls back to in-memory cache when both DB and Redis are down.
@@ -8,6 +8,15 @@
  * - V2_DASHBOARD: Toggle new dashboard vs old
  * - V2_REPORTS: Toggle v2 reports
  * - ALERT_BANNER: Toggle global alert banner
+ * - FEATURE_REACTIONS: Emoji reactions on comments + activity (#1512)
+ *
+ * Visibility:
+ * - ALL_FLAGS — every known flag, exposed via the admin endpoint
+ * - PUBLIC_FLAGS — subset readable by any authenticated user, exposed
+ *   via /api/feature-flags/public for the useFeatureFlag client hook.
+ *   Add a flag here only when its on/off state is safe to leak to all
+ *   users (e.g. UI feature gates). Admin-only state (alert banners
+ *   etc.) stays out of this list.
  */
 
 import { prisma } from "@/lib/prisma";
@@ -22,16 +31,25 @@ const FLAG_DEFAULTS: Record<string, boolean> = {
   V2_DASHBOARD: false,
   V2_REPORTS: false,
   ALERT_BANNER: true,
+  FEATURE_REACTIONS: false,
 };
 
-export type FeatureFlagName = "V2_DASHBOARD" | "V2_REPORTS" | "ALERT_BANNER";
+export type FeatureFlagName =
+  | "V2_DASHBOARD"
+  | "V2_REPORTS"
+  | "ALERT_BANNER"
+  | "FEATURE_REACTIONS";
 
 /** All known flag names */
 export const ALL_FLAGS: FeatureFlagName[] = [
   "V2_DASHBOARD",
   "V2_REPORTS",
   "ALERT_BANNER",
+  "FEATURE_REACTIONS",
 ];
+
+/** Subset of flags safe to expose to non-admin authenticated users. */
+export const PUBLIC_FLAGS: FeatureFlagName[] = ["FEATURE_REACTIONS"];
 
 /** In-memory fallback when both DB and Redis are down */
 let memoryCache: Record<string, boolean> = {};
@@ -122,6 +140,21 @@ export async function getAllFeatureFlags(): Promise<Record<FeatureFlagName, bool
     result[name] = rows.find((f) => f.key === name)?.enabled ?? (FLAG_DEFAULTS[name] ?? false);
   }
   return result as Record<FeatureFlagName, boolean>;
+}
+
+/**
+ * Returns only flags safe for non-admin clients.
+ * Used by the public flag endpoint that backs the useFeatureFlag hook.
+ */
+export async function getPublicFeatureFlags(): Promise<Record<string, boolean>> {
+  const rows = await prisma.featureFlag.findMany({
+    where: { key: { in: PUBLIC_FLAGS } },
+  });
+  const result: Record<string, boolean> = {};
+  for (const name of PUBLIC_FLAGS) {
+    result[name] = rows.find((f) => f.key === name)?.enabled ?? (FLAG_DEFAULTS[name] ?? false);
+  }
+  return result;
 }
 
 /**

--- a/lib/hooks/use-feature-flag.ts
+++ b/lib/hooks/use-feature-flag.ts
@@ -18,7 +18,11 @@ async function fetchFlags(): Promise<Record<FlagName, boolean>> {
   if (cachedFlags) return cachedFlags;
   if (fetchPromise) return fetchPromise;
 
-  fetchPromise = fetch("/api/admin/feature-flags")
+  // Issue #1516: switched from /api/admin/feature-flags (ADMIN-only) to the
+  // public endpoint that returns the PUBLIC_FLAGS subset. The admin endpoint
+  // returned 401 for non-admin users, making every flag read as false in
+  // client components rendered for engineers/managers.
+  fetchPromise = fetch("/api/feature-flags/public")
     .then(async (res) => {
       if (!res.ok) return {};
       const body = await res.json();


### PR DESCRIPTION
Closes #1516

## Bug

Discovered while flipping FEATURE_REACTIONS on after #1515 deploy:

1. lib/feature-flags.ts hardcodes ALL_FLAGS and FeatureFlagName union; FEATURE_REACTIONS was never registered, so getAllFeatureFlags() silently dropped it.
2. useFeatureFlag fetches from /api/admin/feature-flags which is ADMIN-only — engineers/managers got 401, every flag read as false. Effectively, all flag-gated UI was permanently invisible to non-admins.

## Fix

- Register FEATURE_REACTIONS in ALL_FLAGS + FeatureFlagName + FLAG_DEFAULTS
- Add PUBLIC_FLAGS subset and getPublicFeatureFlags() helper
- New endpoint GET /api/feature-flags/public — withAuth, returns only PUBLIC_FLAGS
- useFeatureFlag switched to /api/feature-flags/public

## Why this matters

Without this, no role-aware feature flag works for non-admins. This is a permanent gating bug, not just a #1512 issue. After this fix, future FEATURE_* flags can be added to PUBLIC_FLAGS to be team-visible, and admin-internal flags stay behind the admin endpoint.

## Verification

- npx tsc --noEmit clean
- Manual flow once deployed: non-admin user → /api/feature-flags/public returns {FEATURE_REACTIONS: true} (DB row already enabled from #1515 rollout)