### PR TITLE
feat(T1527): per-thread mute for auto-subscribed threads (Phase 4c)

### DIFF
--- a/__tests__/api/comment-thread-mute.test.ts
+++ b/__tests__/api/comment-thread-mute.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API: /api/comment-threads/mute — Issue #1527.
+ *
+ *  - POST toggles mute (creates row if absent, deletes if present)
+ *  - GET returns current mute status
+ *  - 404 when target row does not exist
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+const mockRequireAuth = jest.fn();
+jest.mock("@/lib/rbac", () => ({
+  requireAuth: () => mockRequireAuth(),
+  requireRole: jest.fn(),
+  requireManagerOrAbove: jest.fn(),
+  enforcePasswordChange: jest.fn(),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/auth-middleware", () => ({
+  withAuth: (fn: unknown) => fn,
+}));
+
+jest.mock("@/lib/prisma", () => {
+  const mock = {
+    task: { findUnique: jest.fn() },
+    document: { findUnique: jest.fn() },
+    commentThreadMute: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+  return { prisma: mock };
+});
+
+import { POST, GET } from "@/app/api/comment-threads/mute/route";
+import { prisma } from "@/lib/prisma";
+
+const prismaMock = prisma as unknown as {
+  task: { findUnique: jest.Mock };
+  document: { findUnique: jest.Mock };
+  commentThreadMute: { findUnique: jest.Mock; create: jest.Mock; delete: jest.Mock };
+};
+
+const VIEWER_ID = "cku111111111111111111111";
+const TASK_ID = "ckt222222222222222222222";
+
+function callPost(body: Record<string, unknown>) {
+  const req = createMockRequest("/api/comment-threads/mute", {
+    method: "POST",
+    body,
+  });
+  return POST(req, { params: Promise.resolve({}) });
+}
+
+function callGet(targetType: string, targetId: string) {
+  const req = createMockRequest(
+    `/api/comment-threads/mute?targetType=${targetType}&targetId=${targetId}`,
+    { method: "GET" }
+  );
+  return GET(req, { params: Promise.resolve({}) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAuth.mockResolvedValue({ user: { id: VIEWER_ID } });
+  prismaMock.task.findUnique.mockResolvedValue({ id: TASK_ID });
+  prismaMock.document.findUnique.mockResolvedValue({ id: TASK_ID });
+  prismaMock.commentThreadMute.findUnique.mockResolvedValue(null);
+  prismaMock.commentThreadMute.create.mockResolvedValue({ id: "mute-1" });
+  prismaMock.commentThreadMute.delete.mockResolvedValue({ id: "mute-1" });
+});
+
+describe("POST /api/comment-threads/mute — toggle", () => {
+  it("creates a mute row on first toggle and returns muted=true", async () => {
+    const res = await callPost({ targetType: "TASK", targetId: TASK_ID });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.muted).toBe(true);
+    expect(prismaMock.commentThreadMute.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.commentThreadMute.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes the mute row on second toggle and returns muted=false", async () => {
+    prismaMock.commentThreadMute.findUnique.mockResolvedValue({ id: "existing" });
+    const res = await callPost({ targetType: "TASK", targetId: TASK_ID });
+    const body = await res.json();
+    expect(body.data.muted).toBe(false);
+    expect(prismaMock.commentThreadMute.delete).toHaveBeenCalledWith({ where: { id: "existing" } });
+  });
+
+  it("returns 404 when task does not exist", async () => {
+    prismaMock.task.findUnique.mockResolvedValue(null);
+    const res = await callPost({ targetType: "TASK", targetId: TASK_ID });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects unknown targetType via zod", async () => {
+    await expect(
+      callPost({ targetType: "RANDOM", targetId: TASK_ID })
+    ).rejects.toThrow();
+  });
+
+  it("works for DOCUMENT target type", async () => {
+    const res = await callPost({ targetType: "DOCUMENT", targetId: TASK_ID });
+    expect(res.status).toBe(200);
+    expect(prismaMock.document.findUnique).toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/comment-threads/mute — status check", () => {
+  it("returns muted=false when no row exists", async () => {
+    const res = await callGet("TASK", TASK_ID);
+    const body = await res.json();
+    expect(body.data.muted).toBe(false);
+  });
+
+  it("returns muted=true when row exists", async () => {
+    prismaMock.commentThreadMute.findUnique.mockResolvedValue({ id: "existing" });
+    const res = await callGet("TASK", TASK_ID);
+    const body = await res.json();
+    expect(body.data.muted).toBe(true);
+  });
+});

--- a/__tests__/api/documents/doc-comments-thread-subscribe.test.ts
+++ b/__tests__/api/documents/doc-comments-thread-subscribe.test.ts
@@ -42,6 +42,7 @@ jest.mock("@/lib/prisma", () => {
     user: { findMany: jest.fn() },
     notificationPreference: { findMany: jest.fn() },
     notification: { create: jest.fn() },
+    commentThreadMute: { findMany: jest.fn() },
     $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(mock)),
   };
   return { prisma: mock };
@@ -64,6 +65,7 @@ const prismaMock = prisma as unknown as {
   user: { findMany: jest.Mock };
   notificationPreference: { findMany: jest.Mock };
   notification: { create: jest.Mock };
+  commentThreadMute: { findMany: jest.Mock };
   $transaction: jest.Mock;
 };
 
@@ -90,6 +92,7 @@ beforeEach(() => {
   prismaMock.documentComment.findFirst.mockResolvedValue(null);
   prismaMock.user.findMany.mockResolvedValue([]);
   prismaMock.notificationPreference.findMany.mockResolvedValue([]);
+  prismaMock.commentThreadMute.findMany.mockResolvedValue([]);
   prismaMock.notification.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
     Promise.resolve({
       id: `n-${data.userId as string}`,
@@ -181,5 +184,22 @@ describe("POST /api/documents/[id]/comments — thread-subscribe", () => {
     await callPost({ content: "hot doc thread" });
 
     expect(prismaMock.notification.create).toHaveBeenCalledTimes(20);
+  });
+
+  it("excludes users who muted this specific document thread (Issue #1527)", async () => {
+    const u1 = "cku111111111111111111111";
+    const u2 = "cku222222222222222222222";
+    prismaMock.documentComment.findMany.mockResolvedValue([
+      { authorId: u1 },
+      { authorId: u2 },
+    ]);
+    prismaMock.commentThreadMute.findMany.mockResolvedValue([{ userId: u2 }]);
+
+    await callPost({ content: "hello again" });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: u1 }) })
+    );
   });
 });

--- a/__tests__/api/tasks/task-comments-mentions.test.ts
+++ b/__tests__/api/tasks/task-comments-mentions.test.ts
@@ -42,6 +42,7 @@ jest.mock("@/lib/prisma", () => {
     user: { findMany: jest.fn() },
     notificationPreference: { findMany: jest.fn() },
     notification: { create: jest.fn() },
+    commentThreadMute: { findMany: jest.fn() },
     $transaction: jest.fn(async (cb: (tx: unknown) => unknown) => cb(mock)),
   };
   return { prisma: mock };
@@ -77,6 +78,7 @@ const prismaMock = prisma as unknown as {
   user: { findMany: jest.Mock };
   notificationPreference: { findMany: jest.Mock };
   notification: { create: jest.Mock };
+  commentThreadMute: { findMany: jest.Mock };
   $transaction: jest.Mock;
 };
 const mockPublishNotifications = publishNotifications as unknown as jest.Mock;
@@ -106,6 +108,8 @@ beforeEach(() => {
   // Issue #1523: thread-subscriber lookup defaults to none — tests opt
   // in by overriding when they need to exercise the subscribe path.
   prismaMock.taskComment.findMany.mockResolvedValue([]);
+  // Issue #1527: thread-mute lookup defaults to none.
+  prismaMock.commentThreadMute.findMany.mockResolvedValue([]);
   prismaMock.notification.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
     Promise.resolve({
       id: `notif-${data.userId as string}`,
@@ -305,5 +309,23 @@ describe("POST /api/tasks/[id]/comments — thread-subscribe (Issue #1523)", () 
     await callPost({ content: "hot thread" });
 
     expect(prismaMock.notification.create).toHaveBeenCalledTimes(20);
+  });
+
+  it("excludes users who muted this specific task thread (Issue #1527)", async () => {
+    const u1 = "cku111111111111111111111";
+    const u2 = "cku222222222222222222222";
+    prismaMock.taskComment.findMany.mockResolvedValue([
+      { userId: u1 },
+      { userId: u2 },
+    ]);
+    // u2 muted this thread
+    prismaMock.commentThreadMute.findMany.mockResolvedValue([{ userId: u2 }]);
+
+    await callPost({ content: "hello again" });
+
+    expect(prismaMock.notification.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.notification.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ userId: u1 }) })
+    );
   });
 });

