### PR TITLE
feat(T1539-15): timer 跑超過 9 小時時警告（防忘了停）

### DIFF
--- a/__tests__/components/timesheet-grid.test.tsx
+++ b/__tests__/components/timesheet-grid.test.tsx
@@ -37,6 +37,7 @@ jest.mock("lucide-react", () => ({
   FileDown: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-file-down" {...props} />,
   RefreshCw: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-refresh" {...props} />,
   Lock: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-lock" {...props} />,
+  AlertTriangle: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="icon-alert-triangle" {...props} />,
 }));
 
 // ─── Test data ───────────────────────────────────────────────────────────────
@@ -506,6 +507,54 @@ describe("TimesheetTimer", () => {
 
     expect(screen.getByTestId("timer-stop-btn")).toBeInTheDocument();
     expect(screen.getByText("正在計時：Feature Development")).toBeInTheDocument();
+  });
+
+  // Issue #1539-15: stale timer warning (>9h)
+  describe("stale timer warning (#1539-15)", () => {
+    function staleProps(elapsedSeconds: number) {
+      return {
+        ...defaultTimerProps,
+        timer: {
+          isRunning: true,
+          taskId: "task-1",
+          taskLabel: "long task",
+          startTime: Date.now() - elapsedSeconds * 1000,
+          entryId: "entry-1",
+        },
+        elapsed: elapsedSeconds,
+      };
+    }
+
+    it("does not mark stale below 9 hours", () => {
+      render(<TimesheetTimer {...staleProps(8 * 3600)} />);
+      const container = screen.getByTestId("timesheet-timer");
+      expect(container.getAttribute("data-stale")).toBeNull();
+      expect(screen.queryByTestId("timer-stale-icon")).not.toBeInTheDocument();
+    });
+
+    it("marks stale at 9 hours threshold", () => {
+      render(<TimesheetTimer {...staleProps(9 * 3600)} />);
+      const container = screen.getByTestId("timesheet-timer");
+      expect(container.getAttribute("data-stale")).toBe("true");
+      expect(screen.getByTestId("timer-stale-icon")).toBeInTheDocument();
+    });
+
+    it("marks stale beyond 9 hours", () => {
+      render(<TimesheetTimer {...staleProps(11 * 3600)} />);
+      const container = screen.getByTestId("timesheet-timer");
+      expect(container.getAttribute("data-stale")).toBe("true");
+    });
+
+    it("does not mark stale when timer not running (even if elapsed > 9h)", () => {
+      const props = {
+        ...defaultTimerProps,
+        timer: null,
+        elapsed: 10 * 3600,
+      };
+      render(<TimesheetTimer {...props} />);
+      const container = screen.getByTestId("timesheet-timer");
+      expect(container.getAttribute("data-stale")).toBeNull();
+    });
   });
 
   it("clicking stop calls onStop", async () => {

--- a/app/components/timesheet/timesheet-timer.tsx
+++ b/app/components/timesheet/timesheet-timer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { Play, Square, Clock } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Play, Square, Clock, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { type TimerState, type TaskOption } from "./use-timesheet";
 
@@ -25,14 +26,35 @@ function formatElapsed(seconds: number): string {
   return `${pad(h)}:${pad(m)}:${pad(s)}`;
 }
 
+// Issue #1539-15: stale timer threshold (9 hours = beyond a normal workday)
+const STALE_THRESHOLD_SECONDS = 9 * 3600;
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function TimesheetTimer({ timer, elapsed, tasks, onStart, onStop }: TimesheetTimerProps) {
   const [selectedTaskId, setSelectedTaskId] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const staleToastFiredRef = useRef(false);
 
   const isRunning = timer?.isRunning ?? false;
+  const isStale = isRunning && elapsed >= STALE_THRESHOLD_SECONDS;
+
+  // Issue #1539-15: warn user once when timer crosses 9-hour threshold
+  // (likely forgot to stop). Reset flag when timer stops/restarts.
+  useEffect(() => {
+    if (!isRunning) {
+      staleToastFiredRef.current = false;
+      return;
+    }
+    if (isStale && !staleToastFiredRef.current) {
+      staleToastFiredRef.current = true;
+      const hours = Math.floor(elapsed / 3600);
+      toast.warning(`計時器已跑 ${hours} 小時 — 忘了停嗎？`, {
+        duration: 10000,
+      });
+    }
+  }, [isRunning, isStale, elapsed]);
 
   async function handleStart() {
     setLoading(true);
@@ -55,19 +77,26 @@ export function TimesheetTimer({ timer, elapsed, tasks, onStart, onStop }: Times
     <div
       className={cn(
         "flex flex-col sm:flex-row items-start sm:items-center gap-3 px-4 py-3 rounded-xl border transition-colors",
-        isRunning
-          ? "bg-emerald-500/5 border-emerald-500/20"
-          : "bg-card border-border"
+        isStale
+          ? "bg-amber-500/10 border-amber-500/40"
+          : isRunning
+            ? "bg-emerald-500/5 border-emerald-500/20"
+            : "bg-card border-border"
       )}
       data-testid="timesheet-timer"
+      data-stale={isStale ? "true" : undefined}
     >
       {/* Timer icon + display */}
       <div className="flex items-center gap-3">
-        <Clock className={cn("h-4 w-4", isRunning ? "text-emerald-500" : "text-muted-foreground")} />
+        {isStale ? (
+          <AlertTriangle className="h-4 w-4 text-amber-500" data-testid="timer-stale-icon" />
+        ) : (
+          <Clock className={cn("h-4 w-4", isRunning ? "text-emerald-500" : "text-muted-foreground")} />
+        )}
         <div
           className={cn(
             "text-xl sm:text-2xl font-mono font-bold tabular-nums transition-colors",
-            isRunning ? "text-emerald-500" : "text-muted-foreground/30"
+            isStale ? "text-amber-500" : isRunning ? "text-emerald-500" : "text-muted-foreground/30"
           )}
           data-testid="timer-display"
         >


### PR DESCRIPTION
Closes #1566

## Summary

常見抱怨：用戶開計時器忘了停 → 累積一整夜 / 一整週末，事後得手動修錯誤工時。

之前 #1539 系列補了很多 affordance / forgiveness 改動，但 timer 本身沒 stale check。這是漏網之魚。

## 設計

`<TimesheetTimer>` 加 stale 偵測：

| 狀態 | 視覺 |
|------|------|
| 未跑 | 灰色靜態 |
| 跑中 < 9h | emerald 綠（正常 OK） |
| 跑中 ≥ 9h | **amber 警告色** + AlertTriangle ⚠ |

跨過閾值那一刻顯示 toast「計時器已跑 N 小時 — 忘了停嗎？」（10 秒）。

**Cross-over 邏輯**：用 ref 標記是否已 toast。timer 停止後 ref 重置，下次再啟動可再次 toast。避免 hot-reload / re-render 重複觸發（同 #1539-5 模式）。

## 為什麼是 9 小時

- 8h = 標準工作日，可能還在 OT 中
- **9h** = 多半已下班/吃晚餐忘了停（sweet spot）
- 太低（6h）誤殺長會
- 太高（12h）救援太晚

## 為什麼視覺主、toast 輔

- 視覺 indicator 在頁面上一直存在（不會 timeout 消失）
- Toast 只是 nudge — 用戶在其他 tab 工作時也能注意
- 過閾值後不持續催促（避免每 1h toast 騷擾）

## 測試

4 個 stale tests：
- < 9h → 不 stale
- ≥ 9h → stale + AlertTriangle icon
- > 9h → stale 維持
- 不 running → 即使 elapsed 大也不 stale

加上 AlertTriangle mock 補強。269 個 timesheet 測試全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)