### PR TITLE
feat(T1539-12): 刪除工時加 5 秒復原 toast (undo)

### DIFF
--- a/__tests__/components/timesheet-use-delete-with-undo.test.tsx
+++ b/__tests__/components/timesheet-use-delete-with-undo.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * Tests: useDeleteWithUndo hook (Issue #1539-12)
+ *
+ * Covers:
+ * - Server delete called with correct id
+ * - Toast shown with action button after delete
+ * - Click "復原" recreates the entry via saveEntry with original fields
+ * - Missing entry (already deleted by another tab) doesn't crash
+ * - Undo failure shows error toast
+ * - Decimal-as-string hours coerced via Number()
+ */
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { useDeleteWithUndo } from "@/app/components/timesheet/use-delete-with-undo";
+import type { TimeEntry } from "@/app/components/timesheet/use-timesheet";
+
+const mockToast = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock("sonner", () => ({
+  toast: Object.assign(
+    (...args: unknown[]) => mockToast(...args),
+    {
+      success: (...args: unknown[]) => mockToastSuccess(...args),
+      error: (...args: unknown[]) => mockToastError(...args),
+    },
+  ),
+}));
+
+const SAMPLE_ENTRY: TimeEntry = {
+  id: "e1",
+  taskId: "t1",
+  date: "2026-04-25T00:00:00Z",
+  hours: 2.5,
+  category: "PLANNED_TASK",
+  description: "fix prod bug",
+  startTime: "10:00",
+  endTime: "12:30",
+  overtimeType: "NONE",
+  subTaskId: "st1",
+};
+
+describe("useDeleteWithUndo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls deleteEntry with the given id", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [SAMPLE_ENTRY], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e1");
+    });
+
+    expect(deleteEntry).toHaveBeenCalledWith("e1");
+  });
+
+  it("shows undo toast after delete", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [SAMPLE_ENTRY], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e1");
+    });
+
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast.mock.calls[0][0]).toBe("已刪除工時");
+    const toastOptions = mockToast.mock.calls[0][1];
+    expect(toastOptions.duration).toBe(5000);
+    expect(toastOptions.action.label).toBe("復原");
+    expect(typeof toastOptions.action.onClick).toBe("function");
+  });
+
+  it("recreates entry via saveEntry when undo clicked", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [SAMPLE_ENTRY], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e1");
+    });
+
+    const undoFn = mockToast.mock.calls[0][1].action.onClick;
+    await act(async () => {
+      await undoFn();
+    });
+
+    expect(saveEntry).toHaveBeenCalledWith(
+      "t1",                    // taskId
+      "2026-04-25",            // date (split off T)
+      2.5,                     // hours coerced
+      "PLANNED_TASK",          // category
+      "fix prod bug",          // description
+      "NONE",                  // overtimeType
+      undefined,               // existingId (not editing)
+      "st1",                   // subTaskId
+      "10:00",                 // startTime
+      "12:30",                 // endTime
+    );
+    expect(mockToastSuccess).toHaveBeenCalledWith("已復原");
+  });
+
+  it("shows error toast when undo fails", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockRejectedValue(new Error("save failed"));
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [SAMPLE_ENTRY], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e1");
+    });
+
+    const undoFn = mockToast.mock.calls[0][1].action.onClick;
+    await act(async () => {
+      await undoFn();
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith("復原失敗，請手動重新建立");
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("doesn't crash when entry not found in entries array", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("nonexistent");
+    });
+
+    expect(deleteEntry).toHaveBeenCalledWith("nonexistent");
+    // No toast shown because entry wasn't found
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("coerces Decimal-as-string hours via Number()", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const entryWithStringHours = { ...SAMPLE_ENTRY, hours: "3.5" as unknown as number };
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [entryWithStringHours], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e1");
+    });
+
+    const undoFn = mockToast.mock.calls[0][1].action.onClick;
+    await act(async () => {
+      await undoFn();
+    });
+
+    const callArgs = saveEntry.mock.calls[0];
+    expect(callArgs[2]).toBe(3.5); // hours coerced to number
+  });
+
+  it("handles missing optional fields gracefully", async () => {
+    const deleteEntry = jest.fn().mockResolvedValue(undefined);
+    const saveEntry = jest.fn().mockResolvedValue(undefined);
+    const minimalEntry: TimeEntry = {
+      id: "e2",
+      taskId: null, // free entry
+      date: "2026-04-25",
+      hours: 1,
+      category: "ADMIN",
+      description: null,
+    };
+    const { result } = renderHook(() =>
+      useDeleteWithUndo({ entries: [minimalEntry], deleteEntry, saveEntry })
+    );
+
+    await act(async () => {
+      await result.current("e2");
+    });
+
+    const undoFn = mockToast.mock.calls[0][1].action.onClick;
+    await act(async () => {
+      await undoFn();
+    });
+
+    expect(saveEntry).toHaveBeenCalledWith(
+      null, // taskId
+      "2026-04-25",
+      1,
+      "ADMIN",
+      "", // description fallback
+      "NONE", // overtimeType fallback
+      undefined,
+      null, // subTaskId
+      null, // startTime
+      null, // endTime
+    );
+  });
+});

