### PR TITLE
feat(T1537): warm empty-state copy for YourWeek widget

### DIFF
--- a/app/components/dashboard/your-week-widget.tsx
+++ b/app/components/dashboard/your-week-widget.tsx
@@ -73,7 +73,7 @@ function StatBlock({ icon, label, primary, secondary, tone = "neutral" }: StatBl
 }
 
 function celebrationFor(s: Summary): string | null {
-  // Pick the most encouraging metric; skip when nothing happened yet.
+  // Pick the most encouraging metric; warm fallback for the all-zero case.
   if (s.completedTasks.current > 0 && s.completedTasks.delta > 0) {
     return `🎉 本週完成 ${s.completedTasks.current} 個任務，比上週多 ${s.completedTasks.delta} 個`;
   }
@@ -86,6 +86,17 @@ function celebrationFor(s: Summary): string | null {
   }
   if (s.completedTasks.current > 0) {
     return `✅ 本週已完成 ${s.completedTasks.current} 個任務`;
+  }
+  // Issue #1537: warm new-week empty state instead of bare zeros.
+  // Per #1505 design principles — never negative-tone. Gentle/encouraging
+  // when context fits; silent when "0 completed mid-week" might just mean
+  // "you do non-task work" or "you're on leave" — no shame either way.
+  const day = new Date().getDay(); // 0=Sun..6=Sat
+  if (day === 1 || day === 2) {
+    return "🌱 新的一週剛開始";
+  }
+  if (day === 0 || day === 6) {
+    return "☕ 週末愉快";
   }
   return null;
 }


### PR DESCRIPTION
Tiny copy polish for the bare-zero week case.

## What

When a user's week is all-zero (no completed tasks, no logged hours, 0 active days), YourWeek used to render the stat grid with no celebration line — slightly flat. New behavior:

- **Mon/Tue all-zero** → "🌱 新的一週剛開始" — gentle start-of-week nudge
- **Sat/Sun all-zero** → "☕ 週末愉快" — rest is fine
- **Wed/Thu/Fri all-zero** → silent (per non-toxic principle: 0 mid-week might just mean you're on leave or doing non-task work — no commentary needed)

## Self-discipline note

First draft had "還沒開工？什麼時候都不算晚" — passive-aggressive in tone. Caught on review by re-reading my own `non-toxic-team-social-layer.md` skill (saved this session): "never negative-tone — skip the metric if there's nothing positive to say." Replaced with genuinely warm or silence.

## Verification

- tsc clean
- 1 file +12 -3 (effectively a copy change)