### PR TITLE
feat(T1539-8): timesheet empty state 加 quick-log CTA + controlled mode

### DIFF
--- a/__tests__/components/timesheet-quick-log-button.test.tsx
+++ b/__tests__/components/timesheet-quick-log-button.test.tsx
@@ -216,4 +216,49 @@ describe("QuickLogButton", () => {
     expect(select.options).toHaveLength(3); // 1 free + 2 tasks
     expect(select.options[0].text).toBe("自由工時（無任務）");
   });
+
+  // Issue #1539-8: controlled mode (external trigger via prop)
+  describe("controlled mode (Issue #1539-8)", () => {
+    it("opens modal when controlled open prop is true", () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      const onOpenChange = jest.fn();
+      const { rerender } = render(
+        <QuickLogButton tasks={TASKS} onSave={onSave} open={false} onOpenChange={onOpenChange} />
+      );
+      expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+
+      rerender(
+        <QuickLogButton tasks={TASKS} onSave={onSave} open={true} onOpenChange={onOpenChange} />
+      );
+      expect(screen.getByTestId("quick-log-modal")).toBeInTheDocument();
+    });
+
+    it("calls onOpenChange when trigger button clicked in controlled mode", () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      const onOpenChange = jest.fn();
+      render(
+        <QuickLogButton tasks={TASKS} onSave={onSave} open={false} onOpenChange={onOpenChange} />
+      );
+      fireEvent.click(screen.getByTestId("quick-log-trigger"));
+      expect(onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    it("calls onOpenChange when modal closed via cancel in controlled mode", () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      const onOpenChange = jest.fn();
+      render(
+        <QuickLogButton tasks={TASKS} onSave={onSave} open={true} onOpenChange={onOpenChange} />
+      );
+      fireEvent.click(screen.getByTestId("quick-log-cancel"));
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("falls back to internal state when uncontrolled", () => {
+      const onSave = jest.fn().mockResolvedValue(undefined);
+      render(<QuickLogButton tasks={TASKS} onSave={onSave} />);
+      expect(screen.queryByTestId("quick-log-modal")).not.toBeInTheDocument();
+      fireEvent.click(screen.getByTestId("quick-log-trigger"));
+      expect(screen.getByTestId("quick-log-modal")).toBeInTheDocument();
+    });
+  });
 });

--- a/__tests__/pages/timesheet.test.tsx
+++ b/__tests__/pages/timesheet.test.tsx
@@ -123,11 +123,13 @@ describe("Timesheet Page", () => {
       render(<TimesheetPage />);
     });
     await waitFor(() => {
-      expect(screen.getByText("從看板選擇任務或先建立一個")).toBeInTheDocument();
+      expect(screen.getByText("這週還沒有相關任務")).toBeInTheDocument();
     });
     const kanbanLink = screen.getByRole("link", { name: "前往看板" });
     expect(kanbanLink).toBeInTheDocument();
     expect(kanbanLink).toHaveAttribute("href", "/kanban");
