### PR TITLE
feat(T1539-5): timesheet 加「週工時達標」溫和慶祝 toast

### DIFF
--- a/__tests__/components/timesheet-week-completion-celebration.test.tsx
+++ b/__tests__/components/timesheet-week-completion-celebration.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Component tests: WeekCompletionCelebration (Issue #1539-5)
+ *
+ * Covers:
+ * - Fires toast when crossing 40h threshold for the first time this week
+ * - One-shot per week (persists to localStorage)
+ * - Doesn't fire on subsequent renders / re-mounts after threshold met
+ * - Doesn't fire if already at/above threshold on mount (no cross-over)
+ * - Per-week ledger keyed by weekStartIso (different week → fresh trigger)
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { WeekCompletionCelebration } from "@/app/components/timesheet/week-completion-celebration";
+
+const mockToastSuccess = jest.fn();
+jest.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+jest.mock("@/lib/safe-number", () => ({
+  safeFixed: (n: number, d: number) => (n ?? 0).toFixed(d),
+}));
+
+describe("WeekCompletionCelebration", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("does not fire when total stays below threshold", () => {
+    render(<WeekCompletionCelebration weeklyTotal={20} weekStartIso="2026-04-20" />);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when starting at/above threshold (no cross-over)", () => {
+    render(<WeekCompletionCelebration weeklyTotal={45} weekStartIso="2026-04-20" />);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("fires toast when crossing 40h threshold for the first time", () => {
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={38} weekStartIso="2026-04-20" />
+    );
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+
+    rerender(<WeekCompletionCelebration weeklyTotal={41} weekStartIso="2026-04-20" />);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess.mock.calls[0][0]).toContain("41.0");
+    expect(mockToastSuccess.mock.calls[0][0]).toContain("週末快樂");
+  });
+
+  it("persists fired state to localStorage", () => {
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={38} weekStartIso="2026-04-20" />
+    );
+    rerender(<WeekCompletionCelebration weeklyTotal={42} weekStartIso="2026-04-20" />);
+
+    expect(window.localStorage.getItem("titan:timesheet:celebrated:2026-04-20")).toBe("1");
+  });
+
+  it("does not fire again after celebration recorded (same week, re-mount)", () => {
+    window.localStorage.setItem("titan:timesheet:celebrated:2026-04-20", "1");
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={38} weekStartIso="2026-04-20" />
+    );
+    rerender(<WeekCompletionCelebration weeklyTotal={45} weekStartIso="2026-04-20" />);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("fires fresh toast for a new week", () => {
+    // Last week was celebrated
+    window.localStorage.setItem("titan:timesheet:celebrated:2026-04-13", "1");
+
+    // This week (different weekStart) crosses threshold
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={38} weekStartIso="2026-04-20" />
+    );
+    rerender(<WeekCompletionCelebration weeklyTotal={42} weekStartIso="2026-04-20" />);
+
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom threshold", () => {
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={28} weekStartIso="2026-04-20" threshold={30} />
+    );
+    rerender(<WeekCompletionCelebration weeklyTotal={32} weekStartIso="2026-04-20" threshold={30} />);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when total dips below then bounces back to same value", () => {
+    // Start: 41 (already above; first render just sets the ref)
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={41} weekStartIso="2026-04-20" />
+    );
+    expect(mockToastSuccess).not.toHaveBeenCalled(); // no cross-over yet
+
+    // Dip below (e.g. user deletes an entry)
+    rerender(<WeekCompletionCelebration weeklyTotal={38} weekStartIso="2026-04-20" />);
+
+    // Cross over again
+    rerender(<WeekCompletionCelebration weeklyTotal={41} weekStartIso="2026-04-20" />);
+
+    // Now expected to celebrate this time (it crossed again from below)
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("doesn't double-fire when localStorage already has the key (race-safe)", () => {
+    // Pre-existing celebration entry from a previous session
+    window.localStorage.setItem("titan:timesheet:celebrated:2026-04-20", "1");
+
+    const { rerender } = render(
+      <WeekCompletionCelebration weeklyTotal={20} weekStartIso="2026-04-20" />
+    );
+    rerender(<WeekCompletionCelebration weeklyTotal={45} weekStartIso="2026-04-20" />);
+    rerender(<WeekCompletionCelebration weeklyTotal={50} weekStartIso="2026-04-20" />);
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("returns null (renders nothing visible)", () => {
+    const { container } = render(
+      <WeekCompletionCelebration weeklyTotal={20} weekStartIso="2026-04-20" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -13,6 +13,7 @@ import {
   TimesheetTimer,
   QuickLogButton,
   TopTasksSuggestion,
+  WeekCompletionCelebration,
   CalendarDayView,
   CalendarWeekView,
   CalendarMonthView,
@@ -99,6 +100,12 @@ export default function TimesheetPage() {
         onSave={(taskId, date, hours, category) =>
           ts.saveEntry(taskId, date, hours, category, "", "NONE")
         }
+      />
+
+      {/* Week-completion celebration — Issue #1539-5 (renderless toast trigger) */}
+      <WeekCompletionCelebration
+        weeklyTotal={ts.weeklyTotal}
+        weekStartIso={ts.weekStart.toISOString().split("T")[0]}
       />
 
       {/* Toolbar */}

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -7,6 +7,7 @@ export { TimesheetToolbar } from "./timesheet-toolbar";
 export { TimesheetTimer } from "./timesheet-timer";
 export { QuickLogButton } from "./quick-log-button";
 export { TopTasksSuggestion } from "./top-tasks-suggestion";
+export { WeekCompletionCelebration } from "./week-completion-celebration";
 export { TemplateSelector } from "./template-selector";
 export { CalendarDayView } from "./calendar-day-view";
 export { CalendarWeekView } from "./calendar-week/index";

--- a/app/components/timesheet/week-completion-celebration.tsx
+++ b/app/components/timesheet/week-completion-celebration.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+/**
+ * WeekCompletionCelebration — Issue #1539-5 (from #1538 audit)
+ *
+ * Detects when the user's weekly hours cross the "complete" threshold
+ * (default 40h) for the first time this week and shows a calm,
+ * non-patronizing toast.
+ *
+ * Design philosophy (from non-toxic-team-social-layer skill):
+ * - One-shot per week, never spam
+ * - "肯定" not "誇獎" — neutral acknowledgement, not "good job!"
+ * - Toast, not modal — never interrupt work
+ * - No comparison to others (would create competition / shame)
+ * - Mid-week zero gets silence (not "still 0h?" passive aggression)
+ */
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { safeFixed } from "@/lib/safe-number";
+
+interface WeekCompletionCelebrationProps {
+  /** Current week's total logged hours */
+  weeklyTotal: number;
+  /** ISO week start date (YYYY-MM-DD) used as celebration ledger key */
+  weekStartIso: string;
+  /** Threshold for "完成" — defaults to 40h */
+  threshold?: number;
+}
+
+const STORAGE_PREFIX = "titan:timesheet:celebrated:";
+const DEFAULT_THRESHOLD = 40;
+
+function makeKey(weekStartIso: string): string {
+  return `${STORAGE_PREFIX}${weekStartIso}`;
+}
+
+export function WeekCompletionCelebration({
+  weeklyTotal,
+  weekStartIso,
+  threshold = DEFAULT_THRESHOLD,
+}: WeekCompletionCelebrationProps) {
+  // Track previous total to detect cross-over (rather than re-firing on re-renders)
+  const prevTotalRef = useRef<number>(weeklyTotal);
+  // Track whether we've already fired for the active week (avoids hot-reload double-fire)
+  const firedThisRenderRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!weekStartIso) return;
+
+    const key = makeKey(weekStartIso);
+    const alreadyCelebrated = window.localStorage.getItem(key) === "1";
+
+    if (alreadyCelebrated) {
+      prevTotalRef.current = weeklyTotal;
+      return;
+    }
+
+    const prev = prevTotalRef.current;
+    prevTotalRef.current = weeklyTotal;
+
+    // Trigger when crossing from below to at-or-above threshold
+    const justCrossed = prev < threshold && weeklyTotal >= threshold;
+
+    if (justCrossed && !firedThisRenderRef.current) {
+      firedThisRenderRef.current = true;
+      window.localStorage.setItem(key, "1");
+      toast.success(
+        `本週累計 ${safeFixed(weeklyTotal, 1)} 小時 — 週末快樂 🎉`,
+        {
+          duration: 5000,
+        },
+      );
+    }
+  }, [weeklyTotal, weekStartIso, threshold]);
+
+  // Reset firedThisRenderRef when week changes (user navigates to another week)
+  useEffect(() => {
+    firedThisRenderRef.current = false;
+  }, [weekStartIso]);
+
+  return null;
+}


### PR DESCRIPTION
Closes #1546

## Summary

從 #1538 工時模組可用性審計的 backlog 第 5 項。

**問題**：團隊成員每週填完 40h 工時是個 ritual，但目前零反饋 — 填完跟沒填一樣。**同時要避免**「太棒了你達標！」這種讓專業工程師翻白眼的 patronizing 訊息。

## 設計（遵循 non-toxic-team-social-layer skill）

`<WeekCompletionCelebration>` — renderless 元件（純 hook + toast 觸發器，return null）：

- **觸發**：weeklyTotal 從 < threshold 跨過 ≥ threshold 那一刻（cross-over，非每次 ≥ 都觸發）
- **訊息**：`本週累計 40.5 小時 — 週末快樂 🎉` — 中性肯定，非誇獎
- **頻率**：每週只觸發一次（localStorage `titan:timesheet:celebrated:<weekStart>`）
- **形式**：toast（5 秒），非 modal
- **無比較**：不跟上週/同事比較
- **無催促**：未達 40h 不顯示（mid-week 零工時不跳訊息）
- **可調**：`threshold` prop 可調，預設 40

### 為什麼是 cross-over，不是 ≥40

避免 hot-reload、re-mount、用戶切回該週時重複觸發。只有「真的跨過」才慶祝。

### 為什麼是 renderless

純行為觸發器，不佔視覺空間。元件 return null，內部 useEffect 在 weeklyTotal 變化時判斷。

## 測試

10 個 tests 覆蓋：
- cross-over 觸發
- 一開始就 ≥ threshold 不觸發
- localStorage 持久化
- 跨週重新可觸發
- custom threshold
- dip-then-bounce 重新觸發
- pre-existing celebration key race-safe

既有 185 個 timesheet 測試無回歸。

## 驗收（部署後）

- [ ] 工時從 38 → 41 看到 toast
- [ ] 該週重整頁面 → 不再次觸發
- [ ] 切下一週 → 該週首次跨過時可再觸發
- [ ] 整週未達 40h → 完全沉默
- [ ] 一開始就 ≥40 進來 → 不觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)