### PR TITLE
feat(T1523): auto-subscribe to commented task threads (Phase 4a)

### DIFF
--- a/__tests__/api/tasks/task-comments-mentions.test.ts
+++ b/__tests__/api/tasks/task-comments-mentions.test.ts
@@ -38,7 +38,7 @@ jest.mock("next-auth", () => ({
 jest.mock("@/lib/prisma", () => {
   const mock = {
     task: { findUnique: jest.fn() },
-    taskComment: { create: jest.fn() },
+    taskComment: { create: jest.fn(), findMany: jest.fn() },
     user: { findMany: jest.fn() },
     notificationPreference: { findMany: jest.fn() },
     notification: { create: jest.fn() },
@@ -73,7 +73,7 @@ import { publishNotifications } from "@/lib/notification-publisher";
 // Typed handles onto the factory-created mocks.
 const prismaMock = prisma as unknown as {
   task: { findUnique: jest.Mock };
-  taskComment: { create: jest.Mock };
+  taskComment: { create: jest.Mock; findMany: jest.Mock };
   user: { findMany: jest.Mock };
   notificationPreference: { findMany: jest.Mock };
   notification: { create: jest.Mock };
@@ -103,6 +103,9 @@ beforeEach(() => {
   });
   prismaMock.user.findMany.mockResolvedValue([]);
   prismaMock.notificationPreference.findMany.mockResolvedValue([]);
+  // Issue #1523: thread-subscriber lookup defaults to none — tests opt
+  // in by overriding when they need to exercise the subscribe path.
+  prismaMock.taskComment.findMany.mockResolvedValue([]);
   prismaMock.notification.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
     Promise.resolve({
       id: `notif-${data.userId as string}`,
@@ -218,5 +221,89 @@ describe("POST /api/tasks/[id]/comments — @mention wiring", () => {
     expect(prismaMock.taskComment.create).toHaveBeenCalledTimes(1);
     // Publish was attempted (fire-and-forget).
     expect(mockPublishNotifications).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/tasks/[id]/comments — thread-subscribe (Issue #1523)", () => {
+  it("notifies prior commenters with TASK_COMMENTED type", async () => {
+    const u1 = "cku111111111111111111111";
+    const u2 = "cku222222222222222222222";
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { userId: u1 },
+      { userId: u2 },
+    ]);
+
+    await callPost({ content: "follow up reply" });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(2);
+    const calls = prismaMock.notification.create.mock.calls.map(
+      ([arg]: [{ data: { userId: string; type: string } }]) => arg.data
+    );
+    const userIds = calls.map((c: { userId: string }) => c.userId);
+    expect(userIds).toEqual(expect.arrayContaining([u1, u2]));
+    for (const c of calls) {
+      expect(c.type).toBe("TASK_COMMENTED");
+    }
+  });
+
+  it("does not notify the comment author about their own reply", async () => {
+    prismaMock.taskComment.findMany.mockResolvedValue([{ userId: AUTHOR_ID }]);
+    await callPost({ content: "I reply to my own thread" });
+    expect(prismaMock.notification.create).not.toHaveBeenCalled();
+  });
+
+  it("avoids duplicate notification when prior commenter is also @mentioned", async () => {
+    const dual = "cku333333333333333333333";
+    prismaMock.user.findMany.mockResolvedValue([{ id: dual }]);
+    prismaMock.taskComment.findMany.mockResolvedValue([{ userId: dual }]);
+
+    await callPost({
+      content: "@dual recent context",
+      mentionedUserIds: [dual],
+    });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: dual, type: "MENTION" }),
+      })
+    );
+  });
+
+  it("respects NotificationPreference opt-out for TASK_COMMENTED", async () => {
+    const u1 = "cku111111111111111111111";
+    const u2 = "cku222222222222222222222";
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { userId: u1 },
+      { userId: u2 },
+    ]);
+    prismaMock.notificationPreference.findMany.mockImplementation(
+      ({ where }: { where: { type: string } }) => {
+        if (where.type === "TASK_COMMENTED") {
+          return Promise.resolve([{ userId: u2 }]);
+        }
+        return Promise.resolve([]);
+      }
+    );
+
+    await callPost({ content: "ping" });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: u1 }) })
+    );
+  });
+
+  it("caps subscriber notifications at 20 even with many prior commenters", async () => {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      `cku${String(i).padStart(21, "0")}` // valid-looking cuid (24 chars total: cku + 21 zeros)
+    );
+    prismaMock.taskComment.findMany.mockResolvedValue(
+      many.map((id) => ({ userId: id }))
+    );
+
+    await callPost({ content: "hot thread" });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(20);
   });
 });

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -96,7 +96,8 @@ export const POST = withAuth(async (
       : [];
   const mentionedIds = activeMentioned.map((u) => u.id);
 
-  // Atomic: create comment + mention notifications in single transaction.
+  // Atomic: create comment + mention notifications + thread-subscriber
+  // notifications in a single transaction.
   const { comment, notifications } = await prisma.$transaction(async (tx) => {
     const created = await tx.taskComment.create({
       data: {
@@ -109,45 +110,98 @@ export const POST = withAuth(async (
       },
     });
 
-    if (mentionedIds.length === 0) {
-      return { comment: created, notifications: [] };
-    }
-
-    // Respect per-user NotificationPreference opt-out for MENTION type.
-    const optedOut = await tx.notificationPreference.findMany({
-      where: {
-        userId: { in: mentionedIds },
-        type: "MENTION",
-        enabled: false,
-      },
-      select: { userId: true },
-    });
-    const optedOutSet = new Set(optedOut.map((p) => p.userId));
-    const targets = mentionedIds.filter((id) => !optedOutSet.has(id));
-
-    if (targets.length === 0) {
-      return { comment: created, notifications: [] };
-    }
-
     const preview = sanitized.substring(0, 140);
-    const title = `${created.user.name} 在任務「${task.title}」中提到你`;
+    const allCreated: Awaited<ReturnType<typeof tx.notification.create>>[] = [];
 
-    const created_notifications = await Promise.all(
-      targets.map((userId) =>
-        tx.notification.create({
-          data: {
-            userId,
-            type: "MENTION",
-            title,
-            body: preview,
-            relatedId: taskId,
-            relatedType: "Task",
-          },
-        })
-      )
-    );
+    // ── 1. Direct @mention notifications ─────────────────────────────────
+    let mentionTargets: string[] = [];
+    if (mentionedIds.length > 0) {
+      const optedOutMention = await tx.notificationPreference.findMany({
+        where: {
+          userId: { in: mentionedIds },
+          type: "MENTION",
+          enabled: false,
+        },
+        select: { userId: true },
+      });
+      const optedOutMentionSet = new Set(optedOutMention.map((p) => p.userId));
+      mentionTargets = mentionedIds.filter((id) => !optedOutMentionSet.has(id));
 
-    return { comment: created, notifications: created_notifications };
+      if (mentionTargets.length > 0) {
+        const mentionTitle = `${created.user.name} 在任務「${task.title}」中提到你`;
+        const mentionRows = await Promise.all(
+          mentionTargets.map((userId) =>
+            tx.notification.create({
+              data: {
+                userId,
+                type: "MENTION",
+                title: mentionTitle,
+                body: preview,
+                relatedId: taskId,
+                relatedType: "Task",
+              },
+            })
+          )
+        );
+        allCreated.push(...mentionRows);
+      }
+    }
+
+    // ── 2. Thread-subscriber notifications (Issue #1523) ─────────────────
+    // Anyone who has previously commented on this task is implicitly
+    // subscribed. Notify them about the new comment, except:
+    //   - the comment author themselves
+    //   - users already getting a MENTION notification this turn (avoid dup)
+    //   - users opted out of TASK_COMMENTED type
+    const SUBSCRIBER_CAP = 20;
+    const priorCommenters = await tx.taskComment.findMany({
+      where: { taskId, deletedAt: null, userId: { not: session.user.id } },
+      distinct: ["userId"],
+      select: { userId: true },
+      take: SUBSCRIBER_CAP + 5, // small buffer; we cap after dedup with mentions
+    });
+    // Defense-in-depth: SQL filter excludes the author, but also drop in
+    // memory in case the row leaked through.
+    const candidateSubscribers = priorCommenters
+      .map((r) => r.userId)
+      .filter((uid) => uid !== session.user.id && !mentionTargets.includes(uid));
+
+    let subscriberTargets: string[] = [];
+    if (candidateSubscribers.length > 0) {
+      const optedOutSub = await tx.notificationPreference.findMany({
+        where: {
+          userId: { in: candidateSubscribers },
+          type: "TASK_COMMENTED",
+          enabled: false,
+        },
+        select: { userId: true },
+      });
+      const optedOutSubSet = new Set(optedOutSub.map((p) => p.userId));
+      subscriberTargets = candidateSubscribers
+        .filter((uid) => !optedOutSubSet.has(uid))
+        .slice(0, SUBSCRIBER_CAP);
+
+      if (subscriberTargets.length > 0) {
+        const subTitle = `${created.user.name} 在「${task.title}」回覆了`;
+        const subRows = await Promise.all(
+          subscriberTargets.map((userId) =>
+            tx.notification.create({
+              data: {
+                userId,
+                type: "TASK_COMMENTED",
+                title: subTitle,
+                body: preview,
+                relatedId: taskId,
+                relatedType: "Task",
+              },
+            })
+          )
+        );
+        allCreated.push(...subRows);
+      }
+    }
+
+    return { comment: created, notifications: allCreated };
   });
 
   // Fire-and-forget SSE publish (outside tx; Redis failure must not rollback comment).


### PR DESCRIPTION
Refs #1523 · Parent #1505

## What

If you've commented on a task, you now auto-subscribe to subsequent comments on it — no explicit follow needed. Closes the "did anyone reply?" loop without requiring users to remember which threads to watch.

## Implementation

- POST /api/tasks/[id]/comments creates **two** kinds of notifications atomically (in addition to the comment row):
  1. **MENTION** for users explicitly @-mentioned (existing #1506 behavior)
  2. **TASK_COMMENTED** for prior commenters on the same task (NEW)
- Prior commenters derived implicitly: `SELECT DISTINCT userId FROM task_comments WHERE taskId=? AND deletedAt IS NULL`. Participation = subscription. No new schema, no manual follow.
- Defense-in-depth: filter author both in SQL and in memory
- Hard cap 20 subscribers (insurance against runaway hot threads)
- Skips users already getting MENTION this turn (no duplicate)
- Respects NotificationPreference opt-out for TASK_COMMENTED

## Why no schema change

`TASK_COMMENTED` was already in the NotificationType enum (added long ago, never wired). `task_comments.userId` already gives us the subscriber list. So this is purely a behavior-add — zero migration.

## Tests

12 unit cases, all green:
- 7 existing mention tests (still pass after refactor)
- 5 new thread-subscribe tests covering: notifies prior commenters, no self-notify, dedup with @mention, opt-out, 20-cap

## Non-goals

- Document comments thread-subscribe (Phase 4b)
- Explicit mute UI / TaskSubscription model (deferred — global type opt-out works as coarse mute today)

## Expected CI

Same pre-existing a11y cascade. Admin-merge per memory criteria when non-e2e green.