### PR TITLE
feat(T1520): daily reaction digest notification (Phase 2.1)

### DIFF
--- a/__tests__/api/cron-reaction-digest.test.ts
+++ b/__tests__/api/cron-reaction-digest.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API: POST /api/cron/reaction-digest — Issue #1520.
+ *
+ * Covers:
+ *  - 24h reaction window aggregation per recipient
+ *  - Self-reactions are filtered
+ *  - Per-day idempotency (skip recipients who already got today's digest)
+ *  - NotificationPreference opt-out is honored
+ *  - Empty input → no notifications, no errors
+ *  - Redis lock is acquired + released
+ */
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn().mockResolvedValue(null),
+}));
+
+const verifyCronSecret = jest.fn();
+jest.mock("@/lib/cron-auth", () => ({
+  verifyCronSecret: () => verifyCronSecret(),
+}));
+
+const redisInstance = {
+  set: jest.fn().mockResolvedValue("OK"),
+  del: jest.fn().mockResolvedValue(1),
+};
+jest.mock("@/lib/redis", () => ({
+  getRedisClient: () => redisInstance,
+}));
+
+jest.mock("@/lib/notification-publisher", () => ({
+  publishNotifications: jest.fn(),
+}));
+
+jest.mock("@/lib/prisma", () => {
+  const mock = {
+    reaction: { findMany: jest.fn() },
+    taskComment: { findMany: jest.fn() },
+    documentComment: { findMany: jest.fn() },
+    taskActivity: { findMany: jest.fn() },
+    notification: { findMany: jest.fn(), create: jest.fn() },
+    notificationPreference: { findMany: jest.fn() },
+    user: { findMany: jest.fn() },
+  };
+  return { prisma: mock };
+});
+
+import { POST } from "@/app/api/cron/reaction-digest/route";
+import { prisma } from "@/lib/prisma";
+
+const prismaMock = prisma as unknown as {
+  reaction: { findMany: jest.Mock };
+  taskComment: { findMany: jest.Mock };
+  documentComment: { findMany: jest.Mock };
+  taskActivity: { findMany: jest.Mock };
+  notification: { findMany: jest.Mock; create: jest.Mock };
+  notificationPreference: { findMany: jest.Mock };
+  user: { findMany: jest.Mock };
+};
+
+function call() {
+  // Minimal NextRequest stub for verifyCronSecret + apiHandler signature.
+  const req = {
+    url: "http://localhost/api/cron/reaction-digest",
+    method: "POST",
+    headers: new Headers(),
+    json: async () => ({}),
+  } as unknown as import("next/server").NextRequest;
+  return POST(req, { params: Promise.resolve({}) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  verifyCronSecret.mockReturnValue(null); // null = auth ok
+  redisInstance.set.mockResolvedValue("OK");
+  prismaMock.reaction.findMany.mockResolvedValue([]);
+  prismaMock.taskComment.findMany.mockResolvedValue([]);
+  prismaMock.documentComment.findMany.mockResolvedValue([]);
+  prismaMock.taskActivity.findMany.mockResolvedValue([]);
+  prismaMock.notification.findMany.mockResolvedValue([]);
+  prismaMock.notificationPreference.findMany.mockResolvedValue([]);
+  prismaMock.user.findMany.mockResolvedValue([]);
+  prismaMock.notification.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+    Promise.resolve({
+      id: `n-${data.userId as string}`,
+      isRead: false,
+      createdAt: new Date(),
+      ...data,
+    })
+  );
+});
+
+describe("POST /api/cron/reaction-digest", () => {
+  it("returns 0 inserted when no reactions in window", async () => {
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(0);
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("groups by recipient + emoji and creates one Notification per recipient", async () => {
+    prismaMock.reaction.findMany.mockResolvedValue([
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "tc1", emoji: "👍" },
+      { userId: "bob", targetType: "TASK_COMMENT", targetId: "tc1", emoji: "👍" },
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "tc2", emoji: "❤️" },
+    ]);
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { id: "tc1", userId: "owner1" },
+      { id: "tc2", userId: "owner2" },
+    ]);
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: "alice", name: "Alice" },
+      { id: "bob", name: "Bob" },
+    ]);
+
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(2);
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(2);
+    const calls = prismaMock.notification.create.mock.calls.map(
+      ([arg]: [{ data: { userId: string; body: string } }]) => arg.data
+    );
+    const owner1 = calls.find((c: { userId: string }) => c.userId === "owner1");
+    expect(owner1).toBeDefined();
+    expect(owner1.body).toContain("👍");
+    expect(owner1.body).toContain("Alice");
+    expect(owner1.body).toContain("Bob");
+  });
+
+  it("filters self-reactions", async () => {
+    prismaMock.reaction.findMany.mockResolvedValue([
+      // alice reacts to her own comment — should be ignored
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "tc1", emoji: "👍" },
+    ]);
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { id: "tc1", userId: "alice" },
+    ]);
+
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(0);
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("skips recipients who already received today's digest", async () => {
+    prismaMock.reaction.findMany.mockResolvedValue([
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "tc1", emoji: "👍" },
+    ]);
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { id: "tc1", userId: "owner1" },
+    ]);
+    prismaMock.notification.findMany.mockResolvedValue([{ userId: "owner1" }]);
+    prismaMock.user.findMany.mockResolvedValue([{ id: "alice", name: "Alice" }]);
+
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(0);
+    expect(body.data.skipped_already_sent).toBe(1);
+  });
+
+  it("respects NotificationPreference opt-out", async () => {
+    prismaMock.reaction.findMany.mockResolvedValue([
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "tc1", emoji: "👍" },
+      { userId: "bob", targetType: "TASK_COMMENT", targetId: "tc2", emoji: "👍" },
+    ]);
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { id: "tc1", userId: "owner1" },
+      { id: "tc2", userId: "owner2" },
+    ]);
+    prismaMock.notificationPreference.findMany.mockResolvedValue([{ userId: "owner1" }]);
+    prismaMock.user.findMany.mockResolvedValue([
+      { id: "alice", name: "Alice" },
+      { id: "bob", name: "Bob" },
+    ]);
+
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: "owner2" }) })
+    );
+  });
+
+  it("acquires + releases the redis lock", async () => {
+    await call();
+    expect(redisInstance.set).toHaveBeenCalledWith(
+      "cron:reaction-digest:lock",
+      "1",
+      "EX",
+      300,
+      "NX"
+    );
+    expect(redisInstance.del).toHaveBeenCalledWith("cron:reaction-digest:lock");
+  });
+
+  it("skips entire run when redis lock is already held", async () => {
+    redisInstance.set.mockResolvedValueOnce(null); // SET NX fails
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.skipped).toBe(true);
+    expect(prismaMock.reaction.findMany).not.toHaveBeenCalled();
+  });
+
+  it("drops reactions whose target row has been deleted", async () => {
+    prismaMock.reaction.findMany.mockResolvedValue([
+      { userId: "alice", targetType: "TASK_COMMENT", targetId: "ghost", emoji: "👍" },
+    ]);
+    // taskComment.findMany returns no row for "ghost"
+    prismaMock.taskComment.findMany.mockResolvedValue([]);
+
+    const res = await call();
+    const body = await res.json();
+    expect(body.data.inserted).toBe(0);
+  });
+});

