### PR TITLE
test(T1539-14): timesheet page integration smoke 防止 #1539 元件失聯

### DIFF
--- a/__tests__/pages/timesheet.test.tsx
+++ b/__tests__/pages/timesheet.test.tsx
@@ -153,3 +153,123 @@ describe("Timesheet Page", () => {
     expect(document.body).toBeDefined();
   });
 });
+
+// ─── #1539 series integration smoke tests (Issue #1539-14) ──────────────────
+// Backstops the full timesheet page wiring so future refactors don't silently
+// drop one of the #1539 series components. Each test asserts a specific
+// component is mounted via its data-testid.
+
+describe("Timesheet Page — #1539 integration backstop (Issue #1539-14)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    } as Response);
+  });
+
+  it("mounts TimesheetModesBanner (#1539-6) when not dismissed", async () => {
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("timesheet-modes-banner")).toBeInTheDocument();
+    });
+  });
+
+  it("hides TimesheetModesBanner when dismissed", async () => {
+    window.localStorage.setItem("titan:timesheet:modes-banner-dismissed", "1");
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    expect(screen.queryByTestId("timesheet-modes-banner")).not.toBeInTheDocument();
+  });
+
+  it("mounts QuickLogButton trigger chip (#1539-2)", async () => {
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("quick-log-trigger")).toBeInTheDocument();
+    });
+  });
+
+  it("does not mount TopTasksSuggestion when API returns empty (#1539-4)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("time-entries/top-tasks")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ data: { items: [], windowDays: 14 } }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalled();
+    });
+    expect(screen.queryByTestId("top-tasks-suggestion")).not.toBeInTheDocument();
+  });
+
+  it("mounts TopTasksSuggestion when API returns items (#1539-4)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("time-entries/top-tasks")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            data: {
+              items: [
+                {
+                  taskId: "t1",
+                  taskTitle: "Refactor",
+                  category: "PLANNED",
+                  totalHours: 12,
+                  entryCount: 4,
+                  avgHoursPerEntry: 3,
+                  lastEntryDate: "2026-04-22",
+                },
+              ],
+              windowDays: 14,
+            },
+          }),
+        } as Response);
+      }
+      return Promise.resolve({ ok: true, json: async () => [] } as Response);
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("top-tasks-suggestion")).toBeInTheDocument();
+    });
+  });
+
+  it("renders weekly progress hint in toolbar when ts.weeklyTotal available (#1539-11)", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("time-entries/stats")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: async () => [
+          { id: "e1", userId: "u1", taskId: "task-1", date: "2024-01-15", hours: 8, category: "PLANNED_TASK", description: null, task: { title: "T1" } },
+        ],
+      } as Response);
+    });
+    const { default: TimesheetPage } = await import("@/app/(app)/timesheet/page");
+    await act(async () => {
+      render(<TimesheetPage />);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("toolbar-weekly-progress")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #1564

## Summary

Eighth-pass 觀察。13 個 #1539 PR 累積後，每元件有獨立單元測試，但**整體 page 是否真的把它們 mount 上**沒有 backstop。

**歷史教訓**：#963 的 `DailyDigestBanner` 寫好但從未 import — 整整一個版本是 dead code（直到 #1539-7 才修）。如果未來有人重構 `page.tsx` 不小心拿掉某個元件，個別 unit test 都會 pass、但用戶看不到該元件。

## 變更

`__tests__/pages/timesheet.test.tsx` 新增 `#1539 integration backstop` describe block。

| Backstop | 斷言 |
|----------|------|
| TimesheetModesBanner | localStorage clean → mounted |
| TimesheetModesBanner | localStorage dismissed → not mounted |
| QuickLogButton trigger | 永遠 mounted |
| TopTasksSuggestion | API empty → not mounted |
| TopTasksSuggestion | API has items → mounted |
| Toolbar weekly progress | 有 entries 時 mounted |

每個 test 用 `data-testid` 作為斷言 anchor，不依賴 copy text（避免 copy 變更時誤殺）。

## 驗證機制

如果未來 PR 試圖移除 `<TimesheetModesBanner />` 從 page.tsx，會立刻 fail：

```
✕ mounts TimesheetModesBanner (#1539-6) when not dismissed
  Expected: timesheet-modes-banner to be in document
  Received: not found
```

## 測試結果

6 個新 backstop tests + 既有 timesheet tests。265 個 timesheet+calendar 測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)