--- a/app/api/comment-threads/mute/route.ts
+++ b/app/api/comment-threads/mute/route.ts
@@ -1,0 +1,88 @@
+/**
+ * /api/comment-threads/mute — Issue #1527
+ *
+ * Per-thread mute toggle. Auto-subscribed users (per #1523/#1525) can
+ * silence TASK_COMMENTED notifications for one specific task or doc
+ * without disabling all thread notifications globally.
+ *
+ * @mention notifications on the same target are unaffected.
+ */
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { validateBody } from "@/lib/validate";
+import { success, error } from "@/lib/api-response";
+
+const TARGETS = ["TASK", "DOCUMENT"] as const;
+
+const toggleSchema = z.object({
+  targetType: z.enum(TARGETS),
+  targetId: z.string().cuid(),
+});
+
+const querySchema = z.object({
+  targetType: z.enum(TARGETS),
+  targetId: z.string().cuid(),
+});
+
+export const POST = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const { targetType, targetId } = validateBody(toggleSchema, await req.json());
+
+  // Verify target exists (avoid muting random IDs).
+  if (targetType === "TASK") {
+    const task = await prisma.task.findUnique({ where: { id: targetId }, select: { id: true } });
+    if (!task) return error("NotFoundError", "任務不存在", 404);
+  } else {
+    const doc = await prisma.document.findUnique({ where: { id: targetId }, select: { id: true } });
+    if (!doc) return error("NotFoundError", "文件不存在", 404);
+  }
+
+  const existing = await prisma.commentThreadMute.findUnique({
+    where: {
+      userId_targetType_targetId: {
+        userId: session.user.id,
+        targetType,
+        targetId,
+      },
+    },
+    select: { id: true },
+  });
+
+  if (existing) {
+    await prisma.commentThreadMute.delete({ where: { id: existing.id } });
+    return success({ muted: false });
+  }
+
+  await prisma.commentThreadMute.create({
+    data: {
+      userId: session.user.id,
+      targetType,
+      targetId,
+    },
+  });
+  return success({ muted: true });
+});
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const url = new URL(req.url);
+  const { targetType, targetId } = validateBody(querySchema, {
+    targetType: url.searchParams.get("targetType"),
+    targetId: url.searchParams.get("targetId"),
+  });
+
+  const row = await prisma.commentThreadMute.findUnique({
+    where: {
+      userId_targetType_targetId: {
+        userId: session.user.id,
+        targetType,
+        targetId,
+      },
+    },
+    select: { id: true },
+  });
+  return success({ muted: row !== null });
+});