--- a/app/api/cron/reaction-digest/route.ts
+++ b/app/api/cron/reaction-digest/route.ts
@@ -1,0 +1,259 @@
+/**
+ * POST /api/cron/reaction-digest — Issue #1520 (Phase 2.1 of #1505)
+ *
+ * Aggregates the last 24h of Reactions and emits one batched
+ * Notification per recipient summarizing who reacted to their
+ * comments + activity items.
+ *
+ * Why batch: real-time push for every individual reaction would create
+ * exactly the kind of notification noise reactions are supposed to
+ * replace. A daily digest at a predictable time gives the recipient
+ * the affirmation without the spam.
+ *
+ * Protected by CRON_SECRET. Per-day idempotent: if a REACTION_DIGEST
+ * notification already exists for a user today, skip.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { success } from "@/lib/api-response";
+import { apiHandler } from "@/lib/api-handler";
+import { verifyCronSecret } from "@/lib/cron-auth";
+import { getRedisClient } from "@/lib/redis";
+import { logger } from "@/lib/logger";
+import { publishNotifications } from "@/lib/notification-publisher";
+
+const LOCK_KEY = "cron:reaction-digest:lock";
+const LOCK_TTL = 300; // 5 minutes
+
+const TARGET_TYPES = ["TASK_COMMENT", "DOCUMENT_COMMENT", "ACTIVITY"] as const;
+type TargetType = (typeof TARGET_TYPES)[number];
+
+interface ReactionRow {
+  userId: string;     // reactor
+  targetType: TargetType;
+  targetId: string;
+  emoji: string;
+}
+
+/**
+ * Resolve the recipient (creator) for each reaction target. Returns a
+ * map keyed by `${targetType}:${targetId}` → creator userId. Targets
+ * whose row was deleted are dropped.
+ */
+async function resolveRecipients(
+  rows: ReactionRow[]
+): Promise<Map<string, string>> {
+  const idsByType: Record<TargetType, Set<string>> = {
+    TASK_COMMENT: new Set(),
+    DOCUMENT_COMMENT: new Set(),
+    ACTIVITY: new Set(),
+  };
+  for (const r of rows) idsByType[r.targetType].add(r.targetId);
+
+  const [taskComments, docComments, activities] = await Promise.all([
+    idsByType.TASK_COMMENT.size > 0
+      ? prisma.taskComment.findMany({
+          where: { id: { in: Array.from(idsByType.TASK_COMMENT) } },
+          select: { id: true, userId: true },
+        })
+      : Promise.resolve([]),
+    idsByType.DOCUMENT_COMMENT.size > 0
+      ? prisma.documentComment.findMany({
+          where: { id: { in: Array.from(idsByType.DOCUMENT_COMMENT) } },
+          select: { id: true, authorId: true },
+        })
+      : Promise.resolve([]),
+    idsByType.ACTIVITY.size > 0
+      ? prisma.taskActivity.findMany({
+          where: { id: { in: Array.from(idsByType.ACTIVITY) } },
+          select: { id: true, userId: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const map = new Map<string, string>();
+  for (const tc of taskComments) map.set(`TASK_COMMENT:${tc.id}`, tc.userId);
+  for (const dc of docComments) map.set(`DOCUMENT_COMMENT:${dc.id}`, dc.authorId);
+  for (const a of activities) map.set(`ACTIVITY:${a.id}`, a.userId);
+  return map;
+}
+
+interface RecipientGroup {
+  reactorIds: Set<string>;
+  byEmoji: Map<string, Set<string>>; // emoji → reactor ids
+  totalReactions: number;
+}
+
+function buildGroups(
+  rows: ReactionRow[],
+  recipientByTarget: Map<string, string>
+): Map<string, RecipientGroup> {
+  const groups = new Map<string, RecipientGroup>();
+  for (const r of rows) {
+    const recipient = recipientByTarget.get(`${r.targetType}:${r.targetId}`);
+    if (!recipient) continue;
+    if (recipient === r.userId) continue; // skip self-reactions
+    let g = groups.get(recipient);
+    if (!g) {
+      g = { reactorIds: new Set(), byEmoji: new Map(), totalReactions: 0 };
+      groups.set(recipient, g);
+    }
+    g.reactorIds.add(r.userId);
+    g.totalReactions += 1;
+    const set = g.byEmoji.get(r.emoji) ?? new Set<string>();
+    set.add(r.userId);
+    g.byEmoji.set(r.emoji, set);
+  }
+  return groups;
+}
+
+function formatBody(g: RecipientGroup, names: Map<string, string>): string {
+  // "👍 3 個（Alice、Bob、Charlie）／ ❤️ 2 個（David、Eve）"
+  const parts: string[] = [];
+  for (const [emoji, users] of g.byEmoji.entries()) {
+    const named = Array.from(users).slice(0, 3).map((id) => names.get(id) ?? id);
+    const extra = users.size > 3 ? ` 等 ${users.size} 人` : "";
+    parts.push(`${emoji} ${users.size} 個（${named.join("、")}${extra}）`);
+  }
+  return parts.join(" ／ ");
+}
+
+export const POST = apiHandler(async (req: NextRequest) => {
+  const authError = verifyCronSecret(req);
+  if (authError) return authError;
+
+  const redis = getRedisClient();
+  if (redis) {
+    const acquired = await redis.set(LOCK_KEY, "1", "EX", LOCK_TTL, "NX");
+    if (!acquired) {
+      logger.warn(
+        { event: "cron_reaction_digest_skipped" },
+        "Skipped: previous run still active"
+      );
+      return success({ skipped: true, reason: "lock_held" });
+    }
+  }
+
+  try {
+    const now = new Date();
+    const since = new Date(now);
+    since.setHours(now.getHours() - 24);
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    const reactions: ReactionRow[] = await prisma.reaction.findMany({
+      where: { createdAt: { gte: since } },
+      select: { userId: true, targetType: true, targetId: true, emoji: true },
+    });
+
+    if (reactions.length === 0) {
+      return success({ inserted: 0, recipients: 0 });
+    }
+
+    const recipientByTarget = await resolveRecipients(reactions);
+    const groups = buildGroups(reactions, recipientByTarget);
+
+    if (groups.size === 0) {
+      return success({ inserted: 0, recipients: 0 });
+    }
+
+    const recipientIds = Array.from(groups.keys());
+
+    // Skip recipients who already received a REACTION_DIGEST today
+    // (per-day idempotency without a separate ledger).
+    const existing = await prisma.notification.findMany({
+      where: {
+        userId: { in: recipientIds },
+        type: "REACTION_DIGEST",
+        createdAt: { gte: todayStart },
+      },
+      select: { userId: true },
+    });
+    const alreadySent = new Set(existing.map((n) => n.userId));
+
+    // Honor per-user opt-out for REACTION_DIGEST.
+    const optedOut = await prisma.notificationPreference.findMany({
+      where: {
+        userId: { in: recipientIds },
+        type: "REACTION_DIGEST",
+        enabled: false,
+      },
+      select: { userId: true },
+    });
+    const optedOutSet = new Set(optedOut.map((p) => p.userId));
+
+    // Resolve display names for body text.
+    const reactorIds = new Set<string>();
+    for (const g of groups.values()) {
+      for (const id of g.reactorIds) reactorIds.add(id);
+    }
+    const users = await prisma.user.findMany({
+      where: { id: { in: Array.from(reactorIds) } },
+      select: { id: true, name: true },
+    });
+    const nameMap = new Map(users.map((u) => [u.id, u.name]));
+
+    const created: Array<{
+      id: string;
+      userId: string;
+      type: string;
+      title: string;
+      body: string | null;
+      isRead: boolean;
+      createdAt: Date;
+      relatedId: string | null;
+      relatedType: string | null;
+    }> = [];
+
+    for (const [recipientId, g] of groups.entries()) {
+      if (alreadySent.has(recipientId) || optedOutSet.has(recipientId)) continue;
+      const title = `${g.reactorIds.size} 人對你的內容做了反應`;
+      const body = formatBody(g, nameMap);
+      const n = await prisma.notification.create({
+        data: {
+          userId: recipientId,
+          type: "REACTION_DIGEST",
+          title,
+          body,
+          relatedId: recipientId,
+          relatedType: "User",
+        },
+      });
+      created.push(n);
+    }
+
+    if (created.length > 0) {
+      try {
+        await publishNotifications(
+          created.map((n) => ({
+            id: n.id,
+            userId: n.userId,
+            type: n.type,
+            title: n.title,
+            body: n.body,
+            isRead: n.isRead,
+            createdAt: n.createdAt,
+            relatedId: n.relatedId,
+            relatedType: n.relatedType,
+          }))
+        );
+      } catch (err) {
+        logger.warn({ err }, "[reaction-digest] publish failed (non-fatal)");
+      }
+    }
+
+    return success({
+      inserted: created.length,
+      recipients: groups.size,
+      skipped_already_sent: alreadySent.size,
+      skipped_opted_out: optedOutSet.size,
+    });
+  } finally {
+    if (redis) {
+      try {
+        await redis.del(LOCK_KEY);
+      } catch {
+        // swallow
+      }
+    }
+  }
+});

--- a/prisma/migrations/20260425100000_add_reaction_digest_notification_type/migration.sql
+++ b/prisma/migrations/20260425100000_add_reaction_digest_notification_type/migration.sql
@@ -1,0 +1,9 @@
+-- Add REACTION_DIGEST to NotificationType enum (Issue #1520)
+-- Idempotent: works on fresh migrate deploy and existing prod (db push).
+DO $$
+BEGIN
+  ALTER TYPE "NotificationType" ADD VALUE IF NOT EXISTS 'REACTION_DIGEST';
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -827,6 +827,7 @@ enum NotificationType {
   DAILY_DIGEST          // Issue #1321: 每日個人摘要
   WEEKLY_DIGEST         // Issue #1321: 每週主管摘要
   MENTION               // Issue #1506: 評論 @mention 通知
+  REACTION_DIGEST       // Issue #1520: 反應每日彙總
 }
 
 model Notification {


### PR DESCRIPTION
Refs #1520 · Parent #1505 · Builds on Phase 2 reactions (#1512)

## Why

Phase 2 reactions are live but they don't notify anyone. We deliberately deferred per-reaction push to avoid noise — but skipping notifications entirely means an introvert teammate who doesn't visit TITAN that day misses the affirmation.

Solution: one batched notification per recipient per day summarizing all the reactions to their content in the last 24h.

## What's in

- `REACTION_DIGEST` added to NotificationType enum (guarded migration)
- New cron route `POST /api/cron/reaction-digest`:
  - Aggregates last 24h of Reaction rows
  - Resolves recipient via TaskComment.userId / DocumentComment.authorId / TaskActivity.userId
  - Drops self-reactions
  - Per-day idempotent (skips users with REACTION_DIGEST notification today)
  - Respects `NotificationPreference.enabled=false` for REACTION_DIGEST
  - Body lists top 3 reactors per emoji
  - Redis lock (5min TTL) prevents concurrent runs
  - SSE publish to wake notification-bell live
- 8 unit tests

## Verification

- Migration applied on throwaway postgres:16-alpine
- 8/8 unit tests pass
- `npx tsc --noEmit` clean

## Cron schedule

Endpoint is wired; the actual cron timing (e.g. 08:00 daily) is a separate config concern handled by the titan-cron container's schedule yaml. Will update that in a follow-up tiny PR or be picked up automatically depending on how titan-cron discovers cron endpoints.

## Non-goals

- Real-time per-reaction push (intentionally not done — that's the noise)
- Email channel (separate; can wire via existing email-notifications cron pipeline later)

## Expected CI

Same pre-existing a11y cascade pattern; admin-merge per memory criteria when all non-e2e green.