### PR TITLE
feat(T1539-3): pivot tabs 從 timesheet 移到 /reports

### DIFF
--- a/__tests__/components/reports-pivot.test.tsx
+++ b/__tests__/components/reports-pivot.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Tests: WeeklyPivotReport + MonthlyPivotReport — Issue #1539-3
+ *
+ * Covers:
+ * - Pivot reports load data from view=pivot endpoint
+ * - Render pivot table headers / totals / loading / error states
+ */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { WeeklyPivotReport } from "@/app/components/reports/report-weekly-pivot";
+import { MonthlyPivotReport } from "@/app/components/reports/report-monthly-pivot";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => "/reports",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("@/lib/api-client", () => ({
+  extractData: (body: { data?: unknown }) => body?.data ?? body ?? null,
+  extractItems: (body: { data?: unknown[] }) =>
+    Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [],
+}));
+
+const PIVOT_PAYLOAD = {
+  data: {
+    period: { start: "2026-04-20", end: "2026-04-26", label: "2026-04-20 ~ 2026-04-26" },
+    rows: [
+      {
+        userId: "u1",
+        userName: "王大明",
+        cells: { PLANNED_TASK: 30, INCIDENT: 5 },
+        total: 35,
+        overtimeTotal: 2,
+      },
+      {
+        userId: "u2",
+        userName: "李小華",
+        cells: { PLANNED_TASK: 28, ADMIN: 4 },
+        total: 32,
+        overtimeTotal: 0,
+      },
+    ],
+    categories: ["PLANNED_TASK", "INCIDENT", "ADMIN"],
+    categoryTotals: { PLANNED_TASK: 58, INCIDENT: 5, ADMIN: 4 },
+    grandTotal: 67,
+    grandOvertimeTotal: 2,
+  },
+};
+
+describe("Pivot reports — Issue #1539-3", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockImplementation(async () => ({
+      ok: true,
+      json: () => Promise.resolve(PIVOT_PAYLOAD),
+    }));
+  });
+
+  it("WeeklyPivotReport calls weekly endpoint with view=pivot", async () => {
+    render(<WeeklyPivotReport from="2026-04-20" />);
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/reports/weekly");
+    expect(url).toContain("view=pivot");
+    expect(url).toContain("weekStart=2026-04-20");
+  });
+
+  it("WeeklyPivotReport renders pivot data", async () => {
+    render(<WeeklyPivotReport from="2026-04-20" />);
+    await waitFor(() => {
+      expect(screen.getByText("週報摘要")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("王大明")).toBeInTheDocument();
+      expect(screen.getByText("李小華")).toBeInTheDocument();
+    });
+  });
+
+  it("MonthlyPivotReport derives YYYY-MM from from-date", async () => {
+    render(<MonthlyPivotReport from="2026-04-20" />);
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/reports/monthly");
+    expect(url).toContain("view=pivot");
+    expect(url).toContain("month=2026-04");
+  });
+
+  it("MonthlyPivotReport renders title with month", async () => {
+    render(<MonthlyPivotReport from="2026-04-20" />);
+    await waitFor(() => {
+      expect(screen.getByText(/月報摘要 2026-04/)).toBeInTheDocument();
+    });
+  });
+
+  it("WeeklyPivotReport handles fetch error gracefully", async () => {
+    mockFetch.mockImplementation(async () => ({
+      ok: false,
+      json: () => Promise.resolve({ error: "Server error" }),
+    }));
+    render(<WeeklyPivotReport from="2026-04-20" />);
+    await waitFor(() => {
+      // ReportError displays a message; check for retry button presence
+      expect(screen.getByRole("button", { name: /重試|retry/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/pages/reports.test.tsx
+++ b/__tests__/pages/reports.test.tsx
@@ -12,6 +12,13 @@ jest.mock("next-auth/react", () => ({
   })),
 }));
 
+// Issue #1539-3: reports/page.tsx now uses useSearchParams for ?id=<report> deep-link
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => "/reports",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -56,9 +56,10 @@ function ReportsV2Inner() {
   const [reportYear, setReportYear] = useState(new Date().getFullYear());
 
   // Issue #1539-3: deep-link via ?id=<report> so callers (e.g. timesheet page)
-  // can jump straight to a specific report.
+  // can jump straight to a specific report. Null-safe in case caller didn't
+  // wrap in Suspense.
   useEffect(() => {
-    const requested = searchParams.get("id");
+    const requested = searchParams?.get("id");
     if (requested && REPORT_IDS.has(requested)) {
       setActiveReport(requested as ReportId);
     }

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -8,9 +8,10 @@
  * report-table.tsx (HR / audit / project table reports).
  */
 
-import { useState } from "react";
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { Calendar } from "lucide-react";
-import { ReportSidebarNav, type ReportId, ORIGINAL_REPORT_IDS } from "@/app/components/reports/report-filters";
+import { ReportSidebarNav, type ReportId, ORIGINAL_REPORT_IDS, REPORTS } from "@/app/components/reports/report-filters";
 import {
   UtilizationReport,
   VelocityReport,
@@ -46,10 +47,22 @@ function defaultDateRange(): { from: string; to: string } {
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
-export default function ReportsV2Page() {
+const REPORT_IDS = new Set<string>(REPORTS.map((r) => r.id));
+
+function ReportsV2Inner() {
+  const searchParams = useSearchParams();
   const [activeReport, setActiveReport] = useState<ReportId>("utilization");
   const [dateRange, setDateRange] = useState(defaultDateRange);
   const [reportYear, setReportYear] = useState(new Date().getFullYear());
+
+  // Issue #1539-3: deep-link via ?id=<report> so callers (e.g. timesheet page)
+  // can jump straight to a specific report.
+  useEffect(() => {
+    const requested = searchParams.get("id");
+    if (requested && REPORT_IDS.has(requested)) {
+      setActiveReport(requested as ReportId);
+    }
+  }, [searchParams]);
 
   return (
     <div className="flex flex-col lg:flex-row h-full gap-4">
@@ -133,5 +146,13 @@ export default function ReportsV2Page() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function ReportsV2Page() {
+  return (
+    <Suspense fallback={<div className="text-sm text-muted-foreground p-4">載入中...</div>}>
+      <ReportsV2Inner />
+    </Suspense>
   );
 }

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2, CalendarDays, TableProperties, Clock } from "lucide-react";
+import { Loader2, CalendarDays, Clock } from "lucide-react";
 import Link from "next/link";
 import {
   useTimesheet,
@@ -20,10 +20,7 @@ import {
 import { TimesheetListView } from "@/app/components/timesheet-list-view";
 import { TimeSummary } from "@/app/components/time-summary";
 import { PageLoading, PageError, PageEmpty } from "@/app/components/page-states";
-import { TimesheetPivotTable, type TimesheetPivotData } from "@/app/components/timesheet-pivot-table";
 import { cn } from "@/lib/utils";
-
-type SummaryTab = "timesheet" | "weekly-pivot" | "monthly-pivot";
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
@@ -35,10 +32,6 @@ export default function TimesheetPage() {
   const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [calendarDate, setCalendarDate] = useState<Date>(() => new Date());
-  const [summaryTab, setSummaryTab] = useState<SummaryTab>("timesheet");
-  const [pivotData, setPivotData] = useState<TimesheetPivotData | null>(null);
-  const [pivotLoading, setPivotLoading] = useState(false);
-  const pivotCache = useRef<Map<string, TimesheetPivotData>>(new Map());
 
   const ts = useTimesheet(userFilter || undefined);
 
@@ -52,34 +45,6 @@ export default function TimesheetPage() {
     Promise.all(taskIds.map((id) => ts.fetchSubTasks(id))).catch(() => { toast.error("子任務載入失敗，請重新整理"); });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ts.taskRows]);
-
-  // Fetch pivot data when tab switches (Issue #832)
-  const fetchPivot = useCallback(async (tab: SummaryTab) => {
-    if (tab === "timesheet") return;
-    const cached = pivotCache.current.get(tab);
-    if (cached) { setPivotData(cached); return; }
-    setPivotLoading(true);
-    try {
-      const endpoint = tab === "weekly-pivot"
-        ? "/api/reports/weekly?view=pivot"
-        : `/api/reports/monthly?view=pivot&month=${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, "0")}`;
-      const res = await fetch(endpoint);
-      if (res.ok) {
-        const body = await res.json();
-        const data = body?.data ?? null;
-        setPivotData(data);
-        if (data) pivotCache.current.set(tab, data);
-      } else {
-        toast.error("報表載入失敗，請稍後再試");
-      }
-    } finally {
-      setPivotLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchPivot(summaryTab);
-  }, [summaryTab, fetchPivot]);
 
   // Load users for manager filter
   useEffect(() => {
@@ -144,30 +109,9 @@ export default function TimesheetPage() {
         getDateStr={ts.getDateStr}
       />
 
-      {/* Manager actions — Issue #832: added pivot tabs */}
+      {/* Manager actions — Issue #1539-3: pivot tabs moved to /reports */}
       {isManager && (
         <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
-          <div className="flex items-center bg-muted/50 rounded-lg p-0.5 gap-0.5">
-            {([
-              { key: "timesheet" as SummaryTab, label: "工時填報" },
-              { key: "weekly-pivot" as SummaryTab, label: "週報摘要" },
-              { key: "monthly-pivot" as SummaryTab, label: "月報摘要" },
-            ]).map(({ key, label }) => (
-              <button
-                key={key}
-                onClick={() => setSummaryTab(key)}
-                className={cn(
-                  "flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 text-xs sm:text-sm rounded-md transition-colors whitespace-nowrap",
-                  summaryTab === key
-                    ? "bg-background text-foreground font-medium shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                {key !== "timesheet" && <TableProperties className="h-3.5 w-3.5" />}
-                {label}
-              </button>
-            ))}
-          </div>
           <button
             onClick={() => router.push("/timesheet/monthly")}
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors"
@@ -175,39 +119,34 @@ export default function TimesheetPage() {
             <CalendarDays className="h-4 w-4" />
             月曆
           </button>
+          <Link
+            href="/reports?id=weekly-pivot"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
+          >
+            週報摘要 →
+          </Link>
+          <Link
+            href="/reports?id=monthly-pivot"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-muted transition-colors text-muted-foreground"
+          >
+            月報摘要 →
+          </Link>
           <select
-          aria-label="篩選使用者"
-          value={userFilter}
-          onChange={(e) => setUserFilter(e.target.value)}
-          className="self-start bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
-        >
-          <option value="">我的工時</option>
-          {users.map((u) => (
-            <option key={u.id} value={u.id}>{u.name}</option>
-          ))}
-        </select>
-        </div>
-      )}
-
-      {/* Pivot table view (Issue #832) */}
-      {summaryTab !== "timesheet" && (
-        <div className="border border-border rounded-xl overflow-hidden bg-card">
-          <div className="px-4 py-3 border-b border-border">
-            <h2 className="text-sm font-medium text-foreground">
-              {summaryTab === "weekly-pivot" ? "週報" : "月報"}摘要 — 人員 × 類別 Pivot Table
-            </h2>
-            {pivotData && (
-              <p className="text-xs text-muted-foreground mt-0.5">
-                期間：{pivotData.period.label}
-              </p>
-            )}
-          </div>
-          <TimesheetPivotTable data={pivotData ?? { period: { start: "", end: "", label: "" }, rows: [], categories: [], categoryTotals: {}, grandTotal: 0, grandOvertimeTotal: 0 }} loading={pivotLoading} />
+            aria-label="篩選使用者"
+            value={userFilter}
+            onChange={(e) => setUserFilter(e.target.value)}
+            className="self-start bg-background border border-border rounded-md px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
+          >
+            <option value="">我的工時</option>
+            {users.map((u) => (
+              <option key={u.id} value={u.id}>{u.name}</option>
+            ))}
+          </select>
         </div>
       )}
 
       {/* Content area */}
-      <div className={cn("flex flex-col gap-4", summaryTab !== "timesheet" && "hidden")}>
+      <div className="flex flex-col gap-4">
         {/* Stats summary */}
         <div className="flex-shrink-0">
           {ts.statsLoading ? (

--- a/app/components/reports-extended.tsx
+++ b/app/components/reports-extended.tsx
@@ -18,6 +18,8 @@ import { TimeDistributionReport } from "./reports/report-time-distribution";
 import { TimesheetComplianceReport } from "./reports/report-timesheet-compliance";
 import { TrendsReport } from "./reports/report-trends";
 import { WeeklyReport } from "./reports/report-weekly";
+import { WeeklyPivotReport } from "./reports/report-weekly-pivot";
+import { MonthlyPivotReport } from "./reports/report-monthly-pivot";
 import { WorkloadReport } from "./reports/report-workload";
 import { V2ChangeSummaryReport } from "./reports/report-v2-change-summary";
 import { V2EarnedValueReport } from "./reports/report-v2-earned-value";
@@ -59,6 +61,10 @@ export function ReportsExtended({ activeReport, from, to, year }: ReportsExtende
       return <WeeklyReport from={from} />;
     case "monthly":
       return <MonthlyReport from={from} />;
+    case "weekly-pivot":
+      return <WeeklyPivotReport from={from} />;
+    case "monthly-pivot":
+      return <MonthlyPivotReport from={from} />;
 
     // 分析
     case "delay-change":

--- a/app/components/reports/report-filters.tsx
+++ b/app/components/reports/report-filters.tsx
@@ -24,7 +24,7 @@ export type ReportId =
   | "utilization" | "velocity" | "kpi-trend" | "unplanned"
   | "time-summary" | "overtime" | "audit-summary" | "login-activity" | "project-status" | "project-budget"
   | "completion-rate"
-  | "department-timesheet" | "time-distribution" | "timesheet-compliance" | "weekly" | "monthly"
+  | "department-timesheet" | "time-distribution" | "timesheet-compliance" | "weekly" | "monthly" | "weekly-pivot" | "monthly-pivot"
   | "delay-change" | "workload" | "custom" | "trends" | "kpi"
   | "v2-change-summary" | "v2-earned-value" | "v2-incident-sla" | "v2-kpi-composite"
   | "v2-kpi-correlation" | "v2-milestone-achievement" | "v2-overdue-analysis"
@@ -100,6 +100,8 @@ export const REPORT_CATEGORIES: ReportCategory[] = [
       { id: "timesheet-compliance", label: "工時合規", icon: Shield, description: "填報合規率統計" },
       { id: "weekly", label: "週報", icon: Calendar, description: "週度工作摘要" },
       { id: "monthly", label: "月報", icon: Calendar, description: "月度工作摘要" },
+      { id: "weekly-pivot", label: "週報摘要 (Pivot)", icon: BarChart3, description: "人員 × 類別週度 Pivot" },
+      { id: "monthly-pivot", label: "月報摘要 (Pivot)", icon: BarChart3, description: "人員 × 類別月度 Pivot" },
     ],
   },
   {

--- a/app/components/reports/report-monthly-pivot.tsx
+++ b/app/components/reports/report-monthly-pivot.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * MonthlyPivotReport — Issue #1539-3 (from #1538 audit)
+ *
+ * Person × Category pivot table view of the monthly timesheet summary.
+ * Replaces the "月報摘要" tab that previously lived inside /timesheet.
+ */
+
+import { useReportData, ReportLoading, ReportError, ReportHeader } from "./report-shared";
+import { TimesheetPivotTable, type TimesheetPivotData } from "../timesheet-pivot-table";
+
+export function MonthlyPivotReport({ from }: { from: string }) {
+  // Derive YYYY-MM from the from date
+  const month = from.substring(0, 7);
+  const url = `/api/reports/monthly?view=pivot&month=${encodeURIComponent(month)}`;
+  const { data, loading, error, reload } = useReportData<TimesheetPivotData>(url);
+
+  if (loading) return <ReportLoading message="載入月報摘要..." />;
+  if (error) return <ReportError message={error} onRetry={reload} />;
+
+  return (
+    <div>
+      <ReportHeader
+        title={`月報摘要 ${month}`}
+        description={data?.period?.label ? `期間：${data.period.label}` : "人員 × 類別 Pivot"}
+      />
+      <TimesheetPivotTable
+        data={data ?? { period: { start: "", end: "", label: "" }, rows: [], categories: [], categoryTotals: {}, grandTotal: 0, grandOvertimeTotal: 0 }}
+      />
+    </div>
+  );
+}

--- a/app/components/reports/report-weekly-pivot.tsx
+++ b/app/components/reports/report-weekly-pivot.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * WeeklyPivotReport — Issue #1539-3 (from #1538 audit)
+ *
+ * Person × Category pivot table view of the weekly timesheet summary.
+ * Replaces the "週報摘要" tab that previously lived inside /timesheet
+ * (which was visible only to managers but cluttered the engineer-facing
+ * timesheet page). Now lives where reporting belongs.
+ */
+
+import { useReportData, ReportLoading, ReportError, ReportHeader } from "./report-shared";
+import { TimesheetPivotTable, type TimesheetPivotData } from "../timesheet-pivot-table";
+
+export function WeeklyPivotReport({ from }: { from: string }) {
+  const url = `/api/reports/weekly?view=pivot&weekStart=${encodeURIComponent(from)}`;
+  const { data, loading, error, reload } = useReportData<TimesheetPivotData>(url);
+
+  if (loading) return <ReportLoading message="載入週報摘要..." />;
+  if (error) return <ReportError message={error} onRetry={reload} />;
+
+  return (
+    <div>
+      <ReportHeader
+        title="週報摘要"
+        description={data?.period?.label ? `期間：${data.period.label}` : "人員 × 類別 Pivot"}
+      />
+      <TimesheetPivotTable
+        data={data ?? { period: { start: "", end: "", label: "" }, rows: [], categories: [], categoryTotals: {}, grandTotal: 0, grandOvertimeTotal: 0 }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1542

## Summary

從 #1538 工時模組可用性審計的 backlog 第 3 項。

把 /timesheet 上的「週報摘要」「月報摘要」 pivot tabs（manager-only）移到 `/reports` 頁面，理由：

- **Reports 屬於 reports 頁面**：person × category pivot 是 reporting 性質
- **Engineer 流程更聚焦**：/timesheet 不再混雜 manager-only tab 切換邏輯
- **timesheet/page.tsx 瘦身 ~50 行**：移除 `pivotData` / `pivotLoading` / `pivotCache` state、`fetchPivot` callback、`useEffect`、整個 hidden display 區塊

## 變更

1. **新檔** `app/components/reports/report-weekly-pivot.tsx` + `report-monthly-pivot.tsx`：呼叫 `?view=pivot` 端點，渲染共用 `TimesheetPivotTable`
2. **報表 nav** 加兩個 item「週報摘要 (Pivot)」「月報摘要 (Pivot)」
3. **deep-link 支援**：`/reports?id=weekly-pivot` 直接開該報表（用 `useSearchParams` 包 Suspense）
4. **/timesheet manager 列**：原本三 tab 換成「月曆」+「週報摘要 →」+「月報摘要 →」三個 link，更直觀

## 測試

- 5 個新 pivot report 測試（`__tests__/components/reports-pivot.test.tsx`）
- 既有 176 個 timesheet + reports 測試全綠
- typecheck 通過

## 驗收（部署後）

- [ ] /reports 左 nav 看到「週報摘要 (Pivot)」「月報摘要 (Pivot)」
- [ ] 點擊各自正確顯示 pivot 表
- [ ] /timesheet（manager）點「週報摘要 →」直達 /reports?id=weekly-pivot
- [ ] /timesheet engineer 視角不顯示 manager 列
- [ ] /timesheet 主畫面照常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)