+    // Issue #1539-8: empty state now also exposes a quick-log CTA
+    expect(screen.getByTestId("empty-state-quick-log")).toBeInTheDocument();
   });
 
   it("renders without crash when hours fields are null in time entries", async () => {

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Loader2, CalendarDays, Clock } from "lucide-react";
+import { Loader2, CalendarDays, Clock, Plus } from "lucide-react";
 import Link from "next/link";
 import {
   useTimesheet,
@@ -36,6 +36,8 @@ export default function TimesheetPage() {
   const [users, setUsers] = useState<{ id: string; name: string }[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [calendarDate, setCalendarDate] = useState<Date>(() => new Date());
+  // Issue #1539-8: lift quick-log open state so empty state CTA can trigger same modal
+  const [quickLogOpen, setQuickLogOpen] = useState(false);
 
   const ts = useTimesheet(userFilter || undefined);
 
@@ -100,6 +102,8 @@ export default function TimesheetPage() {
           onSave={(taskId, date, hours, category, description, overtimeType) =>
             ts.saveEntry(taskId, date, hours, category, description, overtimeType)
           }
+          open={quickLogOpen}
+          onOpenChange={setQuickLogOpen}
         />
       </div>
 
@@ -200,15 +204,25 @@ export default function TimesheetPage() {
           ) : ts.taskRows.filter(r => r.taskId !== null).length === 0 && viewMode === "grid" ? (
             <PageEmpty
               icon={<Clock className="h-10 w-10" />}
-              title="從看板選擇任務或先建立一個"
-              description="工時紀錄會依照你在看板上的任務自動帶入"
+              title="這週還沒有相關任務"
+              description="可以直接快速記時數（不限定任務），或前往看板建立 / 認領任務"
               action={
-                <Link
-                  href="/kanban"
-                  className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-card hover:bg-accent text-foreground rounded-lg border border-border shadow-sm hover:shadow transition-all"
-                >
-                  前往看板
-                </Link>
+                <div className="flex flex-col sm:flex-row gap-2 items-center">
+                  <button
+                    onClick={() => setQuickLogOpen(true)}
+                    className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg shadow-sm transition-all"
+                    data-testid="empty-state-quick-log"
+                  >
+                    <Plus className="h-4 w-4" />
+                    快速記時數
+                  </button>
+                  <Link
+                    href="/kanban"
+                    className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-card hover:bg-accent text-foreground rounded-lg border border-border shadow-sm hover:shadow transition-all"
+                  >
+                    前往看板
+                  </Link>
+                </div>
               }
             />
           ) : viewMode === "grid" ? (

--- a/app/components/timesheet/quick-log-button.tsx
+++ b/app/components/timesheet/quick-log-button.tsx
@@ -34,6 +34,13 @@ type QuickLogButtonProps = {
     description: string,
     overtimeType: OvertimeType,
   ) => Promise<void>;
+  /**
+   * Issue #1539-8: optional controlled mode so other entry points
+   * (e.g. empty state CTA) can trigger the same modal.
+   * If omitted, component manages its own open state internally.
+   */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 const CATEGORY_OPTIONS: { value: string; label: string }[] = [
@@ -49,8 +56,10 @@ const LAST_CATEGORY_KEY = "titan:quickLog:lastCategory";
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function QuickLogButton({ tasks, onSave }: QuickLogButtonProps) {
-  const [open, setOpen] = useState(false);
+export function QuickLogButton({ tasks, onSave, open: controlledOpen, onOpenChange }: QuickLogButtonProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
   const [submitting, setSubmitting] = useState(false);
   const [taskId, setTaskId] = useState<string>("");
   const [date, setDate] = useState<string>(() => formatLocalDate(new Date()));


### PR DESCRIPTION
Closes #1552

## Summary

#1538 audit second-pass 發現的問題：empty state 把用戶推向看板，藏起 quick-log 與自由工時動線。新人首次進入會以為「必須先有 task」— dead-end。

## 變更

### 1. QuickLogButton 加 controlled mode（backward-compatible）

```tsx
type Props = {
  tasks, onSave, // existing
  open?: boolean;            // NEW: optional controlled
  onOpenChange?: (b: boolean) => void;
};
```

不傳時走 internal state，既有 caller 完全不需改。

### 2. Empty state 改 copy + 加 primary CTA

```
這週還沒有相關任務

可以直接快速記時數（不限定任務），或前往看板建立 / 認領任務

[+ 快速記時數]  [前往看板]
```

兩個 CTA 並排（mobile 堆疊）。「+ 快速記時數」是 primary，按下開啟頁面頂部 QuickLogButton 的同一個 modal（lift up state）。

## 為什麼這樣設計

- **共用一個 modal**：避免兩個 modal instance 引發 state 不一致
- **向後相容 props**：QuickLogButton 既有 caller（如未來其他頁面）不需改
- **保留「前往看板」**：仍是合理動線之一，只是不再唯一

## 測試

- 4 個新 controlled-mode tests
- 更新 timesheet page 的 empty-state 斷言（新 copy + 新 CTA）
- 202 個 timesheet 測試全綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)