### PR TITLE
feat(T1539-9): timesheet list view empty state 加 quick-log CTA（mobile）

### DIFF
--- a/__tests__/components/timesheet-list-view-empty.test.tsx
+++ b/__tests__/components/timesheet-list-view-empty.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Component tests: TimesheetListView empty state (Issue #1539-9)
+ *
+ * Mobile users auto-switch to list view, so this view's empty state is the
+ * first surface a brand-new mobile user sees. Original showed plain text
+ * "本週尚無工時記錄" with no CTA — dead-end.
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TimesheetListView } from "@/app/components/timesheet-list-view";
+
+jest.mock("lucide-react", () => ({
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
+}));
+
+jest.mock("@/lib/safe-number", () => ({
+  safeFixed: (n: number, d: number) => (n ?? 0).toFixed(d),
+}));
+
+describe("TimesheetListView empty state", () => {
+  it("renders 'no entries' text when entries empty", () => {
+    render(<TimesheetListView entries={[]} />);
+    expect(screen.getByText("本週尚無工時記錄")).toBeInTheDocument();
+  });
+
+  it("does not render quick-log CTA when onQuickLog not provided", () => {
+    render(<TimesheetListView entries={[]} />);
+    expect(screen.queryByTestId("list-view-empty-quick-log")).not.toBeInTheDocument();
+  });
+
+  it("renders quick-log CTA when onQuickLog provided", () => {
+    const onQuickLog = jest.fn();
+    render(<TimesheetListView entries={[]} onQuickLog={onQuickLog} />);
+    expect(screen.getByTestId("list-view-empty-quick-log")).toBeInTheDocument();
+    expect(screen.getByText("快速記時數")).toBeInTheDocument();
+  });
+
+  it("calls onQuickLog when CTA clicked", () => {
+    const onQuickLog = jest.fn();
+    render(<TimesheetListView entries={[]} onQuickLog={onQuickLog} />);
+    fireEvent.click(screen.getByTestId("list-view-empty-quick-log"));
+    expect(onQuickLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show empty state when entries exist", () => {
+    render(
+      <TimesheetListView
+        entries={[
+          {
+            id: "e1",
+            date: "2026-04-25",
+            hours: 8,
+            category: "PLANNED_TASK",
+            description: "test",
+          } as never,
+        ]}
+        onQuickLog={jest.fn()}
+      />
+    );
+    expect(screen.queryByText("本週尚無工時記錄")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("list-view-empty-quick-log")).not.toBeInTheDocument();
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -275,6 +275,7 @@ export default function TimesheetPage() {
             <TimesheetListView
               entries={ts.entries}
               onDelete={ts.deleteEntry}
+              onQuickLog={() => setQuickLogOpen(true)}
             />
           )}
         </div>

--- a/app/components/timesheet-list-view.tsx
+++ b/app/components/timesheet-list-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { safeFixed } from "@/lib/safe-number";
 import { type TimeEntry, CATEGORIES } from "./time-entry-cell";
@@ -9,6 +10,8 @@ import { type TimeEntry, CATEGORIES } from "./time-entry-cell";
 type TimesheetListViewProps = {
   entries: TimeEntry[];
   onDelete?: (id: string) => Promise<void>;
+  /** Issue #1539-9: optional callback to trigger quick-log modal from empty state */
+  onQuickLog?: () => void;
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -34,7 +37,7 @@ function formatTime(timeStr: string | null | undefined): string {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps) {
+export function TimesheetListView({ entries, onDelete, onQuickLog }: TimesheetListViewProps) {
   // Sort by date descending, then by startTime descending
   const sorted = [...entries].sort((a, b) => {
     const dateCompare = b.date.localeCompare(a.date);
@@ -54,8 +57,18 @@ export function TimesheetListView({ entries, onDelete }: TimesheetListViewProps)
 
   if (sorted.length === 0) {
     return (
-      <div className="text-center py-8 text-sm text-muted-foreground">
-        本週尚無工時記錄
+      <div className="text-center py-12 px-4">
+        <p className="text-sm text-muted-foreground mb-4">本週尚無工時記錄</p>
+        {onQuickLog && (
+          <button
+            onClick={onQuickLog}
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg shadow-sm transition-all"
+            data-testid="list-view-empty-quick-log"
+          >
+            <Plus className="h-4 w-4" />
+            快速記時數
+          </button>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Closes #1554

## Summary

Third-pass 觀察。`TimesheetListView` 的 empty state（mobile 預設 view）只有純文字「本週尚無工時記錄」、無 CTA — mobile 新人首次體驗 dead-end。

## 變更

### TimesheetListView 加 optional onQuickLog prop

```tsx
type Props = {
  entries: TimeEntry[];
  onDelete?: ...;
  onQuickLog?: () => void; // NEW
};
```

提供時 empty state 額外渲染「+ 快速記時數」主色 CTA。不傳則行為不變（向後相容）。

### Page 注入 callback

Page 已在 #1539-8 lift up `quickLogOpen` state，list view 直接共用同一個 modal instance：

```tsx
<TimesheetListView
  entries={ts.entries}
  onDelete={ts.deleteEntry}
  onQuickLog={() => setQuickLogOpen(true)}
/>
```

## 為什麼這個重要

mobile 是 timesheet 最常被用的 form factor — `useEffect` 會 auto-switch viewMode 到 list 當 width < 768px。所以 list view empty state 是手機新人**第一個看到**的畫面。

## 測試

5 個 tests 覆蓋：empty/CTA visibility/click handler/non-empty fallback/missing-prop fallback。
既有 207 個 timesheet 測試全綠（202+5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## #1538 audit 進度

| # | 主題 | 狀態 |
|---|------|------|
| 1 | today auto-focus | ✅ |
| 2 | sticky 快速記時數 | ✅ |
| 3 | pivot tabs 移到 reports | ✅ |
| 4 | 你最常做的事建議 | ✅ |
| 5 | 週工時達標慶祝 | ✅ |
| 6 | onboarding modes banner | ✅ |
| 7 | 整合 DailyDigestBanner（修 #963 漏整合） | ✅ |
| 8 | empty state quick-log CTA | ✅ |
| 9 | **本 PR** — list view empty state CTA（mobile） | ⬅ |