### PR TITLE
feat(T1539-2): /timesheet 加 sticky「快速記時數」CTA + modal

### DIFF
--- a/__tests__/components/timesheet-quick-log-button.test.tsx
+++ b/__tests__/components/timesheet-quick-log-button.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * Component tests: QuickLogButton (Issue #1539-2)
+ *
+ * Covers:
+ * - Trigger button renders with correct label
+ * - Modal opens on click and closes on Esc / backdrop / cancel
+ * - Form defaults: today's date, hours=1, category=PLANNED_TASK
+ * - Validation: rejects 0 / negative / > 24 hours
+ * - Save calls onSave with correct args, then closes modal
+ * - localStorage persists last-used category
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QuickLogButton } from "@/app/components/timesheet/quick-log-button";
+
+jest.mock("lucide-react", () => ({
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+  X: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-x" {...props} />,
+  Loader2: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-loader" {...props} />,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const TASKS = [
+  { id: "task-1", title: "Refactor api layer" },
+  { id: "task-2", title: "Add reaction digest" },
+];
+
+function renderButton(onSave = jest.fn().mockResolvedValue(undefined)) {
+  render(<QuickLogButton tasks={TASKS} onSave={onSave} />);
+  return { onSave };
+}
+
+describe("QuickLogButton", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("renders trigger button with correct label", () => {
+    renderButton();
+    expect(screen.getByTestId("quick-log-trigger")).toHaveTextContent("快速記時數");
+  });
+
+  it("opens modal when trigger clicked, closes on backdrop click", async () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    expect(screen.getByTestId("quick-log-modal")).toBeInTheDocument();
+
+    // backdrop click — click the dialog container (target === currentTarget)
+    fireEvent.click(screen.getByTestId("quick-log-modal"));
+    expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+  });
+
+  it("closes on Esc key", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    expect(screen.getByTestId("quick-log-modal")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+  });
+
+  it("closes when cancel button clicked", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    fireEvent.click(screen.getByTestId("quick-log-cancel"));
+    expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+  });
+
+  it("uses today's date as default", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    const dateInput = screen.getByTestId("quick-log-date") as HTMLInputElement;
+    const today = new Date();
+    const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+    expect(dateInput.value).toBe(expected);
+  });
+
+  it("defaults to 1 hour and PLANNED_TASK category", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    expect((screen.getByTestId("quick-log-hours") as HTMLInputElement).value).toBe("1");
+    expect((screen.getByTestId("quick-log-category") as HTMLSelectElement).value).toBe("PLANNED_TASK");
+  });
+
+  it("rejects zero hours", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    fireEvent.change(screen.getByTestId("quick-log-hours"), { target: { value: "0" } });
+    fireEvent.click(screen.getByTestId("quick-log-save"));
+    await waitFor(() => {
+      expect(onSave).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects hours > 24", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    fireEvent.change(screen.getByTestId("quick-log-hours"), { target: { value: "25" } });
+    fireEvent.click(screen.getByTestId("quick-log-save"));
+    await waitFor(() => {
+      expect(onSave).not.toHaveBeenCalled();
+    });
+  });
+
+  it("saves with correct args and closes modal", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+
+    fireEvent.change(screen.getByTestId("quick-log-hours"), { target: { value: "2.5" } });
+    fireEvent.change(screen.getByTestId("quick-log-task"), { target: { value: "task-1" } });
+    fireEvent.change(screen.getByTestId("quick-log-category"), { target: { value: "INCIDENT" } });
+    fireEvent.change(screen.getByTestId("quick-log-description"), { target: { value: "客戶緊急請求" } });
+
+    fireEvent.click(screen.getByTestId("quick-log-save"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        "task-1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+        2.5,
+        "INCIDENT",
+        "客戶緊急請求",
+        "NONE",
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+    });
+  });
+
+  it("passes null taskId when free entry chosen", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    // Default value is "" (free entry), so don't change task
+    fireEvent.click(screen.getByTestId("quick-log-save"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        null,
+        expect.any(String),
+        1,
+        "PLANNED_TASK",
+        "",
+        "NONE",
+      );
+    });
+  });
+
+  it("persists last-used category to localStorage", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    fireEvent.change(screen.getByTestId("quick-log-category"), { target: { value: "LEARNING" } });
+    fireEvent.click(screen.getByTestId("quick-log-save"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+    expect(window.localStorage.getItem("titan:quickLog:lastCategory")).toBe("LEARNING");
+  });
+
+  it("restores last-used category on mount", () => {
+    window.localStorage.setItem("titan:quickLog:lastCategory", "ADMIN");
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    expect((screen.getByTestId("quick-log-category") as HTMLSelectElement).value).toBe("ADMIN");
+  });
+
+  it("ignores invalid stored category", () => {
+    window.localStorage.setItem("titan:quickLog:lastCategory", "BOGUS");
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    expect((screen.getByTestId("quick-log-category") as HTMLSelectElement).value).toBe("PLANNED_TASK");
+  });
+
+  it("Cmd+Enter saves form", async () => {
+    const { onSave } = renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    fireEvent.change(screen.getByTestId("quick-log-hours"), { target: { value: "3" } });
+
+    // Find the modal inner container (where onKeyDown is bound)
+    const hoursInput = screen.getByTestId("quick-log-hours");
+    fireEvent.keyDown(hoursInput, { key: "Enter", metaKey: true });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        null,
+        expect.any(String),
+        3,
+        "PLANNED_TASK",
+        "",
+        "NONE",
+      );
+    });
+  });
+
+  it("renders all 6 category options", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    const select = screen.getByTestId("quick-log-category") as HTMLSelectElement;
+    expect(select.options).toHaveLength(6);
+  });
+
+  it("renders task options including free-entry", () => {
+    renderButton();
+    fireEvent.click(screen.getByTestId("quick-log-trigger"));
+    const select = screen.getByTestId("quick-log-task") as HTMLSelectElement;
+    expect(select.options).toHaveLength(3); // 1 free + 2 tasks
+    expect(select.options[0].text).toBe("自由工時（無任務）");
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -11,6 +11,7 @@ import {
   TimesheetGrid,
   TimesheetToolbar,
   TimesheetTimer,
+  QuickLogButton,
   CalendarDayView,
   CalendarWeekView,
   CalendarMonthView,
@@ -107,14 +108,24 @@ export default function TimesheetPage() {
   return (
     <div className="flex flex-col gap-4">
       <h1 className="sr-only">工時紀錄</h1>
-      {/* Timer — sticky on top */}
-      <TimesheetTimer
-        timer={ts.timer}
-        elapsed={ts.elapsed}
-        tasks={ts.tasks}
-        onStart={ts.startTimer}
-        onStop={ts.stopTimer}
-      />
+      {/* Timer + Quick log — sticky actions row */}
+      <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+        <div className="flex-1">
+          <TimesheetTimer
+            timer={ts.timer}
+            elapsed={ts.elapsed}
+            tasks={ts.tasks}
+            onStart={ts.startTimer}
+            onStop={ts.stopTimer}
+          />
+        </div>
+        <QuickLogButton
+          tasks={ts.tasks}
+          onSave={(taskId, date, hours, category, description, overtimeType) =>
+            ts.saveEntry(taskId, date, hours, category, description, overtimeType)
+          }
+        />
+      </div>
 
       {/* Toolbar */}
       <TimesheetToolbar

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -5,6 +5,7 @@ export { TimesheetGrid } from "./timesheet-grid";
 export { TimesheetCell } from "./timesheet-cell";
 export { TimesheetToolbar } from "./timesheet-toolbar";
 export { TimesheetTimer } from "./timesheet-timer";
+export { QuickLogButton } from "./quick-log-button";
 export { TemplateSelector } from "./template-selector";
 export { CalendarDayView } from "./calendar-day-view";
 export { CalendarWeekView } from "./calendar-week/index";

--- a/app/components/timesheet/quick-log-button.tsx
+++ b/app/components/timesheet/quick-log-button.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+/**
+ * Quick-Log Button — Issue #1539-2 (from #1538 audit backlog)
+ *
+ * Problem: /timesheet has timer, grid, list, and calendar views — but no
+ * always-visible entry point for "I just finished something, log it now."
+ * Users in calendar/list/mobile-list view had to navigate back to grid,
+ * find a cell, and double-click. That breaks flow.
+ *
+ * Design:
+ * - Floating sticky button on /timesheet, visible across all view modes
+ * - Click opens a focused modal with task / date / hours / category / note
+ * - Defaults: today's date, hours=1.0, category=last-used or PLANNED_TASK
+ * - Keyboard: Esc closes, Cmd/Ctrl+Enter saves
+ * - On save: calls hook saveEntry() so existing optimistic update + stats refresh kicks in
+ */
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Plus, Loader2, X } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { formatLocalDate } from "@/lib/utils/date";
+import type { TaskOption, OvertimeType } from "./use-timesheet";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type QuickLogButtonProps = {
+  tasks: TaskOption[];
+  onSave: (
+    taskId: string | null,
+    date: string,
+    hours: number,
+    category: string,
+    description: string,
+    overtimeType: OvertimeType,
+  ) => Promise<void>;
+};
+
+const CATEGORY_OPTIONS: { value: string; label: string }[] = [
+  { value: "PLANNED_TASK", label: "計畫任務" },
+  { value: "ADDED_TASK", label: "追加任務" },
+  { value: "INCIDENT", label: "事件處理" },
+  { value: "SUPPORT", label: "技術支援" },
+  { value: "ADMIN", label: "行政庶務" },
+  { value: "LEARNING", label: "學習進修" },
+];
+
+const LAST_CATEGORY_KEY = "titan:quickLog:lastCategory";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function QuickLogButton({ tasks, onSave }: QuickLogButtonProps) {
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [taskId, setTaskId] = useState<string>("");
+  const [date, setDate] = useState<string>(() => formatLocalDate(new Date()));
+  const [hours, setHours] = useState<string>("1");
+  const [category, setCategory] = useState<string>("PLANNED_TASK");
+  const [description, setDescription] = useState<string>("");
+  const hoursInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Restore last-used category from localStorage
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const saved = window.localStorage.getItem(LAST_CATEGORY_KEY);
+    if (saved && CATEGORY_OPTIONS.some((c) => c.value === saved)) {
+      setCategory(saved);
+    }
+  }, []);
+
+  // When modal opens: reset date to today, focus hours input, restore last category
+  useEffect(() => {
+    if (!open) return;
+    setDate(formatLocalDate(new Date()));
+    // Focus hours input on next tick so Modal mount finishes
+    const t = setTimeout(() => hoursInputRef.current?.select(), 30);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  // Esc to close
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const handleSave = useCallback(async () => {
+    const parsed = Number.parseFloat(hours);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      toast.error("請輸入大於 0 的時數");
+      hoursInputRef.current?.focus();
+      return;
+    }
+    if (parsed > 24) {
+      toast.error("單筆時數不得超過 24 小時");
+      hoursInputRef.current?.focus();
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await onSave(
+        taskId || null,
+        date,
+        parsed,
+        category,
+        description.trim(),
+        "NONE",
+      );
+      // Persist category preference
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(LAST_CATEGORY_KEY, category);
+      }
+      toast.success(`已記錄 ${parsed} 小時`);
+      setOpen(false);
+      // Reset transient fields
+      setHours("1");
+      setDescription("");
+    } catch (e) {
+      // saveEntry already toasts on parsing errors at server level; this is the fallback.
+      toast.error("儲存失敗，請稍後再試");
+      console.error("[quick-log] save failed", e);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [taskId, date, hours, category, description, onSave]);
+
+  function handleSubmitKey(e: React.KeyboardEvent) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+  }
+
+  return (
+    <>
+      {/* Trigger button — sits inline in the toolbar row */}
+      <button
+        onClick={() => setOpen(true)}
+        className={cn(
+          "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors",
+          "bg-primary text-primary-foreground hover:bg-primary/90",
+        )}
+        data-testid="quick-log-trigger"
+        aria-label="快速記時數"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        快速記時數
+      </button>
+
+      {/* Modal */}
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4 bg-black/50"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="quick-log-title"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setOpen(false);
+          }}
+          data-testid="quick-log-modal"
+        >
+          <div
+            className="w-full sm:max-w-md bg-card border border-border rounded-t-xl sm:rounded-xl shadow-xl p-4 space-y-3"
+            onKeyDown={handleSubmitKey}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <h3 id="quick-log-title" className="text-sm font-semibold">
+                快速記時數
+              </h3>
+              <button
+                onClick={() => setOpen(false)}
+                className="p-1 rounded hover:bg-muted transition-colors"
+                aria-label="關閉"
+                data-testid="quick-log-close"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Hours — primary field, autoFocus */}
+            <div>
+              <label htmlFor="quick-log-hours" className="block text-xs font-medium text-muted-foreground mb-1">
+                時數
+              </label>
+              <input
+                ref={hoursInputRef}
+                id="quick-log-hours"
+                type="number"
+                inputMode="decimal"
+                step="0.5"
+                min="0"
+                max="24"
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+                className="w-full px-3 py-2 text-base border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+                data-testid="quick-log-hours"
+              />
+            </div>
+
+            {/* Date */}
+            <div>
+              <label htmlFor="quick-log-date" className="block text-xs font-medium text-muted-foreground mb-1">
+                日期
+              </label>
+              <input
+                id="quick-log-date"
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.target.value)}
+                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+                data-testid="quick-log-date"
+              />
+            </div>
+
+            {/* Task select */}
+            <div>
+              <label htmlFor="quick-log-task" className="block text-xs font-medium text-muted-foreground mb-1">
+                任務
+              </label>
+              <select
+                id="quick-log-task"
+                value={taskId}
+                onChange={(e) => setTaskId(e.target.value)}
+                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring cursor-pointer"
+                data-testid="quick-log-task"
+              >
+                <option value="">自由工時（無任務）</option>
+                {tasks.map((t) => (
+                  <option key={t.id} value={t.id}>{t.title}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Category */}
+            <div>
+              <label htmlFor="quick-log-category" className="block text-xs font-medium text-muted-foreground mb-1">
+                類別
+              </label>
+              <select
+                id="quick-log-category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring cursor-pointer"
+                data-testid="quick-log-category"
+              >
+                {CATEGORY_OPTIONS.map((c) => (
+                  <option key={c.value} value={c.value}>{c.label}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label htmlFor="quick-log-description" className="block text-xs font-medium text-muted-foreground mb-1">
+                簡述（選填）
+              </label>
+              <input
+                id="quick-log-description"
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="例如：跟客戶開會討論驗收"
+                maxLength={200}
+                className="w-full px-3 py-2 text-sm border border-border rounded-md bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+                data-testid="quick-log-description"
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-between gap-2 pt-1">
+              <span className="text-[10px] text-muted-foreground/70">
+                ⌘/Ctrl + Enter 直接儲存
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setOpen(false)}
+                  disabled={submitting}
+                  className="px-3 py-1.5 text-xs rounded-md bg-muted hover:bg-muted/80 disabled:opacity-50"
+                  data-testid="quick-log-cancel"
+                >
+                  取消
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={submitting}
+                  className="px-3 py-1.5 text-xs rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 inline-flex items-center gap-1.5"
+                  data-testid="quick-log-save"
+                >
+                  {submitting && <Loader2 className="h-3 w-3 animate-spin" />}
+                  儲存
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #1540

## Summary

從 #1538 工時模組可用性審計的 backlog 第 2 項。

新增 `QuickLogButton` 元件 — 掛在 /timesheet 頂部 timer 同一行的主色 CTA + modal，跨所有 view 模式可用，解決 calendar / list / mobile 用戶補登工時必須先切回 grid view 的動線問題。

## 設計重點

- **主色 CTA「+ 快速記時數」**：永遠可達，不論在哪個 view 模式
- **Modal 設計**：
  - 時數欄 autoFocus（最常改的）
  - 日期預設今天
  - 任務預設自由工時，可選現有任務清單
  - 類別記住上次選擇（localStorage `titan:quickLog:lastCategory`）
  - 備註選填，最多 200 字
- **鍵盤**：Esc 關閉、Cmd/Ctrl+Enter 直接儲存
- **行動裝置**：bottom sheet 樣式（`rounded-t-xl` + `items-end`）
- **前端驗證**：`0 < hours ≤ 24`，與 `validateDailyLimit` 一致
- **複用既有 hook**：透過 `ts.saveEntry()` 走 optimistic update + stats 自動刷新

## 影響範圍

| 檔案 | 變更 |
|------|------|
| `app/components/timesheet/quick-log-button.tsx` | 新檔（306 行） |
| `app/components/timesheet/index.ts` | 加 1 個 export |
| `app/(app)/timesheet/page.tsx` | timer 區塊改 flex 容器，加 QuickLogButton |
| `__tests__/components/timesheet-quick-log-button.test.tsx` | 新檔（16 tests） |

## Test plan

- [x] 16 個新單元測試全綠
- [x] 既有 39 個 timesheet 測試無回歸（grid + page）
- [x] typecheck 沉默通過
- [ ] 部署後手動驗證：
  - [ ] /timesheet 在 grid / list / calendar 模式都看到 sticky CTA
  - [ ] 點擊開啟 modal，autoFocus 時數欄
  - [ ] 改類別後關閉再開，類別保持為上次選擇
  - [ ] 儲存後 grid 立即出現新 entry
  - [ ] 行動裝置上 modal 從底部彈出

🤖 Generated with [Claude Code](https://claude.com/claude-code)