### PR TITLE
feat(T1539-11): timesheet toolbar 加本週工時進度提示 (X.Xh / 40h)

### DIFF
--- a/__tests__/components/timesheet-grid.test.tsx
+++ b/__tests__/components/timesheet-grid.test.tsx
@@ -546,4 +546,46 @@ describe("TimesheetToolbar — week navigation", () => {
     render(<TimesheetToolbar {...defaultToolbarProps} />);
     expect(screen.getByText("2024/01/15 — 2024/01/21")).toBeInTheDocument();
   });
+
+  // Issue #1539-11: weekly progress hint in subtitle
+  describe("weekly progress hint (#1539-11)", () => {
+    it("hides progress when weeklyTotal not provided", () => {
+      render(<TimesheetToolbar {...defaultToolbarProps} />);
+      expect(screen.queryByTestId("toolbar-weekly-progress")).not.toBeInTheDocument();
+    });
+
+    it("shows weekly progress when weeklyTotal provided", () => {
+      render(<TimesheetToolbar {...defaultToolbarProps} weeklyTotal={28.5} />);
+      const progress = screen.getByTestId("toolbar-weekly-progress");
+      expect(progress).toBeInTheDocument();
+      expect(progress).toHaveTextContent("本週 28.5h / 40h");
+    });
+
+    it("respects custom weeklyTarget", () => {
+      render(
+        <TimesheetToolbar {...defaultToolbarProps} weeklyTotal={20} weeklyTarget={32} />
+      );
+      expect(screen.getByTestId("toolbar-weekly-progress")).toHaveTextContent(
+        "本週 20.0h / 32h"
+      );
+    });
+
+    it("uses emerald color when totalHours >= target", () => {
+      render(<TimesheetToolbar {...defaultToolbarProps} weeklyTotal={42} />);
+      const progress = screen.getByTestId("toolbar-weekly-progress");
+      expect(progress.className).toMatch(/emerald/);
+    });
+
+    it("uses neutral color when totalHours below target", () => {
+      render(<TimesheetToolbar {...defaultToolbarProps} weeklyTotal={20} />);
+      const progress = screen.getByTestId("toolbar-weekly-progress");
+      expect(progress.className).not.toMatch(/emerald/);
+    });
+
+    it("renders 0h when weeklyTotal is 0", () => {
+      render(<TimesheetToolbar {...defaultToolbarProps} weeklyTotal={0} />);
+      const progress = screen.getByTestId("toolbar-weekly-progress");
+      expect(progress).toHaveTextContent("本週 0.0h / 40h");
+    });
+  });
 });

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -136,6 +136,7 @@ export default function TimesheetPage() {
         entries={ts.entries}
         daysCount={ts.daysCount}
         getDateStr={ts.getDateStr}
+        weeklyTotal={ts.weeklyTotal}
       />
 
       {/* Manager actions — Issue #1539-3: pivot tabs moved to /reports */}

--- a/app/components/timesheet/timesheet-toolbar.tsx
+++ b/app/components/timesheet/timesheet-toolbar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronLeft, ChevronRight, Grid3X3, List, Calendar, CalendarDays, Copy, FileDown, RefreshCw, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { safeFixed } from "@/lib/safe-number";
 import { TemplateSelector } from "./template-selector";
 import { OvertimeBadge } from "./overtime-badge";
 import { type TimeEntry } from "./use-timesheet";
@@ -26,6 +27,10 @@ type TimesheetToolbarProps = {
   entries?: TimeEntry[];
   daysCount?: number;
   getDateStr?: (offset: number) => string;
+  /** Issue #1539-11: weekly total hours (shown as "X.Xh / 40h" in subtitle) */
+  weeklyTotal?: number;
+  /** Issue #1539-11: target hours (default 40) */
+  weeklyTarget?: number;
 };
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -44,6 +49,8 @@ export function TimesheetToolbar({
   entries,
   daysCount,
   getDateStr,
+  weeklyTotal,
+  weeklyTarget = 40,
 }: TimesheetToolbarProps) {
   const [copying, setCopying] = useState(false);
   const [copyResult, setCopyResult] = useState<"success" | "error" | null>(null);
@@ -76,7 +83,22 @@ export function TimesheetToolbar({
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
         <div>
           <h1 className="text-lg sm:text-xl font-semibold tracking-tight">工時紀錄</h1>
-          <p className="text-muted-foreground text-xs sm:text-sm mt-0.5">{weekRange}</p>
+          <p className="text-muted-foreground text-xs sm:text-sm mt-0.5 flex flex-wrap items-center gap-x-2">
+            <span>{weekRange}</span>
+            {typeof weeklyTotal === "number" && (
+              <span
+                className={cn(
+                  "tabular-nums font-medium",
+                  weeklyTotal >= weeklyTarget
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-foreground/70",
+                )}
+                data-testid="toolbar-weekly-progress"
+              >
+                · 本週 {safeFixed(weeklyTotal, 1)}h / {weeklyTarget}h
+              </span>
+            )}
+          </p>
         </div>
 
         <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
Closes #1558

## Summary

Fifth-pass 觀察。多個 dead-end 修補後，再走整個頁面發現**正向缺口**：沒有任何地方告訴用戶「本週累計幾小時」。

#1539-5 的達標慶祝只在 cross-over 那一刻 toast 一次。其他時間用戶想知道「還差多少？」需要捲到 stats 區或心算。

## 變更

Toolbar 副標尾巴 inline 顯示進度：

```
工時紀錄
2024/01/15 — 2024/01/21 · 本週 28.5h / 40h
```

- **不增加垂直空間**（同副標 row）
- **達標 emerald 綠**（呼應 #1539-5 慶祝色系）
- **未達 neutral 灰**，無催促文案
- `weeklyTarget` prop 預設 40，可調
- `weeklyTotal` 不傳則不顯示（向後相容）

## 設計理念

延續 #1539 系列的「肯定不催促」原則：
- 顯示資訊（X / 40h）讓用戶自行判斷
- 達標只是顏色變化，不跳模態 / 額外 toast
- 未達顯示中性顏色，不引發焦慮

## 測試

6 新 progress tests：
- 不傳 weeklyTotal → 不顯示
- 傳 weeklyTotal → 正確 format
- 自訂 weeklyTarget → 正確 reflect
- 達標 → emerald 顏色
- 未達 → neutral 顏色
- 0h → 仍顯示但不警告

249 個 timesheet+calendar 測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)