### PR TITLE
feat(T1539-10): calendar-day-view mobile empty state 加 quick-log CTA

### DIFF
--- a/__tests__/components/calendar-day-view.test.tsx
+++ b/__tests__/components/calendar-day-view.test.tsx
@@ -21,6 +21,7 @@ jest.mock("lucide-react", () => ({
   ChevronRight: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-chevron-right" {...props} />,
   Clock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-clock" {...props} />,
   Lock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-lock" {...props} />,
+  Plus: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-plus" {...props} />,
 }));
 
 // ─── Test data ───────────────────────────────────────────────────────────────
@@ -400,5 +401,35 @@ describe("Grid dimensions", () => {
     const grid = screen.getByTestId("time-grid");
     const expectedHeight = (MAX_HOUR - MIN_HOUR) * HOUR_HEIGHT;
     expect(grid.style.height).toBe(`${expectedHeight}px`);
+  });
+});
+
+// ─── Mobile empty-state quick-log CTA (Issue #1539-10) ──────────────────────
+
+describe("Mobile empty state CTA (Issue #1539-10)", () => {
+  test("does not render quick-log CTA when onQuickLog not provided", () => {
+    render(<CalendarDayView {...defaultProps} entries={[]} />);
+    expect(screen.queryByTestId("calendar-day-mobile-quick-log")).not.toBeInTheDocument();
+  });
+
+  test("renders quick-log CTA in mobile empty state when onQuickLog provided", () => {
+    const onQuickLog = jest.fn();
+    render(<CalendarDayView {...defaultProps} entries={[]} onQuickLog={onQuickLog} />);
+    expect(screen.getByTestId("calendar-day-mobile-quick-log")).toBeInTheDocument();
+  });
+
+  test("calls onQuickLog when CTA clicked", () => {
+    const onQuickLog = jest.fn();
+    render(<CalendarDayView {...defaultProps} entries={[]} onQuickLog={onQuickLog} />);
+    fireEvent.click(screen.getByTestId("calendar-day-mobile-quick-log"));
+    expect(onQuickLog).toHaveBeenCalledTimes(1);
+  });
+
+  test("hides CTA when day has entries", () => {
+    const onQuickLog = jest.fn();
+    render(
+      <CalendarDayView {...defaultProps} entries={[makeEntry()]} onQuickLog={onQuickLog} />
+    );
+    expect(screen.queryByTestId("calendar-day-mobile-quick-log")).not.toBeInTheDocument();
   });
 });

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -252,6 +252,7 @@ export default function TimesheetPage() {
               onDateChange={setCalendarDate}
               onSaveEntry={ts.saveEntry}
               onDeleteEntry={ts.deleteEntry}
+              onQuickLog={() => setQuickLogOpen(true)}
             />
           ) : viewMode === "calendar-week" ? (
             <CalendarWeekView

--- a/app/components/timesheet/calendar-day-view.tsx
+++ b/app/components/timesheet/calendar-day-view.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { safeFixed } from "@/lib/safe-number";
 import { type TimeEntry, type OvertimeType, type TaskOption } from "./use-timesheet";
 import { CATEGORIES } from "./timesheet-cell";
-import { ChevronLeft, ChevronRight, Clock } from "lucide-react";
+import { ChevronLeft, ChevronRight, Clock, Plus } from "lucide-react";
 import { formatLocalDate } from "@/lib/utils/date";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -74,6 +74,8 @@ type CalendarDayViewProps = {
     endTime?: string | null
   ) => Promise<void>;
   onDeleteEntry: (id: string) => Promise<void>;
+  /** Issue #1539-10: optional callback for mobile empty-state quick-log CTA */
+  onQuickLog?: () => void;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -85,6 +87,7 @@ export function CalendarDayView({
   onDateChange,
   onSaveEntry,
   onDeleteEntry,
+  onQuickLog,
 }: CalendarDayViewProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const [dragState, setDragState] = useState<{
@@ -651,8 +654,18 @@ export function CalendarDayView({
       {/* Mobile: simplified list view */}
       <div className="sm:hidden space-y-2" data-testid="mobile-time-list">
         {dayEntries.length === 0 ? (
-          <div className="text-center text-sm text-muted-foreground py-6">
-            今天尚無工時紀錄
+          <div className="text-center py-8">
+            <p className="text-sm text-muted-foreground mb-3">今天尚無工時紀錄</p>
+            {onQuickLog && (
+              <button
+                onClick={onQuickLog}
+                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 rounded-lg shadow-sm transition-all"
+                data-testid="calendar-day-mobile-quick-log"
+              >
+                <Plus className="h-4 w-4" />
+                快速記時數
+              </button>
+            )}
           </div>
         ) : (
           dayEntries.map((entry) => (


### PR DESCRIPTION
Closes #1556

## Summary

Fourth-pass 觀察。完成 #1539-9（list view mobile CTA）後再走 calendar-day-view，mobile 區塊有相同 dead-end pattern。

## 變更

複用 #1539-9 的 `onQuickLog` optional callback pattern：

```tsx
type Props = {
  // existing
  onQuickLog?: () => void;
};
```

mobile 區塊（`sm:hidden`）的 empty state 額外渲染主色「+ 快速記時數」CTA。Page 注入 `() => setQuickLogOpen(true)` 共用 modal state（自 #1539-8 lift up）。

不傳 `onQuickLog` 行為不變（既有 caller 不需改）。

## 測試

- 4 個新 mobile-CTA tests
- 補既有 mock 加入 `Plus`
- 243 個 timesheet+calendar 測試全綠（239+4）

## 模式重用累積成果

「main page lift up modal state + 各 view 透過 optional callback 注入 trigger」這個 pattern 現在套用於：
- 頂部 chip QuickLogButton (#1539-8 controlled)
- Grid view empty state (#1539-8)
- List view empty state (#1539-9)
- Calendar day view mobile empty (#1539-10) ← 本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)