### PR TITLE
feat(T1539-13): timesheet-cell hover tooltip 教 affordance

### DIFF
--- a/__tests__/components/timesheet-grid.test.tsx
+++ b/__tests__/components/timesheet-grid.test.tsx
@@ -233,6 +233,46 @@ describe("TimesheetCell — inline edit flow", () => {
     jest.clearAllMocks();
   });
 
+  // Issue #1539-13: hover tooltip teaches affordance
+  describe("hover tooltip (#1539-13)", () => {
+    it("shows 'add' tooltip on empty cell", () => {
+      render(<TimesheetCell {...defaultCellProps} />);
+      const btn = screen.getByTestId("cell-button");
+      expect(btn.getAttribute("title")).toContain("點擊新增時數");
+      expect(btn.getAttribute("title")).toContain("雙擊");
+    });
+
+    it("shows 'edit' tooltip on cell with entry", () => {
+      const entry: TimeEntry = {
+        id: "e1",
+        taskId: "task-1",
+        date: "2024-01-15",
+        hours: 3,
+        category: "PLANNED_TASK",
+        description: "test",
+      };
+      render(<TimesheetCell {...defaultCellProps} entries={[entry]} />);
+      const btn = screen.getByTestId("cell-button");
+      expect(btn.getAttribute("title")).toContain("點擊修改時數");
+      expect(btn.getAttribute("title")).toContain("雙擊編詳細");
+    });
+
+    it("shows 'locked' tooltip on locked entry", () => {
+      const lockedEntry: TimeEntry = {
+        id: "e1",
+        taskId: "task-1",
+        date: "2024-01-15",
+        hours: 3,
+        category: "PLANNED_TASK",
+        description: "test",
+        locked: true,
+      };
+      render(<TimesheetCell {...defaultCellProps} entries={[lockedEntry]} />);
+      const btn = screen.getByTestId("cell-button");
+      expect(btn.getAttribute("title")).toContain("已核准鎖定");
+    });
+  });
+
   // (a) Inline edit flow: click cell -> input appears -> type "3" -> press Enter -> save called with hours=3
   it("click cell -> input appears -> type '3' -> Enter -> save called with hours=3", async () => {
     const user = userEvent.setup();

--- a/app/components/timesheet/timesheet-cell.tsx
+++ b/app/components/timesheet/timesheet-cell.tsx
@@ -399,6 +399,14 @@ export function TimesheetCell({
         <button
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
+          /* Issue #1539-13: hover tooltip teaches affordance — single-click vs double-click */
+          title={
+            allLocked
+              ? "已核准鎖定，無法編輯"
+              : entry && totalHours > 0
+                ? "點擊修改時數，雙擊編詳細（分類、備註、加班）"
+                : "點擊新增時數，雙擊填寫詳細"
+          }
           className={cn(
             "w-full h-9 rounded-md border text-xs transition-all relative",
             "focus:outline-none focus:ring-2 focus:ring-ring/30",


### PR DESCRIPTION
Closes #1562

## Summary

Seventh-pass 觀察。grid cell 有兩種互動但無 affordance 提示：

- **單擊** → inline 數字輸入
- **雙擊** → 詳細編輯 modal（分類、備註、加班）

新人不會發現雙擊功能。頁面底部有 help text，但很多人直接上手都不會看到。

## 解法

最低成本：native HTML `title` 屬性。三種狀態：

| 狀態 | Tooltip |
|------|---------|
| Locked | 已核准鎖定，無法編輯 |
| Has entry | 點擊修改時數，雙擊編詳細（分類、備註、加班） |
| Empty | 點擊新增時數，雙擊填寫詳細 |

## 為什麼不用 custom tooltip 元件

- Native title 零 JS 重量、零 portal、零 positioning logic
- 對「教 affordance」的次要訊息 sufficient
- Mobile 自動切到 list view，桌面 hover 是自然行為

## 測試

3 個新 tooltip tests 覆蓋三種狀態。259 個 timesheet+calendar 測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)