### PR TITLE
feat(T1539-7): 整合 DailyDigestBanner 到 timesheet（修 #963 漏整合）

### DIFF
--- a/__tests__/components/timesheet-daily-digest-banner.test.tsx
+++ b/__tests__/components/timesheet-daily-digest-banner.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Component tests: DailyDigestBanner (Issue #1539-7)
+ *
+ * Backstops the integration that #1539-7 added — element was dead code
+ * since #963 because it was never imported into a page. These tests guard
+ * the contract so future refactors don't silently break it again.
+ */
+import React from "react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { DailyDigestBanner } from "@/app/components/timesheet/daily-digest-banner";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+jest.mock("lucide-react", () => ({
+  Clock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-clock" {...props} />,
+  Check: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-check" {...props} />,
+  ChevronDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-down" {...props} />,
+  ChevronUp: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-up" {...props} />,
+  X: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-x" {...props} />,
+  Loader2: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-loader" {...props} />,
+}));
+
+const SUGGESTION_PAYLOAD = {
+  data: [
+    {
+      id: "s1",
+      taskId: "t1",
+      taskTitle: "Refactor billing API",
+      type: "time_entry",
+      suggestedHours: 2.5,
+      date: "2026-04-25",
+      startedAt: "2026-04-25T10:00:00Z",
+      completedAt: "2026-04-25T12:30:00Z",
+      category: "PLANNED_TASK",
+      alreadyLogged: false,
+    },
+    {
+      id: "s2",
+      taskId: "t2",
+      taskTitle: "Production hotfix",
+      type: "time_entry",
+      suggestedHours: 1,
+      date: "2026-04-25",
+      startedAt: null,
+      completedAt: "2026-04-25T15:00:00Z",
+      category: "INCIDENT",
+      alreadyLogged: false,
+    },
+    {
+      id: "s3",
+      taskId: "t3",
+      taskTitle: "Already-logged task",
+      type: "time_entry",
+      suggestedHours: 1,
+      date: "2026-04-25",
+      startedAt: null,
+      completedAt: null,
+      category: "ADMIN",
+      alreadyLogged: true, // should be filtered out
+    },
+  ],
+};
+
+describe("DailyDigestBanner — integration backstop", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(SUGGESTION_PAYLOAD),
+    });
+  });
+
+  it("renders nothing during initial loading", () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+    render(<DailyDigestBanner />);
+    expect(screen.queryByText(/今天有/)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when API returns empty array", async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: [] }) });
+    render(<DailyDigestBanner />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByText(/今天有/)).not.toBeInTheDocument();
+  });
+
+  it("renders banner with pending suggestion count (excludes alreadyLogged)", async () => {
+    render(<DailyDigestBanner />);
+    await waitFor(() => {
+      expect(screen.getByText(/今天有 2 筆工時建議待確認/)).toBeInTheDocument();
+    });
+  });
+
+  it("expands to show suggestion details on chevron click", async () => {
+    render(<DailyDigestBanner />);
+    await waitFor(() => screen.getByText(/今天有 2 筆/));
+    fireEvent.click(screen.getByLabelText("展開"));
+    expect(screen.getByText("Refactor billing API")).toBeInTheDocument();
+    expect(screen.getByText("Production hotfix")).toBeInTheDocument();
+  });
+
+  it("calls confirm-suggestions endpoint with selected entries", async () => {
+    render(<DailyDigestBanner />);
+    await waitFor(() => screen.getByText(/今天有 2 筆/));
+
+    const confirmBtn = screen.getByText(/確認 2 筆/);
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      const calls = mockFetch.mock.calls;
+      const confirmCall = calls.find(([url]) => (url as string).includes("/confirm-suggestions"));
+      expect(confirmCall).toBeDefined();
+      const body = JSON.parse((confirmCall![1] as RequestInit).body as string);
+      expect(body.suggestions).toHaveLength(2);
+      expect(body.suggestions[0]).toMatchObject({
+        taskId: "t1",
+        hours: 2.5,
+        category: "PLANNED_TASK",
+      });
+    });
+  });
+
+  it("hides banner after dismiss button clicked", async () => {
+    render(<DailyDigestBanner />);
+    await waitFor(() => screen.getByText(/今天有 2 筆/));
+    fireEvent.click(screen.getByLabelText("關閉"));
+    expect(screen.queryByText(/今天有 2 筆/)).not.toBeInTheDocument();
+  });
+
+  it("silently ignores fetch errors (banner is non-critical)", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"));
+    render(<DailyDigestBanner />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByText(/今天有/)).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -15,6 +15,7 @@ import {
   TopTasksSuggestion,
   WeekCompletionCelebration,
   TimesheetModesBanner,
+  DailyDigestBanner,
   CalendarDayView,
   CalendarWeekView,
   CalendarMonthView,
@@ -79,6 +80,9 @@ export default function TimesheetPage() {
 
       {/* Onboarding banner — dismissible, explains 3 entry modes (Issue #1539-6) */}
       <TimesheetModesBanner />
+
+      {/* Daily digest — Issue #1539-7: surfaces today's task-status-driven suggestions */}
+      <DailyDigestBanner />
 
       {/* Timer + Quick log — sticky actions row */}
       <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">


### PR DESCRIPTION
Closes #1550

## Summary

從 #1538 audit 完成 6 項後 second-pass 觀察發現：`DailyDigestBanner`（#963 寫好的元件）從來沒被任何頁面 import — 整整一個版本都是 dead code。

```
$ grep -rn DailyDigestBanner app/
app/components/timesheet/daily-digest-banner.tsx:4: * DailyDigestBanner — Issue #963
app/components/timesheet/daily-digest-banner.tsx:28:export function DailyDigestBanner()
app/components/timesheet/index.ts:18:export { DailyDigestBanner }
```

## 變更

1. 在 `/timesheet` 加 `<DailyDigestBanner />`，放在 ModesBanner 之後、Timer 之前
2. 補 7 個 backstop 測試覆蓋此整合，防止再次失聯

## 行為

- 拉 `/api/time-entries/suggestions` 取得今天 task status-change-driven 建議
- 顯示「今天有 N 筆工時建議待確認」
- 展開可看每筆建議的時間範圍與推算時數
- 一鍵批次 POST `/api/time-entries/confirm-suggestions`
- 失敗安靜降級（banner 不顯示，不擋頁面）

連動 #1539 系列：
- 拖 task 到 IN_PROGRESS → banner 提示「建議開始計時」
- 拖 task 到 DONE → banner 提示「建議記錄 N 小時」（從 status 變更時間自動推算）

## 測試

7 個元件 backstop 測試 + 既有 191 個 timesheet 測試無回歸（198 total）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## #1538 audit 整體完成狀態

#1539-1 ✅ today auto-focus
#1539-2 ✅ sticky 快速記時數
#1539-3 ✅ pivot tabs 移到 reports
#1539-4 ✅ 你最常做的事建議列
#1539-5 ✅ 週工時達標慶祝
#1539-6 ✅ onboarding modes banner
#1539-7 ⬅ **本 PR** — 整合 DailyDigestBanner（修 #963 漏整合）