### PR TITLE
chore(T1520): schedule reaction-digest cron daily 08:15

### DIFF
--- a/scripts/cron-entrypoint.sh
+++ b/scripts/cron-entrypoint.sh
@@ -61,6 +61,9 @@ cat > /etc/crontabs/root <<EOF
 # 08:30 Mondays — weekly verification reminder
 30 8 * * 1 ${CURL} ${TITAN_APP_URL}/api/cron/verification-reminder || true
 
+# 08:15 daily — reaction digest (Issue #1520, batched 24h reaction summary)
+15 8 * * * ${CURL} ${TITAN_APP_URL}/api/cron/reaction-digest || true
+
 # 03:00 daily — hard-delete soft-deleted records older than 24h (Issue #1324)
 0 3 * * * ${CURL} ${TITAN_APP_URL}/api/cron/cleanup-deleted || true
 EOF


### PR DESCRIPTION
Refs #1520 · Wires the endpoint from #1521 into titan-cron crontab.

## What

Added line to scripts/cron-entrypoint.sh:
```
15 8 * * * ${CURL} ${TITAN_APP_URL}/api/cron/reaction-digest || true
```

08:15 daily picked to avoid the 08:00 collision with daily-digest + email-digest.

## Verification needed post-merge

- Rebuild titan-cron image: `docker compose build titan-cron` (handled by upgrade.sh)
- Restart container: `docker compose up -d titan-cron`
- Verify crontab: `docker exec titan-cron cat /etc/crontabs/root | grep reaction`

## Expected CI

Single-line shell change. Same pre-existing a11y cascade pattern; admin-merge under usual criteria.