### PR TITLE
feat(T1539-4): timesheet 加「你最常做的事」智慧建議列

### DIFF
--- a/__tests__/api/time-entries-top-tasks.test.ts
+++ b/__tests__/api/time-entries-top-tasks.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * API: GET /api/time-entries/top-tasks — Issue #1539-4.
+ *
+ * Covers:
+ *  - Aggregates user's recent entries by taskId and returns top N
+ *  - Defaults: 14 days lookback, top 5
+ *  - Caps query params: max 60 days, max 10 limit
+ *  - Decimal-as-string hours coerced to Number (T1538)
+ *  - Skips entries without taskId or task relation
+ *  - Caller-scoped (no userId override)
+ */
+import { createMockRequest } from "../utils/test-utils";
+
+jest.mock("next/headers", () => ({
+  headers: jest.fn(() => new Map()),
+  cookies: jest.fn(() => ({ get: jest.fn() })),
+}));
+
+const mockRequireAuth = jest.fn();
+jest.mock("@/lib/rbac", () => ({
+  requireAuth: () => mockRequireAuth(),
+  requireRole: jest.fn(),
+  requireManagerOrAbove: jest.fn(),
+  enforcePasswordChange: jest.fn(),
+}));
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("@/lib/auth-middleware", () => ({
+  withAuth: (fn: unknown) => fn,
+}));
+
+jest.mock("@/lib/prisma", () => {
+  const mock = {
+    timeEntry: { findMany: jest.fn() },
+  };
+  return { prisma: mock };
+});
+
+import { GET } from "@/app/api/time-entries/top-tasks/route";
+import { prisma } from "@/lib/prisma";
+
+const prismaMock = prisma as unknown as {
+  timeEntry: { findMany: jest.Mock };
+};
+
+const USER_ID = "cku111111111111111111111";
+
+function callGet(query = "") {
+  const req = createMockRequest(`/api/time-entries/top-tasks${query}`, { method: "GET" });
+  return GET(req, { params: Promise.resolve({}) });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRequireAuth.mockResolvedValue({ user: { id: USER_ID } });
+});
+
+describe("GET /api/time-entries/top-tasks", () => {
+  it("returns empty list when user has no entries", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([]);
+    const res = await callGet();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.items).toEqual([]);
+    expect(body.data.windowDays).toBe(14);
+  });
+
+  it("aggregates entries by taskId and sorts by totalHours desc", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([
+      { taskId: "t1", hours: 3, date: new Date("2026-04-21"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+      { taskId: "t1", hours: 4, date: new Date("2026-04-22"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+      { taskId: "t2", hours: 2, date: new Date("2026-04-22"), task: { id: "t2", title: "Task B", category: "INCIDENT" } },
+      { taskId: "t3", hours: 1, date: new Date("2026-04-23"), task: { id: "t3", title: "Task C", category: "ADMIN" } },
+    ]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.data.items).toHaveLength(3);
+    expect(body.data.items[0]).toMatchObject({
+      taskId: "t1",
+      taskTitle: "Task A",
+      totalHours: 7,
+      entryCount: 2,
+      avgHoursPerEntry: 3.5,
+    });
+    expect(body.data.items[1].taskId).toBe("t2");
+    expect(body.data.items[2].taskId).toBe("t3");
+  });
+
+  it("respects limit query param (clamped to max 10)", async () => {
+    const entries = Array.from({ length: 15 }, (_, i) => ({
+      taskId: `t${i}`,
+      hours: 15 - i, // descending hours
+      date: new Date("2026-04-22"),
+      task: { id: `t${i}`, title: `Task ${i}`, category: "PLANNED" },
+    }));
+    prismaMock.timeEntry.findMany.mockResolvedValue(entries);
+
+    const res1 = await callGet("?limit=3");
+    const body1 = await res1.json();
+    expect(body1.data.items).toHaveLength(3);
+
+    const res2 = await callGet("?limit=999");
+    const body2 = await res2.json();
+    expect(body2.data.items).toHaveLength(10); // capped at MAX_LIMIT
+  });
+
+  it("respects days query param (clamped to max 60)", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([]);
+    await callGet("?days=30");
+    const where1 = prismaMock.timeEntry.findMany.mock.calls[0][0].where;
+    expect(where1.userId).toBe(USER_ID);
+    expect(where1.isDeleted).toBe(false);
+    expect((where1.date as { gte: Date }).gte).toBeInstanceOf(Date);
+
+    await callGet("?days=999");
+    // Just confirm no crash; clamp behavior tested via output below.
+    const body = await (await callGet("?days=999")).json();
+    expect(body.data.windowDays).toBe(60);
+  });
+
+  it("falls back to defaults when query params invalid", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([]);
+    const res = await callGet("?days=abc&limit=xyz");
+    const body = await res.json();
+    expect(body.data.windowDays).toBe(14);
+  });
+
+  it("coerces Decimal-as-string hours via Number()", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([
+      { taskId: "t1", hours: "2.5", date: new Date("2026-04-21"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+      { taskId: "t1", hours: "3.5", date: new Date("2026-04-22"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+    ]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.data.items[0].totalHours).toBe(6); // 2.5 + 3.5 = 6
+    expect(body.data.items[0].avgHoursPerEntry).toBe(3);
+  });
+
+  it("skips entries with null taskId or missing task relation", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([
+      { taskId: null, hours: 5, date: new Date("2026-04-22"), task: null },
+      { taskId: "t1", hours: 2, date: new Date("2026-04-22"), task: null }, // missing relation
+      { taskId: "t1", hours: 3, date: new Date("2026-04-23"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+    ]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0].totalHours).toBe(3);
+  });
+
+  it("uses lastEntryDate as YYYY-MM-DD of most-recent entry", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([
+      { taskId: "t1", hours: 2, date: new Date("2026-04-21T10:00:00Z"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+      { taskId: "t1", hours: 3, date: new Date("2026-04-23T15:00:00Z"), task: { id: "t1", title: "Task A", category: "PLANNED" } },
+    ]);
+    const res = await callGet();
+    const body = await res.json();
+    expect(body.data.items[0].lastEntryDate).toBe("2026-04-23");
+  });
+
+  it("scopes query to caller userId only", async () => {
+    prismaMock.timeEntry.findMany.mockResolvedValue([]);
+    await callGet();
+    const where = prismaMock.timeEntry.findMany.mock.calls[0][0].where;
+    expect(where.userId).toBe(USER_ID);
+    expect(where.isDeleted).toBe(false);
+    expect(where.taskId).toEqual({ not: null });
+  });
+});

--- a/__tests__/components/timesheet-top-tasks-suggestion.test.tsx
+++ b/__tests__/components/timesheet-top-tasks-suggestion.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Component tests: TopTasksSuggestion (Issue #1539-4)
+ *
+ * Covers:
+ * - Hidden when fetch fails or returns empty
+ * - Renders collapsed by default
+ * - Expand/collapse persists to localStorage
+ * - +1h click calls onSave with today's date and 1 hour
+ * - Maps task category to TimeCategory enum
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TopTasksSuggestion } from "@/app/components/timesheet/top-tasks-suggestion";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("lucide-react", () => ({
+  Lightbulb: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-bulb" {...props} />,
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+  Loader2: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-loader" {...props} />,
+  ChevronDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-down" {...props} />,
+  ChevronRight: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-right" {...props} />,
+}));
+
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/api-client", () => ({
+  extractData: (body: { data?: unknown }) => body?.data ?? body ?? null,
+}));
+
+const TASKS_PAYLOAD = {
+  data: {
+    items: [
+      { taskId: "t1", taskTitle: "Refactor API layer", category: "PLANNED", totalHours: 12, entryCount: 4, avgHoursPerEntry: 3, lastEntryDate: "2026-04-22" },
+      { taskId: "t2", taskTitle: "Production bug fix", category: "INCIDENT", totalHours: 5, entryCount: 2, avgHoursPerEntry: 2.5, lastEntryDate: "2026-04-21" },
+    ],
+    windowDays: 14,
+  },
+};
+
+function renderComponent({ saveError = false }: { saveError?: boolean } = {}) {
+  const onLogged = jest.fn();
+  const onSave = jest.fn().mockImplementation(async () => {
+    if (saveError) throw new Error("save failed");
+  });
+  render(<TopTasksSuggestion onLogged={onLogged} onSave={onSave} />);
+  return { onLogged, onSave };
+}
+
+describe("TopTasksSuggestion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(TASKS_PAYLOAD),
+    });
+  });
+
+  it("renders nothing while loading", () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    renderComponent();
+    expect(screen.queryByTestId("top-tasks-suggestion")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when API returns empty", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { items: [], windowDays: 14 } }),
+    });
+    renderComponent();
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("top-tasks-suggestion")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when fetch fails (silent fallback)", async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({ error: "boom" }) });
+    renderComponent();
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("top-tasks-suggestion")).not.toBeInTheDocument();
+  });
+
+  it("renders header with task count when data loaded", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId("top-tasks-suggestion")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/2 個任務/)).toBeInTheDocument();
+  });
+
+  it("starts collapsed by default", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId("top-tasks-suggestion")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("top-tasks-list")).not.toBeInTheDocument();
+  });
+
+  it("expands when toggle clicked, persists to localStorage", async () => {
+    renderComponent();
+    await waitFor(() => screen.getByTestId("top-tasks-toggle"));
+    fireEvent.click(screen.getByTestId("top-tasks-toggle"));
+    expect(screen.getByTestId("top-tasks-list")).toBeInTheDocument();
+    expect(window.localStorage.getItem("titan:topTasks:expanded")).toBe("1");
+  });
+
+  it("restores expanded state from localStorage", async () => {
+    window.localStorage.setItem("titan:topTasks:expanded", "1");
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId("top-tasks-list")).toBeInTheDocument();
+    });
+  });
+
+  it("renders task chips with title and stats when expanded", async () => {
+    window.localStorage.setItem("titan:topTasks:expanded", "1");
+    renderComponent();
+    await waitFor(() => screen.getByText("Refactor API layer"));
+    expect(screen.getByText("Production bug fix")).toBeInTheDocument();
+    expect(screen.getByText(/14 天累計 12.0h/)).toBeInTheDocument();
+  });
+
+  it("calls onSave with today's date when +1h clicked", async () => {
+    window.localStorage.setItem("titan:topTasks:expanded", "1");
+    const { onSave, onLogged } = renderComponent();
+    await waitFor(() => screen.getByTestId("top-tasks-log-t1"));
+
+    fireEvent.click(screen.getByTestId("top-tasks-log-t1"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        "t1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/), // today
+        1,
+        "PLANNED_TASK", // mapped from "PLANNED"
+      );
+    });
+    await waitFor(() => {
+      expect(onLogged).toHaveBeenCalled();
+    });
+  });
+
+  it("maps INCIDENT category correctly", async () => {
+    window.localStorage.setItem("titan:topTasks:expanded", "1");
+    const { onSave } = renderComponent();
+    await waitFor(() => screen.getByTestId("top-tasks-log-t2"));
+
+    fireEvent.click(screen.getByTestId("top-tasks-log-t2"));
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        "t2",
+        expect.any(String),
+        1,
+        "INCIDENT",
+      );
+    });
+  });
+
+  it("calls fetch with default params (days=14, limit=5)", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("days=14");
+    expect(url).toContain("limit=5");
+  });
+
+  it("does not call onLogged when save fails", async () => {
+    window.localStorage.setItem("titan:topTasks:expanded", "1");
+    const { onSave, onLogged } = renderComponent({ saveError: true });
+    await waitFor(() => screen.getByTestId("top-tasks-log-t1"));
+
+    fireEvent.click(screen.getByTestId("top-tasks-log-t1"));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    expect(onLogged).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -12,6 +12,7 @@ import {
   TimesheetToolbar,
   TimesheetTimer,
   QuickLogButton,
+  TopTasksSuggestion,
   CalendarDayView,
   CalendarWeekView,
   CalendarMonthView,
@@ -91,6 +92,14 @@ export default function TimesheetPage() {
           }
         />
       </div>
+
+      {/* Top tasks suggestion — Issue #1539-4 */}
+      <TopTasksSuggestion
+        onLogged={ts.refresh}
+        onSave={(taskId, date, hours, category) =>
+          ts.saveEntry(taskId, date, hours, category, "", "NONE")
+        }
+      />
 
       {/* Toolbar */}
       <TimesheetToolbar

--- a/app/api/time-entries/top-tasks/route.ts
+++ b/app/api/time-entries/top-tasks/route.ts
@@ -1,0 +1,126 @@
+/**
+ * GET /api/time-entries/top-tasks — Issue #1539-4 (from #1538 audit)
+ *
+ * Returns the user's most-frequent tasks over the recent window so the
+ * timesheet UI can suggest "你最常做的事 — 一鍵套用今天 1h" entries.
+ *
+ * Why this exists separately from /api/time-entries/suggestions:
+ *   - suggestions returns today's status-change-driven hints (real-time)
+ *   - top-tasks returns historical-frequency-driven hints (Monday morning recall)
+ *
+ * Query params:
+ *   days  — lookback window in days (default 14, max 60)
+ *   limit — number of tasks (default 5, max 10)
+ */
+
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { withAuth } from "@/lib/auth-middleware";
+import { requireAuth } from "@/lib/rbac";
+import { success } from "@/lib/api-response";
+
+export interface TopTask {
+  taskId: string;
+  taskTitle: string;
+  category: string;
+  totalHours: number;
+  entryCount: number;
+  avgHoursPerEntry: number;
+  lastEntryDate: string;
+}
+
+const DEFAULT_DAYS = 14;
+const MAX_DAYS = 60;
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 10;
+
+export const GET = withAuth(async (req: NextRequest) => {
+  const session = await requireAuth();
+  const userId = session.user.id;
+
+  const { searchParams } = new URL(req.url);
+  const daysParam = parseInt(searchParams.get("days") ?? "", 10);
+  const limitParam = parseInt(searchParams.get("limit") ?? "", 10);
+
+  const days = Number.isFinite(daysParam) && daysParam > 0
+    ? Math.min(daysParam, MAX_DAYS)
+    : DEFAULT_DAYS;
+  const limit = Number.isFinite(limitParam) && limitParam > 0
+    ? Math.min(limitParam, MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+  since.setHours(0, 0, 0, 0);
+
+  // Pull user's recent entries; cap at 5000 for safety (1500 entries * 100 days = unlikely).
+  const entries = await prisma.timeEntry.findMany({
+    where: {
+      userId,
+      isDeleted: false,
+      taskId: { not: null },
+      date: { gte: since },
+    },
+    select: {
+      taskId: true,
+      hours: true,
+      date: true,
+      task: { select: { id: true, title: true, category: true } },
+    },
+    orderBy: { date: "desc" },
+    take: 5000,
+  });
+
+  // Aggregate by taskId
+  const acc = new Map<string, {
+    taskId: string;
+    taskTitle: string;
+    category: string;
+    totalHours: number;
+    entryCount: number;
+    lastEntryDate: Date;
+  }>();
+
+  for (const e of entries) {
+    if (!e.taskId || !e.task) continue;
+    const existing = acc.get(e.taskId);
+    // Issue #1538: hours can be Prisma Decimal as string over the wire — coerce.
+    const hrs = Number(e.hours ?? 0);
+    if (existing) {
+      existing.totalHours += hrs;
+      existing.entryCount += 1;
+      if (e.date > existing.lastEntryDate) existing.lastEntryDate = e.date;
+    } else {
+      acc.set(e.taskId, {
+        taskId: e.taskId,
+        taskTitle: e.task.title,
+        category: e.task.category,
+        totalHours: hrs,
+        entryCount: 1,
+        lastEntryDate: e.date,
+      });
+    }
+  }
+
+  // Sort by totalHours desc, take top N
+  const sorted = Array.from(acc.values())
+    .sort((a, b) => b.totalHours - a.totalHours)
+    .slice(0, limit);
+
+  const result: TopTask[] = sorted.map((t) => ({
+    taskId: t.taskId,
+    taskTitle: t.taskTitle,
+    category: t.category,
+    totalHours: Math.round(t.totalHours * 10) / 10,
+    entryCount: t.entryCount,
+    avgHoursPerEntry: t.entryCount > 0
+      ? Math.round((t.totalHours / t.entryCount) * 10) / 10
+      : 0,
+    lastEntryDate: t.lastEntryDate.toISOString().split("T")[0],
+  }));
+
+  return success({
+    items: result,
+    windowDays: days,
+  });
+});

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -6,6 +6,7 @@ export { TimesheetCell } from "./timesheet-cell";
 export { TimesheetToolbar } from "./timesheet-toolbar";
 export { TimesheetTimer } from "./timesheet-timer";
 export { QuickLogButton } from "./quick-log-button";
+export { TopTasksSuggestion } from "./top-tasks-suggestion";
 export { TemplateSelector } from "./template-selector";
 export { CalendarDayView } from "./calendar-day-view";
 export { CalendarWeekView } from "./calendar-week/index";

--- a/app/components/timesheet/top-tasks-suggestion.tsx
+++ b/app/components/timesheet/top-tasks-suggestion.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * TopTasksSuggestion — Issue #1539-4 (from #1538 audit)
+ *
+ * Pulls the user's top 5 most-frequent tasks over the last 14 days and
+ * renders them as one-click chips. Solves the Monday-morning recall problem:
+ * "我上週做了什麼？" Now: a glance at this row tells you and lets you log
+ * 1h with a single click.
+ *
+ * Design:
+ * - Collapsible: shows compact "💡 你最常做的事" header by default
+ * - Expanded: 5 chips with task title + last-week hours + quick "+1h 今天"
+ * - Empty state: hidden entirely (no clutter when user is brand new)
+ * - Failure: silent (toast only), don't block the page
+ */
+import { useState, useEffect, useCallback } from "react";
+import { Lightbulb, Plus, Loader2, ChevronDown, ChevronRight } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import { formatLocalDate } from "@/lib/utils/date";
+import { extractData } from "@/lib/api-client";
+import { safeFixed } from "@/lib/safe-number";
+
+interface TopTask {
+  taskId: string;
+  taskTitle: string;
+  category: string;
+  totalHours: number;
+  entryCount: number;
+  avgHoursPerEntry: number;
+  lastEntryDate: string;
+}
+
+interface TopTasksResponse {
+  items: TopTask[];
+  windowDays: number;
+}
+
+interface TopTasksSuggestionProps {
+  /** Called after a quick-log succeeds so parent can refresh the timesheet */
+  onLogged: () => void;
+  /** Save handler from useTimesheet — wired through page.tsx */
+  onSave: (taskId: string, date: string, hours: number, category: string) => Promise<void>;
+}
+
+const STORAGE_KEY = "titan:topTasks:expanded";
+
+function mapCategory(taskCategory: string): string {
+  const map: Record<string, string> = {
+    PLANNED: "PLANNED_TASK",
+    ADDED: "ADDED_TASK",
+    INCIDENT: "INCIDENT",
+    SUPPORT: "SUPPORT",
+    ADMIN: "ADMIN",
+    LEARNING: "LEARNING",
+  };
+  return map[taskCategory] ?? "PLANNED_TASK";
+}
+
+export function TopTasksSuggestion({ onLogged, onSave }: TopTasksSuggestionProps) {
+  const [tasks, setTasks] = useState<TopTask[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [savingTaskId, setSavingTaskId] = useState<string | null>(null);
+
+  // Restore last expanded state
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setExpanded(window.localStorage.getItem(STORAGE_KEY) === "1");
+  }, []);
+
+  // Fetch on mount
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch("/api/time-entries/top-tasks?days=14&limit=5")
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error("fetch failed"))))
+      .then((body) => {
+        if (cancelled) return;
+        const data = extractData<TopTasksResponse>(body);
+        setTasks(data?.items ?? []);
+      })
+      .catch(() => {
+        // Silent — this is a nice-to-have, not core
+        if (!cancelled) setTasks([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  function toggleExpanded() {
+    const next = !expanded;
+    setExpanded(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+    }
+  }
+
+  const handleQuickLog = useCallback(async (task: TopTask) => {
+    setSavingTaskId(task.taskId);
+    const today = formatLocalDate(new Date());
+    try {
+      await onSave(task.taskId, today, 1, mapCategory(task.category));
+      toast.success(`已記錄 1h — ${task.taskTitle}`);
+      onLogged();
+    } catch (e) {
+      toast.error("快速記錄失敗，請稍後再試");
+      console.error("[top-tasks] quick log failed", e);
+    } finally {
+      setSavingTaskId(null);
+    }
+  }, [onSave, onLogged]);
+
+  // Hide entirely if loading first time or no tasks (avoid empty-state clutter)
+  if (loading || tasks.length === 0) return null;
+
+  return (
+    <div className="border border-border rounded-lg bg-muted/20" data-testid="top-tasks-suggestion">
+      <button
+        onClick={toggleExpanded}
+        className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+        aria-expanded={expanded}
+        data-testid="top-tasks-toggle"
+      >
+        <span className="flex items-center gap-1.5">
+          <Lightbulb className="h-3.5 w-3.5 text-amber-500" />
+          你最常做的事 (近 14 天)
+          <span className="text-[10px] text-muted-foreground/70">— {tasks.length} 個任務</span>
+        </span>
+        {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+      </button>
+
+      {expanded && (
+        <div className="px-3 pb-3 space-y-1.5" data-testid="top-tasks-list">
+          {tasks.map((task) => {
+            const saving = savingTaskId === task.taskId;
+            return (
+              <div
+                key={task.taskId}
+                className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-card border border-border/50 text-xs"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">{task.taskTitle}</div>
+                  <div className="text-[10px] text-muted-foreground/70 mt-0.5">
+                    14 天累計 {safeFixed(task.totalHours, 1)}h · {task.entryCount} 筆 · 平均 {safeFixed(task.avgHoursPerEntry, 1)}h/筆
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleQuickLog(task)}
+                  disabled={saving}
+                  className={cn(
+                    "flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded text-[11px] font-medium transition-colors disabled:opacity-50",
+                    "bg-primary/10 text-primary hover:bg-primary/20",
+                  )}
+                  data-testid={`top-tasks-log-${task.taskId}`}
+                  aria-label={`快速記 1 小時到 ${task.taskTitle}`}
+                >
+                  {saving ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <Plus className="h-3 w-3" />
+                  )}
+                  +1h 今天
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #1544

## Summary

從 #1538 工時模組可用性審計的 backlog 第 4 項。

**問題**：禮拜一進 /timesheet 想填上週工時，得爬看板/活動重建記憶。
**洞察**：團隊成員每週其實在做差不多的事 — 把「最近 14 天最常記時的 5 個任務」列出，多數人一鍵就能套用。

## 設計

### API `GET /api/time-entries/top-tasks`
- Query: `days` (預設 14, max 60), `limit` (預設 5, max 10)
- 聚合 caller 過去 N 天 entries by taskId
- 計算 totalHours / entryCount / avgHoursPerEntry / lastEntryDate
- 排除 isDeleted、null taskId、缺 task relation
- Decimal-as-string 用 `Number()` 防禦

### UI `<TopTasksSuggestion>`
- 掛在 timesheet 頂部 timer/quick-log row 之後
- 預設 collapsed: `💡 你最常做的事 (近 14 天) — N 個任務`
- 展開: 5 個 chip 顯示 task + `14 天累計 Xh · N 筆 · 平均 Yh/筆` + 「+1h 今天」按鈕
- 一鍵記錄：自動 map task category（PLANNED → PLANNED_TASK），預設 1h、今天
- 展開狀態 persist 到 localStorage `titan:topTasks:expanded`
- 失敗/empty 安靜降級不顯示（避免新人空狀態看到一片空）

## 測試

- API 9 tests（aggregate、limit、days clamp、Decimal-as-string、null/missing relation）
- UI 12 tests（loading、empty、fetch error、expand persist、+1h click、category mapping）
- 既有 175 個 timesheet 測試無回歸

## 驗收（部署後）

- [ ] 進 /timesheet 看到「💡 你最常做的事 (近 14 天)」摺疊列
- [ ] 展開顯示 5 個 chip
- [ ] 點「+1h 今天」立刻記 1h
- [ ] 記錄後 grid 自動刷新
- [ ] 展開狀態跨頁/重整保留
- [ ] 新使用者無 entries 時整個元件隱藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)