--- a/app/(app)/timesheet/page.tsx
+++ b/app/(app)/timesheet/page.tsx
@@ -8,6 +8,7 @@ import { Loader2, CalendarDays, Clock, Plus } from "lucide-react";
 import Link from "next/link";
 import {
   useTimesheet,
+  useDeleteWithUndo,
   TimesheetGrid,
   TimesheetToolbar,
   TimesheetTimer,
@@ -63,6 +64,13 @@ export default function TimesheetPage() {
       })
       .catch(() => { toast.warning("使用者清單載入失敗"); });
   }, [isManager]);
+
+  // Issue #1539-12: delete with 5-sec undo toast (extracted hook for testability)
+  const handleDeleteWithUndo = useDeleteWithUndo({
+    entries: ts.entries,
+    deleteEntry: ts.deleteEntry,
+    saveEntry: ts.saveEntry,
+  });
 
   // Auto-switch to list on mobile (initial + resize)
   useEffect(() => {
@@ -242,7 +250,7 @@ export default function TimesheetPage() {
               getEntriesForCell={ts.getEntriesForCell}
               onQuickSave={ts.quickSave}
               onFullSave={ts.saveEntry}
-              onDelete={ts.deleteEntry}
+              onDelete={handleDeleteWithUndo}
               onAddTaskRow={ts.addTaskRow}
             />
           ) : viewMode === "calendar" ? (
@@ -252,7 +260,7 @@ export default function TimesheetPage() {
               tasks={ts.tasks}
               onDateChange={setCalendarDate}
               onSaveEntry={ts.saveEntry}
-              onDeleteEntry={ts.deleteEntry}
+              onDeleteEntry={handleDeleteWithUndo}
               onQuickLog={() => setQuickLogOpen(true)}
             />
           ) : viewMode === "calendar-week" ? (
@@ -264,7 +272,7 @@ export default function TimesheetPage() {
               onNextWeek={ts.nextWeek}
               onThisWeek={ts.goToThisWeek}
               onSaveEntry={ts.saveEntry}
-              onDeleteEntry={ts.deleteEntry}
+              onDeleteEntry={handleDeleteWithUndo}
             />
           ) : viewMode === "calendar-month" ? (
             <CalendarMonthView
@@ -276,7 +284,7 @@ export default function TimesheetPage() {
           ) : (
             <TimesheetListView
               entries={ts.entries}
-              onDelete={ts.deleteEntry}
+              onDelete={handleDeleteWithUndo}
               onQuickLog={() => setQuickLogOpen(true)}
             />
           )}

--- a/app/components/timesheet/index.ts
+++ b/app/components/timesheet/index.ts
@@ -1,5 +1,6 @@
 export { useTimesheet } from "./use-timesheet";
 export { useTimer } from "./use-timer";
+export { useDeleteWithUndo } from "./use-delete-with-undo";
 export { useWeekNavigation } from "./use-week-navigation";
 export { TimesheetGrid } from "./timesheet-grid";
 export { TimesheetCell } from "./timesheet-cell";

--- a/app/components/timesheet/use-delete-with-undo.ts
+++ b/app/components/timesheet/use-delete-with-undo.ts
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * useDeleteWithUndo — Issue #1539-12
+ *
+ * Wraps the timesheet hook's deleteEntry to add a 5-second undo toast.
+ * Strategy: server-delete immediately, snapshot the entry locally, and if
+ * the user clicks "復原" within 5s, recreate the same entry via saveEntry.
+ *
+ * Backend untouched. Restored entry gets a new id but is visually identical.
+ */
+import { useCallback } from "react";
+import { toast } from "sonner";
+import type { OvertimeType, TimeEntry } from "./use-timesheet";
+
+type SaveEntry = (
+  taskId: string | null,
+  date: string,
+  hours: number,
+  category: string,
+  description: string,
+  overtimeType: OvertimeType,
+  existingId?: string,
+  subTaskId?: string | null,
+  startTime?: string | null,
+  endTime?: string | null,
+) => Promise<void>;
+
+type DeleteEntry = (id: string) => Promise<void>;
+
+interface UseDeleteWithUndoArgs {
+  entries: TimeEntry[];
+  deleteEntry: DeleteEntry;
+  saveEntry: SaveEntry;
+}
+
+export function useDeleteWithUndo({
+  entries,
+  deleteEntry,
+  saveEntry,
+}: UseDeleteWithUndoArgs) {
+  return useCallback(
+    async (id: string) => {
+      const original = entries.find((e) => e.id === id);
+      await deleteEntry(id);
+      if (!original) return;
+
+      toast("已刪除工時", {
+        duration: 5000,
+        action: {
+          label: "復原",
+          onClick: async () => {
+            try {
+              await saveEntry(
+                original.taskId,
+                original.date.split("T")[0],
+                Number(original.hours ?? 0),
+                original.category,
+                original.description ?? "",
+                (original.overtimeType ?? "NONE"),
+                undefined, // not editing existing
+                original.subTaskId ?? null,
+                original.startTime ?? null,
+                original.endTime ?? null,
+              );
+              toast.success("已復原");
+            } catch {
+              toast.error("復原失敗，請手動重新建立");
+            }
+          },
+        },
+      });
+    },
+    [entries, deleteEntry, saveEntry],
+  );
+}


### PR DESCRIPTION
Closes #1560

## Summary

Sixth-pass 觀察：完成 11 項 #1539 改動後重新審視「**最容易誤觸發/最讓人懊惱**」的動作 — 刪除工時。一旦點錯沒有救濟機制。

## 設計（業界標準 5-sec undo pattern）

- **Server delete 立即執行**（backend 完全不變）
- 刪除後 toast 5 秒含「復原」action button
- 點「復原」→ 用 snapshot 資料透過 saveEntry() 重建（新 id 但內容一致）
- 復原失敗 → 錯誤 toast 但不影響原刪除

## 抽成獨立 hook

`useDeleteWithUndo` 在 `app/components/timesheet/use-delete-with-undo.ts`：

```tsx
const handleDelete = useDeleteWithUndo({
  entries: ts.entries,
  deleteEntry: ts.deleteEntry,
  saveEntry: ts.saveEntry,
});

// 傳到所有 view：grid / list / calendar-day / calendar-week
<TimesheetGrid onDelete={handleDelete} />
<TimesheetListView onDelete={handleDelete} />
<CalendarDayView onDeleteEntry={handleDelete} />
```

獨立 hook 好處：
1. 易單元測試（7 tests，這些 testing 內聯 callback 很難）
2. 未來 dashboard 等其他頁面可重用
3. page.tsx 保持精簡（從 30 行壓回 5 行）

## 測試

7 個 hook tests 覆蓋：
- 正常 delete + toast
- Click 復原 → saveEntry with all original fields
- 復原失敗 → error toast
- Entry not found in array → no crash
- Decimal-as-string hours coerced
- Missing optional fields (taskId, subTaskId, startTime) → null fallback

256 個 timesheet 測試全綠（249+7）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)