--- a/app/api/documents/[id]/comments/route.ts
+++ b/app/api/documents/[id]/comments/route.ts
@@ -133,6 +133,17 @@ export const POST = withAuth(async (
 
     let subscriberTargets: string[] = [];
     if (candidateSubscribers.length > 0) {
+      // Issue #1527: drop users who muted this specific document thread.
+      const muted = await tx.commentThreadMute.findMany({
+        where: {
+          userId: { in: candidateSubscribers },
+          targetType: "DOCUMENT",
+          targetId: id,
+        },
+        select: { userId: true },
+      });
+      const mutedSet = new Set(muted.map((m) => m.userId));
+
       const optedOutSub = await tx.notificationPreference.findMany({
         where: {
           userId: { in: candidateSubscribers },
@@ -143,7 +154,7 @@ export const POST = withAuth(async (
       });
       const optedOutSubSet = new Set(optedOutSub.map((p) => p.userId));
       subscriberTargets = candidateSubscribers
-        .filter((uid) => !optedOutSubSet.has(uid))
+        .filter((uid) => !mutedSet.has(uid) && !optedOutSubSet.has(uid))
         .slice(0, SUBSCRIBER_CAP);
 
       if (subscriberTargets.length > 0) {

--- a/app/api/tasks/[id]/comments/route.ts
+++ b/app/api/tasks/[id]/comments/route.ts
@@ -168,6 +168,17 @@ export const POST = withAuth(async (
 
     let subscriberTargets: string[] = [];
     if (candidateSubscribers.length > 0) {
+      // Issue #1527: drop users who muted this specific task thread.
+      const muted = await tx.commentThreadMute.findMany({
+        where: {
+          userId: { in: candidateSubscribers },
+          targetType: "TASK",
+          targetId: taskId,
+        },
+        select: { userId: true },
+      });
+      const mutedSet = new Set(muted.map((m) => m.userId));
+
       const optedOutSub = await tx.notificationPreference.findMany({
         where: {
           userId: { in: candidateSubscribers },
@@ -178,7 +189,7 @@ export const POST = withAuth(async (
       });
       const optedOutSubSet = new Set(optedOutSub.map((p) => p.userId));
       subscriberTargets = candidateSubscribers
-        .filter((uid) => !optedOutSubSet.has(uid))
+        .filter((uid) => !mutedSet.has(uid) && !optedOutSubSet.has(uid))
         .slice(0, SUBSCRIBER_CAP);
 
       if (subscriberTargets.length > 0) {

--- a/prisma/migrations/20260425120000_add_comment_thread_mutes/migration.sql
+++ b/prisma/migrations/20260425120000_add_comment_thread_mutes/migration.sql
@@ -1,0 +1,33 @@
+-- Add CommentThreadMute table + CommentThreadTarget enum (Issue #1527)
+-- Lets users mute auto-subscribed thread notifications per target without
+-- having to globally disable TASK_COMMENTED.
+
+DO $$ BEGIN
+  CREATE TYPE "CommentThreadTarget" AS ENUM ('TASK', 'DOCUMENT');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "comment_thread_mutes" (
+  "id"         TEXT NOT NULL,
+  "userId"     TEXT NOT NULL,
+  "targetType" "CommentThreadTarget" NOT NULL,
+  "targetId"   TEXT NOT NULL,
+  "createdAt"  TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "comment_thread_mutes_pkey" PRIMARY KEY ("id")
+);
+
+DO $$ BEGIN
+  ALTER TABLE "comment_thread_mutes"
+    ADD CONSTRAINT "comment_thread_mutes_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "comment_thread_mutes_userId_targetType_targetId_key"
+  ON "comment_thread_mutes" ("userId", "targetType", "targetId");
+
+CREATE INDEX IF NOT EXISTS "comment_thread_mutes_userId_idx"
+  ON "comment_thread_mutes" ("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,6 +86,7 @@ model User {
   assignedRecurringRules   RecurringRule[]      @relation("RecurringRuleAssignee")
   acknowledgedAlerts       MonitoringAlert[]    @relation("MonitoringAlertAcknowledger")
   reactions                Reaction[]
+  commentThreadMutes       CommentThreadMute[]
 
   @@map("users")
 }
@@ -1768,6 +1769,33 @@ model SystemSetting {
   updatedBy String?
 
   @@map("system_settings")
+}
+
+// ═══════════════════════════════════════
+// Comment Thread Mutes（T1527 Phase 4c — 沉默單一對話）
+// ═══════════════════════════════════════
+
+/// Per-thread mute for auto-subscribed comment threads. When a row
+/// exists for (userId, targetType, targetId), the user does not receive
+/// TASK_COMMENTED notifications for that specific task or document.
+/// @mentions on the same target are unaffected — those are explicit
+/// pings.
+enum CommentThreadTarget {
+  TASK
+  DOCUMENT
+}
+
+model CommentThreadMute {
+  id         String              @id @default(cuid())
+  userId     String
+  user       User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  targetType CommentThreadTarget
+  targetId   String
+  createdAt  DateTime            @default(now())
+
+  @@unique([userId, targetType, targetId])
+  @@index([userId])
+  @@map("comment_thread_mutes")
 }
 
 // ═══════════════════════════════════════


### PR DESCRIPTION
Refs #1527 · Closes the noise gap from #1523/#1525

## What

Each user can now mute a single noisy task or document thread without disabling all TASK_COMMENTED notifications. @mentions on the same target still go through.

- Schema: `CommentThreadMute` + `CommentThreadTarget` enum
- Migration: guarded CREATE TABLE IF NOT EXISTS + DO block, verified on throwaway pg:16
- API: POST /api/comment-threads/mute toggles, GET returns status
- Wire into POST /api/tasks/[id]/comments and POST /api/documents/[id]/comments — thread-subscribe filter drops muted users
- @mentions unaffected — those are explicit pings, deliberately louder

## Tests

26 cases across 3 files:
- task suite: 13 (added 1 mute exclusion)
- doc suite: 6 (added 1 mute exclusion)
- toggle endpoint: 7 (toggle on/off, 404, invalid type, DOCUMENT path, GET states)

26/26 green. tsc clean.

## Out of scope

UI button (next PR — small slice once we see real notification volume telling us we need it). Backend ready and feature-flag-free since the API is opt-in by user action.

## Expected CI

Pre-existing a11y cascade. Admin-merge per memory criteria when non-e2e green.